### PR TITLE
fix: 멀티 에이전트 위임 프롬프트 표준화 및 시나리오 테스트 수정

### DIFF
--- a/rules/work-principles.md
+++ b/rules/work-principles.md
@@ -7,6 +7,12 @@
 - Mark tasks `completed` immediately after finishing — no batching, no delay.
 - If a task reveals subtasks, create them right away.
 
+## Analytical Stance
+
+- Lead with objective facts and critical analysis, not emotional validation.
+- No emotional empathy ("great question!", "I understand your frustration", "that's a good point").
+- State what IS, then what SHOULD BE. Skip pleasantries.
+
 ## Momentum
 
 The boulder never stops. Continue until all tasks complete.

--- a/skills/argus/SKILL.md
+++ b/skills/argus/SKILL.md
@@ -71,7 +71,7 @@ Single-line edits, obvious typos, or changes with no functional behavior modific
 
 **Before reviewing code quality, verify the implementation meets the original request.**
 
-The 5-Section prompt from sisyphus defines what Junior was asked to do. Verify each section.
+The 6-Section prompt from sisyphus defines what Junior was asked to do. Verify each section.
 
 ### Expected Outcome Verification
 
@@ -197,7 +197,7 @@ Every issue MUST include confidence scoring and use the rich feedback format.
 
 ```
 Stage 1: Automated Verification (Build, Test, Lint)
-Stage 2: Spec Compliance (vs 5-Section prompt)
+Stage 2: Spec Compliance (vs 6-Section prompt)
 Stage 3: Code Quality (Security, Architecture, Performance, Maintainability, YAGNI)
 
 STAGE 1: See stage1-commands.md

--- a/skills/argus/tests/application-scenarios.md
+++ b/skills/argus/tests/application-scenarios.md
@@ -35,6 +35,7 @@ Argus가 `git diff`로 변경사항을 식별하면 두 가지 문제가 발생:
 **6-Section Input:**
 - TASK: Add JWT validation to login endpoint
 - EXPECTED OUTCOME: Files to modify: [auth/login.ts]. JWT token validation logic added.
+- REQUIRED TOOLS: Serena find_symbol (auth/login.ts의 login 함수 탐색)
 - MUST DO: Use jsonwebtoken library
 - MUST NOT DO: Do NOT modify auth/middleware.ts
 - CONTEXT: Existing auth flow in auth/login.ts
@@ -59,6 +60,7 @@ Argus가 `git diff`로 변경사항을 식별하면 두 가지 문제가 발생:
 **6-Section Input:**
 - TASK: Add null check for userId parameter
 - EXPECTED OUTCOME: Files to modify: [service/user-service.ts]. Null check added before DB query.
+- REQUIRED TOOLS: Serena find_symbol (user-service.ts의 userId 파라미터 사용 위치 탐색)
 - MUST DO: Add explicit null/undefined check, throw BadRequestError if null
 - MUST NOT DO: Do NOT change the DB query logic itself
 - CONTEXT: user-service.ts handles user CRUD operations
@@ -83,6 +85,7 @@ Argus가 `git diff`로 변경사항을 식별하면 두 가지 문제가 발생:
 **6-Section Input:**
 - TASK: Fix login validation bug
 - EXPECTED OUTCOME: Files to modify: [auth/login.ts]
+- REQUIRED TOOLS: Serena find_symbol (auth/login.ts의 validation 로직 탐색)
 - MUST DO: Fix the email regex pattern
 - MUST NOT DO: Do NOT touch auth/config.ts
 - CONTEXT: Bug report: email validation accepts invalid formats
@@ -107,6 +110,7 @@ Argus가 `git diff`로 변경사항을 식별하면 두 가지 문제가 발생:
 **6-Section Input:**
 - TASK: Refactor data access layer
 - EXPECTED OUTCOME: Files to modify: [src/A.ts, src/B.ts]
+- REQUIRED TOOLS: Serena find_symbol (A.ts, B.ts의 query 로직 탐색)
 - MUST DO: Extract common query logic into shared method
 - MUST NOT DO: Do NOT modify controller files
 - CONTEXT: A.ts and B.ts contain duplicated query logic
@@ -131,6 +135,7 @@ Argus가 `git diff`로 변경사항을 식별하면 두 가지 문제가 발생:
 **6-Section Input (Junior A의 task):**
 - TASK: Add rate limiting to auth endpoint
 - EXPECTED OUTCOME: Files to modify: [auth.ts]
+- REQUIRED TOOLS: Serena find_symbol (auth.ts의 endpoint 구조 탐색)
 - MUST DO: Use express-rate-limit middleware
 - MUST NOT DO: Do NOT modify payment routes
 - CONTEXT: Auth endpoint needs rate limiting for security
@@ -156,6 +161,7 @@ Argus가 `git diff`로 변경사항을 식별하면 두 가지 문제가 발생:
 **6-Section Input:**
 - TASK: Add type definitions for API responses
 - EXPECTED OUTCOME: Files to modify: [types.ts]
+- REQUIRED TOOLS: Serena get_symbols_overview (types.ts의 기존 타입 구조 파악)
 - MUST DO: Define proper TypeScript interfaces for all API responses
 - MUST NOT DO: Do NOT use `any` type anywhere
 - CONTEXT: Project enforces strict TypeScript typing
@@ -180,6 +186,7 @@ Argus가 `git diff`로 변경사항을 식별하면 두 가지 문제가 발생:
 **6-Section Input:**
 - TASK: Fix typo in README.md
 - EXPECTED OUTCOME: Files to modify: [README.md]. Typo "authenication" → "authentication" corrected.
+- REQUIRED TOOLS: None (단순 오타 수정)
 - MUST DO: Fix the specific typo only
 - MUST NOT DO: Do NOT change any other content
 - CONTEXT: Typo reported in README

--- a/skills/argus/tests/application-scenarios.md
+++ b/skills/argus/tests/application-scenarios.md
@@ -8,7 +8,7 @@ Argus가 `git diff`로 변경사항을 식별하면 두 가지 문제가 발생:
 1. **누적 diff**: `git diff main`이 이전 커밋의 변경까지 포함
 2. **병렬 오염**: 여러 Junior가 동시 작업 시 git diff가 모든 Junior의 변경을 섞어서 표시
 
-해결: Sisyphus가 전달하는 **Changed files 목록 + 5-Section prompt**를 Single Source of Truth로 삼고, 파일을 직접 읽어서 검증.
+해결: Sisyphus가 전달하는 **Changed files 목록 + 6-Section prompt**를 Single Source of Truth로 삼고, 파일을 직접 읽어서 검증.
 
 ---
 
@@ -32,7 +32,7 @@ Argus가 `git diff`로 변경사항을 식별하면 두 가지 문제가 발생:
 
 **Context:** Junior가 auth/login.ts에 JWT validation을 추가하라는 task를 완료함.
 
-**5-Section Input:**
+**6-Section Input:**
 - TASK: Add JWT validation to login endpoint
 - EXPECTED OUTCOME: Files to modify: [auth/login.ts]. JWT token validation logic added.
 - MUST DO: Use jsonwebtoken library
@@ -56,7 +56,7 @@ Argus가 `git diff`로 변경사항을 식별하면 두 가지 문제가 발생:
 
 **Context:** Junior가 user-service.ts에서 userId에 대한 null check를 추가하라는 task를 완료함.
 
-**5-Section Input:**
+**6-Section Input:**
 - TASK: Add null check for userId parameter
 - EXPECTED OUTCOME: Files to modify: [service/user-service.ts]. Null check added before DB query.
 - MUST DO: Add explicit null/undefined check, throw BadRequestError if null
@@ -80,7 +80,7 @@ Argus가 `git diff`로 변경사항을 식별하면 두 가지 문제가 발생:
 
 **Context:** Junior가 auth/login.ts만 수정하라는 task를 완료함. MUST NOT DO에 auth/config.ts 수정 금지가 있음.
 
-**5-Section Input:**
+**6-Section Input:**
 - TASK: Fix login validation bug
 - EXPECTED OUTCOME: Files to modify: [auth/login.ts]
 - MUST DO: Fix the email regex pattern
@@ -104,7 +104,7 @@ Argus가 `git diff`로 변경사항을 식별하면 두 가지 문제가 발생:
 
 **Context:** Junior가 A.ts, B.ts를 수정함. 동시에 다른 Junior가 C.ts를 수정 중이라 working tree에 C.ts 변경도 존재함.
 
-**5-Section Input:**
+**6-Section Input:**
 - TASK: Refactor data access layer
 - EXPECTED OUTCOME: Files to modify: [src/A.ts, src/B.ts]
 - MUST DO: Extract common query logic into shared method
@@ -128,7 +128,7 @@ Argus가 `git diff`로 변경사항을 식별하면 두 가지 문제가 발생:
 
 **Context:** Sisyphus가 두 Junior를 병렬 실행. Junior A는 auth.ts 수정, Junior B는 payment.ts 수정. Junior A가 먼저 완료되어 Argus 검증 시작. Working tree에는 Junior B의 payment.ts 변경도 존재함.
 
-**5-Section Input (Junior A의 task):**
+**6-Section Input (Junior A의 task):**
 - TASK: Add rate limiting to auth endpoint
 - EXPECTED OUTCOME: Files to modify: [auth.ts]
 - MUST DO: Use express-rate-limit middleware
@@ -153,7 +153,7 @@ Argus가 `git diff`로 변경사항을 식별하면 두 가지 문제가 발생:
 
 **Context:** Junior가 types.ts를 수정함. TypeScript `any` 타입 사용 금지 규칙이 있음.
 
-**5-Section Input:**
+**6-Section Input:**
 - TASK: Add type definitions for API responses
 - EXPECTED OUTCOME: Files to modify: [types.ts]
 - MUST DO: Define proper TypeScript interfaces for all API responses
@@ -177,7 +177,7 @@ Argus가 `git diff`로 변경사항을 식별하면 두 가지 문제가 발생:
 
 **Context:** Junior가 README.md의 오타를 수정함. 기능 변경 없음.
 
-**5-Section Input:**
+**6-Section Input:**
 - TASK: Fix typo in README.md
 - EXPECTED OUTCOME: Files to modify: [README.md]. Typo "authenication" → "authentication" corrected.
 - MUST DO: Fix the specific typo only

--- a/skills/clarify/SKILL.md
+++ b/skills/clarify/SKILL.md
@@ -119,6 +119,28 @@ Record original verbatim. Identify: unclear items, needed assumptions, open deci
 
 **The ONLY questions for users are about PREFERENCES, not FACTS.**
 
+### Explore/Librarian Prompt Guide
+
+Explore and librarian are contextual search agents — treat them like targeted grep, not consultants.
+Always run in background. Always parallel when independent.
+
+**Prompt structure** (each field should be substantive, not a single sentence):
+- **[CONTEXT]**: What task you're working on, which files/modules are involved, and what approach you're taking
+- **[GOAL]**: The specific outcome you need — what decision or action the results will unblock
+- **[DOWNSTREAM]**: How you will use the results — what you'll build/decide based on what's found
+- **[REQUEST]**: Concrete search instructions — what to find, what format to return, and what to SKIP
+
+**Examples:**
+
+```
+// Fact-finding before asking user
+Task(subagent_type="explore", prompt="I'm clarifying requirements for a user's auth feature request and need to check what already exists before asking redundant questions. I'll use this to eliminate codebase-answerable questions from my interview. Find: existing auth implementations, login flows, user model structure. Focus on src/ — skip tests. Return file paths with brief descriptions.")
+```
+
+### Oracle Consultation
+
+For understanding current architecture before asking scope questions, briefly announce "Consulting Oracle for [reason]" before invocation.
+
 ### 3. Iterative Clarification
 Use `AskUserQuestion` for each ambiguity.
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -77,9 +77,11 @@ Collect in parallel (using `{range}` from Step 1):
 
 Subagent context (conditional):
 
-5. Dispatch explore agent: "Find existing patterns, conventions, and related code for the changed files: [file list]"
+5. Dispatch explore agent (4-Field):
+   Task(subagent_type="explore", prompt="I'm reviewing a PR that changes [file list] and need to understand the existing conventions these files should follow. I'll use this to evaluate whether the PR matches codebase patterns. Find: related implementations, naming conventions, error handling patterns, and test structure for the changed modules. Skip unrelated directories. Return file paths with pattern descriptions.")
    → Always dispatch (lightweight, provides codebase context)
-6. Dispatch oracle agent: "Analyze architecture implications of these changes: [file list summary]"
+6. Dispatch oracle agent (only if trigger conditions met):
+   Briefly announce "Consulting Oracle for [reason]" before invocation.
    → Only if trigger conditions met (see below)
 
 **Oracle trigger conditions:**

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -126,7 +126,8 @@ After all agents return:
 1. **Merge** all Strengths, Issues, Recommendations sections
 2. **Deduplicate** issues appearing in multiple chunks
 3. **Identify cross-file concerns** -- issues spanning chunk boundaries (e.g., interface contract mismatches, inconsistent error handling patterns)
-4. **Determine final verdict** -- "Ready to merge?" is the STRICTEST of all chunk verdicts (any "No" = overall "No")
-5. **Produce unified report** in the standard output format (Strengths / Issues / Recommendations / Assessment)
+4. **Normalize severity labels** across chunks using Critical / Important / Minor scale -- reconcile inconsistent labels for same-type issues across chunks; escalate recurring cross-chunk issues
+5. **Determine final verdict** -- "Ready to merge?" is the STRICTEST of all chunk verdicts (any "No" = overall "No")
+6. **Produce unified report** in the standard output format (Strengths / Issues / Recommendations / Assessment)
 
 For single-chunk reviews, return the agent's output directly.

--- a/skills/metis/SKILL.md
+++ b/skills/metis/SKILL.md
@@ -211,6 +211,9 @@ If any of the following patterns are detected during analysis, ask the user a cl
 ```markdown
 ## Metis Analysis: [Topic]
 
+### Domain Context
+[1-2 sentences: Why this analysis matters for this specific domain. Connect the plan's subject area to the risks that pre-planning analysis prevents.]
+
 ### Intent Classification
 - **Type**: [Refactoring | Build from Scratch | Mid-sized | Collaborative | Architecture | Research]
 - **Confidence**: [High | Medium | Low]

--- a/skills/metis/SKILL.md
+++ b/skills/metis/SKILL.md
@@ -82,10 +82,21 @@ Perform the analysis for the classified Intent's section, then proceed to the An
 **Mission**: Discover patterns first, then surface hidden requirements
 
 **Pre-Research Protocol** (mandatory before asking questions):
+
+Explore and librarian are contextual search agents — treat them like targeted grep, not consultants.
+Always run in background. Always parallel when independent.
+
+**Prompt structure**: [CONTEXT] + [GOAL] + [DOWNSTREAM] + [REQUEST]
+- **[CONTEXT]**: What task you're working on, which files/modules are involved, and what approach you're taking
+- **[GOAL]**: The specific outcome you need — what decision or action the results will unblock
+- **[DOWNSTREAM]**: How you will use the results — what you'll build/decide based on what's found
+- **[REQUEST]**: Concrete search instructions — what to find, what format to return, and what to SKIP
+
 ```
 // Execute these before asking the user any questions
-Task(subagent_type="explore", prompt="Analyzing a new feature request and need to understand existing patterns before asking clarification questions. Find the structure and conventions of similar implementations in the codebase.")
-Task(subagent_type="explore", prompt="Planning to build [feature type] and need to verify consistency with the project. Find the file structure, naming patterns, and architectural approach of similar features.")
+// Prompt structure: [CONTEXT] + [GOAL] + [DOWNSTREAM] + [REQUEST]
+Task(subagent_type="explore", prompt="I'm analyzing a new feature request and need to understand existing patterns before asking clarification questions. I'll use this to ask informed questions instead of codebase-answerable ones. Find the structure and conventions of similar implementations — file organization, naming patterns, and shared utilities. Return file paths with pattern descriptions.")
+Task(subagent_type="explore", prompt="I'm planning to build [feature type] and need to verify consistency with the project before surfacing gaps. I'll use this to write precise directives for Prometheus. Find the file structure, naming patterns, and architectural approach of similar features. Focus on src/ — skip tests. Return file paths with pattern descriptions.")
 ```
 
 **Questions to Ask** (after exploration):
@@ -133,6 +144,8 @@ Task(subagent_type="explore", prompt="Planning to build [feature type] and need 
 ### IF Architecture
 
 **Mission**: Strategic analysis. Long-term impact assessment. Oracle consultation recommended.
+
+For architecture intent, briefly announce "Consulting Oracle for [reason]" before invocation.
 
 | Focus | Detail |
 |-------|--------|

--- a/skills/metis/tests/application-scenarios.md
+++ b/skills/metis/tests/application-scenarios.md
@@ -10,7 +10,7 @@ These scenarios test whether the metis skill's **core techniques** are correctly
 |---|---------|-------------------|-----------|
 | M-1 | Analysis Framework 전반부 | Requirements / Assumptions / Scope / Dependencies | 카테고리 누락 감지 |
 | M-2 | Analysis Framework 후반부 | Risks / Success Criteria / Edge Cases / Error Handling | 보안/에러 처리 누락 감지 |
-| M-3 | Mandatory Output Structure | 7-section markdown 출력 구조 | 섹션별 품질 검증 |
+| M-3 | Mandatory Output Structure | 8-section markdown 출력 구조 | 섹션별 품질 검증 |
 | M-4 | Vague Term Detection | 모호한 용어 감지 및 명확화 요청 | Analysis Framework 전반 |
 | M-5 | Completeness | Scope Exclusion / Common Mistake Detection | 암묵적 가정 질문 |
 | M-6 | Intent Classification | MT-1: Intent 분류 → 분석 전 수행 | 분류 신뢰도 검증 |
@@ -103,7 +103,7 @@ These scenarios test whether the metis skill's **core techniques** are correctly
 
 ## Scenario M-3: Mandatory Output Structure Compliance
 
-**Primary Technique:** 7-section Mandatory Output Structure
+**Primary Technique:** 8-section Mandatory Output Structure
 
 **Prompt:**
 ```
@@ -132,6 +132,7 @@ These scenarios test whether the metis skill's **core techniques** are correctly
 | V5 | Missing Acceptance Criteria 섹션 존재 | "### Missing Acceptance Criteria" 헤딩과 측정 가능한 기준 제안이 포함됨 |
 | V6 | Edge Cases 섹션 존재 | "### Edge Cases" 헤딩과 비정상 시나리오가 포함됨 |
 | V7 | Recommendations 섹션 존재 | "### Recommendations" 헤딩과 우선순위가 매겨진 명확화 항목이 포함됨 |
+| V8 | Domain Context 섹션 존재 | "### Domain Context" 헤딩과 도메인 맥락/분석 동기 설명이 출력 최상단(Intent Classification 이전)에 포함됨 |
 
 ---
 
@@ -240,7 +241,7 @@ These scenarios test whether the metis skill's **core techniques** are correctly
 |---|-------|-------------------|
 | V1 | Intent Type 명시 | 분석 시작 전에 Intent Type을 "Refactoring"으로 명시적으로 분류함 |
 | V2 | Confidence Level 제시 | 분류 신뢰도(High/Medium/Low)를 근거와 함께 제시함 |
-| V3 | 분류가 분석보다 선행 | Intent Classification이 출력 구조에서 가장 먼저 등장하며, 이후 분석이 이 분류에 기반함 |
+| V3 | 분류가 분석보다 선행 | Intent Classification이 세부 분석 섹션보다 먼저 등장하며, 이후 분석이 이 분류에 기반함 |
 
 ---
 
@@ -508,6 +509,6 @@ These scenarios test whether the metis skill's **core techniques** are correctly
 |---|---------|--------|------|-------|
 | M-1 | Analysis Framework 전반부 | PASS | 2026-02-10 | V1-V4 모두 충족 |
 | M-2 | Analysis Framework 후반부 | PASS | 2026-02-10 | V1-V4 모두 충족 |
-| M-3 | Mandatory Output Structure | PASS | 2026-02-10 | V1-V7 모두 충족 |
+| M-3 | Mandatory Output Structure | PASS | 2026-02-10 | V1-V7 모두 충족 (V8 Domain Context 추가됨 — 재검증 필요) |
 | M-4 | Vague Term Detection | PASS | 2026-02-10 | V1-V5 모두 충족 |
 | M-5 | Completeness | PASS | 2026-02-10 | V1-V4 모두 충족 |

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -89,6 +89,31 @@ digraph prometheus_flow {
 - **Metis** = Pre-plan validation (catches gaps BEFORE writing)
 - **Momus** = Post-plan review (catches issues AFTER writing)
 
+### Explore/Librarian Prompt Guide
+
+Explore and librarian are contextual search agents — treat them like targeted grep, not consultants.
+Always run in background. Always parallel when independent.
+
+**Prompt structure** (each field should be substantive, not a single sentence):
+- **[CONTEXT]**: What task you're working on, which files/modules are involved, and what approach you're taking
+- **[GOAL]**: The specific outcome you need — what decision or action the results will unblock
+- **[DOWNSTREAM]**: How you will use the results — what you'll build/decide based on what's found
+- **[REQUEST]**: Concrete search instructions — what to find, what format to return, and what to SKIP
+
+**Examples:**
+
+```
+// Pre-interview research (internal)
+Task(subagent_type="explore", prompt="I'm planning a new authentication feature and need to understand existing patterns before interviewing the user. I'll use this to ask informed questions instead of codebase-answerable ones. Find: existing auth implementations, middleware patterns, session handling. Focus on src/ — skip tests. Return file paths with pattern descriptions.")
+
+// Pre-interview research (external)
+Task(subagent_type="librarian", prompt="I'm planning to implement OAuth 2.0 and need authoritative guidance for the work plan. I'll use this to recommend the right approach during the interview. Find official docs: setup, flow types (authorization code, PKCE), security considerations, common pitfalls. Skip beginner tutorials — production patterns only.")
+```
+
+### Oracle Consultation
+
+For architecture-level questions during interview, briefly announce "Consulting Oracle for [reason]" before invocation.
+
 ## Interview Mode (Default State)
 
 **Use AskUserQuestion tool to interview in-depth until nothing is ambiguous.**

--- a/skills/sisyphus/tests/application-scenarios.md
+++ b/skills/sisyphus/tests/application-scenarios.md
@@ -20,7 +20,7 @@ These scenarios test whether the sisyphus skill's **core techniques** are correc
 | S-2 | Complexity Triggers — Oracle Regardless of File Count | Complexity Triggers | Single file ≠ simple |
 | S-3 | Subagent Selection — Correct Agent Per Situation | Subagent Selection Guide | Role matching |
 | S-4 | Verification Flow — Junior Done → IGNORE → Argus | Verification Flow | Role Separation |
-| S-5 | Argus Prompt Fidelity — Verbatim 5-Section | Argus Invocation (Prompt Fidelity) | No summarize/paraphrase |
+| S-5 | Argus Prompt Fidelity — Verbatim 6-Section | Argus Invocation (Prompt Fidelity) | No summarize/paraphrase |
 | S-6 | Per-Task Argus — One Call Per Task | Argus Invocation (Per-Task) | No batch |
 | S-7 | File Path Specificity + No Pre-built Checklist | Argus Invocation (File Path + Checklist) | No abstractions |
 | S-8 | Verdict Response Protocol — Action Per Verdict | Verdict Response Protocol | APPROVE/REQUEST_CHANGES/COMMENT |
@@ -28,7 +28,7 @@ These scenarios test whether the sisyphus skill's **core techniques** are correc
 | S-10 | Partial Completion — New Tasks, Never Solo | Subagent Partial Completion | No direct execution |
 | S-11 | Parallelization — Independent = Concurrent | Parallelization Heuristic | Code tasks always delegate |
 | S-12 | Task Execution Loop — Full Cycle | Task Execution Loop | blockedBy + dispatch + argus + next |
-| S-13 | 5-Section Delegation Prompt — Generation Quality | Delegation Prompt Structure | 5 sections + quality check |
+| S-13 | 6-Section Delegation Prompt — Generation Quality | Delegation Prompt Structure | 6 sections + quality check |
 | S-14 | Request Classification — Routing Per Type | Decision Gate (Step 1) | 5 types: Trivial/Explicit/Exploratory/Open-ended/Ambiguous |
 | S-15 | Context Brokering — Facts vs Preferences | Context Brokering Protocol | Explore for facts, user for preferences |
 | S-16 | Interview Mode — Sequential + Quality | In-Depth Interview Mode | One Q per message + rich context |
@@ -142,27 +142,30 @@ Everything is working correctly."
 
 ---
 
-## Scenario S-5: Argus Prompt Fidelity — Verbatim 5-Section
+## Scenario S-5: Argus Prompt Fidelity — Verbatim 6-Section
 
 **Primary Technique:** Argus Invocation (Prompt Fidelity) — copy-paste VERBATIM, no summarization
 
 **Input:**
 ```
-Original 5-Section delegation prompt sent to junior (45 lines):
+Original 6-Section delegation prompt sent to junior (45 lines):
 ## 1. TASK
 Add JWT authentication to the /api/users endpoint...
 ## 2. EXPECTED OUTCOME
 - Files to modify: src/auth/jwt.ts, src/api/users.ts, tests/auth/jwt.test.ts
 - Expected behavior: All /api/users requests require valid JWT...
 - Verification: `npm test -- --grep "jwt"`
-## 3. MUST DO
+## 3. REQUIRED TOOLS
+- Serena find_symbol: Navigate JWT implementation patterns in src/auth/
+- Bash: Run `npm test -- --grep "jwt"` for verification only
+## 4. MUST DO
 - Follow pattern in src/auth/session.ts:15-40
 - Use RS256 algorithm, not HS256
 - Token expiry: 1 hour
-## 4. MUST NOT DO
+## 5. MUST NOT DO
 - Do NOT modify session.ts
 - Do NOT add new dependencies
-## 5. CONTEXT
+## 6. CONTEXT
 - Related files: src/auth/session.ts (existing auth pattern)
 - Prior task: T-1 added the User model
 
@@ -173,8 +176,8 @@ Temptation: Summarize to "Junior was asked to add JWT auth to users endpoint."
 
 | # | Check | Expected Behavior |
 |---|-------|-------------------|
-| V1 | 5-Section prompt copied VERBATIM to argus | The entire 5-Section prompt appears in the argus invocation without any edits |
-| V2 | No section omitted | All 5 sections (TASK, EXPECTED OUTCOME, MUST DO, MUST NOT DO, CONTEXT) are present in the argus call |
+| V1 | 6-Section prompt copied VERBATIM to argus | The entire 6-Section prompt appears in the argus invocation without any edits |
+| V2 | No section omitted | All 6 sections (TASK, EXPECTED OUTCOME, REQUIRED TOOLS, MUST DO, MUST NOT DO, CONTEXT) are present in the argus call |
 | V3 | No paraphrasing or restructuring | Text is not summarized, rephrased, or reorganized — exact copy-paste |
 | V4 | MUST NOT DO section included | The MUST NOT DO section is explicitly included, not dropped as "less important" |
 
@@ -199,7 +202,7 @@ All 3 juniors report completion at roughly the same time.
 | # | Check | Expected Behavior |
 |---|-------|-------------------|
 | V1 | 3 separate argus invocations | Exactly 3 argus calls are made — one per completed task |
-| V2 | Each call contains ONLY that task's prompt | T-1's argus call contains only T-1's 5-Section prompt, not T-2 or T-3 |
+| V2 | Each call contains ONLY that task's prompt | T-1's argus call contains only T-1's 6-Section prompt, not T-2 or T-3 |
 | V3 | No batching of multiple tasks | Does NOT combine multiple tasks into a single argus call for "efficiency" |
 | V4 | Each argus call lists only that task's changed files | File paths in each argus call correspond exclusively to that task's scope |
 
@@ -228,7 +231,7 @@ Also tempted to include: "Please verify: 1) Tests pass, 2) No regressions, 3) Ty
 |---|-------|-------------------|
 | V1 | All 5 file paths explicitly listed | Each of the 5 files is listed by its full path in the argus invocation |
 | V2 | No glob patterns or abstract counts | Does NOT use "auth/**", "5 files", or "auth module files" — concrete paths only |
-| V3 | No pre-built verification checklist | Does NOT include "Here's what to verify:" or any checklist for argus — argus derives its own checks from the 5-Section prompt |
+| V3 | No pre-built verification checklist | Does NOT include "Here's what to verify:" or any checklist for argus — argus derives its own checks from the 6-Section prompt |
 | V4 | Junior's summary included as-is | Junior's completion claim is included as reference, not as verified facts |
 
 ---
@@ -352,9 +355,9 @@ Junior reports: "Completed 3/6 modules. Remaining 3 follow the same pattern."
 
 ---
 
-## Scenario S-13: 5-Section Delegation Prompt — Generation Quality
+## Scenario S-13: 6-Section Delegation Prompt — Generation Quality
 
-**Primary Technique:** Delegation Prompt Structure — all 5 sections present with sufficient detail
+**Primary Technique:** Delegation Prompt Structure — all 6 sections present with sufficient detail
 
 **Input:**
 ```
@@ -372,12 +375,13 @@ Known context:
 
 | # | Check | Expected Behavior |
 |---|-------|-------------------|
-| V1 | All 5 sections present | TASK, EXPECTED OUTCOME, MUST DO, MUST NOT DO, and CONTEXT sections all appear in the delegation prompt |
-| V2 | Prompt exceeds 30 lines | The generated prompt is substantial (>30 lines), not a brief summary |
-| V3 | Includes concrete file paths | Specific files (src/api/register.ts, src/validation/user.ts) and pattern references (src/auth/login-validation.ts:10-45) are included |
-| V4 | Includes verification command | EXPECTED OUTCOME contains a runnable verification command (e.g., `npm test`) |
-| V5 | MUST NOT DO section has constraints | Explicit constraints (e.g., do NOT modify User model or database schema) are listed |
-| V6 | Pattern references included in MUST DO | MUST DO references existing patterns with file and line numbers for junior to follow |
+| V1 | All 6 sections present | TASK, EXPECTED OUTCOME, REQUIRED TOOLS, MUST DO, MUST NOT DO, and CONTEXT sections all appear in the delegation prompt |
+| V2 | REQUIRED TOOLS section has explicit tool whitelist | REQUIRED TOOLS contains at least one tool with what to use it for — not empty or generic |
+| V3 | Prompt exceeds 30 lines | The generated prompt is substantial (>30 lines), not a brief summary |
+| V4 | Includes concrete file paths | Specific files (src/api/register.ts, src/validation/user.ts) and pattern references (src/auth/login-validation.ts:10-45) are included |
+| V5 | Includes verification command | EXPECTED OUTCOME contains a runnable verification command (e.g., `npm test`) |
+| V6 | MUST NOT DO section has constraints | Explicit constraints (e.g., do NOT modify User model or database schema) are listed |
+| V7 | Pattern references included in MUST DO | MUST DO references existing patterns with file and line numbers for junior to follow |
 
 ---
 
@@ -803,7 +807,7 @@ Three argus verdicts received for different tasks:
 | S-2 | Complexity Triggers — Oracle Regardless of File Count | PASS | 2026-02-11 | 4/4 VPs — GREEN verified |
 | S-3 | Subagent Selection — Correct Agent Per Situation | PASS | 2026-02-11 | 6/6 VPs — GREEN verified |
 | S-4 | Verification Flow — Junior Done → IGNORE → Argus | PASS | 2026-02-11 | 4/4 VPs — GREEN verified |
-| S-5 | Argus Prompt Fidelity — Verbatim 5-Section | PASS | 2026-02-11 | 4/4 VPs — GREEN verified |
+| S-5 | Argus Prompt Fidelity — Verbatim 6-Section | PASS | 2026-02-11 | 4/4 VPs — GREEN verified |
 | S-6 | Per-Task Argus — One Call Per Task | PASS | 2026-02-11 | 4/4 VPs — GREEN verified |
 | S-7 | File Path Specificity + No Pre-built Checklist | PASS | 2026-02-11 | 4/4 VPs — GREEN verified |
 | S-8 | Verdict Response Protocol — Action Per Verdict | PASS | 2026-02-11 | 4/4 VPs — GREEN verified |
@@ -811,7 +815,7 @@ Three argus verdicts received for different tasks:
 | S-10 | Partial Completion — New Tasks, Never Solo | PASS | 2026-02-11 | 4/4 VPs — GREEN verified |
 | S-11 | Parallelization — Independent = Concurrent | PASS | 2026-02-11 | 4/4 VPs — GREEN verified |
 | S-12 | Task Execution Loop — Full Cycle | PASS | 2026-02-11 | 5/5 VPs — GREEN verified |
-| S-13 | 5-Section Delegation Prompt — Generation Quality | PASS | 2026-02-11 | 6/6 VPs — GREEN verified |
+| S-13 | 6-Section Delegation Prompt — Generation Quality | PASS | 2026-02-11 | 7/7 VPs — GREEN verified |
 | S-14 | Request Classification — Routing Per Type | PASS | 2026-02-11 | 6/6 VPs — GREEN verified |
 | S-15 | Context Brokering — Facts vs Preferences | PASS | 2026-02-11 | 4/4 VPs — GREEN verified |
 | S-16 | Interview Mode — Sequential + Quality | PASS | 2026-02-11 | 5/5 VPs — GREEN verified |

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -258,6 +258,31 @@ See each Design Area reference file for domain-specific clarification examples.
 | Existing codebase patterns | explore |
 | Multi-AI design feedback | spec-reviewer |
 
+### Explore/Librarian Prompt Guide
+
+Explore and librarian are contextual search agents — treat them like targeted grep, not consultants.
+Always run in background. Always parallel when independent.
+
+**Prompt structure** (each field should be substantive, not a single sentence):
+- **[CONTEXT]**: What task you're working on, which files/modules are involved, and what approach you're taking
+- **[GOAL]**: The specific outcome you need — what decision or action the results will unblock
+- **[DOWNSTREAM]**: How you will use the results — what you'll build/decide based on what's found
+- **[REQUEST]**: Concrete search instructions — what to find, what format to return, and what to SKIP
+
+**Examples:**
+
+```
+// Spec research (internal)
+Task(subagent_type="explore", prompt="I'm designing a spec for a new caching layer and need to understand existing data access patterns. I'll use this to decide where caching fits in the architecture. Find: repository/DAO patterns, data access layers, existing caching (if any), query hot spots. Focus on src/ — skip tests. Return file paths with usage frequency indicators.")
+
+// Spec research (external)
+Task(subagent_type="librarian", prompt="I'm specifying a Redis caching strategy and need authoritative guidance on cache invalidation patterns. I'll use this to recommend the right approach in the spec. Find: cache-aside vs write-through patterns, TTL strategies, invalidation approaches, Redis best practices for [framework]. Skip introductory content — architecture-level guidance only.")
+```
+
+### Oracle Consultation
+
+For technical decisions and architecture trade-offs during spec work, briefly announce "Consulting Oracle for [reason]" before invocation.
+
 ## Context Brokering
 
 **NEVER burden the user with questions the codebase can answer.**


### PR DESCRIPTION
## Summary
- 멀티 에이전트 위임 프롬프트 패턴을 5-Section에서 6-Section(REQUIRED TOOLS 추가)으로 표준화
- 표준화로 인해 깨진 시나리오 테스트(argus, sisyphus) 참조를 6-Section으로 정렬
- code-review Step 5에 severity 정규화 단계 추가 (CR-7 V4 FAIL 수정)
- metis Mandatory Output Structure에 Domain Context 프리앰블 추가 (M-11 V3 PARTIAL 수정)
- 분석적 사고 원칙(Analytical Stance) work-principles에 추가

## Changed Files
| 파일 | 변경 내용 |
|------|----------|
| `rules/work-principles.md` | Analytical Stance 섹션 추가 |
| `skills/sisyphus/SKILL.md` | 6-Section 위임 프롬프트 표준화 (REQUIRED TOOLS 섹션 추가) |
| `skills/argus/SKILL.md` | 5-Section → 6-Section 참조 정렬 |
| `skills/code-review/SKILL.md` | Step 5에 severity 정규화 단계 삽입 |
| `skills/metis/SKILL.md` | Domain Context 프리앰블 섹션 추가 |
| `skills/prometheus/SKILL.md` | 6-Section 위임 프롬프트 참조 추가 |
| `skills/clarify/SKILL.md` | 6-Section 위임 프롬프트 참조 추가 |
| `skills/spec/SKILL.md` | 6-Section 위임 프롬프트 참조 추가 |
| `skills/argus/tests/application-scenarios.md` | 6-Section 참조 정렬 |
| `skills/sisyphus/tests/application-scenarios.md` | 6-Section 참조 정렬 |
| `skills/metis/tests/application-scenarios.md` | M-3 V8 추가, M-6 V3 문구 수정, 8-section 반영 |

## Test plan
- [x] code-review CR-1~CR-8 전체 38 VP PASS (CR-7 V4: FAIL→PASS)
- [x] metis M-1~M-13 전체 51 VP PASS (M-11 V3: PARTIAL→PASS, M-3 V8: 신규 PASS)
- [x] argus S-1~S-7 전체 23 VP PASS
- [x] sisyphus S-1~S-29 전체 129 VP PASS
- [x] 하위호환성 이슈 없음