### PR TITLE
feat: 계획→실행→검증 파이프라인 자급자족화

### DIFF
--- a/agents/argus.md
+++ b/agents/argus.md
@@ -11,6 +11,8 @@ You are Argus, the guardian agent. Follow the argus skill exactly.
 
 **Output**: Structured verification with:
 - **Summary**: Issue counts by severity (Critical/High/Medium/Low)
-- **Stage 0**: Automated Verification
-- **Stage 1**: Code Quality
+- **Stage 1**: Automated Verification
+- **Stage 2**: Spec Compliance
+- **Stage 3**: Hands-On QA
+- **Stage 4**: Code Quality
 - **Verdict**: APPROVE / REQUEST_CHANGES / COMMENT

--- a/agents/explore.md
+++ b/agents/explore.md
@@ -1,6 +1,6 @@
 ---
 name: explore
-description: Codebase search specialist - finds file locations, implementations, code patterns. Returns actionable results without follow-up questions needed. NOT for external docs (use librarian instead)
+description: Use when delegating codebase search for files, patterns, implementations — returns structured results with absolute paths. NOT for external docs (use librarian)
 model: sonnet
 skills: explore
 ---

--- a/agents/librarian.md
+++ b/agents/librarian.md
@@ -1,6 +1,6 @@
 ---
 name: librarian
-description: External documentation researcher - searches official docs, GitHub, package registries, Stack Overflow. NOT for internal codebase (use explore agent instead)
+description: Use when delegating external documentation research — returns findings with mandatory source URLs. NOT for internal codebase (use explore)
 model: sonnet
 skills: librarian
 ---

--- a/agents/metis.md
+++ b/agents/metis.md
@@ -1,6 +1,6 @@
 ---
 name: metis
-description: Pre-planning consultant - reviews plans, specs, requirements before implementation to catch missing questions, undefined guardrails, unvalidated assumptions, scope risks
+description: Use when delegating pre-implementation review of plans, specs, or requirements — returns structured gap analysis with verdict
 model: opus
 skills: metis
 ---

--- a/agents/momus.md
+++ b/agents/momus.md
@@ -1,6 +1,6 @@
 ---
 name: momus
-description: Work plan review expert and critic
+description: Use when delegating work plan critique — returns simulation-based review with certainty-classified findings and verdict
 model: opus
 skills: momus
 ---

--- a/agents/oracle.md
+++ b/agents/oracle.md
@@ -1,6 +1,6 @@
 ---
 name: oracle
-description: Strategic Architecture & Debugging Advisor (READ-ONLY consultant) - analyzes, diagnoses, recommends but NEVER implements
+description: Use when delegating architecture analysis or debugging diagnosis — returns root cause + prioritized recommendations with file:line citations. Never modifies files
 model: opus
 skills: oracle
 ---

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -64,6 +64,9 @@ if [ -z "$PROJECT_NAME" ]; then
   PROJECT_NAME=$(basename "$PROJECT_ROOT")
 fi
 
+# Sanitize: replace spaces with hyphens to prevent shell parsing issues
+PROJECT_NAME="${PROJECT_NAME// /-}"
+
 # Export OMT_PROJECT via Claude env file
 if [ -n "$CLAUDE_ENV_FILE" ]; then
   echo "export OMT_PROJECT=$PROJECT_NAME" >> "$CLAUDE_ENV_FILE"

--- a/skills/argus/checklists.md
+++ b/skills/argus/checklists.md
@@ -1,6 +1,6 @@
 # Code Quality Checklists
 
-Quality review checklists organized by severity level. Use during Stage 3 of the code review process.
+Quality review checklists organized by severity level. Use during Stage 4 of the code review process.
 
 ---
 

--- a/skills/argus/stage1-commands.md
+++ b/skills/argus/stage1-commands.md
@@ -88,7 +88,7 @@ When project lacks build tools, tests, or linter:
    - JavaScript: `node --check file.js`
    - Shell: `bash -n script.sh`
 
-2. **Document gaps as findings** for Stage 3
+2. **Document gaps as findings** for Stage 4
    - "No test coverage" -> recommend adding tests
    - "No linter configured" -> recommend setup
 
@@ -117,7 +117,7 @@ When project lacks build tools, tests, or linter:
 ## Stage 1 Failure = Immediate Stop
 
 If ANY check fails:
-1. **Do NOT proceed to Stage 2 or Stage 3**
+1. **Do NOT proceed to Stage 2, Stage 3, or Stage 4**
 2. Report the failure with specific output
 3. Issue `REQUEST_CHANGES` immediately
 4. Wait for fix and re-run Stage 1

--- a/skills/argus/stage3-handson.md
+++ b/skills/argus/stage3-handson.md
@@ -1,0 +1,183 @@
+# Stage 3: Hands-On QA
+
+Verify user-facing behavior by actually running the changed code. This is not optional when applicable.
+
+---
+
+## Step 3.1: Determine Applicability
+
+**Infer change type from the 6-Section prompt's TASK and EXPECTED OUTCOME sections.**
+
+### Decision Logic
+
+| Signal in Prompt | Change Type | Action |
+|------------------|-------------|--------|
+| API endpoint, route, handler, REST, HTTP | API | Verify with `curl` |
+| UI, page, component, frontend, render | Frontend | Verify with `playwright` |
+| CLI command, terminal output, TUI, interactive | CLI / TUI | Verify with interactive Bash |
+| Refactoring, internal logic, utility, helper, config | Internal only | **Skip Stage 3** |
+| Documentation, markdown, comments only | Non-code | **Skip Stage 3** |
+
+### When Multiple Types Apply
+
+If changes span multiple types (e.g., API + Frontend), verify each applicable type independently.
+
+### Skip Documentation
+
+When skipping Stage 3, document in output:
+
+```
+Stage 3 Result: SKIPPED (internal logic only / non-code change)
+```
+
+---
+
+## Step 3.2: Server / Application Lifecycle
+
+**Argus manages the full lifecycle: start, verify, stop.**
+
+### Start
+
+1. Discover the start command (same discovery logic as Stage 1 command discovery)
+2. Run the server/application in background using `run_in_background`
+3. Wait for readiness (health check endpoint, port listening, or startup log message)
+4. If startup fails after reasonable timeout, report as Stage 3 FAIL
+
+### Stop
+
+After ALL verification completes (pass or fail):
+
+1. Terminate the background process
+2. Confirm process is stopped
+3. Clean up any temporary resources
+
+**Never leave a server running.** Leaked processes corrupt subsequent reviews.
+
+### Lifecycle Failures
+
+| Failure | Action |
+|---------|--------|
+| Server won't start | REQUEST_CHANGES ("server fails to start") |
+| Server crashes during test | REQUEST_CHANGES ("server crashed during verification") |
+| Server won't stop | Kill process forcefully, report as finding |
+
+---
+
+## Step 3.3: API Verification (curl)
+
+**Verify API endpoints respond correctly with `curl`.**
+
+### Procedure
+
+1. Identify endpoints affected by the change (from EXPECTED OUTCOME)
+2. Construct `curl` commands for each endpoint
+3. Verify response status code, body structure, and key values
+
+### curl Usage
+
+```bash
+# Basic GET
+curl -s -o /dev/null -w "%{http_code}" http://localhost:{port}/endpoint
+
+# POST with body
+curl -s -X POST http://localhost:{port}/endpoint \
+  -H "Content-Type: application/json" \
+  -d '{"key": "value"}'
+
+# Capture full response
+curl -s http://localhost:{port}/endpoint | jq .
+```
+
+### Verification Criteria
+
+| Criterion | Pass Condition |
+|-----------|----------------|
+| Status code | Matches expected (200, 201, 400, etc.) |
+| Response body | Contains expected fields/values |
+| Error cases | Returns appropriate error response |
+
+---
+
+## Step 3.4: Frontend Verification (playwright)
+
+**Verify UI behavior with `playwright`.**
+
+### Procedure
+
+1. Ensure playwright is installed in the project (check `package.json`)
+2. Navigate to the affected page/component
+3. Verify visual elements render correctly
+4. Test user interactions described in EXPECTED OUTCOME
+
+### Verification Criteria
+
+| Criterion | Pass Condition |
+|-----------|----------------|
+| Page loads | No console errors, expected elements visible |
+| Interaction | Click/input produces expected result |
+| Navigation | Routes resolve to correct pages |
+
+---
+
+## Step 3.5: CLI / TUI Verification (Interactive Bash)
+
+**Verify CLI output and behavior by executing commands directly.**
+
+### Procedure
+
+1. Identify the CLI commands affected by the change
+2. Execute each command with expected arguments
+3. Verify stdout/stderr output matches expectations
+
+### Verification Criteria
+
+| Criterion | Pass Condition |
+|-----------|----------------|
+| Exit code | Matches expected (0 for success) |
+| stdout | Contains expected output |
+| stderr | No unexpected errors |
+| Side effects | Files created/modified as expected |
+
+---
+
+## Stage 3 Output Format
+
+```markdown
+## Stage 3: Hands-On QA
+
+**Applicability:** [API / Frontend / CLI / SKIPPED (reason)]
+
+| Verification | Status | Details |
+|--------------|--------|---------|
+| Server start | PASS / FAIL | [startup details] |
+| [Endpoint/Page/Command] | PASS / FAIL | [response/behavior summary] |
+| Server stop | PASS / FAIL | [cleanup details] |
+
+**Stage 3 Result:** PASS -> Proceed to Stage 4 / FAIL -> REQUEST_CHANGES / SKIPPED -> Proceed to Stage 4
+```
+
+---
+
+## Stage 3 Failure = Immediate Stop
+
+If ANY verification fails:
+1. **Do NOT proceed to Stage 4**
+2. Report the failure with specific output (response body, error message, screenshot reference)
+3. **Stop** the server/application
+4. Issue `REQUEST_CHANGES` immediately
+5. Wait for fix and re-run from Stage 1
+
+---
+
+## Red Flags for Stage 3
+
+| Excuse | Reality |
+|--------|---------|
+| "Tests already cover this" | Tests verify units. Hands-on verifies integration. |
+| "Server setup is too complex" | If it's too complex to start, it's too complex to ship. |
+| "It's just a minor API change" | Minor changes break clients. Verify the contract. |
+| "Frontend testing is slow" | Slow verification beats broken UI in production. |
+| "I can see the code is correct" | "Can see" != "verified". Run it. |
+| "It worked in the test suite" | Test suite mocks may hide real integration issues. |
+| "No test data available" | Create minimal test data. No excuses. |
+| "Skip for internal changes" | If truly internal, document skip. Don't use as escape hatch. |

--- a/skills/metis/SKILL.md
+++ b/skills/metis/SKILL.md
@@ -192,6 +192,7 @@ For architecture intent, briefly announce "Consulting Oracle for [reason]" befor
 | **AC Quality** | Well-formed? Observable outcomes? Verification methods concrete? |
 | **Edge Cases** | Unusual inputs/states/scenarios? |
 | **Error Handling** | What happens when things fail? |
+| **Verifiability** | Can completion of each requirement be verified? Does each AC have a concrete verification method? |
 
 **Your job is finding gaps, not giving approval.**
 
@@ -203,6 +204,7 @@ For architecture intent, briefly announce "Consulting Oracle for [reason]" befor
 - Do NOT accept acceptance criteria that list files or functions as outcomes ("create X.js with functions A, B") — criteria must describe observable state changes
 - Do NOT accept acceptance criteria with vague verification ("dry-run review", "verify it works", "confirm functionality") — verification must be a concrete command, assertion, or observable state
 - Do NOT accept acceptance criteria that restate the task ("Authentication is implemented") — criteria must describe what is TRUE after completion, not what ACTION was taken
+- Do NOT accept requirements or acceptance criteria whose completion cannot be objectively verified
 - Do NOT miss security/error handling questions
 
 <AI_Slop_Detection>
@@ -260,6 +262,7 @@ AC Quality Checks:
 - Each criterion has a concrete verification method (command, assertion, or observable state)?
 - No file-listing criteria (implementation details instead of outcomes)?
 - No vague verification ("verify it works", "dry-run review")?
+- Every requirement has at least one AC that makes its completion verifiable?
 
 ### Edge Cases
 1. [Unusual scenario] - [How to handle]
@@ -285,13 +288,15 @@ AC Quality Checks:
 
 ### Verdict Criteria
 
-| Verdict | Condition | Effect |
-|---------|-----------|--------|
-| **APPROVE** | Critical gaps 없음. 분석 결과 high-impact 이슈가 발견되지 않음. | Prometheus가 즉시 플랜 생성 가능 |
-| **REQUEST_CHANGES** | Critical gaps 존재. Missing Questions, Undefined Guardrails, Unvalidated Assumptions 등에서 high-impact 항목이 1개 이상 발견됨. | 해당 항목 해소 후 Metis 재검증 필요. Prometheus 진행 차단. |
-| **COMMENT** | Minor gaps 또는 edge cases만 존재. 플랜 품질에 영향을 주지만 차단 사유는 아님. | Prometheus가 플랜에 반영하되 진행은 허용 |
+**MANDATORY GATE — Verifiability**: Requirements and acceptance criteria MUST be in a form where completion can be objectively verified. If this gate fails, verdict is REQUEST_CHANGES regardless of all other criteria.
 
-**Critical gap 판정 기준**: 해당 gap이 해소되지 않으면 Prometheus가 올바른 플랜을 생성할 수 없는 경우 (예: 핵심 요구사항 누락, 범위 미정의, 검증 불가능한 AC)
+| Verdict | Condition |
+|---------|-----------|
+| **APPROVE** | ALL of: (1) Every requirement has an AC that makes its completion verifiable, (2) Every AC has a concrete verification method (command, assertion, or observable state), (3) IN/OUT Scope both defined, (4) No [CERTAIN] findings from 4 Criteria |
+| **REQUEST_CHANGES** | ANY of: (1) Requirement exists without verifiable AC, (2) AC verification method is abstract ("verify it works", "confirm functionality"), (3) IN or OUT Scope missing, (4) One or more [CERTAIN] findings |
+| **COMMENT** | No blocking conditions, but advisory recommendations exist: (1) Edge case not addressed but inferable, (2) AC verifiable but precision could improve, (3) [POSSIBLE]-only findings |
+
+**Critical gap determination**: A gap is critical when it makes completion verification impossible — either a requirement has no way to confirm it's done, or an AC has no concrete verification method.
 
 </Verdict_Criteria>
 

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -222,6 +222,23 @@ Before classifying intent, load project context files from `~/.omt/$OMT_PROJECT/
 
 **Do vs Delegate exemption:** Topics covered by loaded context files are exempt from the mandatory explore delegation rule in the Do vs Delegate Decision Matrix. If a context file already answers an architecture or convention question, Prometheus may use that answer directly instead of dispatching explore.
 
+## Intent Classification (Phase 0)
+
+After loading context, classify the user's request into one of four tiers. Classification determines interview depth, NOT Clearance requirements.
+
+| Intent | Criteria | Interview Strategy |
+|--------|----------|-------------------|
+| **Trivial** | Single file, <10 lines, obvious fix | 1-2 questions, rapid plan. Still minimum 1 interview question before Clearance. |
+| **Scoped** | 1-3 files, clear scope | Standard interview, full Clearance |
+| **Complex** | 3+ files, multi-component | Deep interview, explore MANDATORY before forming questions |
+| **Architecture** | System design, infrastructure, long-term impact | Oracle MANDATORY (NO EXCEPTIONS), explore + librarian parallel |
+
+**Clearance Checklist 5 items unchanged for ALL intents.** Only interview depth varies.
+
+**Note:** Classification is Prometheus-internal (distinct from Metis's Phase 0 intent classification which serves analysis strategy).
+
+**Note:** User can request reclassification if they disagree.
+
 ## Interview Mode (Default State)
 
 **Use AskUserQuestion tool to interview in-depth until nothing is ambiguous.**

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -525,52 +525,25 @@ Overall structure:
 **Do NOT invoke metis during interview phase or upon receiving the initial request.**
 
 **Metis Consultation Flow:**
-1. Invoke metis with the 5-Section Invocation Template below
+1. Invoke metis with the 3-Section Invocation Template below
 2. Receive Metis verdict (APPROVE / REQUEST_CHANGES / COMMENT)
 3. Act on verdict per the table below
 4. **Repeat until APPROVE**
 
-**Metis Invocation Template (5-Section):**
+**Metis Invocation Template (3-Section):**
 
-Invoke metis with this structure. On re-invocation after REQUEST_CHANGES, use the same structure with updated content — metis is stateless and reviews each submission independently. If a previous finding was reviewed but a different decision was made due to tradeoffs or constraints, reflect the decision and rationale in the relevant section (Key Decisions, Scope, or AC).
+Invoke metis with this structure. On re-invocation after REQUEST_CHANGES, use the same structure with updated content — metis is stateless and reviews each submission independently. If a previous finding was reviewed but a different decision was made, reflect it in the relevant section (Scope or AC).
 
 ```markdown
 ## 1. USER GOAL
 - **Original Request**: [User's original request — verbatim or faithful paraphrase]
 - **Core Objective**: [Distilled core objective from interview]
 
-## 2. INTERVIEW FINDINGS
-### Key Decisions
-| Topic | Decision | Rationale |
-|-------|----------|-----------|
-| [Decision topic] | [User's choice] | [Rationale — preference, codebase constraint, best practice] |
-
-### User Deferrals
-| Topic | Autonomous Decision | Basis |
-|-------|-------------------|-------|
-| [Deferred topic] | [Selected approach] | [Codebase pattern / industry practice] |
-
-(If no deferrals, write "None")
-
-## 3. RESEARCH FINDINGS
-### Codebase (explore)
-- [Finding]: [Impact on planning]
-
-### External (librarian)
-- [Documentation / best practice]: [Impact on approach]
-
-### Oracle (if consulted)
-- [Feasibility / risk analysis result]: [Implication]
-
-(If agent not dispatched, write "Not dispatched")
-
-## 4. SCOPE & TECHNICAL APPROACH
+## 2. SCOPE
 - **IN Scope**: [What will be built]
 - **OUT of Scope**: [What is excluded]
-- **Technical Approach**: [Decided approach]
-- **Approach Validation**: [Validation basis]
 
-## 5. ACCEPTANCE CRITERIA
+## 3. ACCEPTANCE CRITERIA
 [Confirmed AC in full — paste verbatim. No summarizing.]
 ```
 
@@ -578,17 +551,16 @@ Invoke metis with this structure. On re-invocation after REQUEST_CHANGES, use th
 
 | Anti-Pattern | Example | Problem |
 |-------------|---------|---------|
-| Summarized AC | "Logout feature AC" without full criteria | Metis cannot evaluate AC quality |
-| Omitted deferrals | User Deferrals section missing | Unvalidated assumptions undetectable |
-| Vague research | "Codebase explored" without specifics | Cannot judge if findings incorporated |
-| Abstract scope | "Build the feature" without IN/OUT | Scope creep risk unanalyzable |
+| Summarized AC | "Logout feature AC" without full criteria | Metis cannot evaluate AC verifiability |
+| Abstract scope | "Build the feature" without IN/OUT | Scope completeness uncheckable |
+| Missing user goal | Sending AC without original request context | Metis cannot classify intent |
 
 **Verdict Handling:**
 
 | Verdict | Action |
 |---------|--------|
 | **APPROVE** | Proceed to presenting results to user. Gate passed. |
-| **REQUEST_CHANGES** | Return to Interview Mode. Resolve blocking items with the user. Re-invoke metis with the same 5-Section template, content updated to reflect resolutions. **Loop until APPROVE.** |
+| **REQUEST_CHANGES** | Return to Interview Mode. Resolve blocking items with the user. Re-invoke metis with the same 3-Section template, content updated to reflect resolutions. **Loop until APPROVE.** |
 | **COMMENT** | Incorporate findings into the plan. Proceed to presenting results. |
 
 **Post-Metis Summary** (include in plan under Context section):

--- a/skills/prometheus/tests/application-scenarios.md
+++ b/skills/prometheus/tests/application-scenarios.md
@@ -475,7 +475,7 @@ API rate limiting 기능 추가하고 관련 문서도 업데이트해줘
 | P-9 | Acceptance Criteria Drafting | | | AC section rewritten -- verification points updated, needs re-testing |
 | P-10 | Plan Generation + Metis Consultation | **PASS** | 2026-02-11 | 4/4 VP. GREEN: Plan Generation + Subagent Guide + Workflow 모두 건재. 회귀 없음 |
 | P-11 | Subagent Selection | **PASS** | 2026-02-11 | 3/3 VP. GREEN: Subagent Selection Guide + Role Clarity 건재. 회귀 없음 |
-| P-16 | Context Loading | | | |
-| P-17 | Intent Classification | | | |
-| P-18 | Execution Strategy in Plan | | | |
-| P-19 | QA Scenarios in TODO | | | |
+| P-16 | Context Loading | **PASS** | 2026-02-23 | 4/4 VP. GREEN: trust boundary(V1), partial context silent skip(V2), explore for specifics(V3), graceful degradation(V4) 모두 준수 |
+| P-17 | Intent Classification | **PASS** | 2026-02-23 | 4/4 VP. GREEN: G2 boundary rule 적용(V1), scope-unknown→explore(V2), Architecture→Oracle mandatory(V3), depth≠Clearance(V4) 모두 준수 |
+| P-18 | Execution Strategy in Plan | **PASS** | 2026-02-23 | 4/4 VP. GREEN: G3 wave formula 정확 적용(V2), G3 anti-pattern 위반 없음, causal dependencies(V1), critical path(V3), rule compliance(V4) |
+| P-19 | QA Scenarios in TODO | **PASS** | 2026-02-23 | 4/4 VP. GREEN: G6 Tool=CLI command(V4), executable steps(V1), non-trivial failure(V2), G5 non-code simplified format(V3), G6 anti-pattern 위반 없음 |

--- a/skills/prometheus/tests/application-scenarios.md
+++ b/skills/prometheus/tests/application-scenarios.md
@@ -23,6 +23,10 @@ These scenarios test whether the prometheus skill's **core techniques** are corr
 | P-13 | Clearance Checklist | Clearance Checklist | Sequential Interview |
 | P-14 | Metis Feedback Loop | Metis Feedback Loop | Plan Generation + Gap Classification |
 | P-15 | Failure Mode Avoidance | Failure Mode Avoidance | Sequential Interview + Plan Generation |
+| P-16 | Context Loading | Context Loading | Context Brokering Protocol |
+| P-17 | Intent Classification | Intent Classification | Interview Mode |
+| P-18 | Execution Strategy in Plan | Execution Strategy | Plan Template Structure |
+| P-19 | QA Scenarios in TODO | QA Scenarios | Plan Template Structure |
 
 ---
 
@@ -360,6 +364,91 @@ Interview is completed (all clarifying questions answered, acceptance criteria c
 
 ---
 
+## Scenario P-16: Context Loading
+
+**Primary Technique:** Context Loading — 프로젝트 컨텍스트 사전 로딩으로 인터뷰 전 배경 지식 확보
+
+**Prompt:**
+```
+우리 프로젝트에 OAuth 2.0 인증 추가해줘
+```
+
+**Verification Points:**
+
+| # | Check | Expected Behavior |
+|---|-------|-------------------|
+| V1 | Context files loaded pre-interview | Skill reads `~/.omt/$OMT_PROJECT/context/` files (project.md, conventions.md, decisions.md, gotchas.md) before starting interview |
+| V2 | Context-covered topics skip explore | For architecture/convention questions covered by context files, skill does NOT dispatch explore agent (trust level rule) |
+| V3 | $OMT_PROJECT resolution referenced | Context Loading section references $OMT_PROJECT resolved by SessionStart hook |
+| V4 | Graceful skip on missing context | If context directory doesn't exist, skill proceeds to interview without error or user prompt |
+
+---
+
+## Scenario P-17: Intent Classification
+
+**Primary Technique:** Intent Classification — 요청 규모별 4-tier 분류로 인터뷰 깊이 조절
+
+**Prompt (Trivial intent):**
+```
+헤더 텍스트 "Welcome"을 "Hello"로 변경해줘
+```
+
+**Prompt (Architecture intent):**
+```
+마이크로서비스 아키텍처로 모노리스 분해 계획 세워줘
+```
+
+**Verification Points:**
+
+| # | Check | Expected Behavior |
+|---|-------|-------------------|
+| V1 | Trivial classified correctly | Simple text change classified as Trivial with 1-2 questions only |
+| V2 | Architecture classified correctly | Monolith decomposition classified as Architecture with Oracle MANDATORY |
+| V3 | Clearance unchanged for all intents | Both Trivial and Architecture requests go through same 5-item Clearance Checklist |
+| V4 | User can request reclassification | If user disagrees with classification, skill accepts reclassification request |
+
+---
+
+## Scenario P-18: Execution Strategy in Plan
+
+**Primary Technique:** Execution Strategy — Wave 기반 병렬 실행 전략 생성
+
+**Prompt:**
+```
+사용자 인증 시스템 구현해줘
+```
+
+**Verification Points:**
+
+| # | Check | Expected Behavior |
+|---|-------|-------------------|
+| V1 | Wave visualization present | Generated plan includes Wave visualization format showing parallel execution groups |
+| V2 | Dependency Matrix present | Plan includes abbreviated Dependency Matrix with Blocked By / Blocks columns |
+| V3 | Critical Path identified | Plan states the critical path through dependent tasks |
+| V4 | TODO Parallelization fields | Each TODO contains Blocked By / Blocks / Wave fields |
+
+---
+
+## Scenario P-19: QA Scenarios in TODO
+
+**Primary Technique:** QA Scenarios — TODO별 MANDATORY QA 시나리오 포함
+
+**Prompt:**
+```
+API rate limiting 기능 추가해줘
+```
+
+**Verification Points:**
+
+| # | Check | Expected Behavior |
+|---|-------|-------------------|
+| V1 | QA Scenarios present in every TODO | Each TODO item in the plan contains a QA Scenarios subsection |
+| V2 | 4-field structure | Each QA Scenario has Tool, Preconditions, Steps, Expected fields |
+| V3 | Minimum 2 scenarios per TODO | At least Happy path + Failure/edge case for each TODO |
+| V4 | Verification Strategy references QA | Plan's Verification Strategy section references per-TODO QA Scenarios as primary mechanism |
+
+---
+
 ## Test Results
 
 | # | Scenario | Result | Date | Notes |
@@ -375,3 +464,7 @@ Interview is completed (all clarifying questions answered, acceptance criteria c
 | P-9 | Acceptance Criteria Drafting | | | AC section rewritten -- verification points updated, needs re-testing |
 | P-10 | Plan Generation + Metis Consultation | **PASS** | 2026-02-11 | 4/4 VP. GREEN: Plan Generation + Subagent Guide + Workflow 모두 건재. 회귀 없음 |
 | P-11 | Subagent Selection | **PASS** | 2026-02-11 | 3/3 VP. GREEN: Subagent Selection Guide + Role Clarity 건재. 회귀 없음 |
+| P-16 | Context Loading | | | |
+| P-17 | Intent Classification | | | |
+| P-18 | Execution Strategy in Plan | | | |
+| P-19 | QA Scenarios in TODO | | | |

--- a/skills/prometheus/tests/application-scenarios.md
+++ b/skills/prometheus/tests/application-scenarios.md
@@ -396,7 +396,7 @@ Interview is completed (all clarifying questions answered, acceptance criteria c
 
 **Prompt (boundary — Trivial vs Scoped):**
 ```
-에러 메시지 3곳에서 한글화해줘
+auth.ts, payment.ts, user.ts 3개 파일에서 에러 메시지 한글화해줘
 ```
 
 **Prompt (boundary — Scoped vs Complex):**
@@ -456,7 +456,7 @@ API rate limiting 기능 추가하고 관련 문서도 업데이트해줘
 | V1 | Steps are agent-executable | Steps field contains concrete commands or actions (e.g., `curl -X POST /api/resource 101 times`, `grep 'rate-limit' README.md`) — NOT vague statements like "verify the feature works" or "check that limiting is applied" |
 | V2 | Failure scenario is non-trivial | Edge case scenario tests an actual failure mode specific to the task (e.g., "rate limit counter resets after window expires", "concurrent requests from same IP handled correctly") — NOT generic "invalid input returns error" |
 | V3 | Non-code TODO uses simplified format | Documentation update TODO uses simplified QA format (Preconditions + Expected only, no Tool/Steps) — NOT forced into full 4-field structure that doesn't make sense for docs |
-| V4 | Tool field is specific | Names the actual verification tool (jest, curl, grep, bash) — NOT generic "test runner" or "testing tool". The tool choice matches what the Steps actually use |
+| V4 | Tool field is executable CLI command | Names an executable CLI command (e.g., `bun test`, `curl`, `grep`, `./gradlew test`), NOT a test description ("Header validation") or generic label ("test runner"). The named command must match what Steps actually invoke |
 
 ---
 

--- a/skills/spec-review/SKILL.md
+++ b/skills/spec-review/SKILL.md
@@ -130,7 +130,7 @@ digraph spec_review_decision {
 ## Process
 
 1. Receive design content from caller
-2. Gather shared context from .omt/specs/context/ (if --spec flag provided)
+2. Gather shared context from ~/.omt/$OMT_PROJECT/context/ (if --spec flag provided)
 3. Format structured prompt with design content + context
 4. Dispatch to claude, gemini, codex in parallel
 5. Collect independent opinions
@@ -181,10 +181,10 @@ Context files are **automatically included if they exist, silently skipped if th
 
 | File | Included When |
 |------|---------------|
-| `.omt/specs/context/project.md` | File exists |
-| `.omt/specs/context/conventions.md` | File exists |
-| `.omt/specs/context/decisions.md` | File exists |
-| `.omt/specs/context/gotchas.md` | File exists |
+| `~/.omt/$OMT_PROJECT/context/project.md` | File exists |
+| `~/.omt/$OMT_PROJECT/context/conventions.md` | File exists |
+| `~/.omt/$OMT_PROJECT/context/decisions.md` | File exists |
+| `~/.omt/$OMT_PROJECT/context/gotchas.md` | File exists |
 
 **No context files yet?** That's fine - the review proceeds without them.
 
@@ -315,7 +315,7 @@ We propose using Event Sourcing for order state management because...
 EOF
 ```
 
-**Context (Section 3)**: Automatically populated from `.omt/specs/context/` if files exist. Omit from your request.
+**Context (Section 3)**: Automatically populated from `~/.omt/$OMT_PROJECT/context/` if files exist. Omit from your request.
 
 **Custom context needed?** Just add it to your request content directly - no special flag required.
 

--- a/skills/spec-review/spec-review.config.yaml
+++ b/skills/spec-review/spec-review.config.yaml
@@ -32,5 +32,5 @@ spec-review:
 
   # Spec context configuration
   context:
-    shared_context_dir: ".omt/specs/context"   # All *.md files in this dir
+    shared_context_dir: "~/.omt/${OMT_PROJECT}/context"   # All *.md files in this dir
     specs_dir: ".omt/specs"                     # {specName}/spec.md and {specName}/records/*.md

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -1041,7 +1041,7 @@ spec.md = requirements/design.md
         + {custom-concern}/design.md (if promoted via Emergent Concern Protocol)
 ```
 
-**Note**: Wrapup produces context files (`.omt/specs/context/`), not spec content.
+**Note**: Wrapup produces context files (`~/.omt/$OMT_PROJECT/context/`), not spec content.
 
 ### Record Naming
 

--- a/skills/spec/references/wrapup.md
+++ b/skills/spec/references/wrapup.md
@@ -183,7 +183,7 @@ Apply **Checkpoint Protocol** (see SKILL.md)
 
 #### 4.1 Save Approved Items
 
-- Create: `.omt/specs/context/` directory if needed
+- Create: `~/.omt/$OMT_PROJECT/context/` directory if needed
 - Write: Approved content to appropriate files
 - Format: Append to existing files or create new ones
 


### PR DESCRIPTION
## 📌 Summary

세션 시작 시 프로젝트 컨텍스트를 자동 로딩하고, Prometheus가 실행 가능한 검증 시나리오까지 포함한 계획을 생성하며, Argus가 라이브 앱 대상으로 해당 시나리오를 실행하는 엔드투엔드 자급자족 파이프라인을 구축한다. 부수적으로 agent description을 위임 트리거 문법으로 통일한다.

---

## 🔧 Changes

### Prometheus 기획 파이프라인 5단계 확장

- Context Loading 단계 추가: `~/.omt/$OMT_PROJECT/context/` 파일을 인터뷰 전에 읽어 프로젝트 아키텍처/컨벤션을 사전 파악
- Intent Classification (Phase 0) 추가: 요청을 Trivial / Scoped / Complex / Architecture로 분류하여 인터뷰 깊이를 제어
- Plan Template에 Execution Strategy 섹션 추가: Wave Visualization, Dependency Matrix, Critical Path를 필수 산출물로 지정
- TODO별 QA Scenarios 필수화: Tool / Preconditions / Steps / Expected 4열 테이블로 검증 시나리오 명시
- G2~G6 빈틈 보완: classification boundary rule(G2), wave 공식 + 안티패턴(G3/G4), non-code QA 간소 형식(G5), Tool=CLI command 정의 + 안티패턴(G6)
- P-16~P-19 테스트 시나리오 추가 및 GREEN 통과 기록

기존 인터뷰→계획 2단계 구조에서 Context Loading → Intent Classification → Interview → Plan Generation → Review Gate 5단계로 확장. 계획 산출물이 executor-complete(병렬화 정보 + 검증 시나리오 포함)해져서 인터뷰 트랜스크립트 없이도 실행 가능.

**영향 범위**
`skills/prometheus/SKILL.md` 및 `skills/prometheus/tests/application-scenarios.md`. Prometheus 출력 포맷이 확장되므로 Sisyphus/Junior가 새 포맷을 소비할 수 있어야 함.

### Argus Hands-On QA Stage 추가

- Stage 3 Hands-On QA (`stage3-handson.md`) 신규 생성
- SKILL.md 출력 형식에 Stage 3 반영 (4-stage output)
- `agents/argus.md`에 4-stage 출력 형식 반영
- 테스트 시나리오 A-8~A-12 추가 및 결과 기록

기존 Stage 1(자동 테스트) → Stage 2(스펙 준수) → Stage 4(코드 품질) 사이에 Stage 3(라이브 앱 대상 curl/playwright/bash 검증) 삽입. Stage 3 실패 시 Stage 4 진입 차단.

**영향 범위**
`skills/argus/`, `agents/argus.md`. API, Frontend, CLI 변경 시 적용되며 docs-only/internal-only 변경은 명시적 스킵.

### Agent Description 위임 패턴 통일

- explore, librarian, metis, momus, oracle 5개 agent description을 역할 서술("X specialist")에서 호출 트리거("Use when delegating X")로 일괄 변환

Claude의 subagent 라우팅이 description 필드를 기반으로 하므로, 트리거 조건 중심 문법이 선택 정확도를 높임.

**영향 범위**
`agents/` 내 5개 파일. 각 agent의 실제 프롬프트/동작은 변경 없음.

### Hooks: OMT_PROJECT 환경변수 세팅

- `session-start.sh`에 git remote/worktree로부터 `$OMT_PROJECT` 도출 및 `$CLAUDE_ENV_FILE` 내보내기 추가

Prometheus Context Loading의 선행 조건. worktree 환경에서도 메인 저장소 이름을 정확히 도출.

**영향 범위**
`hooks/session-start.sh`. 세션 시작 시 환경변수 1개 추가. 기존 hook 동작에 영향 없음.

### 기타 정비

- `skills/metis/SKILL.md`: 검증가능성 게이트 판정 기준 구체화 (APPROVE/REQUEST_CHANGES/COMMENT 3단계)
- `skills/spec/`, `skills/spec-review/`: context 경로 `.omt/specs/context/` → `~/.omt/$OMT_PROJECT/context/`로 통합

**영향 범위**
각 스킬 내부에 한정.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. Prometheus 기계적 Wave 배정 (G3)

**배경 및 문제 상황:**
기존 Wave 배정은 가이드라인 수준이어서, agent가 "논리적으로 X를 먼저 해야 한다"는 직관으로 독립 task를 Wave 2로 밀어넣는 패턴이 반복되었다. 이는 불필요한 직렬화를 유발하여 병렬 실행 효율을 저하.

**해결 방안:**
Wave = `max(wave of each blocker) + 1` 공식을 MANDATORY로 지정. 직관 기반 오버라이드를 명시적으로 금지.

**구현 세부사항:**
3가지 규칙으로 구성: (1) 공식 자체, (2) 안티패턴("독립 task를 Wave 2로 배정하는 것은 의존성이 있으면 Blocked By로 표현하고, 없으면 Wave 1") 명시, (3) phantom wave 금지(Verification/Merge/Deploy 같은 행정 단계를 Wave로 추가하지 않음).

**선택과 트레이드오프:**
유연성을 완전히 제거하는 강경한 접근. Agent가 "A를 B보다 먼저 하는 게 자연스럽다"고 판단해도, 실제 의존성이 없으면 같은 Wave에 배치된다. 이는 간혹 비직관적인 배치를 만들 수 있으나, 불필요한 직렬화를 구조적으로 방지한다는 점에서 올바른 트레이드오프.

### 2. Agent Description 위임 패턴 전환

**배경 및 문제 상황:**
Claude의 subagent 라우팅은 agent `description` 필드를 읽고 어떤 agent를 호출할지 결정한다. 기존 description은 "Codebase search specialist — finds file locations..." 형태의 역할 서술이었는데, 이는 "이 agent가 무엇인가"를 설명하지 "언제 이 agent를 호출해야 하는가"를 알려주지 않는다.

**해결 방안:**
5개 순수 위임 agent(explore, librarian, metis, momus, oracle)의 description을 `"Use when delegating [scope] — returns [output contract]. NOT for [anti-use-case]"` 패턴으로 일괄 전환.

**구현 세부사항:**
각 description에 3가지 요소를 포함: (1) 트리거 조건("Use when delegating..."), (2) 출력 계약("returns..."), (3) 안티 유스케이스("NOT for..."). 실제 agent 프롬프트와 동작은 변경하지 않음.

**선택과 트레이드오프:**
Description이 라우팅 최적화만을 위해 존재하게 되어, 사람이 읽을 때 agent의 역할을 즉시 파악하기 어려워질 수 있다. 그러나 description의 1차 소비자가 사람이 아닌 Claude의 라우팅 로직이므로, 기계 최적화를 우선한 결정.

### 3. Argus Stage 3 Hands-On QA

**배경 및 문제 상황:**
기존 Argus는 Stage 1(테스트 러너)로 자동화된 테스트를 실행하고 Stage 2(스펙 준수)/Stage 4(코드 품질)로 정적 리뷰를 수행했다. 그러나 테스트 스위트가 mock 기반인 경우, 실제 서버 구동 + HTTP 호출 수준의 통합 검증이 빠져 있었다.

**해결 방안:**
Stage 2와 Stage 4 사이에 Stage 3 Hands-On QA를 삽입. 실제 앱을 구동하고 curl/playwright/bash로 Prometheus의 QA Scenarios를 실행한 뒤 종료.

**구현 세부사항:**
Stage 3 적용 대상: API, Frontend, CLI 변경. docs-only/internal-only 변경은 명시적으로 스킵하며 스킵 사유를 기록. Stage 3 실패 시 Stage 4 진입을 차단하고 즉시 `REQUEST_CHANGES` 발행. Prometheus의 TODO별 QA Scenarios가 Stage 3의 입력이 되는 의존 관계를 형성.

**선택과 트레이드오프:**
Stage 3은 서버 구동/종료 오버헤드와 환경 의존성(포트 충돌, DB 상태 등)을 추가한다. 또한 Prometheus가 QA Scenario를 잘못 작성하면 Stage 3이 false negative를 발생시킬 수 있다. 이를 감수하고도 "mock이 가리는 통합 실패"를 잡아내는 가치가 더 크다고 판단.

---

## ✅ Checklist

### Prometheus 기획 파이프라인
- [ ] Context Loading에서 `~/.omt/$OMT_PROJECT/context/` 디렉토리 미존재 시 에러 없이 다음 단계로 진행됨
  - `skills/prometheus/SKILL.md`
- [ ] Intent Classification이 3파일 trivial 변경을 Scoped로 분류함 (Trivial이 아님)
  - `skills/prometheus/SKILL.md`
- [ ] Wave 배정이 `max(blockers)+1` 공식을 따르며, Blocked By 없는 task가 Wave 1에 배치됨
  - `skills/prometheus/SKILL.md`
- [ ] QA Scenarios의 Tool 필드가 실행 가능한 CLI 명령어임 (테스트 설명이나 추상 라벨이 아님)
  - `skills/prometheus/SKILL.md`
- [ ] Non-code TODO의 QA Scenarios가 Preconditions + Expected 2열만 사용함
  - `skills/prometheus/SKILL.md`
- [ ] P-16~P-19 GREEN 테스트 결과가 모두 PASS로 기록됨
  - `skills/prometheus/tests/application-scenarios.md`

### Argus Hands-On QA
- [ ] Stage 3이 Stage 2와 Stage 4 사이에 위치하며, 실패 시 Stage 4 진입을 차단함
  - `skills/argus/SKILL.md`, `skills/argus/stage3-handson.md`
- [ ] docs-only 변경 시 Stage 3을 명시적으로 스킵하고 사유를 기록함
  - `skills/argus/stage3-handson.md`

### Agent Description
- [ ] explore, librarian, metis, momus, oracle 5개 agent description이 "Use when delegating..." 패턴을 따름
  - `agents/explore.md`, `agents/librarian.md`, `agents/metis.md`, `agents/momus.md`, `agents/oracle.md`

### Hooks
- [ ] `session-start.sh`가 worktree 환경에서도 올바른 프로젝트 이름을 `$OMT_PROJECT`로 내보냄
  - `hooks/session-start.sh`

---

## 📎 References
- Prometheus G2~G6 빈틈 분석 (Oracle 권고 기반 재설계)
- P-16~P-19 시나리오: `skills/prometheus/tests/application-scenarios.md`
- A-8~A-12 시나리오: `skills/argus/tests/application-scenarios.md`