### PR TITLE
feat: 리뷰 피드백 루프 통일 및 강화

### DIFF
--- a/skills/metis/SKILL.md
+++ b/skills/metis/SKILL.md
@@ -272,9 +272,28 @@ AC Quality Checks:
 - MUST NOT: [Specific anti-pattern to prevent]
 - PATTERN: Follow `[file:lines]` [existing pattern to reference]
 - TOOL: Use `[subagent/tool]` for [purpose]
+
+### Analysis Verdict
+- **Verdict**: [APPROVE / REQUEST_CHANGES / COMMENT]
+- **Blocking Items**: [Critical gaps that must be resolved before planning, or "None"]
+- **Rationale**: [1-2 sentence justification for the verdict]
 ```
 
 </Output_Format>
+
+<Verdict_Criteria>
+
+### Verdict Criteria
+
+| Verdict | Condition | Effect |
+|---------|-----------|--------|
+| **APPROVE** | Critical gaps 없음. 분석 결과 high-impact 이슈가 발견되지 않음. | Prometheus가 즉시 플랜 생성 가능 |
+| **REQUEST_CHANGES** | Critical gaps 존재. Missing Questions, Undefined Guardrails, Unvalidated Assumptions 등에서 high-impact 항목이 1개 이상 발견됨. | 해당 항목 해소 후 Metis 재검증 필요. Prometheus 진행 차단. |
+| **COMMENT** | Minor gaps 또는 edge cases만 존재. 플랜 품질에 영향을 주지만 차단 사유는 아님. | Prometheus가 플랜에 반영하되 진행은 허용 |
+
+**Critical gap 판정 기준**: 해당 gap이 해소되지 않으면 Prometheus가 올바른 플랜을 생성할 수 없는 경우 (예: 핵심 요구사항 누락, 범위 미정의, 검증 불가능한 AC)
+
+</Verdict_Criteria>
 
 <Failure_Modes_To_Avoid>
 
@@ -313,6 +332,7 @@ AC Quality Checks:
 - [ ] Are critical gaps prioritized above "nice-to-haves"?
 - [ ] Is the focus on implementation feasibility? (no market/value judgments)
 - [ ] Do Directives specify concrete actions with MUST/MUST NOT?
+- [ ] Does the verdict match the severity of findings? (critical gaps = REQUEST_CHANGES, minor only = COMMENT, none = APPROVE)
 
 </Final_Checklist>
 

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -606,7 +606,7 @@ Every plan saved to `.omt/plans/{name}.md` MUST follow this structure:
 | Section | Contents |
 |---------|----------|
 | **TL;DR** | Quick summary (1-2 sentences), deliverables (bullet list), estimated effort (Quick/Short/Medium/Large/XL) |
-| **Context** | Original request, interview summary (key decisions), research findings, Metis review (identified gaps and how resolved) |
+| **Context** | Original request, interview summary (key decisions), research findings, Metis review (identified gaps and how resolved), Momus review (findings and how resolved) |
 | **Work Objectives** | Core objective, Definition of Done, Must Have (non-negotiable requirements), Must NOT Have / Guardrails (explicit exclusions, scope boundaries) |
 | **TODOs** | Numbered tasks -- each with: what to do, must NOT do, file/pattern references, acceptance criteria |
 | **Verification Strategy** | Test decision (TDD/tests-after/none), framework, verification commands, final checklist |

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -505,7 +505,7 @@ Overall structure:
 
 ### Metis Feedback Loop (MANDATORY Before Generation)
 
-**Before generating the plan**, invoke the metis skill to catch what you missed. **Metis APPROVE is required to proceed to plan generation. No APPROVE = no plan.**
+**Before generating the plan**, invoke the metis skill to catch what you missed. **Metis must pass (APPROVE or COMMENT) to proceed to plan generation. REQUEST_CHANGES blocks until resolved.**
 
 **Metis Consultation Flow:**
 1. Summarize the planning session (user goal, interview findings, research results)
@@ -547,7 +547,7 @@ When re-invoking metis after REQUEST_CHANGES, include this context so metis can 
 
 ### Momus Feedback Loop (MANDATORY Before Handoff)
 
-**After generating the plan**, invoke the momus skill to review the plan for quality. **Momus APPROVE is required to proceed to handoff. No APPROVE = no handoff.**
+**After generating the plan**, invoke the momus skill to review the plan for quality. **Momus must pass (APPROVE or COMMENT) to proceed to handoff. REQUEST_CHANGES blocks until resolved.**
 
 **Momus Review Flow:**
 1. Generate the plan to `.omt/plans/{name}.md`

--- a/skills/sisyphus/SKILL.md
+++ b/skills/sisyphus/SKILL.md
@@ -474,12 +474,63 @@ Review whether the implementation meets the requirements in the 6-Section prompt
 | Pre-built checklist | "Here's what to verify: [your list]" | Anchors argus, defeats independent derivation |
 | Selective prompt sections | Omitting MUST NOT DO | Argus cannot detect violations of rules it doesn't see |
 
+### Re-review Protocol
+
+When argus returns **REQUEST_CHANGES** and sisyphus-junior completes the fix task, the subsequent argus re-invocation **MUST** include a Re-review Context section. This does NOT apply to initial (first-time) argus invocations.
+
+**Why**: Without re-review context, argus performs a fresh review and may miss whether previous findings were actually addressed, or re-raise already-resolved issues.
+
+#### Re-review Invocation Template
+
+```markdown
+[VERBATIM copy of the 6-Section prompt — same as initial invocation]
+
+---
+
+## REVIEW REQUEST
+- Task: [exact task subject from todo list]
+- Changed files:
+  - [explicit file paths]
+- Junior's summary: [what junior claimed to have done]
+
+---
+
+## Re-review Context
+
+### Previous Verdict
+- **Verdict**: REQUEST_CHANGES
+- **Key Findings**:
+  1. [이전 지적 A 원문]
+  2. [이전 지적 B 원문]
+
+### Changes Made
+| Finding | Change | Intent |
+|---------|--------|--------|
+| [지적 A] | [구체적 수정 내용] | [왜 이 방향으로] |
+| [지적 B] | [구체적 수정 내용] | [왜 이 방향으로] |
+
+### Current State
+[수정 반영된 현재 결과물 — 6-Section prompt의 EXPECTED OUTCOME 기준으로 현재 상태]
+
+Review whether the previous findings have been addressed and whether the implementation now meets the requirements.
+```
+
+#### Re-review Context Rules
+
+| Rule | Requirement |
+|------|-------------|
+| **Scope** | Applies ONLY to re-invocations after REQUEST_CHANGES, not initial invocations |
+| **Previous Findings** | Copy argus's findings VERBATIM — no summarizing or paraphrasing |
+| **Changes Made** | Map each finding to the specific change and explain intent |
+| **Current State** | Describe current state relative to the 6-Section prompt's EXPECTED OUTCOME |
+| **Prompt Fidelity** | The 6-Section prompt and REVIEW REQUEST sections remain identical to initial invocation |
+
 ### Verdict Response Protocol
 
 | Verdict | Sisyphus Action |
 |---------|-----------------|
 | **APPROVE** | Invoke mnemosyne to commit, then mark task completed |
-| **REQUEST_CHANGES** (Critical/High) | Create fix task, re-delegate to sisyphus-junior |
+| **REQUEST_CHANGES** (Critical/High) | Create fix task, re-delegate to sisyphus-junior. **Re-invocation MUST include Re-review Context** |
 | **COMMENT** (Medium only) | Invoke mnemosyne to commit, then mark completed. Create follow-up task if warranted |
 
 ### Fix Task from REQUEST_CHANGES
@@ -490,6 +541,8 @@ Description:
 - Issue: [exact issue from reviewer]
 - Location: [file:lines]
 - Required fix: [specific action]
+- Argus findings (verbatim):
+  > [argus의 원문 피드백 전체 — 요약하지 말 것]
 ```
 
 ---

--- a/skills/sisyphus/SKILL.md
+++ b/skills/sisyphus/SKILL.md
@@ -482,8 +482,43 @@ When argus returns **REQUEST_CHANGES** and sisyphus-junior completes the fix tas
 
 #### Re-review Invocation Template
 
+재리뷰 시, Re-review Context를 `## 6. CONTEXT` 섹션 안에 `###` 서브섹션으로 포함한다. 6-Section 구조를 깨지 않으면서 이전 리뷰 이력을 전달한다.
+
 ```markdown
-[VERBATIM copy of the 6-Section prompt — same as initial invocation]
+## 1. TASK
+[초회와 동일]
+
+## 2. EXPECTED OUTCOME
+[초회와 동일]
+
+## 3. REQUIRED TOOLS
+[초회와 동일]
+
+## 4. MUST DO
+[초회와 동일]
+
+## 5. MUST NOT DO
+[초회와 동일]
+
+## 6. CONTEXT
+- Related files: [초회와 동일]
+- Prior task results: [초회와 동일]
+
+### Re-review Context
+#### Previous Verdict
+- **Verdict**: REQUEST_CHANGES
+- **Key Findings**:
+  1. [이전 지적 A 원문]
+  2. [이전 지적 B 원문]
+
+#### Changes Made
+| Finding | Change | Intent |
+|---------|--------|--------|
+| [지적 A] | [구체적 수정 내용] | [왜 이 방향으로] |
+| [지적 B] | [구체적 수정 내용] | [왜 이 방향으로] |
+
+#### Current State
+[수정 반영된 현재 결과물 — EXPECTED OUTCOME 기준으로 현재 상태]
 
 ---
 
@@ -493,25 +528,6 @@ When argus returns **REQUEST_CHANGES** and sisyphus-junior completes the fix tas
   - [explicit file paths]
 - Junior's summary: [what junior claimed to have done]
 
----
-
-## Re-review Context
-
-### Previous Verdict
-- **Verdict**: REQUEST_CHANGES
-- **Key Findings**:
-  1. [이전 지적 A 원문]
-  2. [이전 지적 B 원문]
-
-### Changes Made
-| Finding | Change | Intent |
-|---------|--------|--------|
-| [지적 A] | [구체적 수정 내용] | [왜 이 방향으로] |
-| [지적 B] | [구체적 수정 내용] | [왜 이 방향으로] |
-
-### Current State
-[수정 반영된 현재 결과물 — 6-Section prompt의 EXPECTED OUTCOME 기준으로 현재 상태]
-
 Review whether the previous findings have been addressed and whether the implementation now meets the requirements.
 ```
 
@@ -520,10 +536,11 @@ Review whether the previous findings have been addressed and whether the impleme
 | Rule | Requirement |
 |------|-------------|
 | **Scope** | Applies ONLY to re-invocations after REQUEST_CHANGES, not initial invocations |
+| **Location** | `## 6. CONTEXT` 안에 `### Re-review Context`로 포함 — 6-Section 바깥에 별도 블록 금지 |
 | **Previous Findings** | Copy argus's findings VERBATIM — no summarizing or paraphrasing |
 | **Changes Made** | Map each finding to the specific change and explain intent |
-| **Current State** | Describe current state relative to the 6-Section prompt's EXPECTED OUTCOME |
-| **Prompt Fidelity** | The 6-Section prompt and REVIEW REQUEST sections remain identical to initial invocation |
+| **Current State** | Describe current state relative to EXPECTED OUTCOME |
+| **Sections 1-5** | 초회와 동일하게 유지 — 변경 금지 |
 
 ### Verdict Response Protocol
 

--- a/skills/spec-review/SKILL.md
+++ b/skills/spec-review/SKILL.md
@@ -78,6 +78,7 @@ This mindset is conveyed to external AIs in every review request.
 ## Review Assessment
 **Status**: No Review Needed
 **Reason**: [Brief explanation - e.g., "Simple CRUD with clear requirements, no architectural decisions"]
+**Verdict**: APPROVE
 Proceed with implementation.
 ```
 
@@ -320,7 +321,7 @@ EOF
 
 ## Advisory Output Format
 
-**ALL 5 SECTIONS ARE MANDATORY. No exceptions.**
+**ALL 6 SECTIONS ARE MANDATORY. No exceptions.**
 
 Chairman synthesizes opinions into:
 
@@ -346,6 +347,12 @@ Chairman synthesizes opinions into:
 ### Action Items
 
 [Suggested next steps based on feedback]
+
+### Review Verdict
+
+- **Verdict**: [APPROVE / REQUEST_CHANGES / COMMENT]
+- **Blocking Concerns**: [해소되지 않은 substantive 우려 목록, 없으면 "None"]
+- **Rationale**: [1-2문장 판정 근거]
 ```
 
 ### Why Every Section Matters
@@ -357,6 +364,19 @@ Chairman synthesizes opinions into:
 | **Concerns Raised** | Catalogues risks - for risk registry | Risks undocumented, no mitigation planning |
 | **Recommendation** | Synthesized judgment - the bottom line | No clear guidance for stakeholder |
 | **Action Items** | Concrete next steps - actionable output | Good advice with no path forward |
+| **Review Verdict** | Machine-readable judgment - enables caller loop control | Caller can't automate review cycles |
+
+### Verdict Criteria
+
+| Verdict | Condition | Meaning |
+|---------|-----------|---------|
+| **APPROVE** | No concerns raised, OR "No Review Needed" shortcut | 수정 없이 진행 가능 |
+| **REQUEST_CHANGES** | Blocking concerns 존재 (substantive 수정 필요) | 우려 해소 전까지 진행 불가 |
+| **COMMENT** | Minor concerns만 존재 (non-blocking) | 진행 가능, 개선 권고 |
+
+**Blocking vs Non-blocking 판정 기준:**
+- **Blocking**: 설계 결함, 확장성 위험, 데이터 정합성 문제, 보안 취약점 등 수정 없이 진행 시 심각한 문제 초래
+- **Non-blocking**: 네이밍 개선, 문서화 보완, 선택적 최적화 등 현재 설계로도 동작에 문제없음
 
 </Output_Format>
 
@@ -405,6 +425,18 @@ Chairman synthesizes opinions into:
 | "This is incomplete without mentioning X" | (nothing - synthesis only) |
 
 **The advisory reflects reviewer input, not chairman expertise.** If the review seems incomplete, that's the actual state of reviewer feedback.
+
+### Verdict Determination
+
+**Chairman determines the verdict by synthesizing reviewer concerns. The verdict reflects reviewer feedback, not chairman opinion.**
+
+| Reviewer Feedback State | Verdict | Rationale |
+|-------------------------|---------|-----------|
+| No concerns from any reviewer | APPROVE | 리뷰어 전원 우려 없음 |
+| Only minor/non-blocking concerns | COMMENT | 진행 가능, 개선 권고 사항 존재 |
+| Any blocking concern from any reviewer | REQUEST_CHANGES | 해소 필요한 substantive 우려 존재 |
+
+**Escalation rule:** 가장 심각한 우려 수준이 verdict를 결정한다. 2명이 APPROVE이더라도 1명이 blocking concern을 제기하면 REQUEST_CHANGES.
 
 ## Result Utilization
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -22,7 +22,7 @@ NO STEP SKIPPING:
 
 NO AREA COMPLETION WITHOUT:
 1. All Steps in the Area completed with user confirmation
-2. spec-reviewer review completed (feedback loop resolved)
+2. spec-review APPROVE verdict received (review loop resolved)
 3. User explicitly declares "Area complete"
 4. All acceptance criteria testable
 5. No "TBD" or vague placeholders remaining
@@ -39,7 +39,7 @@ NO AREA COMPLETION WITHOUT:
 | Error cases defined | Happy path only = production incidents |
 | Every Step presents to user | Skipped steps = missed requirements |
 | User confirmation at every Step | Agent decisions = user blamed |
-| Area completion = spec-reviewer + user gate | Unchecked areas = compounding errors |
+| Area completion = spec-review APPROVE + user gate | Unchecked areas = compounding errors |
 | No Step/Area skipping ever | "Simple" hides complexity |
 | Design proposals include potential risks | Hidden risks = surprise in production |
 | spec.md structure immutable (Progress Status, Area sections) | Removing sections breaks resume and traceability |
@@ -551,9 +551,9 @@ If you have sufficient information, use it to draft a high-quality proposal and 
 
 ## Multi-AI Review Integration
 
-**MANDATORY at Area completion.** After completing all Steps in an Area, ALWAYS delegate to spec-reviewer. This is part of the Area Completion Protocol and cannot be skipped.
+**MANDATORY at Area completion.** After completing all Steps in an Area, ALWAYS delegate to spec-review. This is part of the Area Completion Protocol and cannot be skipped.
 
-The spec-reviewer decides whether a full review is needed or returns "No review needed" for simple cases. Either way, the result MUST be presented to the user.
+The spec-review decides whether a full review is needed or returns "No review needed" (with APPROVE verdict) for simple cases. Either way, the verdict MUST be handled according to the Verdict-Based Flow Control.
 
 ### Feedback Loop Workflow
 
@@ -563,49 +563,57 @@ digraph feedback_loop {
     node [shape=box, style=rounded];
 
     complete_step [label="Area Complete\n(all Steps done, design.md saved)"];
-    delegate [label="MANDATORY: Delegate to\nspec-reviewer agent"];
-    check_response [label="Review needed?", shape=diamond];
-    no_review [label="spec-reviewer returns\n'No review needed'"];
-    present_no_review [label="Present 'No review needed'\nresult to user"];
-    receive_feedback [label="Receive advisory\nfeedback"];
-    analyze [label="Analyze feedback\nForm YOUR opinion"];
-    present [label="Present to user\n(context + recommendation)"];
-    user_decides [label="User decides", shape=diamond, style="rounded,filled", fillcolor="#ccffcc"];
-    incorporate [label="Update design.md\nRecord decisions in records/"];
-    user_final [label="User declares\n'Area complete'", shape=diamond, style="rounded,filled", fillcolor="#ffcccc"];
+    delegate [label="MANDATORY: Delegate to\nspec-review agent"];
+    check_verdict [label="Verdict?", shape=diamond];
+
+    approve [label="APPROVE"];
+    ask_user [label="Ask user:\n'Area 넘어갈까요?'", style="rounded,filled", fillcolor="#ccffcc"];
     next_area [label="Proceed to next Area"];
 
+    request_changes [label="REQUEST_CHANGES"];
+    present_feedback [label="Present feedback to user\n(context + recommendation)"];
+    user_consensus [label="User reviews & agrees\non changes", shape=diamond, style="rounded,filled", fillcolor="#ccffcc"];
+    incorporate [label="Apply changes\nUpdate design.md\nRecord decisions in records/"];
+    re_delegate [label="Re-delegate to spec-review\n(with Re-review Context)"];
+
+    comment [label="COMMENT"];
+    share_comment [label="Share COMMENT with user\n(create follow-up if needed)"];
+
     complete_step -> delegate;
-    delegate -> check_response;
-    check_response -> no_review [label="no"];
-    check_response -> receive_feedback [label="yes"];
-    no_review -> present_no_review;
-    present_no_review -> user_final;
-    receive_feedback -> analyze;
-    analyze -> present;
-    present -> user_decides;
-    user_decides -> incorporate [label="incorporate"];
-    user_decides -> delegate [label="another round"];
-    user_decides -> user_final [label="feedback resolved"];
-    incorporate -> delegate [label="re-review"];
-    user_final -> next_area [label="YES"];
-    user_final -> present [label="NO: more discussion"];
+    delegate -> check_verdict;
+
+    check_verdict -> approve [label="APPROVE"];
+    approve -> ask_user;
+    ask_user -> next_area [label="YES: 'Area complete'"];
+    ask_user -> present_feedback [label="NO: more discussion"];
+
+    check_verdict -> request_changes [label="REQUEST_CHANGES"];
+    request_changes -> present_feedback;
+    present_feedback -> user_consensus;
+    user_consensus -> incorporate [label="agree on changes"];
+    incorporate -> re_delegate;
+    re_delegate -> check_verdict [label="loop until APPROVE"];
+
+    check_verdict -> comment [label="COMMENT"];
+    comment -> share_comment;
+    share_comment -> ask_user [label="proceed"];
 }
 ```
 
 ### Human-in-the-Loop
 
-The final decision on feedback is always made by the **user**.
+The final decision on feedback is always made by the **user**, but spec-review APPROVE is a prerequisite for Area completion.
 
 | Item | Description |
 |------|-------------|
-| AI Role | Provide advice and diverse perspectives |
-| User Role | Final decision maker |
-| Confirmation Point | When User declares "this step complete" |
+| spec-review Role | Quality gate — APPROVE required before Area can complete |
+| AI (spec) Role | Present feedback, form recommendation, facilitate consensus |
+| User Role | Review feedback, agree on changes, declare "Area complete" after APPROVE |
+| Gate Order | spec-review APPROVE first → then user "Area complete" declaration |
 
-### Delegating to spec-reviewer
+### Delegating to spec-review
 
-After completing a step, always delegate to the spec-reviewer agent via Task tool. The spec-reviewer will assess whether a full review is needed.
+After completing all Steps in an Area, always delegate to the spec-review agent via Task tool. The spec-review will assess whether a full review is needed and return a verdict.
 
 **Delegation prompt structure:**
 
@@ -635,37 +643,97 @@ Review the following design and provide multi-AI advisory feedback.
 - **Divergence**: Points where opinions differ
 - **Concerns Raised**: Potential issues identified
 - **Recommendation**: Synthesized advice
+- **Review Verdict**: APPROVE / REQUEST_CHANGES / COMMENT (with blocking concerns list and rationale)
 
 **If no review is needed:**
 - **Status**: "No Review Needed"
+- **Verdict**: APPROVE
 - **Reason**: Brief explanation (e.g., "Simple CRUD with clear requirements")
 
-The spec-reviewer operates in a separate context and returns advisory feedback. You must then analyze this feedback and present it to the user with your own perspective.
+The spec-review operates in a separate context and returns advisory feedback with a verdict. You must then handle the verdict accordingly and present it to the user.
+
+### Re-review Context (MANDATORY for Re-delegation)
+
+When re-delegating to spec-review after applying REQUEST_CHANGES feedback, the delegation prompt MUST include a Re-review Context section. This provides reviewers with full traceability of what was changed and why.
+
+**Re-review delegation prompt structure:**
+
+```markdown
+Review the following design and provide multi-AI advisory feedback.
+
+## Re-review Context
+
+### Previous Verdict
+- **Verdict**: REQUEST_CHANGES
+- **Key Findings**: [이전 리뷰에서 지적된 blocking concerns 원문]
+
+### Changes Made
+| Finding | Change | Intent |
+|---------|--------|--------|
+| [지적 사항] | [수정 내용] | [수정 의도] |
+
+### Current State
+[수정이 반영된 현재 Area design.md 내용]
+
+---
+
+## 1. Current Design Under Review
+[위 Current State와 동일 — 수정 반영된 전체 design.md]
+
+### Key Decisions
+[Key decision points requiring review]
+
+### Questions for Reviewers
+[Specific questions — 특히 이전 지적사항 해소 여부에 대한 질문]
+
+## 2. Previously Finalized Designs (Constraints)
+[Summarize relevant decisions from earlier steps that constrain this design]
+
+## 3. Context
+[Project context, tech stack, constraints]
+```
+
+**Re-review Context omission = VIOLATION.** 리뷰어가 이전 지적사항과 수정 내용을 모르면 effective re-review가 불가능하다.
 
 ### Presenting Feedback to User
 
-After receiving spec-reviewer feedback, YOU must:
+After receiving spec-review feedback, YOU must:
 
-1. **Analyze the feedback** - What do you agree with? What seems overblown?
-2. **Add context** - How does this relate to earlier decisions? What trade-offs exist?
-3. **Form your recommendation** - What do YOU think the user should do? Frame recommendations as options with trade-offs, not as the single right answer.
-4. **Present holistically** - Do not just dump reviewer output. Synthesize it.
-5. **All sections mandatory** - Present every section spec-reviewer returns (Consensus, Divergence, Concerns, Recommendation). No section omission.
+1. **State the verdict** - APPROVE, REQUEST_CHANGES, or COMMENT — make it explicit
+2. **Analyze the feedback** - What do you agree with? What seems overblown?
+3. **Add context** - How does this relate to earlier decisions? What trade-offs exist?
+4. **Form your recommendation** - What do YOU think the user should do? Frame recommendations as options with trade-offs, not as the single right answer.
+5. **Present holistically** - Do not just dump reviewer output. Synthesize it.
+6. **All sections mandatory** - Present every section spec-review returns (Consensus, Divergence, Concerns, Recommendation, Verdict). No section omission.
 
-**Example presentation:**
+**Verdict-specific presentation:**
 
-> "The reviewers raised concerns about the event-sourcing approach for order state management. I partially agree - the concerns about complexity are valid for a team new to this pattern. However, we already decided in Solution Design that we need full audit trails, which constrains us toward event-sourcing.
->
-> My recommendation: Keep event-sourcing but add a detailed implementation guide in the spec to address the learning curve concern. What would you like to do?"
+| Verdict | Presentation |
+|---------|-------------|
+| **APPROVE** | "spec-review APPROVE. [Brief summary]. Area 넘어갈까요?" |
+| **REQUEST_CHANGES** | "spec-review REQUEST_CHANGES. [Blocking concerns 요약 + 권고사항]. 다음과 같이 수정하면 어떨까요? [구체적 수정 제안]" |
+| **COMMENT** | "spec-review COMMENT. [Non-blocking 개선 권고 요약]. 참고하여 진행하겠습니다. [follow-up 필요 시 생성]" |
 
-### User Controls the Loop
+**Example (REQUEST_CHANGES):**
 
-| User Response | Action |
-|---------------|--------|
-| "Incorporate feedback" | Update design.md, create record for each decision made during incorporation in `records/`, re-review if needed |
-| "Skip this feedback" | Record skip reason in `records/`, then proceed without changes |
-| "Need another round" | Delegate to spec-reviewer again |
-| "Step complete" | Save final, proceed to next step |
+> "spec-review **REQUEST_CHANGES**. 리뷰어들이 order state management의 event-sourcing 접근에 blocking concern을 제기했습니다. 팀의 ES 경험 부족과 복잡도 우려가 주요 지적입니다. 다만 Solution Design에서 full audit trail 필요성을 확정했으므로, event-sourcing을 유지하되 상세 구현 가이드를 스펙에 추가하는 방향을 제안합니다. 이 방향에 동의하시나요?"
+
+### Verdict-Based Flow Control
+
+| Verdict | User Interaction | Next Action |
+|---------|-----------------|-------------|
+| **APPROVE** | "Area 넘어갈까요?" 질문 | User "Area complete" 선언 → 다음 Area |
+| **REQUEST_CHANGES** | Blocking concerns + 수정 제안 제시 | User 합의 → 수정 반영 → Re-review Context 포함하여 spec-review 재호출 |
+| **COMMENT** | Non-blocking 개선 권고 공유 | User 확인 → follow-up 생성 가능 → "Area 넘어갈까요?" 질문 |
+
+**REQUEST_CHANGES Loop:**
+1. Present blocking concerns and recommended changes to user
+2. User reviews and agrees on specific changes (user may modify recommendations)
+3. Apply agreed changes to design.md, record decisions in `records/`
+4. Re-delegate to spec-review with **Re-review Context** (MANDATORY)
+5. Repeat until APPROVE received
+
+**CRITICAL: spec-review APPROVE 없이 Area complete 선언 불가.** REQUEST_CHANGES verdict가 반환된 상태에서 유저가 "Area complete"를 선언해도, APPROVE를 받을 때까지 Area를 완료할 수 없다.
 
 ## Record Workflow
 
@@ -811,28 +879,45 @@ digraph area_completion {
     all_steps [label="All Steps in Area\ncompleted with user confirmation"];
     save_area [label="Save complete Area content"];
     present_summary [label="Present summary of\nall decisions to user"];
-    delegate_reviewer [label="MANDATORY: Delegate to\nspec-reviewer for review"];
-    receive_feedback [label="Receive reviewer feedback"];
-    analyze_present [label="Analyze feedback\nPresent to user with recommendation"];
-    user_decides [label="User decides on feedback", shape=diamond, style="rounded,filled", fillcolor="#ccffcc"];
-    incorporate [label="Incorporate feedback\nUpdate design.md\nRecord decisions in records/"];
-    another_round [label="Delegate to\nspec-reviewer again"];
+    delegate_reviewer [label="MANDATORY: Delegate to\nspec-review"];
+    check_verdict [label="Verdict?", shape=diamond];
+
+    approve [label="APPROVE"];
+    ask_complete [label="Ask user:\n'Area 넘어갈까요?'", style="rounded,filled", fillcolor="#ccffcc"];
     user_final [label="User explicitly declares\n'Area complete'", shape=diamond, style="rounded,filled", fillcolor="#ffcccc"];
     announce_next [label="Announce: [Area Name] complete.\nEntry criteria for [Next Area]: [list]"];
+
+    request_changes [label="REQUEST_CHANGES"];
+    present_feedback [label="Present blocking concerns\nto user with recommendation"];
+    user_consensus [label="User agrees on\nchanges to make", shape=diamond, style="rounded,filled", fillcolor="#ccffcc"];
+    incorporate [label="Apply changes\nUpdate design.md\nRecord decisions in records/"];
+    re_review [label="Re-delegate to spec-review\n(Re-review Context MANDATORY)"];
+
+    comment [label="COMMENT"];
+    share_comment [label="Share non-blocking\nconcerns with user"];
 
     all_steps -> save_area;
     save_area -> present_summary;
     present_summary -> delegate_reviewer;
-    delegate_reviewer -> receive_feedback;
-    receive_feedback -> analyze_present;
-    analyze_present -> user_decides;
-    user_decides -> incorporate [label="incorporate"];
-    user_decides -> another_round [label="another round"];
-    user_decides -> user_final [label="feedback resolved"];
-    incorporate -> delegate_reviewer [label="re-review"];
-    another_round -> receive_feedback;
+    delegate_reviewer -> check_verdict;
+
+    check_verdict -> approve [label="APPROVE"];
+    approve -> ask_complete;
+    ask_complete -> user_final;
+
+    check_verdict -> request_changes [label="REQUEST_CHANGES"];
+    request_changes -> present_feedback;
+    present_feedback -> user_consensus;
+    user_consensus -> incorporate [label="agree"];
+    incorporate -> re_review;
+    re_review -> check_verdict [label="loop until\nAPPROVE"];
+
+    check_verdict -> comment [label="COMMENT"];
+    comment -> share_comment;
+    share_comment -> ask_complete [label="proceed"];
+
     user_final -> announce_next [label="YES: 'Area complete'"];
-    user_final -> analyze_present [label="NO: more discussion"];
+    user_final -> present_feedback [label="NO: more discussion"];
 }
 ```
 
@@ -841,17 +926,22 @@ digraph area_completion {
 1. **Verify all Steps completed**: Every Step in the Area must have passed its Checkpoint Protocol
 2. **Save complete Area content**: Write to `{area-directory}/design.md`
 3. **Present Area summary**: Show all decisions made in this Area to user
-4. **MANDATORY spec-reviewer review**: Delegate Area results to spec-reviewer
-   - Even if spec-reviewer returns "No review needed", present this to user
-5. **Feedback loop**: If feedback exists, analyze and present to user with recommendation
-   - User decides: incorporate, request another round, or mark feedback resolved
-   - Loop continues until user is satisfied
+4. **MANDATORY spec-review**: Delegate Area results to spec-review
+5. **Verdict handling**:
+   - **APPROVE** → Proceed to step 6
+   - **REQUEST_CHANGES** → Present blocking concerns to user with recommendation → User agrees on changes → Apply changes, update design.md, record decisions in `records/` → Re-delegate to spec-review with **Re-review Context** (MANDATORY) → Return to step 5
+   - **COMMENT** → Share non-blocking concerns with user, create follow-up if needed → Proceed to step 6
 6. **User final gate**: User MUST explicitly declare "Area complete"
    - Silence is NOT agreement
    - AI CANNOT self-declare Area completion
+   - **spec-review APPROVE 없이 Area complete 선언 불가** — APPROVE가 선행 조건
 7. **Announce next Area**: "[Area Name] complete. Entry criteria for [Next Area]: [list]"
 
-**Without user's explicit "Area complete" declaration, the Area is NOT complete and next Area CANNOT begin.**
+**Two gates must BOTH be passed for Area completion:**
+1. **spec-review APPROVE** (quality gate)
+2. **User "Area complete" declaration** (authority gate)
+
+**Without BOTH gates passed, the Area is NOT complete and next Area CANNOT begin.**
 
 ## Spec Completion Gate
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -733,7 +733,7 @@ After receiving spec-review feedback, YOU must:
 4. Re-delegate to spec-review with **Re-review Context** (MANDATORY)
 5. Repeat until APPROVE received
 
-**CRITICAL: spec-review APPROVE 없이 Area complete 선언 불가.** REQUEST_CHANGES verdict가 반환된 상태에서 유저가 "Area complete"를 선언해도, APPROVE를 받을 때까지 Area를 완료할 수 없다.
+**CRITICAL: spec-review가 pass(APPROVE 또는 COMMENT) 하지 않으면 Area complete 선언 불가.** REQUEST_CHANGES verdict가 반환된 상태에서 유저가 "Area complete"를 선언해도, pass할 때까지 Area를 완료할 수 없다.
 
 ## Record Workflow
 
@@ -934,11 +934,11 @@ digraph area_completion {
 6. **User final gate**: User MUST explicitly declare "Area complete"
    - Silence is NOT agreement
    - AI CANNOT self-declare Area completion
-   - **spec-review APPROVE 없이 Area complete 선언 불가** — APPROVE가 선행 조건
+   - **spec-review가 pass(APPROVE 또는 COMMENT) 없이 Area complete 선언 불가** — REQUEST_CHANGES 상태에서 Area 완료 불가
 7. **Announce next Area**: "[Area Name] complete. Entry criteria for [Next Area]: [list]"
 
 **Two gates must BOTH be passed for Area completion:**
-1. **spec-review APPROVE** (quality gate)
+1. **spec-review pass** — APPROVE 또는 COMMENT (quality gate). REQUEST_CHANGES는 차단.
 2. **User "Area complete" declaration** (authority gate)
 
 **Without BOTH gates passed, the Area is NOT complete and next Area CANNOT begin.**


### PR DESCRIPTION
## Summary
- 모든 리뷰 에이전트(argus, momus, spec-review, metis)의 verdict를 APPROVE / REQUEST_CHANGES / COMMENT 3단계로 통일
- 오케스트레이터(sisyphus, spec, prometheus)에 리뷰어 APPROVE까지 반복하는 강제 피드백 루프 추가
- 재리뷰 시 이전 피드백 + 수정 의도를 포함하는 Re-review Context 프로토콜 도입

## Changes

### 리뷰어 스킬 (verdict 통일)
- **momus**: OKAY/REJECT → APPROVE/REQUEST_CHANGES/COMMENT 라벨 변경
- **spec-review**: Review Verdict 섹션 신규 추가 (기존 5개 섹션 유지)
- **metis**: Analysis Verdict 섹션 신규 추가 (기존 10개 섹션 유지)

### 오케스트레이터 스킬 (피드백 루프 + Re-review Context)
- **sisyphus**: argus 재호출 시 Re-review Context를 6-Section의 CONTEXT 안에 포함하도록 프로토콜 추가
- **spec**: spec-review APPROVE가 Area 진행의 선행 조건 (dual-gate: quality + authority). REQUEST_CHANGES → 유저 합의 → 반영 → 재리뷰 → APPROVE까지 반복
- **prometheus**: metis APPROVE → 플랜 작성 → momus APPROVE → 핸드오프. 두 게이트 모두 mandatory, APPROVE까지 반복. momus를 optional → mandatory로 승격

## Motivation
기존 스킬들의 리뷰 피드백 루프 분석 결과:
- sisyphus/argus만 유일하게 "리뷰어가 승인할 때까지 반복" 구조를 가짐
- spec/spec-review는 유저 매개 루프, spec-review에 verdict 자체가 없음
- prometheus/metis는 원샷 (재검증 없음), momus는 워크플로우에 미통합
- 통일된 verdict 체계와 강제 루프로 모든 워크플로우의 품질 게이트를 일관성 있게 강화

## Test plan
- [ ] sisyphus 워크플로우에서 argus REQUEST_CHANGES 시 Re-review Context가 6-Section CONTEXT 안에 포함되는지 확인
- [ ] spec 워크플로우에서 spec-review REQUEST_CHANGES 시 APPROVE까지 루프가 도는지 확인
- [ ] prometheus 워크플로우에서 metis/momus APPROVE 없이 플랜 작성/핸드오프가 차단되는지 확인
- [ ] momus가 COMMENT 반환 시 진행 허용되는지 확인