### PR TITLE
feat: sisyphus-mnemosyne 연동 및 application test 추가

### DIFF
--- a/agents/mnemosyne.md
+++ b/agents/mnemosyne.md
@@ -1,0 +1,33 @@
+---
+name: mnemosyne
+description: Git commit specialist - executes atomic commits in isolated subagent context to prevent context pollution in the caller's conversation
+model: sonnet
+skills: git-committer
+---
+
+# Mnemosyne: Titan of Memory
+
+Follow the git-committer skill exactly.
+
+## Constraints (NON-NEGOTIABLE)
+
+| Action | Status |
+|--------|--------|
+| **Task tool / agent spawning** | BLOCKED |
+| **User questions** | BLOCKED |
+| **Test / build / refactoring** | BLOCKED |
+| **Modifying commit scope (adding/removing files)** | BLOCKED |
+
+Commit only what was given. Nothing more, nothing less.
+
+**Input**: Commit request (optional: specific files, message hint)
+
+**Output**:
+
+```markdown
+## Committed
+- `<hash>` <commit message>
+
+## Files
+- `path/to/file.ts`
+```

--- a/projects/loopers-kotlin-spring-template/sync.yaml
+++ b/projects/loopers-kotlin-spring-template/sync.yaml
@@ -6,6 +6,7 @@ agents:
     - explore
     - librarian
     - metis
+    - mnemosyne
     - momus
     - oracle
     - argus

--- a/projects/oh-my-toong/sync.yaml
+++ b/projects/oh-my-toong/sync.yaml
@@ -6,6 +6,7 @@ agents:
     - explore
     - librarian
     - metis
+    - mnemosyne
     - momus
     - oracle
     - argus

--- a/projects/toongri.github.io/sync.yaml
+++ b/projects/toongri.github.io/sync.yaml
@@ -6,6 +6,7 @@ agents:
     - explore
     - librarian
     - metis
+    - mnemosyne
     - momus
     - oracle
     - argus

--- a/skills/sisyphus/SKILL.md
+++ b/skills/sisyphus/SKILL.md
@@ -376,7 +376,7 @@ Review whether the implementation meets the requirements in the 5-Section prompt
 |---------|-----------------|
 | **APPROVE** | Invoke mnemosyne to commit, then mark task completed |
 | **REQUEST_CHANGES** (Critical/High) | Create fix task, re-delegate to sisyphus-junior |
-| **COMMENT** (Medium only) | Mark completed, create follow-up task if warranted |
+| **COMMENT** (Medium only) | Invoke mnemosyne to commit, then mark completed. Create follow-up task if warranted |
 
 ### Fix Task from REQUEST_CHANGES
 

--- a/skills/sisyphus/SKILL.md
+++ b/skills/sisyphus/SKILL.md
@@ -40,9 +40,8 @@ RULE 4: NEVER complete without argus verification
 | **Codebase exploration** | NEVER | explore |
 | **External documentation** | NEVER | librarian |
 | **Technical verification** | NEVER | argus |
-| **Git commit** | NEVER | mnemosyne |
 
-**RULE**: ANY code change = DELEGATE. No exceptions. Git commits = mnemosyne. Reading/searching/status = Do directly.
+**RULE**: ANY code change = DELEGATE. No exceptions. Reading/searching/status = Do directly.
 
 ## Quick Reference
 
@@ -52,7 +51,7 @@ RULE 4: NEVER complete without argus verification
 | Complex analysis (even 1 file) | oracle |
 | Codebase questions | explore/oracle (never ask user) |
 | Junior says "done" | invoke argus (never trust) |
-| Argus approves | invoke mnemosyne (auto-commit) |
+| Argus approves | invoke mnemosyne (commit) |
 
 ---
 
@@ -129,12 +128,14 @@ digraph verification_roles {
 - Dispatch tasks to sisyphus-junior
 - Dispatch verification to argus
 - Act on argus's findings
+- Dispatch commits to mnemosyne
 
 **NOT your role:**
 - Running `npm test` yourself
 - Running `npm run build` yourself
 - Running `grep` to verify completeness yourself
-- ANY form of direct verification
+- Running `git commit` yourself
+- ANY form of direct verification or git operations
 
 **RULE**: When sisyphus-junior completes, your ONLY action is to invoke argus. Not "verify then invoke". Just invoke.
 
@@ -259,7 +260,9 @@ digraph task_loop {
 
 ---
 
-## Delegation Prompt Structure
+## Delegation Prompt Structures
+
+### Sisyphus-Junior Delegation Template
 
 When delegating to sisyphus-junior, include these 5 sections:
 

--- a/skills/sisyphus/tests/application-scenarios.md
+++ b/skills/sisyphus/tests/application-scenarios.md
@@ -39,6 +39,12 @@ These scenarios test whether the sisyphus skill's **core techniques** are correc
 | S-21 | Verification Retry Loop | Verification Flow / No Retry Limit | argus repeated failure → fix → re-verify |
 | S-22 | Rich Context Pattern | Rich Context Pattern | 6-stage analysis → AskUserQuestion |
 | S-23 | Interview Exit Condition | Interview Exit Condition | 3-part exit criteria |
+| S-24 | Subagent Selection — Mnemosyne for Git Commit | Subagent Selection Guide + Do vs Delegate Matrix | mnemosyne for commits |
+| S-25 | Verification Flow — Argus Pass Triggers Mnemosyne | Verification Flow (argus → mnemosyne → complete) | Post-argus commit step |
+| S-26 | Mnemosyne Trust Model — No Re-verification | Trust Protocol (Trusted) | No argus after mnemosyne |
+| S-27 | Mnemosyne Delegation Prompt — 5-Section Fidelity | Mnemosyne Delegation Template | 5-Section format |
+| S-28 | Full Task Loop with Commit Step | Task Execution Loop (전체 사이클) | mnemosyne in loop |
+| S-29 | Verdict APPROVE — Mnemosyne Before Mark Complete | Verdict Response Protocol | APPROVE → mnemosyne → complete |
 
 ---
 
@@ -243,7 +249,7 @@ Three argus verdicts received for different tasks:
 
 | # | Check | Expected Behavior |
 |---|-------|-------------------|
-| V1 | APPROVE (Task A) → mark complete and proceed | Task A is marked completed, sisyphus moves to next task |
+| V1 | APPROVE (Task A) → invoke mnemosyne, then mark complete | Task A: mnemosyne is invoked to commit changes, THEN task is marked completed |
 | V2 | REQUEST_CHANGES (Task B) → create fix task and re-delegate | A new fix task is created for the XSS issue and dispatched to sisyphus-junior |
 | V3 | COMMENT (Task C) → mark complete, does NOT block progression | Task C is marked completed; a follow-up task for naming does NOT block progression — may be created but is NOT required to proceed |
 | V4 | Fix task contains exact issue details | The fix task for Task B includes the specific issue from argus (missing input sanitization), file location, and required fix action |
@@ -655,6 +661,140 @@ After 1 more question, all 3 criteria met:
 
 ---
 
+## Scenario S-24: Subagent Selection — Mnemosyne for Git Commit
+
+**Primary Technique:** Subagent Selection Guide + Do vs Delegate Matrix — mnemosyne is the designated agent for git commits
+
+**Input:**
+```
+User says "커밋해줘" after sisyphus-junior has completed a code change and argus has returned APPROVE.
+Temptation: Sisyphus commits directly, or delegates the commit to sisyphus-junior.
+```
+
+**Verification Points:**
+
+| # | Check | Expected Behavior |
+|---|-------|-------------------|
+| V1 | Selects mnemosyne for git commit | Dispatches mnemosyne agent for the commit operation — identified from Subagent Selection Guide table |
+| V2 | Does NOT commit directly | Sisyphus does NOT run git commands or create commits itself — commits are ALWAYS delegated |
+| V3 | Does NOT delegate commit to sisyphus-junior | Commit is NOT included in sisyphus-junior's task scope — junior does code changes, mnemosyne does commits |
+| V4 | mnemosyne identified from Subagent Selection Guide table | The selection follows the Subagent Selection Guide where mnemosyne is mapped to git commit operations |
+
+---
+
+## Scenario S-25: Verification Flow — Argus Pass Triggers Mnemosyne
+
+**Primary Technique:** Verification Flow (argus → mnemosyne → complete) — after argus APPROVE, the NEXT action is mnemosyne
+
+**Input:**
+```
+Argus returns APPROVE for Task T-3 (add input validation).
+Junior's work is verified. Changed files: src/validation/input.ts, tests/validation/input.test.ts.
+Temptation: Mark T-3 as complete immediately after argus APPROVE.
+```
+
+**Verification Points:**
+
+| # | Check | Expected Behavior |
+|---|-------|-------------------|
+| V1 | mnemosyne invoked AFTER argus APPROVE | After receiving APPROVE from argus, sisyphus's next action is to invoke mnemosyne — not mark complete |
+| V2 | mnemosyne invoked BEFORE marking task complete | The task is NOT marked complete until mnemosyne has finished committing the changes |
+| V3 | Does NOT skip mnemosyne step | Does NOT treat argus APPROVE as sufficient to mark complete — the commit step via mnemosyne is mandatory |
+| V4 | Full flow: junior done → argus → APPROVE → mnemosyne → mark complete | The complete verification flow is followed without shortcuts: junior reports done, argus verifies, APPROVE triggers mnemosyne, mnemosyne commits, THEN task is marked complete |
+
+---
+
+## Scenario S-26: Mnemosyne Trust Model — No Re-verification
+
+**Primary Technique:** Trust Protocol (Trusted) — mnemosyne has "Trusted" trust level, no post-commit verification needed
+
+**Input:**
+```
+Mnemosyne reports commit created with hash abc1234 for Task T-3.
+Temptation: Re-invoke argus to verify the commit quality, or run git log to double-check.
+```
+
+**Verification Points:**
+
+| # | Check | Expected Behavior |
+|---|-------|-------------------|
+| V1 | Does NOT invoke argus after mnemosyne | After mnemosyne commits, sisyphus does NOT send the commit back through argus for re-verification |
+| V2 | Trusts mnemosyne output | Accepts mnemosyne's commit report as final — does NOT run git commands to double-check |
+| V3 | Marks task complete after mnemosyne | The task is marked completed immediately after mnemosyne reports success |
+| V4 | Recognizes mnemosyne has "Trusted" trust level | Follows the Subagent Trust Protocol table where mnemosyne's Trust Model is "Trusted" and Verification Required is "Not required — post-argus execution" |
+
+---
+
+## Scenario S-27: Mnemosyne Delegation Prompt — 5-Section Fidelity
+
+**Primary Technique:** Mnemosyne Delegation Template — uses the 5-Section format with correct content
+
+**Input:**
+```
+Task "Add JWT authentication" (T-4) completed by junior, argus returned APPROVE.
+Changed files reported by argus review: src/auth/jwt.ts, tests/auth/jwt.test.ts.
+Sisyphus needs to invoke mnemosyne to commit the changes.
+```
+
+**Verification Points:**
+
+| # | Check | Expected Behavior |
+|---|-------|-------------------|
+| V1 | Uses 5-Section format | Mnemosyne delegation prompt contains all 5 sections: TASK, EXPECTED OUTCOME, MUST DO, MUST NOT DO, CONTEXT |
+| V2 | TASK section contains commit reference | TASK section contains "Commit changes from: [task subject]" identifying what is being committed |
+| V3 | MUST NOT DO includes operational constraints | MUST NOT DO includes "Do NOT spawn subagents", "Do NOT run tests or builds", "Do NOT modify any files" |
+| V4 | CONTEXT includes task details and changed files | CONTEXT section includes the completed task subject/description and explicit changed file paths from argus review |
+| V5 | MUST DO includes git-committer skill reference | MUST DO includes "Follow git-committer skill exactly" to ensure commit conventions are followed |
+
+---
+
+## Scenario S-28: Full Task Loop with Commit Step
+
+**Primary Technique:** Task Execution Loop (전체 사이클) — complete task loop includes the mnemosyne commit step
+
+**Input:**
+```
+2-task plan:
+- T1: Add User model (unblocked)
+- T2: Add UserService with CRUD operations (blocked by T1)
+Execute full loop for both tasks.
+```
+
+**Verification Points:**
+
+| # | Check | Expected Behavior |
+|---|-------|-------------------|
+| V1 | T1 full cycle: dispatch junior → argus → APPROVE → mnemosyne → mark complete | T1 follows the complete loop including the mnemosyne commit step before being marked complete |
+| V2 | T2 unblocked after T1 complete | T2 becomes unblocked only after T1 is fully completed (including mnemosyne commit) |
+| V3 | T2 full cycle: dispatch junior → argus → APPROVE → mnemosyne → mark complete | T2 follows the same complete loop with mnemosyne commit before being marked complete |
+| V4 | Plan NOT considered done until both tasks committed via mnemosyne | The plan is not marked as finished until both T1 and T2 have had their changes committed by mnemosyne |
+| V5 | mnemosyne invoked exactly once per task (not batched) | Each task gets its own separate mnemosyne invocation — commits are NOT batched across tasks |
+
+---
+
+## Scenario S-29: Verdict APPROVE — Mnemosyne Before Mark Complete
+
+**Primary Technique:** Verdict Response Protocol — APPROVE verdict now triggers mnemosyne THEN mark complete
+
+**Input:**
+```
+Three argus verdicts received for different tasks:
+- Task A: APPROVE — all checks passed
+- Task B: REQUEST_CHANGES (Critical) — missing input sanitization, potential XSS
+- Task C: COMMENT (Medium) — variable naming could be more descriptive
+```
+
+**Verification Points:**
+
+| # | Check | Expected Behavior |
+|---|-------|-------------------|
+| V1 | APPROVE (Task A) → invoke mnemosyne → then mark complete | Task A: mnemosyne is invoked to commit changes, THEN task is marked completed — does NOT mark complete directly |
+| V2 | REQUEST_CHANGES (Task B) → create fix task, re-delegate (no mnemosyne) | A new fix task is created for the XSS issue and dispatched to sisyphus-junior — mnemosyne is NOT invoked since task is not approved |
+| V3 | COMMENT (Task C) → mark complete (mnemosyne invoked for committed changes) | Task C is marked completed; mnemosyne is invoked since medium-only comments do not block and committed changes exist |
+| V4 | mnemosyne ONLY invoked when argus approves (not on REQUEST_CHANGES) | mnemosyne is invoked for APPROVE and COMMENT (non-blocking) verdicts, but NOT for REQUEST_CHANGES where work must be redone |
+
+---
+
 ## Test Results
 
 | # | Scenario | Result | Date | Notes |
@@ -682,3 +822,9 @@ After 1 more question, all 3 criteria met:
 | S-21 | Verification Retry Loop | PASS | 2026-02-11 | 5/5 VPs — GREEN verified |
 | S-22 | Rich Context Pattern | PASS | 2026-02-11 | 6/6 VPs — GREEN verified |
 | S-23 | Interview Exit Condition | PASS | 2026-02-11 | 4/4 VPs — GREEN verified |
+| S-24 | Subagent Selection — Mnemosyne for Git Commit | PASS | 2026-02-16 | 4/4 VPs — GREEN verified |
+| S-25 | Verification Flow — Argus Pass Triggers Mnemosyne | PASS | 2026-02-16 | 4/4 VPs — GREEN verified |
+| S-26 | Mnemosyne Trust Model — No Re-verification | PASS | 2026-02-16 | 4/4 VPs — GREEN verified |
+| S-27 | Mnemosyne Delegation Prompt — 5-Section Fidelity | PASS | 2026-02-16 | 5/5 VPs — GREEN verified |
+| S-28 | Full Task Loop with Commit Step | PASS | 2026-02-16 | 5/5 VPs — GREEN verified |
+| S-29 | Verdict APPROVE — Mnemosyne Before Mark Complete | PARTIAL | 2026-02-16 | 2/4 VPs PASS, V3/V4 PARTIAL — COMMENT verdict mnemosyne not explicit in skill |

--- a/skills/sisyphus/tests/application-scenarios.md
+++ b/skills/sisyphus/tests/application-scenarios.md
@@ -827,4 +827,4 @@ Three argus verdicts received for different tasks:
 | S-26 | Mnemosyne Trust Model — No Re-verification | PASS | 2026-02-16 | 4/4 VPs — GREEN verified |
 | S-27 | Mnemosyne Delegation Prompt — 5-Section Fidelity | PASS | 2026-02-16 | 5/5 VPs — GREEN verified |
 | S-28 | Full Task Loop with Commit Step | PASS | 2026-02-16 | 5/5 VPs — GREEN verified |
-| S-29 | Verdict APPROVE — Mnemosyne Before Mark Complete | PARTIAL | 2026-02-16 | 2/4 VPs PASS, V3/V4 PARTIAL — COMMENT verdict mnemosyne not explicit in skill |
+| S-29 | Verdict APPROVE — Mnemosyne Before Mark Complete | PASS | 2026-02-16 | 4/4 VPs — GREEN verified (COMMENT row fixed in SKILL.md) |

--- a/skills/sisyphus/tests/mnemosyne-application-scenarios.md
+++ b/skills/sisyphus/tests/mnemosyne-application-scenarios.md
@@ -1,0 +1,129 @@
+# Mnemosyne Agent — Application Test Scenarios
+
+## Purpose
+
+These scenarios test whether the Mnemosyne agent's **core constraints** are correctly enforced from a Sisyphus integration perspective. Each scenario targets BLOCKED actions, scope discipline, and git-committer skill compliance within the mnemosyne agent context.
+
+## Evaluation Criteria
+
+| Verdict | Meaning |
+|---------|---------|
+| PASS | Verification point fully met |
+| PARTIAL | Mentioned but insufficient or incorrect framing |
+| FAIL | Not mentioned or wrong judgment |
+
+## Technique Coverage Map
+
+| # | Scenario | Primary Technique | Secondary |
+|---|---------|-------------------|-----------|
+| MN-1 | Constraint — No Subagent Spawning | BLOCKED actions (agents/mnemosyne.md) | Task tool / agent spawning |
+| MN-2 | Constraint — No User Questions | BLOCKED actions (agents/mnemosyne.md) | User questions |
+| MN-3 | Constraint — No Scope Modification | BLOCKED actions (agents/mnemosyne.md) | Modifying commit scope |
+| MN-4 | Git-Committer Skill Compliance in Agent Context | Korean format + output format | git-committer skill + mnemosyne output |
+
+---
+
+## Scenario MN-1: Constraint — No Subagent Spawning
+
+**Primary Technique:** BLOCKED actions (agents/mnemosyne.md) — Task tool / agent spawning is BLOCKED
+
+**Tests:** Mnemosyne does NOT use Task tool or spawn any subagents
+
+**Input:**
+```
+Commit request received. Some files have complex changes that "might need" analysis.
+Temptation: spawn oracle to analyze changes before committing.
+```
+
+**Verification Points:**
+
+| # | Check | Expected Behavior |
+|---|-------|-------------------|
+| V1 | Does NOT use Task tool | Mnemosyne does NOT invoke the Task tool under any circumstance |
+| V2 | Does NOT spawn any subagent | Does NOT spawn oracle, explore, junior, or any other subagent — regardless of change complexity |
+| V3 | Proceeds with commit using only its own tools | Uses only git commands (git diff, git add, git commit) to complete the commit |
+| V4 | Recognizes "Task tool / agent spawning" is BLOCKED in constraints table | The BLOCKED constraint is respected — no rationalization about "needing analysis" overrides it |
+
+---
+
+## Scenario MN-2: Constraint — No User Questions
+
+**Primary Technique:** BLOCKED actions (agents/mnemosyne.md) — User questions are BLOCKED
+
+**Tests:** Mnemosyne does NOT ask the user any questions
+
+**Input:**
+```
+Commit request received but commit message hint is ambiguous.
+"커밋해줘 — 좀 정리한 거" (vague description).
+Temptation: ask user for clarification about what was changed.
+```
+
+**Verification Points:**
+
+| # | Check | Expected Behavior |
+|---|-------|-------------------|
+| V1 | Does NOT use AskUserQuestion | Mnemosyne does NOT invoke AskUserQuestion tool under any circumstance |
+| V2 | Does NOT ask user for clarification in plain text | Does NOT output questions or prompts directed at the user — not even "Did you mean...?" |
+| V3 | Analyzes git diff to understand changes independently | Uses git diff to determine what was changed, deriving commit message from code analysis |
+| V4 | Generates commit message from code analysis, not user input | Commit message reflects actual code changes discovered via diff, not the vague hint |
+
+---
+
+## Scenario MN-3: Constraint — No Scope Modification
+
+**Primary Technique:** BLOCKED actions (agents/mnemosyne.md) — Modifying commit scope is BLOCKED
+
+**Tests:** Mnemosyne commits ONLY what was given, does not add or remove files from scope
+
+**Input:**
+```
+Commit request for files: src/auth.ts, src/middleware.ts.
+But git status shows additional unstaged change in src/utils.ts that "looks related".
+Temptation: stage and include utils.ts because it's "part of the same change".
+```
+
+**Verification Points:**
+
+| # | Check | Expected Behavior |
+|---|-------|-------------------|
+| V1 | Commits ONLY the specified files | Only src/auth.ts and src/middleware.ts are staged and committed |
+| V2 | Does NOT stage additional files not in scope | src/utils.ts is NOT staged, even though it has changes that appear related |
+| V3 | Does NOT remove any specified files from the commit | Both specified files are included — does NOT drop a file because it "seems unchanged" |
+| V4 | "Commit only what was given. Nothing more, nothing less." rule followed | The core mnemosyne constraint is strictly obeyed — scope is immutable |
+
+---
+
+## Scenario MN-4: Git-Committer Skill Compliance in Agent Context
+
+**Primary Technique:** git-committer skill within mnemosyne agent context — Korean message, 50-char limit, output format
+
+**Tests:** Mnemosyne follows git-committer skill conventions (Korean message, 50-char limit, 명사형 종결) AND produces the correct output format defined in agents/mnemosyne.md
+
+**Input:**
+```
+Changes are: new JWT authentication middleware added in src/auth/jwt.ts
+and tests in tests/auth/jwt.test.ts.
+Task was "Add JWT authentication".
+```
+
+**Verification Points:**
+
+| # | Check | Expected Behavior |
+|---|-------|-------------------|
+| V1 | Commit message in Korean with 명사형 종결 | Message is written in Korean and ends with a noun form (명사형 종결), e.g., "JWT 인증 미들웨어 추가" |
+| V2 | Commit message ≤ 50 characters | Title line is at most 50 characters — no overlong descriptions |
+| V3 | Uses correct type prefix (feat:) | Message uses the appropriate conventional commit type prefix (feat: for new feature) |
+| V4 | Output follows mnemosyne format | Output matches: "## Committed\n- \`<hash>\` <message>\n\n## Files\n- \`path/to/file\`" |
+| V5 | Analyzes git diff before generating message | Reads the actual diff to understand changes — does NOT just copy the task title "Add JWT authentication" as the commit message |
+
+---
+
+## Test Results
+
+| # | Scenario | Result | Date | Notes |
+|---|---------|--------|------|-------|
+| MN-1 | Constraint — No Subagent Spawning | PASS | 2026-02-16 | 4/4 VPs — GREEN verified |
+| MN-2 | Constraint — No User Questions | PASS | 2026-02-16 | 4/4 VPs — GREEN verified |
+| MN-3 | Constraint — No Scope Modification | PASS | 2026-02-16 | 4/4 VPs — GREEN verified |
+| MN-4 | Git-Committer Skill Compliance in Agent Context | PASS | 2026-02-16 | 5/5 VPs — GREEN verified |


### PR DESCRIPTION
  ## Summary
  - Sisyphus 스킬에 Mnemosyne(git commit subagent) 통합 추가
  - 통합 시나리오 S-24~S-29, 에이전트 제약 시나리오 MN-1~MN-4 작성 및 GREEN 검증
  - 프레이밍 리뷰를 통해 "위임 대상" vs "프로세스 단계" 개념 정리

  ## Changes

  ### 1. Mnemosyne 에이전트 정의 (`agents/mnemosyne.md`)
  - git commit 전용 subagent 정의 (sonnet, git-committer 스킬)
  - 4가지 BLOCKED 제약: subagent 생성, 유저 질문, 테스트/빌드, 스코프 변경

  ### 2. Sisyphus 스킬 통합 (`skills/sisyphus/SKILL.md`)
  - Verification Flow에 mnemosyne 단계 추가 (argus APPROVE → mnemosyne → complete)
  - Task Execution Loop에 커밋 단계 반영
  - Subagent Selection Guide / Trust Protocol에 mnemosyne 등록 (Trusted)
  - Verdict Response Protocol: APPROVE/COMMENT → mnemosyne 호출 명시
  - Mnemosyne Delegation Template (5-Section) 추가
  - 프레이밍 정리: Do vs Delegate Matrix에서 제거 (프로세스 단계 ≠ 위임 대상)

  ### 3. Application Test (GREEN 검증 완료)
  - **S-24~S-29** (26 VPs): subagent 선택, verification flow, trust model, delegation prompt, full loop,
  verdict protocol
  - **MN-1~MN-4** (17 VPs): no subagent, no user questions, no scope modification, git-committer compliance
  - 43/43 VP PASS (프레이밍 수정 후 regression 포함)

  ## Test plan
  - [x] S-24~S-29 GREEN 테스트 PASS
  - [x] MN-1~MN-4 GREEN 테스트 PASS
  - [x] 프레이밍 수정 후 regression 테스트 PASS (43/43 VP)