### PR TITLE
feat: spec 스킬 질문 프로토콜 및 콘텐츠 강화

### DIFF
--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -282,6 +282,11 @@ When user has no preference or cannot decide, select best practice autonomously.
 
 This applies to ALL question types - AskUserQuestion, plain text questions, clarifications. No exceptions.
 
+**Structural Verification Criteria:**
+- Each message to the user contains at most **1 question** requiring a response
+- Bundling questions into numbered lists (1. ... 2. ... 3. ...) or bulleted lists is **prohibited**
+- Context/analysis paragraphs are fine — only the question itself must be singular
+
 ```
 WRONG: "Please answer the following questions: 1. ... 2. ... 3. ... 4. ..."
 RIGHT: "Are Jira comment keywords also trigger targets?"
@@ -291,7 +296,23 @@ RIGHT: "Are Jira comment keywords also trigger targets?"
        ...
 ```
 
+### Question Priority
+
+When multiple questions are pending within a step, ask in order: **Blocking → Important → Nice-to-have**.
+
+| Priority | Definition | Delay Cost |
+|----------|-----------|------------|
+| **Blocking** | Answer changes the structural direction of subsequent steps (scope boundary, technology constraint, architectural decision) | Rework across multiple steps |
+| **Important** | Answer affects one specific area but does not alter the overall direction | Local revision only |
+| **Nice-to-have** | Answer provides polish or detail. Can be deferred without structural impact | None — defer freely |
+
+**Constraint:** Priority ordering applies WITHIN a step. Do NOT collect questions across steps to reorder them.
+
 ### Question Type Selection
+
+**Mandatory Trigger Rules (not suggestions):**
+- When a decision has 2-4 clear, mutually exclusive options → **MUST** use AskUserQuestion
+- When a question is open-ended or has no predefined options → **MUST** use plain text
 
 | Situation | Method | Why |
 |-----------|--------|-----|
@@ -303,6 +324,11 @@ RIGHT: "Are Jira comment keywords also trigger targets?"
 **Do NOT force AskUserQuestion for open-ended questions.** If the answer is open-ended, just ask in plain text.
 
 ### Question Quality Standard
+
+**Consequence Statement Rule:** Every AskUserQuestion option MUST include a `description` field with at least one concrete consequence statement.
+
+- Anti-pattern: `description: "Simple approach"` — RED (no consequence, just a label)
+- Good: `description: "Simple approach — single transaction, but rollback affects all operations if any step fails"` — GREEN (states what happens as a result)
 
 ```yaml
 BAD:

--- a/skills/spec/references/diagram-selection.md
+++ b/skills/spec/references/diagram-selection.md
@@ -96,3 +96,33 @@ flowchart TD
 3. That participant must have **3+ internal branch points** (R3 threshold applies)
 4. The Flowchart must represent **only that participant's internal logic** (no cross-participant interactions)
 5. The Sequence Diagram must reference the decomposition target via `Note over` or similar
+
+## 5. Diagram Presentation Protocol
+
+Every diagram must be presented in a mandatory 3-part sequence:
+
+### 5a. Structure
+
+1. **Why (before diagram)**: State why this diagram is needed and what it verifies. Must contain at least one verification objective.
+2. **Diagram**: The Mermaid diagram itself.
+3. **Interpretation (after diagram)**: 2-3 lines highlighting key structural observations. Must contain at least 2 specific structural observations.
+
+### 5b. Example
+
+> **Why**: To verify responsibility isolation between OrderService and PaymentService, and confirm the transaction boundary does not span all three services.
+>
+> *(Sequence Diagram here)*
+>
+> **Interpretation**: PaymentService is the only participant communicating with external PG — isolating PG dependency. The alt block shows synchronous rollback, meaning the user waits for cleanup.
+
+### 5c. Anti-Pattern
+
+| Anti-Pattern | Correct Approach |
+|--------------|-----------------|
+| Presenting a diagram without Why or Interpretation | Always include all 3 parts in order |
+| Generic/vacuous Why or Interpretation (e.g., "This diagram shows the flow") | State specific verification objectives and structural observations |
+
+### 5d. Nesting with Rich Context Pattern
+
+When combined with the Rich Context Pattern, Diagram Presentation Protocol nests inside Option Analysis:
+- Context → Tension → [Why → Diagram → Interpretation] → Recommendation → AskUserQuestion

--- a/skills/spec/references/requirements.md
+++ b/skills/spec/references/requirements.md
@@ -28,12 +28,36 @@ For each user action the system tracks, clarify exactly when it occurs, how dupl
 - Exclude: "30-second flush cycle", "Redis ZSET", "Kafka Consumer", "Bucket key format"
 - Test: "Is this something a PO would find valuable to understand?" → Yes = Requirement, No = Implementation detail
 
+### Surfacing Ambiguous Requirements
+
+Classify undecided aspects into 3 question types, ordered by priority:
+
+1. **Policy questions** (ask first — blocking): Business rules and policy decisions that must be resolved before design.
+   - e.g., [Policy] "What is the time window for cancellation?"
+   - e.g., [Policy] "What counts as 'order failure' — validation error, payment timeout, inventory shortage?"
+2. **Boundary questions** (ask next): Responsibility and scope boundaries between components or teams.
+   - e.g., [Boundary] "Who owns the cancellation logic — Order Service or Payment Service?"
+   - e.g., [Boundary] "Is partial cancellation (refund only the failed item) in scope?"
+3. **Extension questions** (ask last — non-blocking): Future extensibility considerations that do not block current design.
+   - e.g., [Extension] "Could cancellation rules vary by payment method in the future?"
+   - e.g., [Extension] "Will manual cancellation by CS agents be needed later?"
+
+Label each question with its type and address Policy/blocking questions before Extension questions.
+
 ## Process
 
 ### Step 1: Project Overview
 
 #### 1.1 Define Core Problem
 - Question: What is the core problem this project aims to solve?
+- **3-Perspective Problem Reframing**: Do not accept feature requests at face value. Reframe them as problem statements from 3 perspectives:
+  - **User**: What pain or friction does the user experience?
+  - **Business**: What business value is at risk?
+  - **System**: What technical inconsistency or constraint exists?
+  - Example — Feature request: "Add order cancellation"
+    - User: "users cannot reverse mistaken or unwanted orders"
+    - Business: "irrevocable orders increase CS load and refund costs"
+    - System: "order lifecycle has no reverse transition from CONFIRMED state"
 
 #### 1.2 Business Value Analysis
 - Analysis: Analyze and present possible business values based on user responses

--- a/skills/spec/tests/diagram-selection-application-scenarios.md
+++ b/skills/spec/tests/diagram-selection-application-scenarios.md
@@ -2,7 +2,7 @@
 
 Area: Diagram Selection (Cross-cutting)
 Reference: `skills/spec/references/diagram-selection.md`
-Scenario Count: 3
+Scenario Count: 4
 
 ---
 
@@ -47,3 +47,18 @@ Scenario Count: 3
 **Expected Output**: Decomposition 적용 — (1) 시스템 간 흐름은 Sequence Diagram으로 유지, (2) PaymentService의 내부 분기 로직을 별도 Flowchart로 분리, (3) Sequence Diagram에서 `Note over PaymentService`로 Flowchart 참조. 5가지 Decomposition Criteria 모두 충족 확인.
 
 **Pass Criteria**: (1) Sequence + Flowchart 분리가 이루어지고, (2) Flowchart는 PaymentService 내부 로직만 포함하며, (3) Sequence에서 `Note over` 참조가 포함됨. (4) 5가지 Decomposition Criteria(기존 Sequence 존재, 단일 참여자, 3+ branch points, 내부 로직만, Note over 참조)가 모두 언급됨. 하나라도 누락되면 RED.
+
+---
+
+### DG-4: Diagram Presentation Protocol
+
+**Technique Under Test**: Diagram Presentation Protocol — Why → Diagram → Interpretation sequence (diagram-selection.md)
+
+**Input**: Solution Design step requires a Sequence Diagram for the order creation flow involving Client, OrderService, PaymentService, and InventoryService.
+
+**Expected Output**: Diagram is presented in the mandatory 3-part sequence:
+1. **Why section (before diagram)**: States why this diagram is needed and what it verifies (e.g., "to verify responsibility isolation between OrderService and PaymentService, and confirm the transaction boundary does not span all three services")
+2. **Diagram**: Mermaid Sequence Diagram with participants and interactions
+3. **Interpretation section (after diagram)**: 2-3 lines highlighting key structural points (e.g., "PaymentService is the only participant communicating with external PG — isolating PG dependency. The alt block shows synchronous rollback, meaning the user waits for cleanup.")
+
+**Pass Criteria**: (1) Why section appears BEFORE the diagram. (2) Interpretation section appears AFTER the diagram. (3) Why section contains at least one verification objective. (4) Interpretation section contains at least 2 specific structural observations about the diagram. If the diagram is presented without a preceding Why or a following Interpretation, RED. If Why or Interpretation are generic/vacuous ("This diagram shows the flow"), RED.

--- a/skills/spec/tests/questioning-protocol-application-scenarios.md
+++ b/skills/spec/tests/questioning-protocol-application-scenarios.md
@@ -1,0 +1,70 @@
+# Questioning Protocol Application Scenarios
+
+Area: Questioning Protocol (Cross-cutting)
+Reference: `SKILL.md` (Questioning Protocol, Question Type Selection, Rich Context Pattern sections)
+Scenario Count: 4
+
+---
+
+### QP-1: Question Priority Ordering
+
+**Technique Under Test**: Question Priority Rule — blocking questions first (SKILL.md Questioning Protocol)
+
+**Input**: During Requirements Step 2, three ambiguities are discovered simultaneously:
+1. **Blocking**: "Should this be a new microservice or a module within the existing monolith?" (affects all downstream architecture)
+2. **Important**: "Should error messages be in Korean or English?" (affects UI design only)
+3. **Nice-to-have**: "Should the admin dashboard use the same color scheme?" (cosmetic)
+
+**Expected Output**: Questions are asked in priority order — blocking first, then important, then nice-to-have. The first question presented to the user addresses the microservice vs monolith decision, not the color scheme or language choice.
+
+**Pass Criteria**: (1) The blocking question (microservice vs monolith) is asked FIRST. (2) The nice-to-have question (color scheme) is asked LAST. (3) Each question's priority level is stated or implied through ordering. If questions are asked in random order, or if a nice-to-have question precedes a blocking question, RED.
+
+---
+
+### QP-2: Rich Context with Options and Impact Analysis
+
+**Technique Under Test**: Rich Context Pattern — options with consequence statements (SKILL.md Rich Context Pattern + Question Type Selection)
+
+**Input**: Solution Design step — deciding communication pattern between OrderService and PaymentService. Three viable alternatives: synchronous HTTP, asynchronous messaging (Kafka), hybrid (sync for critical path, async for side effects).
+
+**Expected Output**: The decision is presented with rich context BEFORE asking for user choice:
+1. **Current State**: Brief description of what exists
+2. **Tension/Problem**: Why this decision matters (e.g., "sync is simpler but creates runtime coupling; async decouples but adds complexity")
+3. **Option Analysis**: Each option includes:
+   - Behavior description (what happens at runtime)
+   - At least one concrete consequence/tradeoff statement (e.g., "sync → OrderService is unavailable when PaymentService is down")
+4. **Recommendation**: AI's suggested option with rationale
+5. **AskUserQuestion**: Structured choice with 2-3 options, each option's description containing at least one consequence statement
+
+**Pass Criteria**: (1) Context (current state + tension) appears BEFORE option analysis. (2) Every option has at least one concrete consequence statement (not just "pros: simple, cons: complex"). (3) A recommendation is present. (4) AskUserQuestion is used with properly structured options. If options lack consequence statements, or if plain text is used instead of AskUserQuestion for a decision with clear alternatives, RED.
+
+---
+
+### QP-3: AskUserQuestion Trigger Conditions
+
+**Technique Under Test**: Question Type Selection — AskUserQuestion vs plain text (SKILL.md Question Type Selection table)
+
+**Input**: Two questions arise during Domain Model design:
+1. Decision question: "Should Order and Payment be in the same Aggregate or separate Aggregates?" (2 clear options with different tradeoffs)
+2. Open-ended question: "What business rules apply to order cancellation?"
+
+**Expected Output**:
+- Question 1 (decision with clear options): Uses **AskUserQuestion** with structured options. Each option has a label and a description with consequences.
+- Question 2 (open-ended): Uses **plain text question**. Does NOT force into AskUserQuestion format.
+
+**Pass Criteria**: (1) Decision question uses AskUserQuestion format with option descriptions. (2) Open-ended question uses plain text. (3) Neither question type is misapplied — decision questions are not asked as plain text, and open-ended questions are not forced into AskUserQuestion. If a decision with 2-4 clear options is asked as plain text, RED. If an open-ended question is forced into AskUserQuestion with artificial options, RED.
+
+---
+
+### QP-4: One Question at a Time
+
+**Technique Under Test**: Questioning Protocol — one question per message (SKILL.md Questioning Protocol)
+
+**Input**: During Requirements Step 3, three design decisions need to be made:
+1. Transaction boundary for order creation
+2. Error handling strategy for payment failures
+3. Notification trigger timing
+
+**Expected Output**: Each decision is addressed in a SEPARATE message. The AI asks about transaction boundary first, waits for user response, then asks about error handling, waits, then asks about notification timing. Questions are NOT bundled.
+
+**Pass Criteria**: (1) Each message contains at most 1 user-directed question. (2) No message contains a numbered list of questions (e.g., "1. ... 2. ... 3. ..."). (3) The AI waits for user response between questions. If multiple questions are asked in a single message, RED. If questions are presented as a numbered/bulleted list in one message, RED.

--- a/skills/spec/tests/requirements-application-scenarios.md
+++ b/skills/spec/tests/requirements-application-scenarios.md
@@ -2,7 +2,7 @@
 
 Area: Requirements
 Reference: `skills/spec/references/requirements.md`
-Scenario Count: 3
+Scenario Count: 5
 
 ---
 
@@ -39,3 +39,33 @@ Scenario Count: 3
 **Expected Output**: Business Tolerance("사용자 행동이 1분 내 랭킹에 반영" + 비즈니스 근거)와 Technical Goals("API p95 50ms" + 측정 방법)로 정확히 분리
 
 **Pass Criteria**: 각 항목이 올바른 카테고리에 배치되고, Business Tolerance에는 비즈니스 근거, Technical Goals에는 측정 방법이 포함
+
+---
+
+### RQ-4: 3-Perspective Problem Reframing
+
+**Technique Under Test**: Step 1.1 Define Core Problem — Multi-perspective problem decomposition (requirements.md)
+
+**Input**: Feature request "주문 취소 기능을 추가해주세요"
+
+**Expected Output**: The requirement is not taken at face value as a feature to build. Instead, it is reframed as a problem statement decomposed from 3 perspectives:
+- **User perspective**: What pain or friction the user experiences (e.g., "users cannot reverse mistaken or unwanted orders")
+- **Business perspective**: What value is at risk (e.g., "irrevocable orders increase CS load and refund costs")
+- **System perspective**: What technical inconsistency exists (e.g., "order lifecycle has no reverse transition from CONFIRMED state")
+
+**Pass Criteria**: (1) All 3 perspectives (User, Business, System) are present. (2) The output frames a PROBLEM to solve, not a FEATURE to build. (3) Each perspective surfaces at least one insight not obvious from the raw feature request. If the requirement is accepted at face value ("OK, let's add order cancellation") without reframing, RED.
+
+---
+
+### RQ-5: Question Type Taxonomy
+
+**Technique Under Test**: Surfacing Ambiguous Requirements — Question type classification (requirements.md Principles)
+
+**Input**: Ambiguous requirement "주문 실패 시 결제를 취소한다"
+
+**Expected Output**: Undecided aspects surfaced as explicitly categorized questions:
+- **Policy question(s)**: e.g., "What is the time window for cancellation? Immediate, or within N minutes?", "What counts as 'order failure' — validation error, payment timeout, inventory shortage?"
+- **Boundary question(s)**: e.g., "Who owns the cancellation logic — Order Service or Payment Service?", "Is partial cancellation (refund only the failed item) in scope?"
+- **Extension question(s)**: e.g., "Could cancellation rules vary by payment method in the future?", "Will manual cancellation by CS agents be needed later?"
+
+**Pass Criteria**: (1) At least one question from each of the 3 types (Policy, Boundary, Extension) is present. (2) Each question is labeled with its type. (3) Questions are ordered by priority (blocking/policy questions before extension questions). If questions are asked without type classification, or if any type category is missing, RED.


### PR DESCRIPTION
Content improvements (Phase A):
- requirements.md: 3-Perspective Problem Reframing (Step 1.1)
- requirements.md: Surfacing Ambiguous Requirements 원칙 추가
- diagram-selection.md: Diagram Presentation Protocol 섹션 추가

Questioning Protocol strengthening (Phase B):
- SKILL.md: Question Priority 규칙 (Blocking/Important/Nice-to-have)
- SKILL.md: Structural Verification Criteria (메시지당 1질문)
- SKILL.md: Mandatory Trigger Rules (AskUserQuestion vs plain text)
- SKILL.md: Consequence Statement Rule (옵션별 결과 기술 필수)

Test scenarios (+7):
- RQ-4, RQ-5, DG-4 (content), QP-1~4 (questioning protocol)
- 38/38 시나리오 GREEN, 회귀 없음