### PR TITLE
feat: prometheus/metis 인수조건 품질 검증 강화

### DIFF
--- a/skills/metis/SKILL.md
+++ b/skills/metis/SKILL.md
@@ -175,6 +175,7 @@ For architecture intent, briefly announce "Consulting Oracle for [reason]" befor
 | **Dependencies** | What must exist before work starts? |
 | **Risks** | What could go wrong? Mitigation? |
 | **Success Criteria** | How do we know it's done? Measurable? |
+| **AC Quality** | Well-formed? Observable outcomes? Verification methods concrete? |
 | **Edge Cases** | Unusual inputs/states/scenarios? |
 | **Error Handling** | What happens when things fail? |
 
@@ -185,6 +186,9 @@ For architecture intent, briefly announce "Consulting Oracle for [reason]" befor
 - Do NOT skip categories because they seem "obvious"
 - Do NOT accept vague terms without demanding definitions ("events happen", "preferences", "appropriate")
 - Do NOT accept scope without explicit exclusions
+- Do NOT accept acceptance criteria that list files or functions as outcomes ("create X.js with functions A, B") — criteria must describe observable state changes
+- Do NOT accept acceptance criteria with vague verification ("dry-run review", "verify it works", "confirm functionality") — verification must be a concrete command, assertion, or observable state
+- Do NOT accept acceptance criteria that restate the task ("Authentication is implemented") — criteria must describe what is TRUE after completion, not what ACTION was taken
 - Do NOT miss security/error handling questions
 
 <AI_Slop_Detection>
@@ -233,8 +237,15 @@ If any of the following patterns are detected during analysis, ask the user a cl
 ### Unvalidated Assumptions
 1. [Assumption] - [How to validate]
 
-### Missing Acceptance Criteria
-1. [What success looks like] - [Measurable criterion]
+### Acceptance Criteria Gaps
+1. **Missing**: [What success condition is absent] - [Suggested measurable criterion]
+2. **Poorly-formed**: [Existing criterion that fails quality check] - [What's wrong] - [Suggested rewrite]
+
+AC Quality Checks:
+- Each criterion has an observable outcome (state after completion, not action taken)?
+- Each criterion has a concrete verification method (command, assertion, or observable state)?
+- No file-listing criteria (implementation details instead of outcomes)?
+- No vague verification ("verify it works", "dry-run review")?
 
 ### Edge Cases
 1. [Unusual scenario] - [How to handle]

--- a/skills/metis/tests/application-scenarios.md
+++ b/skills/metis/tests/application-scenarios.md
@@ -21,6 +21,7 @@ These scenarios test whether the metis skill's **core techniques** are correctly
 | M-11 | Why_This_Matters | MT-6: 분석 동기 및 맥락 전달 | 분석 가치 설명 |
 | M-12 | Failure_Modes | MT-7: 안티패턴 회피 (시장 분석, 모호한 발견, 과분석) | 영향도 우선순위 |
 | M-13 | Success_Criteria + Checklist | MT-8: 측정 가능한 기준 및 자기 검증 | 검증 방법 명시 |
+| M-14 | AC Quality Check | AC Quality 검증 — 기존 AC의 품질 결함 감지 | Analysis Guards (AC) |
 
 ---
 
@@ -503,6 +504,45 @@ These scenarios test whether the metis skill's **core techniques** are correctly
 
 ---
 
+## Scenario M-14: AC Quality Check — 기존 인수조건의 구조적 결함 감지
+
+**Primary Technique:** AC Quality Check — 기존 인수조건의 구조적 결함 감지
+
+**Prompt:**
+```
+다음 플랜을 리뷰해줘:
+
+## council 워커 리팩토링 플랜
+
+### 목표
+council과 spec-review 워커의 공통 로직을 추출하고 프롬프트 조립을 구조화한다.
+
+### 작업 항목
+1. 공통 워커 인프라 추출
+2. 구조화된 프롬프트 파이프라인 구축
+
+### 인수조건
+- [ ] skills/shared/lib/worker-core.js 생성 — splitCommand, atomicWriteJson, sleepMs 등 공통 함수 추출
+- [ ] 프롬프트 파이프라인이 구현됨
+- [ ] 기존 테스트 통과 확인
+- [ ] council-worker와 spec-worker가 공통 모듈을 import하여, 중복 함수 없이 동작
+      Verification: grep으로 양쪽 워커에서 공통 모듈 import 확인, 중복 함수 0개
+
+### 기술 스택
+- Node.js, JavaScript
+```
+
+**Verification Points:**
+
+| # | Check | Expected Behavior |
+|---|-------|-------------------|
+| V1 | 파일 나열 AC 감지 | "worker-core.js 생성 -- splitCommand, atomicWriteJson..." 항목이 파일/함수 나열임을 지적하고, observable outcome으로 재작성을 제안 |
+| V2 | 작업 재진술 AC 감지 | "프롬프트 파이프라인이 구현됨"이 작업을 재진술할 뿐 완료 후 상태를 기술하지 않음을 지적 |
+| V3 | 모호한 검증 AC 감지 | "기존 테스트 통과 확인"이 보편적 진리(universal truth)이며 plan-specific하지 않음을 지적 |
+| V4 | 잘 작성된 AC 구분 | 4번째 criterion (공통 모듈 import + grep 검증)은 observable outcome + 구체적 verification이 있으므로 문제로 지적하지 않음 |
+
+---
+
 ## Test Results
 
 | # | Scenario | Result | Date | Notes |
@@ -512,3 +552,4 @@ These scenarios test whether the metis skill's **core techniques** are correctly
 | M-3 | Mandatory Output Structure | PASS | 2026-02-10 | V1-V7 모두 충족 (V8 Domain Context 추가됨 — 재검증 필요) |
 | M-4 | Vague Term Detection | PASS | 2026-02-10 | V1-V5 모두 충족 |
 | M-5 | Completeness | PASS | 2026-02-10 | V1-V4 모두 충족 |
+| M-14 | AC Quality Check | | | AC Quality 검증 추가 — 테스트 필요 |

--- a/skills/metis/tests/application-scenarios.md
+++ b/skills/metis/tests/application-scenarios.md
@@ -130,7 +130,7 @@ These scenarios test whether the metis skill's **core techniques** are correctly
 | V2 | Undefined Guardrails 섹션 존재 | "### Undefined Guardrails" 헤딩과 구체적 경계 정의 제안이 포함됨 |
 | V3 | Scope Risks 섹션 존재 | "### Scope Risks" 헤딩과 스코프 확장 위험 항목이 포함됨 |
 | V4 | Unvalidated Assumptions 섹션 존재 | "### Unvalidated Assumptions" 헤딩과 검증 필요 가정이 포함됨 |
-| V5 | Missing Acceptance Criteria 섹션 존재 | "### Missing Acceptance Criteria" 헤딩과 측정 가능한 기준 제안이 포함됨 |
+| V5 | Acceptance Criteria Gaps 섹션 존재 | "### Acceptance Criteria Gaps" 헤딩과 측정 가능한 기준 제안이 포함됨 |
 | V6 | Edge Cases 섹션 존재 | "### Edge Cases" 헤딩과 비정상 시나리오가 포함됨 |
 | V7 | Recommendations 섹션 존재 | "### Recommendations" 헤딩과 우선순위가 매겨진 명확화 항목이 포함됨 |
 | V8 | Domain Context 섹션 존재 | "### Domain Context" 헤딩과 도메인 맥락/분석 동기 설명이 출력 최상단(Intent Classification 이전)에 포함됨 |
@@ -499,7 +499,7 @@ These scenarios test whether the metis skill's **core techniques** are correctly
 | # | Check | Expected Behavior |
 |---|-------|-------------------|
 | V1 | 발견별 검증 방법 명시 | 각 발견 항목에 "어떻게 이 gap이 해소되었는지 검증할 수 있는가"가 포함됨 (예: "최대 파일 크기 미정의 → 정의 후 해당 크기 초과 파일 업로드 시 413 응답 확인") |
-| V2 | 수락 기준이 테스트 가능 | Missing Acceptance Criteria에서 제안하는 기준이 pass/fail로 판단 가능함 (예: "정상 동작" → "100MB PDF 업로드 후 presigned URL로 다운로드 시 원본과 MD5 일치") |
+| V2 | 수락 기준이 테스트 가능 | Acceptance Criteria Gaps에서 제안하는 기준이 pass/fail로 판단 가능함 (예: "정상 동작" → "100MB PDF 업로드 후 presigned URL로 다운로드 시 원본과 MD5 일치") |
 | V3 | 자기 검증 체크리스트 존재 | 분석 완료 후 "모든 요구사항의 완전성 검토 여부", "발견이 구체적이고 해결 방안 포함 여부" 등 자기 검증 항목이 포함됨 |
 
 ---

--- a/skills/prometheus/tests/application-scenarios.md
+++ b/skills/prometheus/tests/application-scenarios.md
@@ -212,10 +212,10 @@ Skill asks about a design choice (e.g., storage approach, file size limit, valid
 
 | # | Check | Expected Behavior |
 |---|-------|-------------------|
-| V1 | Drafts AC with Functional/Technical criteria | Response includes proposed acceptance criteria with both Functional and Technical sections |
-| V2 | Includes Out of Scope | Acceptance criteria include an explicit Out of Scope section |
-| V3 | Proposes to user for confirmation | Skill presents the draft AC to the user and asks for review/confirmation |
-| V4 | Measurable, testable conditions | Each criterion is specific, measurable, and objectively testable |
+| V1 | Work-item structure with responsibility | AC organized by work item, each with a responsibility statement explaining WHY the item exists separately |
+| V2 | Two-line criterion format | Each criterion follows Observable outcome + indented Verification line structure |
+| V3 | Out of Scope and Not covered | Per-item "Not covered" section + overall "Out of Scope" section present |
+| V4 | Proposes to user for confirmation | Skill presents the draft AC to the user and asks for review/confirmation |
 
 ---
 
@@ -372,6 +372,6 @@ Interview is completed (all clarifying questions answered, acceptance criteria c
 | P-6 | Question Type Selection | **PASS** | 2026-02-11 | 2/2 VP. GREEN: 제거된 섹션과 무관. 회귀 없음 |
 | P-7 | Vague Answer Clarification | **PASS** | 2026-02-11 | 3/3 VP. GREEN: 3-step protocol 그대로. 회귀 없음 |
 | P-8 | User Deferral Handling | **PASS** | 2026-02-11 | 4/4 VP. GREEN: 4-step protocol 그대로. 회귀 없음 |
-| P-9 | Acceptance Criteria Drafting | **PASS** | 2026-02-11 | 4/4 VP. GREEN: MANDATORY 태그 + NEVER proceed 언어로 충분. 회귀 없음 |
+| P-9 | Acceptance Criteria Drafting | | | AC section rewritten -- verification points updated, needs re-testing |
 | P-10 | Plan Generation + Metis Consultation | **PASS** | 2026-02-11 | 4/4 VP. GREEN: Plan Generation + Subagent Guide + Workflow 모두 건재. 회귀 없음 |
 | P-11 | Subagent Selection | **PASS** | 2026-02-11 | 3/3 VP. GREEN: Subagent Selection Guide + Role Clarity 건재. 회귀 없음 |


### PR DESCRIPTION
## Summary
- prometheus의 Acceptance Criteria Drafting 섹션을 전면 개선하여, 파일 나열이 아닌 책임 기반·검증 가능한 인수조건을 생성하도록 강제
- metis의 Analysis Framework에 AC Quality Check를 추가하여, 기존 인수조건의 구조적 결함(파일 나열, 모호한 검증, 작업 재진술)을 감지

## Changes

### prometheus SKILL.md
- SMART 평어 → Generative Constraint (Observable outcome + Verification 2줄 포맷)
- Functional/Technical 분리 폐지 → Work-item 기반 구조 (Responsibility + Criteria + Not covered)
- AC Anti-Patterns 테이블 추가 (파일 나열, 섹션 추가, 모호한 검증, 작업 재진술, 보편 진리)
- Reference Integration 규칙 추가 (레퍼런스 → behavioral constraint 도출 의무화)
- 복잡 예시 추가 (multi-work-item, 레퍼런스 통합, 구체적 검증)

### metis SKILL.md
- Analysis Framework에 AC Quality 행 추가
- Analysis Guards에 AC 품질 검증 3개 추가
- "Missing Acceptance Criteria" → "Acceptance Criteria Gaps" (Missing + Poorly-formed + Quality Checks)

### Test Scenarios
- prometheus P-9: 새 AC 포맷에 맞춰 검증 포인트 업데이트
- metis M-14: AC Quality Check 시나리오 추가 (3개 결함 AC + 1개 정상 AC)

## Test plan
- [x] prometheus P-9 시나리오 재검증 (AC section rewritten)
- [x] metis M-14 시나리오 검증 (신규)
- [x] 기존 P-1~P-8, P-10~P-15 회귀 없음 확인
- [x] 기존 M-1~M-13 회귀 없음 확인