### PR TITLE
refactor: prometheus metis 자동 호출 워크플로우 개선

### DIFF
--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -94,7 +94,7 @@ digraph prometheus_flow {
 | Codebase exploration | explore | Find current implementation, similar features, existing patterns |
 | Architecture/design analysis | oracle | Architecture decisions, risk assessment, feasibility validation during interview |
 | External documentation research | librarian | Official docs, library specs, API references, best practices |
-| Gap analysis | metis | Auto-invoked when Clearance + AC complete — catches missing questions before user is asked to generate plan |
+| Gap analysis | metis | **MANDATORY** — auto-invoked when Clearance + AC complete. Catches missing questions before user is asked to generate plan |
 | Plan review | momus | **MANDATORY** after plan generation -- catches quality issues |
 
 ### Do vs Delegate Decision Matrix
@@ -515,10 +515,11 @@ Overall structure:
 
 **When you feel ready to write the plan** (Clearance Checklist all YES + AC confirmed), invoke the metis skill to validate your work. **Metis must pass (APPROVE or COMMENT) before presenting results to the user. REQUEST_CHANGES blocks until resolved.**
 
-**TIMING: Metis is invoked when ALL of these conditions are met:**
+**TIMING: Metis is invoked when BOTH conditions are met:**
 1. Clearance Checklist: all YES
 2. Acceptance Criteria: drafted and confirmed by user
-3. You judge the interview is complete
+
+> When conditions 1 and 2 are satisfied, the interview is complete by definition. No additional judgment needed.
 
 **Do NOT wait for user to say "generate plan" — invoke metis as soon as you are ready.**
 **Do NOT invoke metis during interview phase or upon receiving the initial request.**

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -643,13 +643,13 @@ Every plan saved to `.omt/plans/{name}.md` MUST follow this structure:
 |---|-------------|-----------------|---------|
 | 1 | **Over-planning** | 30 micro-steps with implementation details | 3-6 actionable tasks with acceptance criteria |
 | 2 | **Under-planning** | "Step 1: Implement the feature" | Break down into verifiable chunks with clear scope |
-| 3 | **Premature generation** | Creating plan before user says "generate" | Stay in interview mode until explicitly triggered |
+| 3 | **Premature metis invocation** | Invoking metis before Clearance + AC complete | Stay in interview mode until Clearance all YES and AC confirmed |
 | 4 | **Skipping confirmation** | Generating plan and immediately handing off | Always present plan summary, wait for explicit "proceed" |
 | 5 | **Architecture redesign** | Proposing rewrite when targeted change suffices | Default to minimal scope; match user's ask |
 | 6 | **Codebase questions to user** | "Where is auth implemented?" | Use explore/oracle to find codebase facts yourself |
 
 ### Example
 
-**Good:** User asks "add dark mode." Prometheus asks (one at a time): "Should dark mode be the default or opt-in?", "What is your timeline priority?" Meanwhile, uses explore to find existing theme/styling patterns. After user says "make it a plan," generates a 4-step plan with clear acceptance criteria.
+**Good:** User asks "add dark mode." Prometheus asks (one at a time): "Should dark mode be the default or opt-in?", "What is your timeline priority?" Meanwhile, uses explore to find existing theme/styling patterns. After Clearance + AC pass, auto-invokes metis. Once metis approves, presents results and asks user to confirm plan generation. Generates a 4-step plan with clear acceptance criteria.
 
 **Bad:** User asks "add dark mode." Prometheus asks 5 questions at once including "What CSS framework do you use?" (codebase fact that explore can answer), generates a 25-step plan without being asked, and starts handing off to executors without confirmation.


### PR DESCRIPTION
## 📌 Summary

prometheus 스킬에서 metis 호출 시점을 사용자의 "generate plan" 트리거 후에서, Clearance + AC 완료 후 자동 호출로 변경하여 조기 호출 문제를 해결하고 사용자 경험을 개선한다.

---

## 🔧 Changes

### Prometheus 워크플로우 다이어그램

- `User says 'generate plan'` 노드 제거
- `Clearance + AC complete?` 자동 게이트 추가
- Metis 통과 후 `Present results / Ask user 'generate plan?'` + `User approves?` 노드 추가

기존에는 사용자가 "generate plan"을 트리거한 후에 metis가 호출되어, 사용자가 즉시 플랜이 나올 것으로 기대하지만 실제로는 metis 루프가 시작되는 UX 불일치가 있었다. 이제 metis는 내부 품질 게이트로 동작하고, 사용자는 검증된 결과만 받는다.

**영향 범위**
다이어그램 구조 변경. 실행 흐름의 노드 순서가 바뀌므로 prometheus를 사용하는 모든 세션에 영향.

### Metis Feedback Loop 섹션

- 제목: `MANDATORY Before Generation` → `Auto-Invoked Before User Confirmation`
- TIMING 조건을 2개로 축소 (Clearance all YES + AC confirmed). 주관적 조건 3("You judge the interview is complete") 제거
- `Do NOT wait for user to say "generate plan"` / `Do NOT invoke metis during interview phase` 지시 추가

**영향 범위**
metis 호출 시점 결정 로직 변경. Clearance + AC 충족 시 자동 진행되므로 사용자 트리거 대기 없음.

### Subagent Selection Guide / Plan Generation / Failure Modes

- metis에 `**MANDATORY**` 라벨 복원하여 momus와 parity 유지
- Plan Generation 트리거를 metis 통과 후 사용자 확인으로 이동
- Failure Modes에서 구 트리거 모델 참조 2건 수정 (`Premature generation` → `Premature metis invocation`, Good 예시 업데이트)

**영향 범위**
문서 일관성 수정. 기존 워크플로우를 참조하던 산재된 표현들을 새 모델로 통일.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. metis 호출 시점: 사용자 트리거 vs 자동 트리거

**배경 및 문제 상황:**
prometheus가 metis를 호출하는 시점이 모호하여 두 가지 문제가 발생했다. (1) `**MANDATORY** before plan generation`이 3곳에 볼드로 강조되어 LLM이 인터뷰 전에 즉시 metis를 호출. (2) 사용자가 "generate plan"을 말한 후에야 metis 루프가 시작되어, 즉시 플랜을 받을 것으로 기대한 사용자가 추가 질문을 받게 됨.

**해결 방안:**
metis를 사용자 트리거가 아닌, Clearance Checklist + AC 확인 완료 시 자동 호출되는 내부 품질 게이트로 전환. 사용자 확인("plan 생성할까요?")은 metis 통과 후로 이동.

**구현 세부사항:**
다이어그램에서 `User says 'generate plan'` 다이아몬드를 `Clearance + AC complete?` 로 교체하고, metis APPROVE 후에 `Present results / Ask user` 단계를 삽입. TIMING 조건에서 주관적 3번("You judge the interview is complete")을 제거하여 조건 1(Clearance all YES) + 조건 2(AC confirmed) 충족 시 결정론적으로 metis가 트리거되도록 함.

**선택과 트레이드오프:**
자동 트리거는 사용자에게 metis 루프를 투명하게 처리할 수 있는 장점이 있으나, 사용자가 metis 결과를 볼 수 없다는 트레이드오프가 있다. 그러나 metis의 목적이 prometheus의 내부 품질 보장이므로, 사용자에게는 검증된 결과만 제시하는 것이 적절하다고 판단. 주관적 조건 3을 제거한 것은 결정론적 성격을 강화하기 위함이며, Clearance의 "No critical ambiguities remaining" 체크가 이미 인터뷰 완료를 내포하므로 중복이었다.

---

## ✅ Checklist

### 워크플로우 재구성
- [ ] 다이어그램에 `User says 'generate plan'` 노드가 존재하지 않음
  - `skills/prometheus/SKILL.md` (다이어그램 섹션)
- [ ] metis는 `Clearance + AC complete?` 통과 후 자동 호출됨
  - `skills/prometheus/SKILL.md` (다이어그램 + TIMING 조건)
- [ ] 사용자 확인("plan 생성할까요?")은 metis APPROVE 후에 발생함
  - `skills/prometheus/SKILL.md` (다이어그램 + Plan Generation 섹션)

### 문서 일관성
- [ ] TIMING 조건이 2개만 존재 (주관적 조건 3 없음)
  - `skills/prometheus/SKILL.md` (Metis Feedback Loop 섹션)
- [ ] Subagent Selection Guide에서 metis에 `**MANDATORY**` 라벨이 있음
  - `skills/prometheus/SKILL.md` (Subagent Selection Guide 테이블)
- [ ] Failure Modes에서 구 트리거 참조가 없음 ("user says generate" 등)
  - `skills/prometheus/SKILL.md` (Failure Modes 섹션)