### PR TITLE
docs: stateless 재리뷰 전환 및 prometheus 호출 템플릿 추가

### DIFF
--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -525,36 +525,71 @@ Overall structure:
 **Do NOT invoke metis during interview phase or upon receiving the initial request.**
 
 **Metis Consultation Flow:**
-1. Summarize the planning session (user goal, interview findings, research results)
-2. Invoke metis to identify: missed questions, missing guardrails, scope creep risks, unvalidated assumptions, missing acceptance criteria, unaddressed edge cases
-3. Receive Metis verdict (APPROVE / REQUEST_CHANGES / COMMENT)
-4. Act on verdict per the table below
-5. **Repeat until APPROVE**
+1. Invoke metis with the 5-Section Invocation Template below
+2. Receive Metis verdict (APPROVE / REQUEST_CHANGES / COMMENT)
+3. Act on verdict per the table below
+4. **Repeat until APPROVE**
+
+**Metis Invocation Template (5-Section):**
+
+Invoke metis with this structure. On re-invocation after REQUEST_CHANGES, use the same structure with updated content — metis is stateless and reviews each submission independently. If a previous finding was reviewed but a different decision was made due to tradeoffs or constraints, reflect the decision and rationale in the relevant section (Key Decisions, Scope, or AC).
+
+```markdown
+## 1. USER GOAL
+- **Original Request**: [User's original request — verbatim or faithful paraphrase]
+- **Core Objective**: [Distilled core objective from interview]
+
+## 2. INTERVIEW FINDINGS
+### Key Decisions
+| Topic | Decision | Rationale |
+|-------|----------|-----------|
+| [Decision topic] | [User's choice] | [Rationale — preference, codebase constraint, best practice] |
+
+### User Deferrals
+| Topic | Autonomous Decision | Basis |
+|-------|-------------------|-------|
+| [Deferred topic] | [Selected approach] | [Codebase pattern / industry practice] |
+
+(If no deferrals, write "None")
+
+## 3. RESEARCH FINDINGS
+### Codebase (explore)
+- [Finding]: [Impact on planning]
+
+### External (librarian)
+- [Documentation / best practice]: [Impact on approach]
+
+### Oracle (if consulted)
+- [Feasibility / risk analysis result]: [Implication]
+
+(If agent not dispatched, write "Not dispatched")
+
+## 4. SCOPE & TECHNICAL APPROACH
+- **IN Scope**: [What will be built]
+- **OUT of Scope**: [What is excluded]
+- **Technical Approach**: [Decided approach]
+- **Approach Validation**: [Validation basis]
+
+## 5. ACCEPTANCE CRITERIA
+[Confirmed AC in full — paste verbatim. No summarizing.]
+```
+
+**Invocation Anti-Patterns:**
+
+| Anti-Pattern | Example | Problem |
+|-------------|---------|---------|
+| Summarized AC | "Logout feature AC" without full criteria | Metis cannot evaluate AC quality |
+| Omitted deferrals | User Deferrals section missing | Unvalidated assumptions undetectable |
+| Vague research | "Codebase explored" without specifics | Cannot judge if findings incorporated |
+| Abstract scope | "Build the feature" without IN/OUT | Scope creep risk unanalyzable |
 
 **Verdict Handling:**
 
 | Verdict | Action |
 |---------|--------|
-| **APPROVE** | Proceed to plan generation. Gate passed. |
-| **REQUEST_CHANGES** | Return to Interview Mode. Resolve all blocking items with the user. Then re-invoke metis with Re-review Context (see template below). **Loop until APPROVE.** |
-| **COMMENT** | Incorporate findings into the plan. Proceed to plan generation. |
-
-**Re-review Context Template (MANDATORY on re-invocation):**
-
-When re-invoking metis after REQUEST_CHANGES, include this context so metis can verify resolution:
-
-```markdown
-## Re-review Context
-### Previous Verdict
-- **Verdict**: REQUEST_CHANGES
-- **Key Findings**: [Previous blocking items — paste original findings verbatim]
-### Changes Made
-| Finding | Change | Intent |
-|---------|--------|--------|
-| [Original finding] | [What was changed/resolved] | [Why this resolves the finding] |
-### Current State
-[Updated interview summary reflecting resolved gaps]
-```
+| **APPROVE** | Proceed to presenting results to user. Gate passed. |
+| **REQUEST_CHANGES** | Return to Interview Mode. Resolve blocking items with the user. Re-invoke metis with the same 5-Section template, content updated to reflect resolutions. **Loop until APPROVE.** |
+| **COMMENT** | Incorporate findings into the plan. Proceed to presenting results. |
 
 **Post-Metis Summary** (include in plan under Context section):
 - **Identified Gaps**: What Metis found (across all iterations)
@@ -568,35 +603,36 @@ When re-invoking metis after REQUEST_CHANGES, include this context so metis can 
 
 **Momus Review Flow:**
 1. Generate the plan to `.omt/plans/{name}.md`
-2. Invoke momus with the plan file path
+2. Invoke momus with the plan file path (see Invocation Format below)
 3. Receive Momus verdict (APPROVE / REQUEST_CHANGES / COMMENT)
 4. Act on verdict per the table below
 5. **Repeat until APPROVE**
+
+**Momus Invocation Format:**
+
+Invoke momus with the plan file path only. Momus reads the file and reviews according to its own 4 Criteria. On re-invocation after REQUEST_CHANGES, send the same path — the plan file content is already updated. Momus is stateless and reviews each submission independently. If a finding was considered but intentionally not adopted, document the rationale in the relevant plan section (Work Objectives guardrails, TODO constraints).
+
+```
+.omt/plans/[name].md
+```
+
+All review context (original request, interview summary, metis results) is already in the plan's Context section per the Plan Template Structure. No supplementary prompt needed.
+
+**Invocation Anti-Patterns:**
+
+| Anti-Pattern | Example | Problem |
+|-------------|---------|---------|
+| Repeating plan content | Restating plan text in prompt | Momus reads the file directly — token waste |
+| Separate metis results | "Metis found X" in prompt | Already in Plan Context + anchoring risk |
+| Adding review instructions | "Please check AC quality" | Momus has its own 4 Criteria |
 
 **Verdict Handling:**
 
 | Verdict | Action |
 |---------|--------|
 | **APPROVE** | Proceed to handoff. Gate passed. |
-| **REQUEST_CHANGES** | Revise the plan to address all [CERTAIN] findings. Then re-invoke momus with Re-review Context (see template below). **Loop until APPROVE.** |
+| **REQUEST_CHANGES** | Revise the plan to address all [CERTAIN] findings. Re-invoke momus with the same plan file path. **Loop until APPROVE.** |
 | **COMMENT** | Incorporate [POSSIBLE] findings into the plan. Proceed to handoff. |
-
-**Re-review Context Template (MANDATORY on re-invocation):**
-
-When re-invoking momus after REQUEST_CHANGES, include this context so momus can verify resolution:
-
-```markdown
-## Re-review Context
-### Previous Verdict
-- **Verdict**: REQUEST_CHANGES
-- **Key Findings**: [Previous [CERTAIN] findings — paste original findings verbatim]
-### Changes Made
-| Finding | Change | Intent |
-|---------|--------|--------|
-| [Original finding] | [What was changed in the plan] | [Why this resolves the finding] |
-### Current State
-[Updated plan file path or summary of revisions made]
-```
 
 **Post-Momus Summary** (append to plan under Context section):
 - **Findings**: What Momus found (across all iterations)

--- a/skills/sisyphus/SKILL.md
+++ b/skills/sisyphus/SKILL.md
@@ -474,81 +474,15 @@ Review whether the implementation meets the requirements in the 6-Section prompt
 | Pre-built checklist | "Here's what to verify: [your list]" | Anchors argus, defeats independent derivation |
 | Selective prompt sections | Omitting MUST NOT DO | Argus cannot detect violations of rules it doesn't see |
 
-### Re-review Protocol
-
-When argus returns **REQUEST_CHANGES** and sisyphus-junior completes the fix task, the subsequent argus re-invocation **MUST** include a Re-review Context section. This does NOT apply to initial (first-time) argus invocations.
-
-**Why**: Without re-review context, argus performs a fresh review and may miss whether previous findings were actually addressed, or re-raise already-resolved issues.
-
-#### Re-review Invocation Template
-
-재리뷰 시, Re-review Context를 `## 6. CONTEXT` 섹션 안에 `###` 서브섹션으로 포함한다. 6-Section 구조를 깨지 않으면서 이전 리뷰 이력을 전달한다.
-
-```markdown
-## 1. TASK
-[초회와 동일]
-
-## 2. EXPECTED OUTCOME
-[초회와 동일]
-
-## 3. REQUIRED TOOLS
-[초회와 동일]
-
-## 4. MUST DO
-[초회와 동일]
-
-## 5. MUST NOT DO
-[초회와 동일]
-
-## 6. CONTEXT
-- Related files: [초회와 동일]
-- Prior task results: [초회와 동일]
-
-### Re-review Context
-#### Previous Verdict
-- **Verdict**: REQUEST_CHANGES
-- **Key Findings**:
-  1. [이전 지적 A 원문]
-  2. [이전 지적 B 원문]
-
-#### Changes Made
-| Finding | Change | Intent |
-|---------|--------|--------|
-| [지적 A] | [구체적 수정 내용] | [왜 이 방향으로] |
-| [지적 B] | [구체적 수정 내용] | [왜 이 방향으로] |
-
-#### Current State
-[수정 반영된 현재 결과물 — EXPECTED OUTCOME 기준으로 현재 상태]
-
----
-
-## REVIEW REQUEST
-- Task: [exact task subject from todo list]
-- Changed files:
-  - [explicit file paths]
-- Junior's summary: [what junior claimed to have done]
-
-Review whether the previous findings have been addressed and whether the implementation now meets the requirements.
-```
-
-#### Re-review Context Rules
-
-| Rule | Requirement |
-|------|-------------|
-| **Scope** | Applies ONLY to re-invocations after REQUEST_CHANGES, not initial invocations |
-| **Location** | `## 6. CONTEXT` 안에 `### Re-review Context`로 포함 — 6-Section 바깥에 별도 블록 금지 |
-| **Previous Findings** | Copy argus's findings VERBATIM — no summarizing or paraphrasing |
-| **Changes Made** | Map each finding to the specific change and explain intent |
-| **Current State** | Describe current state relative to EXPECTED OUTCOME |
-| **Sections 1-5** | 초회와 동일하게 유지 — 변경 금지 |
-
 ### Verdict Response Protocol
 
 | Verdict | Sisyphus Action |
 |---------|-----------------|
 | **APPROVE** | Invoke mnemosyne to commit, then mark task completed |
-| **REQUEST_CHANGES** (Critical/High) | Create fix task, re-delegate to sisyphus-junior. **Re-invocation MUST include Re-review Context** |
+| **REQUEST_CHANGES** (Critical/High) | Create fix task, re-delegate to sisyphus-junior |
 | **COMMENT** (Medium only) | Invoke mnemosyne to commit, then mark completed. Create follow-up task if warranted |
+
+**Note on deliberate trade-offs**: If a previous review finding was intentionally not addressed due to a deliberate trade-off, the decision rationale can optionally be noted in `## 6. CONTEXT` (Prior task results) or in the REVIEW REQUEST (Junior's summary). Argus will independently re-evaluate on re-review; this is informational, not mandatory.
 
 ### Fix Task from REQUEST_CHANGES
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -574,7 +574,7 @@ digraph feedback_loop {
     present_feedback [label="Present feedback to user\n(context + recommendation)"];
     user_consensus [label="User reviews & agrees\non changes", shape=diamond, style="rounded,filled", fillcolor="#ccffcc"];
     incorporate [label="Apply changes\nUpdate design.md\nRecord decisions in records/"];
-    re_delegate [label="Re-delegate to spec-review\n(with Re-review Context)"];
+    re_delegate [label="Re-delegate to spec-review"];
 
     comment [label="COMMENT"];
     share_comment [label="Share COMMENT with user\n(create follow-up if needed)"];
@@ -652,49 +652,6 @@ Review the following design and provide multi-AI advisory feedback.
 
 The spec-review operates in a separate context and returns advisory feedback with a verdict. You must then handle the verdict accordingly and present it to the user.
 
-### Re-review Context (MANDATORY for Re-delegation)
-
-When re-delegating to spec-review after applying REQUEST_CHANGES feedback, the delegation prompt MUST include a Re-review Context section. This provides reviewers with full traceability of what was changed and why.
-
-**Re-review delegation prompt structure:**
-
-```markdown
-Review the following design and provide multi-AI advisory feedback.
-
-## Re-review Context
-
-### Previous Verdict
-- **Verdict**: REQUEST_CHANGES
-- **Key Findings**: [이전 리뷰에서 지적된 blocking concerns 원문]
-
-### Changes Made
-| Finding | Change | Intent |
-|---------|--------|--------|
-| [지적 사항] | [수정 내용] | [수정 의도] |
-
-### Current State
-[수정이 반영된 현재 Area design.md 내용]
-
----
-
-## 1. Current Design Under Review
-[위 Current State와 동일 — 수정 반영된 전체 design.md]
-
-### Key Decisions
-[Key decision points requiring review]
-
-### Questions for Reviewers
-[Specific questions — 특히 이전 지적사항 해소 여부에 대한 질문]
-
-## 2. Previously Finalized Designs (Constraints)
-[Summarize relevant decisions from earlier steps that constrain this design]
-
-## 3. Context
-[Project context, tech stack, constraints]
-```
-
-**Re-review Context omission = VIOLATION.** 리뷰어가 이전 지적사항과 수정 내용을 모르면 effective re-review가 불가능하다.
-
 ### Presenting Feedback to User
 
 After receiving spec-review feedback, YOU must:
@@ -723,15 +680,17 @@ After receiving spec-review feedback, YOU must:
 | Verdict | User Interaction | Next Action |
 |---------|-----------------|-------------|
 | **APPROVE** | "Area 넘어갈까요?" 질문 | User "Area complete" 선언 → 다음 Area |
-| **REQUEST_CHANGES** | Blocking concerns + 수정 제안 제시 | User 합의 → 수정 반영 → Re-review Context 포함하여 spec-review 재호출 |
+| **REQUEST_CHANGES** | Blocking concerns + 수정 제안 제시 | User 합의 → 수정 반영 → spec-review 재호출 |
 | **COMMENT** | Non-blocking 개선 권고 공유 | User 확인 → follow-up 생성 가능 → "Area 넘어갈까요?" 질문 |
 
 **REQUEST_CHANGES Loop:**
 1. Present blocking concerns and recommended changes to user
 2. User reviews and agrees on specific changes (user may modify recommendations)
 3. Apply agreed changes to design.md, record decisions in `records/`
-4. Re-delegate to spec-review with **Re-review Context** (MANDATORY)
+4. Re-delegate to spec-review
 5. Repeat until APPROVE received
+
+> **Note:** If a deliberate trade-off was made against previous review findings, note the decision rationale in `Key Decisions` or `Questions for Reviewers` within the re-delegation prompt. This helps reviewers understand intentional divergences but is not mandatory.
 
 **CRITICAL: spec-review가 pass(APPROVE 또는 COMMENT) 하지 않으면 Area complete 선언 불가.** REQUEST_CHANGES verdict가 반환된 상태에서 유저가 "Area complete"를 선언해도, pass할 때까지 Area를 완료할 수 없다.
 
@@ -891,7 +850,7 @@ digraph area_completion {
     present_feedback [label="Present blocking concerns\nto user with recommendation"];
     user_consensus [label="User agrees on\nchanges to make", shape=diamond, style="rounded,filled", fillcolor="#ccffcc"];
     incorporate [label="Apply changes\nUpdate design.md\nRecord decisions in records/"];
-    re_review [label="Re-delegate to spec-review\n(Re-review Context MANDATORY)"];
+    re_review [label="Re-delegate to spec-review"];
 
     comment [label="COMMENT"];
     share_comment [label="Share non-blocking\nconcerns with user"];
@@ -929,7 +888,7 @@ digraph area_completion {
 4. **MANDATORY spec-review**: Delegate Area results to spec-review
 5. **Verdict handling**:
    - **APPROVE** → Proceed to step 6
-   - **REQUEST_CHANGES** → Present blocking concerns to user with recommendation → User agrees on changes → Apply changes, update design.md, record decisions in `records/` → Re-delegate to spec-review with **Re-review Context** (MANDATORY) → Return to step 5
+   - **REQUEST_CHANGES** → Present blocking concerns to user with recommendation → User agrees on changes → Apply changes, update design.md, record decisions in `records/` → Re-delegate to spec-review → Return to step 5
    - **COMMENT** → Share non-blocking concerns with user, create follow-up if needed → Proceed to step 6
 6. **User final gate**: User MUST explicitly declare "Area complete"
    - Silence is NOT agreement


### PR DESCRIPTION
## 📌 Summary

세 스킬(prometheus, sisyphus, spec)에서 Re-review Context 메커니즘을 제거하여 재리뷰 시 편향 없는 fresh review로 전환하고, prometheus에 metis/momus 구조화된 호출 템플릿을 추가.

---

## 🔧 Changes

### Re-review Context 제거 (sisyphus, spec, prometheus)

- sisyphus: Re-review Protocol 섹션 전체 삭제, Verdict Response Protocol REQUEST_CHANGES 행 간소화
- spec: Re-review Context (MANDATORY for Re-delegation) 섹션 삭제, 5개 참조(다이어그램 라벨 2개, 테이블 1개, 플로우 텍스트 2개) 간소화
- prometheus: metis/momus Re-review Context Template 제거, stateless 재호출로 단순화
- 세 스킬 모두 의도적 트레이드오프 결정 사유를 기존 필드에 선택적으로 기재하는 가이드 추가

기존에는 REQUEST_CHANGES 후 재리뷰 시 이전 findings와 수정 내역을 구조화된 Re-review Context로 전달했으나, 이를 제거하고 초회와 동일한 프롬프트로 재호출하는 방식으로 전환.

**영향 범위**
세 스킬의 재리뷰 플로우 변경. 리뷰어가 매번 동일 조건으로 독립 검증을 수행하게 됨. 의도적으로 수정하지 않은 항목에 대한 결정 사유 전달은 기존 필드(CONTEXT, Junior's summary, Key Decisions 등)를 활용하는 선택적 가이드로 대체.

### prometheus metis/momus 호출 템플릿 추가

- metis 5-Section Invocation Template 추가 (USER GOAL, INTERVIEW FINDINGS, RESEARCH FINDINGS, SCOPE, AC)
- momus Invocation Format 추가 (plan 파일 경로만 전달하는 간결한 구조)
- 양쪽 Invocation Anti-Patterns 테이블 추가

sisyphus에 junior/argus 호출 템플릿이 있는 것처럼, prometheus에도 metis/momus 호출 시 일관된 구조를 강제하는 템플릿 추가.

**영향 범위**
prometheus 스킬 내부 동작. metis/momus 호출 품질 표준화. 기존 플로우 자체의 변경은 없음.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. Anchored Review vs. Stateless Fresh Review

**배경 및 문제 상황:**
Re-review Context는 리뷰어가 이전 findings 대비 수정 여부를 추적하도록 설계됐으나, 실제로는 리뷰어의 관점을 이전 지적사항에 고정(anchoring)시키는 부작용이 있었음. 이전 findings에 집중하다 보면 수정 과정에서 새로 도입된 문제를 놓칠 위험이 존재.

**해결 방안:**
Re-review Context를 완전히 제거하고, 재리뷰 시 초회와 동일한 프롬프트를 전달하여 매번 독립적인 fresh review를 수행하도록 전환.

**구현 세부사항:**
제거 후 남는 문제는 "의도적으로 수정하지 않은 항목"의 결정 사유 전달. 이를 위해 기존 필드를 활용하는 선택적 가이드를 추가:
- sisyphus: `## 6. CONTEXT` (Prior task results) 또는 REVIEW REQUEST (Junior's summary)
- spec: `Key Decisions` 또는 `Questions for Reviewers`
- prometheus: 동일 패턴 적용

별도 섹션이나 필수 구조가 아닌, 기존 필드에 자연스럽게 녹이는 방식.

**선택과 트레이드오프:**
Re-review Context를 유지하면 리뷰어가 이전 지적 대비 수정 추적이 용이하지만, anchoring bias가 발생. 제거하면 동일 문제를 재지적할 수 있으나, 이는 실제로 수정이 안 된 것이므로 정당한 재지적. "해결됐는데 다시 지적"하는 케이스는 코드가 요구사항을 충족하면 발생하지 않음 — 결국 Re-review Context가 해결하려던 문제 자체가 존재하지 않음.

---

## ✅ Checklist

### Re-review Context 제거
- [x] sisyphus/SKILL.md에 "Re-review" 관련 참조가 0건임
  - `skills/sisyphus/SKILL.md`
- [x] spec/SKILL.md에 "Re-review Context" 관련 참조가 0건임
  - `skills/spec/SKILL.md`
- [x] prometheus/SKILL.md에 Re-review Context Template이 제거되었음
  - `skills/prometheus/SKILL.md`
- [x] 세 스킬 모두 의도적 트레이드오프 결정 사유에 대한 선택적 가이드가 존재함
  - `skills/sisyphus/SKILL.md`
  - `skills/spec/SKILL.md`
  - `skills/prometheus/SKILL.md`

### prometheus 호출 템플릿
- [x] metis 5-Section Invocation Template이 존재하며 USER GOAL, INTERVIEW FINDINGS, RESEARCH FINDINGS, SCOPE, AC 섹션을 포함함
  - `skills/prometheus/SKILL.md`
- [x] momus Invocation Format이 존재함
  - `skills/prometheus/SKILL.md`
- [x] metis/momus 각각 Invocation Anti-Patterns 테이블이 존재함
  - `skills/prometheus/SKILL.md`

---

## 📎 References
- 없음