### PR TITLE
chore: 누락 스킬 sync 설정 추가

### DIFF
--- a/projects/loopers-kotlin-spring-template/sync.yaml
+++ b/projects/loopers-kotlin-spring-template/sync.yaml
@@ -66,6 +66,10 @@ skills:
     - oracle
     - testing
     - argus
+    - code-review
+    - make-pr
+    - spec-review
+    - technical-writing
 
 rules:
   items:

--- a/projects/oh-my-toong/sync.yaml
+++ b/projects/oh-my-toong/sync.yaml
@@ -63,6 +63,10 @@ skills:
     - momus
     - oracle
     - argus
+    - code-review
+    - make-pr
+    - spec-review
+    - technical-writing
 
 rules:
   items:

--- a/projects/toongri.github.io/sync.yaml
+++ b/projects/toongri.github.io/sync.yaml
@@ -56,6 +56,10 @@ skills:
     - momus
     - oracle
     - argus
+    - code-review
+    - make-pr
+    - spec-review
+    - technical-writing
     - make-resume
     - review-resume
 


### PR DESCRIPTION
## Summary
- 전체 프로젝트(oh-my-toong, loopers-spring-kotlin-template, toongri.github.io) sync.yaml에 누락된 스킬 4개 추가
- 추가 스킬: `code-review`, `make-pr`, `spec-review`, `technical-writing`

## Test plan
- [ ] `sync.sh` 실행 후 `.claude/skills/`에 4개 스킬 디렉토리 생성 확인
- [ ] 각 프로젝트에서 해당 스킬 invocation 정상 동작 확인