### PR TITLE
feat: collect 실행 지침 추가 (foreground 강제, no-sleep, 내부 폴링 명시)

### DIFF
--- a/agents/chunk-reviewer.md
+++ b/agents/chunk-reviewer.md
@@ -33,7 +33,7 @@ Your job is to orchestrate external AI reviewers, collect their independent resu
 
 You may ONLY execute these commands via Bash:
 - `bun .claude/scripts/chunk-review/job.ts start --prompt-file "$PROMPT_FILE"` — start a review job
-- `bun .claude/scripts/chunk-review/job.ts collect "$JOB_DIR"` — collect results (poll internally)
+- `bun .claude/scripts/chunk-review/job.ts collect "$JOB_DIR"` — collect results (polls internally every 5s, 150s default timeout). No external sleep needed.
 
 **CRITICAL**: Always set `timeout: 180000` on every Bash tool call.
 
@@ -63,10 +63,16 @@ bun .claude/scripts/chunk-review/job.ts start --prompt-file "$PROMPT_FILE"
 Output: JOB_DIR path (one line on stdout)
 
 ### Step 2 — Collect (Bash, timeout: 180000)
-Poll until all reviewers complete. Re-run this step if not done.
+
+`collect` polls internally every 5 seconds until all reviewers complete or its internal timeout (default 150s) expires. No external sleep needed.
+
 ```bash
 bun .claude/scripts/chunk-review/job.ts collect "$JOB_DIR"
 ```
+
+- If response shows `"overallState": "done"` → proceed to Step 3.
+- If response shows `"overallState": "running"` → call `collect` again (same command, foreground, timeout: 180000).
+
 Response JSON (done):
 ```json
 { "overallState": "done", "id": "...", "members": [{ "member": "claude", "outputFilePath": "/path/to/output.txt", "errorMessage": null }] }

--- a/agents/chunk-reviewer.md
+++ b/agents/chunk-reviewer.md
@@ -71,7 +71,7 @@ bun .claude/scripts/chunk-review/job.ts collect "$JOB_DIR"
 ```
 
 - If response shows `"overallState": "done"` → proceed to Step 3.
-- If response shows `"overallState": "running"` → call `collect` again (same command, foreground, timeout: 180000).
+- Otherwise (`"running"`, `"queued"`, etc.) → call `collect` again (same command, foreground, timeout: 180000).
 
 Response JSON (done):
 ```json

--- a/agents/spec-reviewer.md
+++ b/agents/spec-reviewer.md
@@ -166,7 +166,7 @@ bun .claude/scripts/spec-reviewer/job.ts collect "$JOB_DIR"
 ```
 
 - If response shows `"overallState": "done"` → proceed to Phase 3.
-- If response shows `"overallState": "running"` → call `collect` again (same command, foreground, timeout: 180000).
+- Otherwise (`"running"`, `"queued"`, etc.) → call `collect` again (same command, foreground, timeout: 180000).
 
 Response JSON (done):
 ```json

--- a/agents/spec-reviewer.md
+++ b/agents/spec-reviewer.md
@@ -75,7 +75,7 @@ Proceed with implementation.
 
 You may ONLY execute these commands via Bash:
 - `bun .claude/scripts/spec-reviewer/job.ts start --prompt-file "$PROMPT_FILE" [--spec <spec-name>]` — start a review job
-- `bun .claude/scripts/spec-reviewer/job.ts collect "$JOB_DIR"` — collect results (polls internally until done)
+- `bun .claude/scripts/spec-reviewer/job.ts collect "$JOB_DIR"` — collect results (polls internally every 5s, 150s default timeout). No external sleep needed.
 
 **CRITICAL**: Always set `timeout: 180000` on every Bash tool call.
 
@@ -159,11 +159,14 @@ Output: JOB_DIR path (one line on stdout).
 
 ### Phase 2 — Collect (Bash, timeout: 180000)
 
-Poll until all reviewers complete. Re-run this step if not done.
+`collect` polls internally every 5 seconds until all reviewers complete or its internal timeout (default 150s) expires. No external sleep needed.
 
 ```bash
 bun .claude/scripts/spec-reviewer/job.ts collect "$JOB_DIR"
 ```
+
+- If response shows `"overallState": "done"` → proceed to Phase 3.
+- If response shows `"overallState": "running"` → call `collect` again (same command, foreground, timeout: 180000).
 
 Response JSON (done):
 ```json

--- a/skills/agent-council/SKILL.md
+++ b/skills/agent-council/SKILL.md
@@ -60,7 +60,7 @@ digraph council_decision {
 1. Encounter uncertain decision point
 2. Call council with rich context + specific question
 3. Council members provide independent opinions (raw outputs)
-4. **Collect**: `bun .claude/skills/agent-council/scripts/job.ts collect JOB_DIR` — repeat until `overallState` is `"done"`
+4. **Collect**: `bun .claude/skills/agent-council/scripts/job.ts collect JOB_DIR` — polls internally; re-call if `overallState` is `"running"`
 5. **Read each member's output file** via the Read tool
 6. **Synthesize** (you as Chairman): raw outputs → Advisory Format below
 7. Make informed decision based on advisory
@@ -83,50 +83,16 @@ Execute `bun .claude/skills/agent-council/scripts/job.ts` from the project root:
 
 > Note: Always write the council prompt in English for consistent cross-model communication.
 
-### One-shot (Terminal)
-
-For interactive terminal use where you wait for completion:
-
-```bash
-# 1. Start council — capture JOB_DIR
-JOB_DIR=$(bun .claude/skills/agent-council/scripts/job.ts start --stdin <<'EOF'
-## Evaluation Criteria
-[Key principles - in English]
-
-## Project Context
-[Conventions and patterns - in English]
-
-## Target
-[Code or content under review]
-
-## Question
-[Specific points needing judgment - in English]
-EOF
-)
-
-# 2. Collect — poll until overallState is "done"
-while true; do
-  RESULT=$(bun .claude/skills/agent-council/scripts/job.ts collect "$JOB_DIR")
-  echo "$RESULT" | grep -q '"overallState":.*"done"' && break
-  echo "Still running... retrying in 10s"
-  sleep 10
-done
-echo "$RESULT"
-
-# 3. Read each member's output
-# Parse outputFilePath values from $RESULT and cat them, e.g.:
-#   cat /path/to/claude-output.txt
-#   cat /path/to/gemini-output.txt
-
-# 4. Clean up
-bun .claude/skills/agent-council/scripts/job.ts clean "$JOB_DIR"
-```
-
 ### Host Agent Context (Claude Code)
 
 For programmatic use within Claude Code sessions:
 
 **CRITICAL**: Always set `timeout: 180000` on every Bash tool call.
+
+**Hard Constraints:**
+0. **Each Bash call MUST run in FOREGROUND.** All subcommands (start, collect) run synchronously. No background execution. No `run_in_background`.
+1. **Do NOT use `sleep`.** The `collect` subcommand polls internally (5-second intervals, 150-second default timeout). External sleep is redundant and wastes time.
+2. **Exactly-once job start.** The `start` subcommand runs ONCE. Polling (`collect`) may repeat. No job re-creation.
 
 **1. Start council (Bash, timeout: 180000)**
 ```bash
@@ -152,28 +118,14 @@ Output: JOB_DIR path (one line on stdout).
 
 **2. Collect results (Bash, timeout: 180000)**
 
-Poll until all members complete. Re-run this step if not done.
+`collect` polls internally every 5 seconds until all members complete or its internal timeout (default 150s) expires. No external sleep needed.
+
 ```bash
 bun .claude/skills/agent-council/scripts/job.ts collect "$JOB_DIR"
 ```
 
-Response JSON (done):
-```json
-{
-  "overallState": "done",
-  "id": "...",
-  "members": [
-    { "member": "claude", "outputFilePath": "/path/to/output.txt", "errorMessage": null },
-    { "member": "gemini", "outputFilePath": "/path/to/output.txt", "errorMessage": null },
-    { "member": "codex", "outputFilePath": null, "errorMessage": "timed_out" }
-  ]
-}
-```
-
-Response JSON (not done — re-run this step):
-```json
-{ "overallState": "running", "id": "...", "counts": { "total": 3, "done": 1, "running": 2, "queued": 0 } }
-```
+- If response shows `"overallState": "done"` → proceed to Step 3.
+- If response shows `"overallState": "running"` → call `collect` again (same command, foreground, timeout: 180000).
 
 **3. Read raw outputs**
 

--- a/skills/agent-council/SKILL.md
+++ b/skills/agent-council/SKILL.md
@@ -60,7 +60,7 @@ digraph council_decision {
 1. Encounter uncertain decision point
 2. Call council with rich context + specific question
 3. Council members provide independent opinions (raw outputs)
-4. **Collect**: `bun .claude/skills/agent-council/scripts/job.ts collect JOB_DIR` — polls internally; re-call if `overallState` is `"running"`
+4. **Collect**: `bun .claude/skills/agent-council/scripts/job.ts collect JOB_DIR` — polls internally; re-call if not `"done"`
 5. **Read each member's output file** via the Read tool
 6. **Synthesize** (you as Chairman): raw outputs → Advisory Format below
 7. Make informed decision based on advisory
@@ -125,7 +125,7 @@ bun .claude/skills/agent-council/scripts/job.ts collect "$JOB_DIR"
 ```
 
 - If response shows `"overallState": "done"` → proceed to Step 3.
-- If response shows `"overallState": "running"` → call `collect` again (same command, foreground, timeout: 180000).
+- Otherwise (`"running"`, `"queued"`, etc.) → call `collect` again (same command, foreground, timeout: 180000).
 
 **3. Read raw outputs**
 


### PR DESCRIPTION
## 📌 Summary

Council/spec-reviewer/chunk-reviewer의 `collect` 호출 시 foreground 실행 강제, sleep 금지, 내부 폴링 동작을 명시하여 background 전환 및 불필요한 sleep 삽입 오류를 방지한다. One-shot 터미널 워크플로우 삭제.

---

## 🔧 Changes

### agent-council SKILL.md

- One-shot (Terminal) 섹션 전체 삭제 (`while true; sleep 10` 폴링 루프 포함)
- Host Agent Context에 Hard Constraints 블록 추가 (FOREGROUND 강제, sleep 금지, exactly-once start)
- Collect step 설명을 내부 폴링 동작(5초 간격, 150초 기본 timeout) + done/running 분기 지침으로 교체
- Process 섹션 Step 4 문구를 "polls internally; re-call if running"으로 변경

One-shot 패턴은 shell `while-sleep` 루프로 collect를 감싼 문서 패턴이었으며, 실제 코드 모드가 아님. 삭제해도 기능적 영향 없음.

**영향 범위**
agent-council 스킬을 호출하는 모든 host agent의 collect 패턴에 영향. 기존 start → collect → clean 커맨드 자체는 변경 없음.

### spec-reviewer.md / chunk-reviewer.md

- Allowed Bash Usage의 collect 항목에 내부 폴링 정보 추가 ("polls internally every 5s, 150s default timeout")
- Collect Phase/Step 설명에 내부 폴링 동작 + done/running 분기 지침 추가

두 파일은 이미 foreground 강제(`Each Bash call MUST run in FOREGROUND`)와 no-sleep이 있었으므로, collect의 blocking 특성 설명만 보강.

**영향 범위**
spec-reviewer, chunk-reviewer chairman agent의 collect 호출 패턴. 기존 Hard Constraints 및 워크플로우 변경 없음.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. One-shot 섹션 삭제 결정

**배경 및 문제 상황:**
SKILL.md에 "One-shot (Terminal)"과 "Host Agent Context (Claude Code)" 두 가지 사용 패턴이 공존했다. One-shot은 shell `while true; sleep 10` 루프로 collect를 감싼 패턴인데, Host Agent Context에서는 collect를 직접 호출하는 패턴을 안내한다. `collect` 자체가 내부적으로 5초 간격 폴링을 수행하므로(`generic-job.ts:779-811`, 기본 150초 timeout), One-shot의 외부 sleep은 이중 대기를 발생시킨다.

**해결 방안:**
One-shot 섹션을 완전 삭제하고, Host Agent Context 패턴(start → collect → read → synthesize → clean)만 유지.

**구현 세부사항:**
One-shot은 순수 문서 패턴이며 `job.ts`에 별도 코드 경로가 없다. 동일한 start/collect/clean 명령을 shell loop으로 감싼 것이 전부이므로, 삭제해도 기능적 영향 없음.

**선택과 트레이드오프:**
터미널에서 직접 council을 실행하는 사용자를 위한 편의성이 사라지지만, 현재 모든 council 호출은 host agent(Claude Code) 컨텍스트에서 이루어진다. One-shot과 Host Agent 패턴의 공존이 혼동(sleep 삽입, background 전환)의 직접적 원인이었으므로, 단일 패턴 유지가 명확성을 높인다.

### 2. Hard Constraints 블록 도입 (spec-reviewer/chunk-reviewer 패턴 차용)

**배경 및 문제 상황:**
실제 사용에서 agent가 collect를 `run_in_background: true`로 실행하거나 `sleep 45 && collect`로 호출하는 오류가 발생했다. SKILL.md에 "foreground로 실행하라", "sleep을 쓰지 마라"는 명시적 지침이 없었다.

**해결 방안:**
spec-reviewer.md(line 104)와 chunk-reviewer.md(line 104)에 이미 존재하는 Hard Constraints 패턴을 agent-council SKILL.md에도 동일하게 적용.

**구현 세부사항:**
```markdown
**Hard Constraints:**
0. **Each Bash call MUST run in FOREGROUND.** No background execution. No `run_in_background`.
1. **Do NOT use `sleep`.** The `collect` subcommand polls internally (5-second intervals, 150-second default timeout).
2. **Exactly-once job start.** The `start` subcommand runs ONCE. Polling (`collect`) may repeat.
```

**선택과 트레이드오프:**
번호 매기기(0, 1, 2)와 각 항목에 이유를 포함한 형식을 선택했다. 3개의 pressure 시나리오(background 유혹, sleep 유혹, 반복 timeout)로 subagent 테스트를 실행한 결과, 3/3 시나리오에서 에이전트가 올바른 선택을 했다. 특히 sleep 시나리오에서 "even setting the rules aside, the practical analysis leads to the same conclusion"이라고 응답하여, 규칙 암기가 아닌 실질적 이해를 달성했음을 확인.

---

## ✅ Checklist

### agent-council SKILL.md
- [ ] One-shot (Terminal) 섹션이 완전히 삭제되었는지 (`grep "One-shot" SKILL.md` → 0건)
  - `skills/agent-council/SKILL.md`
- [ ] Hard Constraints에 FOREGROUND, no-sleep, exactly-once 3개 항목이 모두 존재하는지
  - `skills/agent-council/SKILL.md`
- [ ] Collect step에 내부 폴링 설명(5초 간격, 150초 timeout)과 done/running 분기 지침이 있는지
  - `skills/agent-council/SKILL.md`
- [ ] `sleep`이 실행 가능한 코드로 존재하지 않는지 (금지 설명 내 언급만 허용)
  - `skills/agent-council/SKILL.md`

### spec-reviewer / chunk-reviewer
- [ ] Allowed Bash Usage의 collect 항목에 "polls internally every 5s, 150s default timeout" 문구가 있는지
  - `agents/spec-reviewer.md`
  - `agents/chunk-reviewer.md`
- [ ] Collect Phase/Step에 done/running 분기 지침이 있는지
  - `agents/spec-reviewer.md`
  - `agents/chunk-reviewer.md`
- [ ] 기존 Hard Constraints("Each Bash call MUST run in FOREGROUND")가 변경 없이 유지되는지
  - `agents/spec-reviewer.md`
  - `agents/chunk-reviewer.md`

---

## 📎 References
- `src/lib/generic-job.ts:779-811` — `cmdCollect` 구현 (COLLECT_POLL_INTERVAL_MS=5000, default timeout 150000ms)