### PR TITLE
refactor: Ralph Loop 프롬프트 정제 및 truncation 개선

### DIFF
--- a/hooks/keyword-detector.sh
+++ b/hooks/keyword-detector.sh
@@ -72,6 +72,9 @@ fi
 # This handles both single-line and multi-line code blocks properly
 PROMPT_NO_CODE=$(echo "$PROMPT" | tr '\n' '\r' | sed 's/```[^`]*```//g' | sed 's/`[^`]*`//g' | tr '\r' '\n')
 
+# Remove system-reminder tags
+PROMPT_CLEAN=$(echo "$PROMPT_NO_CODE" | perl -0pe 's/<system-reminder>.*?<\/system-reminder>//gs' | sed 's/  */ /g' | sed 's/^ *//;s/ *$//')
+
 # Convert to lowercase
 PROMPT_LOWER=$(echo "$PROMPT_NO_CODE" | tr '[:upper:]' '[:lower:]')
 
@@ -102,11 +105,11 @@ EOF
 # Check for ralph keyword (highest priority) - ralph loop activation
 if echo "$PROMPT_LOWER" | grep -qE '\bralph\b'; then
   # Create ralph state file
-  create_ralph_state "$PROJECT_ROOT" "$PROMPT"
+  create_ralph_state "$PROJECT_ROOT" "$PROMPT_CLEAN"
 
   # Output ralph activation message
   cat << EOF
-{"continue": true, "hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": "<ralph-mode>\n**RALPH LOOP ACTIVATED** - Iteration 1/10\n\nYou are in Ralph Loop mode with MANDATORY VERIFICATION GATES.\n\n## CORE RULES\n1. Work until ALL requirements are met\n2. Track progress with TodoWrite tool\n3. When ALL tasks complete, output <promise>DONE</promise> to trigger Oracle verification\n4. After Oracle approves, output <oracle-approved>VERIFIED_COMPLETE</oracle-approved>\n5. Do NOT stop until Oracle approves\n\n## COMPLETION SEQUENCE (MANDATORY)\n\n1. **Complete all tasks** - Check TODO list is empty\n2. **Run verification** - Build, test, lint as applicable\n3. **Output promise** - <promise>DONE</promise>\n4. **Stop hook triggers** - Oracle verification will be requested\n5. **Spawn Oracle** - Verify completion with oracle agent\n6. **Output approval tag** - <oracle-approved>VERIFIED_COMPLETE</oracle-approved>\n7. **Done** - Session can end\n\n## VERIFICATION REQUIREMENTS\n\n- [ ] Build: Fresh run showing SUCCESS\n- [ ] Tests: Fresh run showing ALL PASS\n- [ ] TODO LIST: Zero pending/in_progress tasks\n- [ ] Oracle: Verification approved\n\n### Red Flags (STOP if you catch yourself)\n- Using 'should work', 'probably passes'\n- Skipping build/test because 'nothing changed'\n- Forgetting to output <promise>DONE</promise> when complete\n\nOriginal task: ${PROMPT}\n</ralph-mode>\n\n---\n"}}
+{"continue": true, "hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": "<ralph-mode>\n**RALPH LOOP ACTIVATED** - Iteration 1/10\n\nYou are in Ralph Loop mode with MANDATORY VERIFICATION GATES.\n\n## CORE RULES\n1. Work until ALL requirements are met\n2. Track progress with TodoWrite tool\n3. When ALL tasks complete, output <promise>DONE</promise> to trigger Oracle verification\n4. After Oracle approves, output <oracle-approved>VERIFIED_COMPLETE</oracle-approved>\n5. Do NOT stop until Oracle approves\n\n## COMPLETION SEQUENCE (MANDATORY)\n\n1. **Complete all tasks** - Check TODO list is empty\n2. **Run verification** - Build, test, lint as applicable\n3. **Output promise** - <promise>DONE</promise>\n4. **Stop hook triggers** - Oracle verification will be requested\n5. **Spawn Oracle** - Verify completion with oracle agent\n6. **Output approval tag** - <oracle-approved>VERIFIED_COMPLETE</oracle-approved>\n7. **Done** - Session can end\n\n## VERIFICATION REQUIREMENTS\n\n- [ ] Build: Fresh run showing SUCCESS\n- [ ] Tests: Fresh run showing ALL PASS\n- [ ] TODO LIST: Zero pending/in_progress tasks\n- [ ] Oracle: Verification approved\n\n### Red Flags (STOP if you catch yourself)\n- Using 'should work', 'probably passes'\n- Skipping build/test because 'nothing changed'\n- Forgetting to output <promise>DONE</promise> when complete\n\nOriginal task: ${PROMPT_CLEAN}\n</ralph-mode>\n\n---\n"}}
 EOF
   exit 0
 fi

--- a/hooks/persistent-mode.js
+++ b/hooks/persistent-mode.js
@@ -267,12 +267,12 @@ function formatBlockOutput(reason) {
 function formatContinueOutput() {
   return { continue: true };
 }
-var MAX_PROMPT_LENGTH = 500;
+var MAX_PROMPT_LENGTH = 2e3;
 var MAX_FEEDBACK_LENGTH = 500;
 var MAX_FEEDBACK_COUNT = 3;
 function truncateText(text, maxLength) {
   if (text.length > maxLength) {
-    return text.substring(0, maxLength) + "...[truncated]";
+    return text.substring(0, maxLength) + `...[truncated from ${text.length} chars]`;
   }
   return text;
 }
@@ -293,14 +293,12 @@ ${limitedFeedback.join("\n")}
 Your previous attempt did not include oracle approval. The work is NOT verified complete yet.
 ${feedbackSection}
 CRITICAL INSTRUCTIONS:
-1. Review your progress and the original task
+1. Review your progress and the original task below
 2. Check your todo list - are ALL items marked complete?
-3. Spawn Oracle to verify: Task(subagent_type="oracle", prompt="Verify: ${truncatedPrompt}")
+3. Spawn Oracle to verify: Task(subagent_type="oracle", prompt="Verify task completion: ${truncatedPrompt}")
 4. If Oracle approves, output: <oracle-approved>VERIFIED_COMPLETE</oracle-approved>
 5. Then output: <promise>${promise}</promise>
 6. Do NOT stop until verified by Oracle
-
-Original task: ${truncatedPrompt}
 
 </ralph-loop-continuation>
 

--- a/hooks/tests/test_ralph_message.sh
+++ b/hooks/tests/test_ralph_message.sh
@@ -87,6 +87,91 @@ test_variable_expansion() {
     return 0
 }
 
+# Test: @file mentions produce [referenced files: ...] annotation
+test_file_references() {
+    local output
+    output=$(echo '{"parts": [{"type": "text", "text": "ralph fix this"}, {"type": "file", "file_path": "src/main.kt"}], "cwd": "/tmp"}' | "$HOOK_SCRIPT")
+
+    local message
+    message=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+
+    if [[ "$message" != *"[referenced files: src/main.kt]"* ]]; then
+        echo "FAIL: File reference not found in message"
+        echo "Message excerpt: $(echo "$message" | grep -o 'referenced files:.*' | head -1)"
+        return 1
+    fi
+    echo "PASS: File reference included"
+    return 0
+}
+
+# Test: Multiple @file mentions produce comma-separated file list
+test_multiple_file_references() {
+    local output
+    output=$(echo '{"parts": [{"type": "text", "text": "ralph refactor these"}, {"type": "file", "file_path": "src/Foo.kt"}, {"type": "file", "file_path": "test/FooTest.kt"}], "cwd": "/tmp"}' | "$HOOK_SCRIPT")
+
+    local message
+    message=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+
+    if [[ "$message" != *"[referenced files: src/Foo.kt, test/FooTest.kt]"* ]]; then
+        echo "FAIL: Multiple file references not found"
+        echo "Message excerpt: $(echo "$message" | grep -o 'referenced files:.*' | head -1)"
+        return 1
+    fi
+    echo "PASS: Multiple file references included"
+    return 0
+}
+
+# Test: Code blocks are preserved in ralph prompt
+test_code_blocks_preserved() {
+    local output
+    output=$(printf '{"prompt": "ralph fix this ```kotlin\\nfun foo() = 42\\n```", "cwd": "/tmp"}' | "$HOOK_SCRIPT")
+
+    # Note: Code blocks with newlines produce raw newlines in output,
+    # which breaks JSON parsing. Check raw output instead of jq.
+    if [[ "$output" != *'```kotlin'* ]]; then
+        echo "FAIL: Code block not preserved in message"
+        return 1
+    fi
+    echo "PASS: Code blocks preserved"
+    return 0
+}
+
+# Test: System-reminder tags are removed from ralph prompt
+test_system_reminder_removed() {
+    local output
+    output=$(echo '{"prompt": "ralph fix this <system-reminder>noise</system-reminder> please", "cwd": "/tmp"}' | "$HOOK_SCRIPT")
+
+    local message
+    message=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+
+    if [[ "$message" == *"system-reminder"* ]]; then
+        echo "FAIL: System-reminder tag not removed"
+        return 1
+    fi
+    if [[ "$message" != *"ralph fix this"* ]]; then
+        echo "FAIL: Non-reminder content was lost"
+        return 1
+    fi
+    echo "PASS: System-reminder removed, content preserved"
+    return 0
+}
+
+# Test: No file annotation when no file parts present
+test_no_file_annotation_without_files() {
+    local output
+    output=$(echo '{"prompt": "ralph fix the bug", "cwd": "/tmp"}' | "$HOOK_SCRIPT")
+
+    local message
+    message=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+
+    if [[ "$message" == *"referenced files"* ]]; then
+        echo "FAIL: File annotation present without file parts"
+        return 1
+    fi
+    echo "PASS: No file annotation without file parts"
+    return 0
+}
+
 # Run all tests
 echo "=== Testing Ralph Activation Message ==="
 echo ""
@@ -99,6 +184,11 @@ test_verification_requirements_present || FAILED=1
 test_red_flags_present || FAILED=1
 test_core_rules_present || FAILED=1
 test_variable_expansion || FAILED=1
+test_file_references || FAILED=1
+test_multiple_file_references || FAILED=1
+test_code_blocks_preserved || FAILED=1
+test_system_reminder_removed || FAILED=1
+test_no_file_annotation_without_files || FAILED=1
 
 echo ""
 if [ $FAILED -eq 0 ]; then

--- a/scripts/persistent-mode/src/decision.ts
+++ b/scripts/persistent-mode/src/decision.ts
@@ -25,13 +25,13 @@ function formatContinueOutput(): HookOutput {
   return { continue: true };
 }
 
-const MAX_PROMPT_LENGTH = 500;
+const MAX_PROMPT_LENGTH = 2000;
 const MAX_FEEDBACK_LENGTH = 500;
 const MAX_FEEDBACK_COUNT = 3;
 
 function truncateText(text: string, maxLength: number): string {
   if (text.length > maxLength) {
-    return text.substring(0, maxLength) + '...[truncated]';
+    return text.substring(0, maxLength) + `...[truncated from ${text.length} chars]`;
   }
   return text;
 }
@@ -63,14 +63,12 @@ function buildRalphContinuationMessage(
 Your previous attempt did not include oracle approval. The work is NOT verified complete yet.
 ${feedbackSection}
 CRITICAL INSTRUCTIONS:
-1. Review your progress and the original task
+1. Review your progress and the original task below
 2. Check your todo list - are ALL items marked complete?
-3. Spawn Oracle to verify: Task(subagent_type="oracle", prompt="Verify: ${truncatedPrompt}")
+3. Spawn Oracle to verify: Task(subagent_type="oracle", prompt="Verify task completion: ${truncatedPrompt}")
 4. If Oracle approves, output: <oracle-approved>VERIFIED_COMPLETE</oracle-approved>
 5. Then output: <promise>${promise}</promise>
 6. Do NOT stop until verified by Oracle
-
-Original task: ${truncatedPrompt}
 
 </ralph-loop-continuation>
 


### PR DESCRIPTION
- keyword-detector.sh: ralph state 저장 시 system-reminder 제거한 PROMPT_CLEAN 사용으로 노이즈 감소
- decision.ts: MAX_PROMPT_LENGTH 500→2000, continuation message 내 prompt 중복 제거, truncation suffix에 원본 길이 포함