### PR TITLE
feat: pull CLI 오케스트레이터 구현 — sync 역방향 풀백 도구

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: sync sync-dry validate validate-schema validate-components validate-tests test help
+.PHONY: sync sync-dry validate validate-schema validate-components validate-tests test pull pull-dry help
 
 help:
 	@echo "사용 가능한 명령어:"
@@ -8,6 +8,8 @@ help:
 	@echo "  make validate-schema    - 스키마 검증 (필드, 값 유효성)"
 	@echo "  make validate-components - 컴포넌트 검증 (파일 존재 여부)"
 	@echo "  make test               - 전체 테스트 실행 (Shell + TypeScript)"
+	@echo "  make pull PROJ=<name>   - 프로젝트 배포 파일을 소스로 풀백"
+	@echo "  make pull-dry PROJ=<name> - 풀백 미리보기 (실제 변경 없음)"
 
 sync: validate validate-tests
 	@bun run tools/sync.ts
@@ -27,3 +29,11 @@ validate-tests:
 	@./tools/run-tests.sh
 
 test: validate-tests
+
+pull:
+	@test -n "$(PROJ)" || (echo "PROJ is required. Usage: make pull PROJ=<name>" && exit 1)
+	@bun run tools/pull.ts $(PROJ)
+
+pull-dry:
+	@test -n "$(PROJ)" || (echo "PROJ is required. Usage: make pull-dry PROJ=<name>" && exit 1)
+	@bun run tools/pull.ts $(PROJ) --dry-run

--- a/tools/lib/pull-utils.test.ts
+++ b/tools/lib/pull-utils.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
 
 import { parseFrontmatter } from "./frontmatter.ts";
 import {
@@ -66,15 +69,44 @@ describe("resolveSourcePath", () => {
     expect(result).toBe(`${ROOT}/projects/my-project/skills/testing`);
   });
 
-  it("falls back to global path for unscoped ref when `projectDirName` is provided", () => {
+  it("falls back to global path for unscoped ref when `projectDirName` is provided and project-local doesn't exist", () => {
     const result = resolveSourcePath("oracle", "skills", ROOT, "my-project");
     expect(result).toBe(`${ROOT}/skills/oracle`);
   });
 
-  it("throws on cross-project scoped ref when `projectDirName` differs", () => {
-    expect(() =>
-      resolveSourcePath("other-project:testing", "skills", ROOT, "my-project"),
-    ).toThrow("Cross-project reference not allowed");
+  it("returns error object on cross-project scoped ref when `projectDirName` differs", () => {
+    const result = resolveSourcePath("other-project:testing", "skills", ROOT, "my-project");
+    expect(typeof result).toBe("object");
+    expect(result).toHaveProperty("error");
+    expect((result as { error: string }).error).toContain("Cross-project reference not allowed");
+  });
+
+  it("prefers project-local path when exists for unscoped ref with projectDirName", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "pull-utils-test-"));
+    try {
+      mkdirSync(join(tmpDir, "projects", "my-proj", "skills", "oracle"), { recursive: true });
+      writeFileSync(join(tmpDir, "projects", "my-proj", "skills", "oracle", "SKILL.md"), "# test");
+      mkdirSync(join(tmpDir, "skills", "oracle"), { recursive: true });
+      writeFileSync(join(tmpDir, "skills", "oracle", "SKILL.md"), "# global");
+
+      const result = resolveSourcePath("oracle", "skills", tmpDir, "my-proj");
+      expect(result).toBe(join(tmpDir, "projects", "my-proj", "skills", "oracle"));
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to global when project-local doesn't exist on filesystem", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "pull-utils-test-"));
+    try {
+      mkdirSync(join(tmpDir, "skills", "oracle"), { recursive: true });
+      writeFileSync(join(tmpDir, "skills", "oracle", "SKILL.md"), "# global");
+
+      const result = resolveSourcePath("oracle", "skills", tmpDir, "my-proj");
+      expect(result).toBe(join(tmpDir, "skills", "oracle"));
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("allows same-project scoped ref when `projectDirName` matches", () => {

--- a/tools/lib/pull-utils.test.ts
+++ b/tools/lib/pull-utils.test.ts
@@ -13,32 +13,32 @@ import {
 // ---------------------------------------------------------------------------
 
 describe("resolveDeployedPath", () => {
-  it("agents: .md suffix 붙은 파일 경로 반환", () => {
+  it("returns file path with `.md` suffix for agents", () => {
     const result = resolveDeployedPath("/proj", "claude", "agents", "oracle");
     expect(result).toBe("/proj/.claude/agents/oracle.md");
   });
 
-  it("commands: .md suffix 붙은 파일 경로 반환", () => {
+  it("returns file path with `.md` suffix for commands", () => {
     const result = resolveDeployedPath("/proj", "claude", "commands", "commit");
     expect(result).toBe("/proj/.claude/commands/commit.md");
   });
 
-  it("rules: .md suffix 붙은 파일 경로 반환", () => {
+  it("returns file path with `.md` suffix for rules", () => {
     const result = resolveDeployedPath("/proj", "claude", "rules", "coding");
     expect(result).toBe("/proj/.claude/rules/coding.md");
   });
 
-  it("skills: suffix 없는 디렉터리 경로 반환", () => {
+  it("returns directory path without suffix for skills", () => {
     const result = resolveDeployedPath("/proj", "claude", "skills", "oracle");
     expect(result).toBe("/proj/.claude/skills/oracle");
   });
 
-  it("scripts: suffix 없는 디렉터리 경로 반환", () => {
+  it("returns directory path without suffix for scripts", () => {
     const result = resolveDeployedPath("/proj", "claude", "scripts", "hud");
     expect(result).toBe("/proj/.claude/scripts/hud");
   });
 
-  it("gemini 플랫폼: .gemini/ 디렉터리 사용", () => {
+  it("uses `.gemini/` directory for gemini platform", () => {
     const result = resolveDeployedPath("/proj", "gemini", "skills", "oracle");
     expect(result).toBe("/proj/.gemini/skills/oracle");
   });
@@ -51,24 +51,40 @@ describe("resolveDeployedPath", () => {
 describe("resolveSourcePath", () => {
   const ROOT = "/root/oh-my-toong";
 
-  it("글로벌 ref (skills): {rootDir}/skills/{name} 반환", () => {
+  it("resolves global ref for skills to `{rootDir}/skills/{name}`", () => {
     const result = resolveSourcePath("oracle", "skills", ROOT);
     expect(result).toBe(`${ROOT}/skills/oracle`);
   });
 
-  it("글로벌 ref (commands): {rootDir}/commands/{name} 반환", () => {
+  it("resolves global ref for commands to `{rootDir}/commands/{name}.md`", () => {
     const result = resolveSourcePath("commit", "commands", ROOT);
-    expect(result).toBe(`${ROOT}/commands/commit`);
+    expect(result).toBe(`${ROOT}/commands/commit.md`);
   });
 
-  it("스코프 ref: {rootDir}/projects/{project}/{category}/{name} 반환", () => {
+  it("resolves scoped ref to `{rootDir}/projects/{project}/{category}/{name}`", () => {
     const result = resolveSourcePath("my-project:testing", "skills", ROOT);
     expect(result).toBe(`${ROOT}/projects/my-project/skills/testing`);
   });
 
-  it("projectDirName 제공 시 언스코프 ref는 글로벌 경로로 fallback", () => {
+  it("falls back to global path for unscoped ref when `projectDirName` is provided", () => {
     const result = resolveSourcePath("oracle", "skills", ROOT, "my-project");
     expect(result).toBe(`${ROOT}/skills/oracle`);
+  });
+
+  it("throws on cross-project scoped ref when `projectDirName` differs", () => {
+    expect(() =>
+      resolveSourcePath("other-project:testing", "skills", ROOT, "my-project"),
+    ).toThrow("Cross-project reference not allowed");
+  });
+
+  it("allows same-project scoped ref when `projectDirName` matches", () => {
+    const result = resolveSourcePath("my-project:testing", "skills", ROOT, "my-project");
+    expect(result).toBe(`${ROOT}/projects/my-project/skills/testing`);
+  });
+
+  it("returns `.md` suffix for file-based categories (agents) on new component", () => {
+    const result = resolveSourcePath("new-agent", "agents", ROOT);
+    expect(result).toBe(`${ROOT}/agents/new-agent.md`);
   });
 });
 
@@ -77,25 +93,25 @@ describe("resolveSourcePath", () => {
 // ---------------------------------------------------------------------------
 
 describe("reversePlatformPaths", () => {
-  it("gemini: .gemini/ → .claude/ 치환", () => {
+  it("replaces `.gemini/` with `.claude/`", () => {
     const content = "See .gemini/skills/oracle/ for details";
     const result = reversePlatformPaths(content, "gemini");
     expect(result).toBe("See .claude/skills/oracle/ for details");
   });
 
-  it("codex: .codex/ → .claude/ 치환", () => {
+  it("replaces `.codex/` with `.claude/`", () => {
     const content = "See .codex/skills/oracle/ for details";
     const result = reversePlatformPaths(content, "codex");
     expect(result).toBe("See .claude/skills/oracle/ for details");
   });
 
-  it("claude: 내용 그대로 반환", () => {
+  it("returns content unchanged for claude platform", () => {
     const content = "See .claude/skills/oracle/ for details";
     const result = reversePlatformPaths(content, "claude");
     expect(result).toBe(content);
   });
 
-  it("여러 번 등장하는 경우 모두 치환", () => {
+  it("replaces all occurrences in content", () => {
     const content = ".gemini/agents/oracle.md and .gemini/skills/prometheus/";
     const result = reversePlatformPaths(content, "gemini");
     expect(result).toBe(".claude/agents/oracle.md and .claude/skills/prometheus/");
@@ -123,7 +139,7 @@ ${extra}---
 
 # Oracle body`;
 
-  it("add-skills 있고 소스에 skills 없음: deployed에서 skills 키 제거", () => {
+  it("removes `skills` key when `add-skills` present and source has no skills", () => {
     const deployed = makeDeployedWithSkills(["testing"]);
     const source = makeSource();
     const syncItem = { component: "oracle", "add-skills": ["testing"] };
@@ -134,7 +150,7 @@ ${extra}---
     expect("skills" in frontmatter).toBe(false);
   });
 
-  it("add-skills 있고 소스에 skills 있음: 소스의 skills 값으로 복원", () => {
+  it("restores source `skills` value when `add-skills` present and source has skills", () => {
     const deployed = makeDeployedWithSkills(["testing", "pre-existing"]);
     const source = makeSource("skills:\n  - pre-existing\n");
     const syncItem = { component: "oracle", "add-skills": ["testing"] };
@@ -145,7 +161,7 @@ ${extra}---
     expect(fm["skills"]).toEqual(["pre-existing"]);
   });
 
-  it("add-hooks 있고 소스에 hooks 없음: deployed에서 hooks 키 제거", () => {
+  it("removes `hooks` key when `add-hooks` present and source has no hooks", () => {
     const deployed = `---
 name: oracle
 model: sonnet
@@ -171,7 +187,7 @@ hooks:
     expect("hooks" in fm).toBe(false);
   });
 
-  it("string 아이템: 내용 그대로 반환", () => {
+  it("returns content unchanged for string sync items", () => {
     const deployed = makeDeployedWithSkills(["testing"]);
     const source = makeSource();
     const syncItem = "oracle";
@@ -181,7 +197,7 @@ hooks:
     expect(result).toBe(deployed);
   });
 
-  it("add-skills/add-hooks 없는 오브젝트 아이템: 내용 그대로 반환", () => {
+  it("returns content unchanged for object items without `add-skills`/`add-hooks`", () => {
     const deployed = makeDeployedWithSkills(["testing"]);
     const source = makeSource();
     const syncItem = { component: "oracle", platforms: ["claude"] as const };
@@ -191,7 +207,7 @@ hooks:
     expect(result).toBe(deployed);
   });
 
-  it("deployed body가 결과에 보존됨", () => {
+  it("preserves deployed body in result", () => {
     const deployedBody = "\n# Oracle body with DEPLOYED changes";
     const deployed = `---
 name: oracle

--- a/tools/lib/pull-utils.test.ts
+++ b/tools/lib/pull-utils.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from "bun:test";
+
+import { parseFrontmatter } from "./frontmatter.ts";
+import {
+  resolveDeployedPath,
+  resolveSourcePath,
+  reversePlatformPaths,
+  stripInjectedFrontmatter,
+} from "./pull-utils.ts";
+
+// ---------------------------------------------------------------------------
+// resolveDeployedPath
+// ---------------------------------------------------------------------------
+
+describe("resolveDeployedPath", () => {
+  it("agents: .md suffix 붙은 파일 경로 반환", () => {
+    const result = resolveDeployedPath("/proj", "claude", "agents", "oracle");
+    expect(result).toBe("/proj/.claude/agents/oracle.md");
+  });
+
+  it("commands: .md suffix 붙은 파일 경로 반환", () => {
+    const result = resolveDeployedPath("/proj", "claude", "commands", "commit");
+    expect(result).toBe("/proj/.claude/commands/commit.md");
+  });
+
+  it("rules: .md suffix 붙은 파일 경로 반환", () => {
+    const result = resolveDeployedPath("/proj", "claude", "rules", "coding");
+    expect(result).toBe("/proj/.claude/rules/coding.md");
+  });
+
+  it("skills: suffix 없는 디렉터리 경로 반환", () => {
+    const result = resolveDeployedPath("/proj", "claude", "skills", "oracle");
+    expect(result).toBe("/proj/.claude/skills/oracle");
+  });
+
+  it("scripts: suffix 없는 디렉터리 경로 반환", () => {
+    const result = resolveDeployedPath("/proj", "claude", "scripts", "hud");
+    expect(result).toBe("/proj/.claude/scripts/hud");
+  });
+
+  it("gemini 플랫폼: .gemini/ 디렉터리 사용", () => {
+    const result = resolveDeployedPath("/proj", "gemini", "skills", "oracle");
+    expect(result).toBe("/proj/.gemini/skills/oracle");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveSourcePath
+// ---------------------------------------------------------------------------
+
+describe("resolveSourcePath", () => {
+  const ROOT = "/root/oh-my-toong";
+
+  it("글로벌 ref (skills): {rootDir}/skills/{name} 반환", () => {
+    const result = resolveSourcePath("oracle", "skills", ROOT);
+    expect(result).toBe(`${ROOT}/skills/oracle`);
+  });
+
+  it("글로벌 ref (commands): {rootDir}/commands/{name} 반환", () => {
+    const result = resolveSourcePath("commit", "commands", ROOT);
+    expect(result).toBe(`${ROOT}/commands/commit`);
+  });
+
+  it("스코프 ref: {rootDir}/projects/{project}/{category}/{name} 반환", () => {
+    const result = resolveSourcePath("my-project:testing", "skills", ROOT);
+    expect(result).toBe(`${ROOT}/projects/my-project/skills/testing`);
+  });
+
+  it("projectDirName 제공 시 언스코프 ref는 글로벌 경로로 fallback", () => {
+    const result = resolveSourcePath("oracle", "skills", ROOT, "my-project");
+    expect(result).toBe(`${ROOT}/skills/oracle`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reversePlatformPaths
+// ---------------------------------------------------------------------------
+
+describe("reversePlatformPaths", () => {
+  it("gemini: .gemini/ → .claude/ 치환", () => {
+    const content = "See .gemini/skills/oracle/ for details";
+    const result = reversePlatformPaths(content, "gemini");
+    expect(result).toBe("See .claude/skills/oracle/ for details");
+  });
+
+  it("codex: .codex/ → .claude/ 치환", () => {
+    const content = "See .codex/skills/oracle/ for details";
+    const result = reversePlatformPaths(content, "codex");
+    expect(result).toBe("See .claude/skills/oracle/ for details");
+  });
+
+  it("claude: 내용 그대로 반환", () => {
+    const content = "See .claude/skills/oracle/ for details";
+    const result = reversePlatformPaths(content, "claude");
+    expect(result).toBe(content);
+  });
+
+  it("여러 번 등장하는 경우 모두 치환", () => {
+    const content = ".gemini/agents/oracle.md and .gemini/skills/prometheus/";
+    const result = reversePlatformPaths(content, "gemini");
+    expect(result).toBe(".claude/agents/oracle.md and .claude/skills/prometheus/");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripInjectedFrontmatter
+// ---------------------------------------------------------------------------
+
+describe("stripInjectedFrontmatter", () => {
+  const makeDeployedWithSkills = (skills: string[]) => `---
+name: oracle
+model: sonnet
+skills:
+${skills.map((s) => `  - ${s}`).join("\n")}
+---
+
+# Oracle body`;
+
+  const makeSource = (extra: string = "") => `---
+name: oracle
+model: sonnet
+${extra}---
+
+# Oracle body`;
+
+  it("add-skills 있고 소스에 skills 없음: deployed에서 skills 키 제거", () => {
+    const deployed = makeDeployedWithSkills(["testing"]);
+    const source = makeSource();
+    const syncItem = { component: "oracle", "add-skills": ["testing"] };
+
+    const result = stripInjectedFrontmatter(deployed, source, syncItem);
+
+    const { frontmatter } = parseFrontmatter(result);
+    expect("skills" in frontmatter).toBe(false);
+  });
+
+  it("add-skills 있고 소스에 skills 있음: 소스의 skills 값으로 복원", () => {
+    const deployed = makeDeployedWithSkills(["testing", "pre-existing"]);
+    const source = makeSource("skills:\n  - pre-existing\n");
+    const syncItem = { component: "oracle", "add-skills": ["testing"] };
+
+    const result = stripInjectedFrontmatter(deployed, source, syncItem);
+
+    const { frontmatter: fm } = parseFrontmatter(result);
+    expect(fm["skills"]).toEqual(["pre-existing"]);
+  });
+
+  it("add-hooks 있고 소스에 hooks 없음: deployed에서 hooks 키 제거", () => {
+    const deployed = `---
+name: oracle
+model: sonnet
+hooks:
+  SubagentStop:
+    - matcher: "*"
+      hooks:
+        - type: command
+          command: echo done
+          timeout: 60
+---
+
+# Oracle body`;
+    const source = makeSource();
+    const syncItem = {
+      component: "oracle",
+      "add-hooks": [{ component: "stop-hook", event: "SubagentStop" }],
+    };
+
+    const result = stripInjectedFrontmatter(deployed, source, syncItem);
+
+    const { frontmatter: fm } = parseFrontmatter(result);
+    expect("hooks" in fm).toBe(false);
+  });
+
+  it("string 아이템: 내용 그대로 반환", () => {
+    const deployed = makeDeployedWithSkills(["testing"]);
+    const source = makeSource();
+    const syncItem = "oracle";
+
+    const result = stripInjectedFrontmatter(deployed, source, syncItem);
+
+    expect(result).toBe(deployed);
+  });
+
+  it("add-skills/add-hooks 없는 오브젝트 아이템: 내용 그대로 반환", () => {
+    const deployed = makeDeployedWithSkills(["testing"]);
+    const source = makeSource();
+    const syncItem = { component: "oracle", platforms: ["claude"] as const };
+
+    const result = stripInjectedFrontmatter(deployed, source, syncItem);
+
+    expect(result).toBe(deployed);
+  });
+
+  it("deployed body가 결과에 보존됨", () => {
+    const deployedBody = "\n# Oracle body with DEPLOYED changes";
+    const deployed = `---
+name: oracle
+model: sonnet
+skills:
+  - testing
+---
+${deployedBody}`;
+    const source = makeSource();
+    const syncItem = { component: "oracle", "add-skills": ["testing"] };
+
+    const result = stripInjectedFrontmatter(deployed, source, syncItem);
+
+    expect(result).toContain("DEPLOYED changes");
+  });
+});

--- a/tools/lib/pull-utils.ts
+++ b/tools/lib/pull-utils.ts
@@ -7,7 +7,7 @@ import type { Category, Platform, SyncItem } from "./types.ts";
 // resolveDeployedPath
 // ---------------------------------------------------------------------------
 
-const FILE_BASED_CATEGORIES: Set<Category> = new Set(["agents", "commands", "rules"]);
+export const FILE_BASED_CATEGORIES: Set<Category> = new Set(["agents", "commands", "rules"]);
 
 /**
  * Constructs the deployed file/directory path in the target project.

--- a/tools/lib/pull-utils.ts
+++ b/tools/lib/pull-utils.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import { existsSync } from "fs";
 
 import { parseFrontmatter, serializeFrontmatter } from "./frontmatter.ts";
 import type { Category, Platform, SyncItem } from "./types.ts";
@@ -32,15 +33,17 @@ export function resolveDeployedPath(
 // ---------------------------------------------------------------------------
 
 /**
- * Computes the oh-my-toong source path where pulled content should be written.
+ * Resolves the oh-my-toong source path where pulled content should be written.
  *
- * Pure path computation — does NOT check filesystem existence.
+ * Checks filesystem to match resolveComponentPath's fallback chain
+ * (.md → index.md → SKILL.md → directory). Falls back to default path
+ * computation when no existing file is found (new component case).
+ *
+ * Returns the fully-resolved path including file extension for file-based
+ * categories (agents, commands, rules).
  *
  * Scoped refs:  "project:name" → {rootDir}/projects/{project}/{category}/{name}
  * Global refs:  "name"         → {rootDir}/{category}/{name}
- *
- * When projectDirName is provided, unscoped refs still resolve to global paths
- * (mirrors the global fallback in resolveComponentPath).
  */
 export function resolveSourcePath(
   componentRef: string,
@@ -48,14 +51,56 @@ export function resolveSourcePath(
   rootDir: string,
   projectDirName?: string,
 ): string {
+  let project = "";
+  let name = componentRef;
+
   if (componentRef.includes(":")) {
     const colonIndex = componentRef.indexOf(":");
-    const project = componentRef.slice(0, colonIndex);
-    const name = componentRef.slice(colonIndex + 1);
-    return path.join(rootDir, "projects", project, category, name);
+    project = componentRef.slice(0, colonIndex);
+    name = componentRef.slice(colonIndex + 1);
   }
 
-  return path.join(rootDir, category, componentRef);
+  // Cross-project validation (mirrors resolveComponentPath in resolver.ts)
+  if (project && projectDirName !== undefined && project !== projectDirName) {
+    throw new Error(
+      `Cross-project reference not allowed: ${componentRef} (current project: ${projectDirName})`,
+    );
+  }
+
+  const baseDir = project
+    ? path.join(rootDir, "projects", project, category)
+    : path.join(rootDir, category);
+
+  // Check filesystem for existing components (mirrors tryResolveInDir in resolver.ts)
+  const resolved = tryResolveExisting(baseDir, name, category);
+  if (resolved !== null) return resolved;
+
+  // Default path for new components
+  if (FILE_BASED_CATEGORIES.has(category)) {
+    return path.join(baseDir, `${name}.md`);
+  }
+  return path.join(baseDir, name);
+}
+
+/**
+ * Mirrors tryResolveInDir from resolver.ts — checks existing filesystem locations.
+ */
+function tryResolveExisting(dir: string, name: string, category: string): string | null {
+  const filePath = path.join(dir, `${name}.md`);
+  if (existsSync(filePath)) return filePath;
+
+  const indexPath = path.join(dir, name, "index.md");
+  if (existsSync(indexPath)) return indexPath;
+
+  if (category === "skills") {
+    const skillPath = path.join(dir, name, "SKILL.md");
+    if (existsSync(skillPath)) return path.join(dir, name);
+  }
+
+  const dirPath = path.join(dir, name);
+  if (existsSync(dirPath)) return dirPath;
+
+  return null;
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/lib/pull-utils.ts
+++ b/tools/lib/pull-utils.ts
@@ -3,6 +3,7 @@ import { existsSync } from "fs";
 
 import { parseFrontmatter, serializeFrontmatter } from "./frontmatter.ts";
 import type { Category, Platform, SyncItem } from "./types.ts";
+import { tryResolveInDir } from "./resolver.ts";
 
 // ---------------------------------------------------------------------------
 // resolveDeployedPath
@@ -73,7 +74,7 @@ export function resolveSourcePath(
   // Scoped ref (same project) or no projectDirName: resolve directly
   if (project) {
     const baseDir = path.join(rootDir, "projects", project, category);
-    const resolved = tryResolveExisting(baseDir, name, category);
+    const resolved = tryResolveInDir(baseDir, name, category);
     if (resolved !== null) return resolved;
     if (FILE_BASED_CATEGORIES.has(category)) return path.join(baseDir, `${name}.md`);
     return path.join(baseDir, name);
@@ -83,13 +84,13 @@ export function resolveSourcePath(
   // (mirrors resolver.ts:151-165)
   if (projectDirName !== undefined) {
     const projectBase = path.join(rootDir, "projects", projectDirName, category);
-    const projectResolved = tryResolveExisting(projectBase, name, category);
+    const projectResolved = tryResolveInDir(projectBase, name, category);
     if (projectResolved !== null) return projectResolved;
   }
 
   // Global resolution
   const baseDir = path.join(rootDir, category);
-  const resolved = tryResolveExisting(baseDir, name, category);
+  const resolved = tryResolveInDir(baseDir, name, category);
   if (resolved !== null) return resolved;
 
   // Default path for new components
@@ -97,27 +98,6 @@ export function resolveSourcePath(
     return path.join(baseDir, `${name}.md`);
   }
   return path.join(baseDir, name);
-}
-
-/**
- * Mirrors tryResolveInDir from resolver.ts — checks existing filesystem locations.
- */
-function tryResolveExisting(dir: string, name: string, category: string): string | null {
-  const filePath = path.join(dir, `${name}.md`);
-  if (existsSync(filePath)) return filePath;
-
-  const indexPath = path.join(dir, name, "index.md");
-  if (existsSync(indexPath)) return indexPath;
-
-  if (category === "skills") {
-    const skillPath = path.join(dir, name, "SKILL.md");
-    if (existsSync(skillPath)) return path.join(dir, name);
-  }
-
-  const dirPath = path.join(dir, name);
-  if (existsSync(dirPath)) return dirPath;
-
-  return null;
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/lib/pull-utils.ts
+++ b/tools/lib/pull-utils.ts
@@ -32,6 +32,8 @@ export function resolveDeployedPath(
 // resolveSourcePath
 // ---------------------------------------------------------------------------
 
+export type SourcePathError = { error: string };
+
 /**
  * Resolves the oh-my-toong source path where pulled content should be written.
  *
@@ -43,6 +45,7 @@ export function resolveDeployedPath(
  * categories (agents, commands, rules).
  *
  * Scoped refs:  "project:name" → {rootDir}/projects/{project}/{category}/{name}
+ * Unscoped refs with projectDirName: tries project-local first, then global fallback.
  * Global refs:  "name"         → {rootDir}/{category}/{name}
  */
 export function resolveSourcePath(
@@ -50,7 +53,7 @@ export function resolveSourcePath(
   category: Category,
   rootDir: string,
   projectDirName?: string,
-): string {
+): string | SourcePathError {
   let project = "";
   let name = componentRef;
 
@@ -62,16 +65,30 @@ export function resolveSourcePath(
 
   // Cross-project validation (mirrors resolveComponentPath in resolver.ts)
   if (project && projectDirName !== undefined && project !== projectDirName) {
-    throw new Error(
-      `Cross-project reference not allowed: ${componentRef} (current project: ${projectDirName})`,
-    );
+    return {
+      error: `Cross-project reference not allowed: ${componentRef} (current project: ${projectDirName})`,
+    };
   }
 
-  const baseDir = project
-    ? path.join(rootDir, "projects", project, category)
-    : path.join(rootDir, category);
+  // Scoped ref (same project) or no projectDirName: resolve directly
+  if (project) {
+    const baseDir = path.join(rootDir, "projects", project, category);
+    const resolved = tryResolveExisting(baseDir, name, category);
+    if (resolved !== null) return resolved;
+    if (FILE_BASED_CATEGORIES.has(category)) return path.join(baseDir, `${name}.md`);
+    return path.join(baseDir, name);
+  }
 
-  // Check filesystem for existing components (mirrors tryResolveInDir in resolver.ts)
+  // Unscoped ref with projectDirName: project-local first, then global fallback
+  // (mirrors resolver.ts:151-165)
+  if (projectDirName !== undefined) {
+    const projectBase = path.join(rootDir, "projects", projectDirName, category);
+    const projectResolved = tryResolveExisting(projectBase, name, category);
+    if (projectResolved !== null) return projectResolved;
+  }
+
+  // Global resolution
+  const baseDir = path.join(rootDir, category);
   const resolved = tryResolveExisting(baseDir, name, category);
   if (resolved !== null) return resolved;
 

--- a/tools/lib/pull-utils.ts
+++ b/tools/lib/pull-utils.ts
@@ -1,0 +1,125 @@
+import path from "path";
+
+import { parseFrontmatter, serializeFrontmatter } from "./frontmatter.ts";
+import type { Category, Platform, SyncItem } from "./types.ts";
+
+// ---------------------------------------------------------------------------
+// resolveDeployedPath
+// ---------------------------------------------------------------------------
+
+const FILE_BASED_CATEGORIES: Set<Category> = new Set(["agents", "commands", "rules"]);
+
+/**
+ * Constructs the deployed file/directory path in the target project.
+ *
+ * Pattern: {targetPath}/.{platform}/{category}/{name}[.md]
+ *
+ * File-based categories (agents, commands, rules): append .md suffix.
+ * Directory-based categories (skills, scripts): no suffix.
+ */
+export function resolveDeployedPath(
+  targetPath: string,
+  platform: Platform,
+  category: Category,
+  componentName: string,
+): string {
+  const suffix = FILE_BASED_CATEGORIES.has(category) ? ".md" : "";
+  return path.join(targetPath, `.${platform}`, category, `${componentName}${suffix}`);
+}
+
+// ---------------------------------------------------------------------------
+// resolveSourcePath
+// ---------------------------------------------------------------------------
+
+/**
+ * Computes the oh-my-toong source path where pulled content should be written.
+ *
+ * Pure path computation — does NOT check filesystem existence.
+ *
+ * Scoped refs:  "project:name" → {rootDir}/projects/{project}/{category}/{name}
+ * Global refs:  "name"         → {rootDir}/{category}/{name}
+ *
+ * When projectDirName is provided, unscoped refs still resolve to global paths
+ * (mirrors the global fallback in resolveComponentPath).
+ */
+export function resolveSourcePath(
+  componentRef: string,
+  category: Category,
+  rootDir: string,
+  projectDirName?: string,
+): string {
+  if (componentRef.includes(":")) {
+    const colonIndex = componentRef.indexOf(":");
+    const project = componentRef.slice(0, colonIndex);
+    const name = componentRef.slice(colonIndex + 1);
+    return path.join(rootDir, "projects", project, category, name);
+  }
+
+  return path.join(rootDir, category, componentRef);
+}
+
+// ---------------------------------------------------------------------------
+// reversePlatformPaths
+// ---------------------------------------------------------------------------
+
+/**
+ * Replaces .{platform}/ with .claude/ in file content.
+ *
+ * Inverse of rewritePlatformPaths() in sync.ts.
+ * If platform is "claude", content is returned unchanged.
+ */
+export function reversePlatformPaths(content: string, platform: Platform): string {
+  if (platform === "claude") return content;
+  return content.replace(new RegExp(`\\.${platform}\\/`, "g"), ".claude/");
+}
+
+// ---------------------------------------------------------------------------
+// stripInjectedFrontmatter
+// ---------------------------------------------------------------------------
+
+/**
+ * Removes frontmatter fields injected by push (add-skills / add-hooks) so that
+ * pulled content matches the oh-my-toong source.
+ *
+ * Algorithm:
+ *   1. If syncItem is a string or has no add-skills/add-hooks, return deployedContent as-is.
+ *   2. Parse deployed and source frontmatters.
+ *   3. For add-skills: restore source's skills value (or delete the key if source had none).
+ *   4. For add-hooks:  restore source's hooks  value (or delete the key if source had none).
+ *   5. Return serializeFrontmatter(modified, deployedBody).
+ */
+export function stripInjectedFrontmatter(
+  deployedContent: string,
+  sourceContent: string,
+  syncItem: SyncItem,
+): string {
+  if (typeof syncItem === "string") return deployedContent;
+
+  const hasAddSkills = "add-skills" in syncItem && syncItem["add-skills"] !== undefined;
+  const hasAddHooks = "add-hooks" in syncItem && syncItem["add-hooks"] !== undefined;
+
+  if (!hasAddSkills && !hasAddHooks) return deployedContent;
+
+  const { frontmatter: deployedFm, body: deployedBody } = parseFrontmatter(deployedContent);
+  const { frontmatter: sourceFm } = parseFrontmatter(sourceContent);
+
+  const fm = { ...deployedFm };
+
+  if (hasAddSkills) {
+    if ("skills" in sourceFm) {
+      fm["skills"] = sourceFm["skills"];
+    } else {
+      delete fm["skills"];
+    }
+  }
+
+  if (hasAddHooks) {
+    if ("hooks" in sourceFm) {
+      fm["hooks"] = sourceFm["hooks"];
+    } else {
+      delete fm["hooks"];
+    }
+  }
+
+  return serializeFrontmatter(fm, deployedBody);
+}

--- a/tools/lib/resolver.ts
+++ b/tools/lib/resolver.ts
@@ -178,7 +178,7 @@ export function resolveComponentPath(
  *   2. {dir}/{name}/index.md
  *   3. {dir}/{name}/SKILL.md  (skills only)
  */
-function tryResolveInDir(dir: string, name: string, category: string): string | null {
+export function tryResolveInDir(dir: string, name: string, category: string): string | null {
   // 1. Direct file
   const filePath = join(dir, `${name}.md`);
   if (existsSync(filePath)) return filePath;

--- a/tools/lib/sync-directory.ts
+++ b/tools/lib/sync-directory.ts
@@ -23,7 +23,7 @@ export function isExcluded(filename: string, patterns: string[]): boolean {
  * Recursively collects all file paths under a directory.
  * Returns paths relative to the root dir.
  */
-async function collectFiles(dir: string, rel = ""): Promise<string[]> {
+export async function collectFiles(dir: string, rel = ""): Promise<string[]> {
   const results: string[] = [];
   const entries = await fs.readdir(dir, { withFileTypes: true });
   for (const entry of entries) {
@@ -42,7 +42,7 @@ async function collectFiles(dir: string, rel = ""): Promise<string[]> {
  * Recursively collects all directory paths under a directory.
  * Returns paths relative to the root dir, deepest first.
  */
-async function collectDirs(dir: string, rel = ""): Promise<string[]> {
+export async function collectDirs(dir: string, rel = ""): Promise<string[]> {
   const results: string[] = [];
   let entries: import("fs").Dirent[];
   try {

--- a/tools/lib/sync-directory.ts
+++ b/tools/lib/sync-directory.ts
@@ -1,11 +1,13 @@
 import fs from "fs/promises";
 import path from "path";
 
+export const DEFAULT_EXCLUDE = ["*.test.ts"];
+
 /**
  * Checks if a filename matches any of the given glob-style exclude patterns.
  * Only supports simple "*.ext" wildcard prefix patterns.
  */
-function isExcluded(filename: string, patterns: string[]): boolean {
+export function isExcluded(filename: string, patterns: string[]): boolean {
   for (const pattern of patterns) {
     if (pattern.startsWith("*.")) {
       const suffix = pattern.slice(1); // e.g. ".test.ts"
@@ -94,7 +96,7 @@ export async function syncDirectory(
   target: string,
   options?: { exclude?: string[] }
 ): Promise<void> {
-  const exclude = options?.exclude ?? ["*.test.ts"];
+  const exclude = options?.exclude ?? DEFAULT_EXCLUDE;
 
   // 1. Ensure target directory exists
   await fs.mkdir(target, { recursive: true });

--- a/tools/pull.test.ts
+++ b/tools/pull.test.ts
@@ -51,36 +51,78 @@ function makeSyncYaml(targetPath: string, sections: Partial<SyncYaml>): string {
 // ---------------------------------------------------------------------------
 
 describe("parseCliArgs", () => {
-  it("첫 번째 위치 인수를 projectName으로 파싱", () => {
+  it("parses first positional arg as `projectName`", () => {
     const result = parseCliArgs(["my-project"]);
     expect(result.projectName).toBe("my-project");
     expect(result.platform).toBe("claude");
     expect(result.dryRun).toBe(false);
   });
 
-  it("--dry-run 플래그 파싱", () => {
+  it("parses `--dry-run` flag", () => {
     const result = parseCliArgs(["my-project", "--dry-run"]);
     expect(result.dryRun).toBe(true);
   });
 
-  it("--platform 플래그 파싱", () => {
+  it("parses `--platform` flag", () => {
     const result = parseCliArgs(["my-project", "--platform", "gemini"]);
     expect(result.platform).toBe("gemini");
   });
 
-  it("--category 플래그 파싱", () => {
+  it("parses `--category` flag", () => {
     const result = parseCliArgs(["my-project", "--category", "skills"]);
     expect(result.categoryFilter).toBe("skills");
   });
 
-  it("--component 플래그 파싱", () => {
+  it("parses `--component` flag", () => {
     const result = parseCliArgs(["my-project", "--category", "skills", "--component", "oracle"]);
     expect(result.componentFilter).toBe("oracle");
   });
 
-  it("projectName 없으면 빈 문자열 반환", () => {
+  it("returns empty `projectName` when no positional arg", () => {
     const result = parseCliArgs(["--dry-run"]);
     expect(result.projectName).toBe("");
+  });
+
+  it("exits with code 1 for invalid `--platform` value", async () => {
+    let exitCode: number | undefined;
+    const originalExit = process.exit.bind(process);
+    (process as unknown as { exit: (code?: number) => never }).exit = (code?: number) => {
+      exitCode = code;
+      throw new Error("process.exit called");
+    };
+
+    try {
+      await captureStderr(async () => {
+        parseCliArgs(["my-project", "--platform", "gemni"]);
+      });
+    } catch {
+      // Expected
+    } finally {
+      (process as unknown as { exit: (code?: number) => never }).exit = originalExit;
+    }
+
+    expect(exitCode).toBe(1);
+  });
+
+  it("exits with code 1 for invalid `--category` value", async () => {
+    let exitCode: number | undefined;
+    const originalExit = process.exit.bind(process);
+    (process as unknown as { exit: (code?: number) => never }).exit = (code?: number) => {
+      exitCode = code;
+      throw new Error("process.exit called");
+    };
+
+    try {
+      await captureStderr(async () => {
+        parseCliArgs(["my-project", "--category", "skill"]);
+      });
+    } catch {
+      // Expected
+    } finally {
+      (process as unknown as { exit: (code?: number) => never }).exit = originalExit;
+    }
+
+    expect(exitCode).toBe(1);
   });
 });
 
@@ -125,7 +167,7 @@ describe("pullProject", () => {
   // 1. 전체 풀 테스트
   // -------------------------------------------------------------------------
 
-  it("스킬과 에이전트를 대상에서 소스로 전체 풀", async () => {
+  it("pulls skills and agents from target to source", async () => {
     const syncYamlContent = makeSyncYaml(targetPath, {
       skills: { items: ["test-skill"] },
       agents: { items: ["test-agent"] },
@@ -160,7 +202,7 @@ describe("pullProject", () => {
   // 2. Dry-run 테스트
   // -------------------------------------------------------------------------
 
-  it("dry-run 모드에서 파일 변경 없음, 출력에 컴포넌트 포함", async () => {
+  it("does not modify files in `--dry-run` mode", async () => {
     const syncYamlContent = makeSyncYaml(targetPath, {
       skills: { items: ["dry-skill"] },
     });
@@ -190,7 +232,7 @@ describe("pullProject", () => {
   // 3. 존재하지 않는 프로젝트 이름
   // -------------------------------------------------------------------------
 
-  it("존재하지 않는 프로젝트 이름이면 종료 코드 1로 실패", async () => {
+  it("exits with code 1 for nonexistent project", async () => {
     let exitCode: number | undefined;
     const originalExit = process.exit.bind(process);
     (process as unknown as { exit: (code?: number) => never }).exit = (code?: number) => {
@@ -215,7 +257,7 @@ describe("pullProject", () => {
   // 4. 카테고리 필터 테스트
   // -------------------------------------------------------------------------
 
-  it("--category skills 필터: 스킬만 풀, 에이전트는 미변경", async () => {
+  it("pulls only skills when `--category skills` filter is applied", async () => {
     const syncYamlContent = makeSyncYaml(targetPath, {
       skills: { items: ["filter-skill"] },
       agents: { items: ["filter-agent"] },
@@ -254,7 +296,7 @@ describe("pullProject", () => {
   // 5. 컴포넌트 필터 테스트
   // -------------------------------------------------------------------------
 
-  it("--category skills --component target-skill: 해당 스킬만 풀", async () => {
+  it("pulls only `target-skill` with `--category skills --component target-skill`", async () => {
     const syncYamlContent = makeSyncYaml(targetPath, {
       skills: { items: ["target-skill", "other-skill"] },
     });
@@ -286,7 +328,7 @@ describe("pullProject", () => {
   // 6. --component without --category 에러
   // -------------------------------------------------------------------------
 
-  it("--component 지정 시 --category 없으면 오류 및 종료 코드 1", async () => {
+  it("detects `--component` without `--category` via `parseCliArgs` output", async () => {
     // This is validated in import.meta.main, but we test the CLI arg combination
     // by simulating the check. The main guard in pull.ts handles this before pullProject.
     // We verify the parseCliArgs output allows the caller to detect the issue.
@@ -323,7 +365,7 @@ describe("pullProject", () => {
   // 7. 배포된 컴포넌트 누락 경고
   // -------------------------------------------------------------------------
 
-  it("동기화 목록에 있지만 배포 경로에 없는 컴포넌트 경고 후 계속 진행", async () => {
+  it("warns on missing deployed component and continues pulling others", async () => {
     const syncYamlContent = makeSyncYaml(targetPath, {
       skills: { items: ["missing-skill", "present-skill"] },
     });
@@ -360,7 +402,7 @@ describe("pullProject", () => {
   // 8. 플랫폼 카테고리 지원 여부
   // -------------------------------------------------------------------------
 
-  it("--platform gemini --category agents: gemini는 agents 미지원이므로 스킵", async () => {
+  it("skips agents for `--platform gemini` (unsupported category)", async () => {
     const syncYamlContent = makeSyncYaml(targetPath, {
       agents: { items: ["gemini-agent"] },
       skills: { items: ["gemini-skill"] },
@@ -393,7 +435,7 @@ describe("pullProject", () => {
   // 9. Gemini commands TOML 형식 미지원 경고
   // -------------------------------------------------------------------------
 
-  it("--platform gemini --category commands: TOML 미지원 경고 출력, 소스 파일 미변경", async () => {
+  it("warns on gemini commands TOML incompatibility and skips pull", async () => {
     const syncYamlContent = makeSyncYaml(targetPath, {
       commands: { items: ["test-cmd"] },
     });
@@ -422,7 +464,7 @@ describe("pullProject", () => {
   // 10. 플랫폼 경로 역변환
   // -------------------------------------------------------------------------
 
-  it("gemini 플랫폼 풀 시 .gemini/ 경로를 .claude/로 역변환", async () => {
+  it("reverses `.gemini/` paths to `.claude/` when pulling gemini platform", async () => {
     const syncYamlContent = makeSyncYaml(targetPath, {
       skills: { items: ["path-skill"] },
     });
@@ -445,10 +487,10 @@ describe("pullProject", () => {
   });
 
   // -------------------------------------------------------------------------
-  // 10. 에이전트 인젝션된 프론트매터 제거
+  // 11. 에이전트 인젝션된 프론트매터 제거
   // -------------------------------------------------------------------------
 
-  it("add-skills로 인젝션된 프론트매터 skills 필드 제거", async () => {
+  it("strips injected `skills` frontmatter field from agent via `add-skills`", async () => {
     const syncYamlContent = makeSyncYaml(targetPath, {
       agents: {
         items: [
@@ -483,10 +525,10 @@ describe("pullProject", () => {
   });
 
   // -------------------------------------------------------------------------
-  // 11. 스크립트 파일 및 디렉터리 풀
+  // 12. 스크립트 파일 및 디렉터리 풀
   // -------------------------------------------------------------------------
 
-  it("스크립트 단일 파일 풀 (파일 타입)", async () => {
+  it("pulls single-file script directory", async () => {
     const syncYamlContent = makeSyncYaml(targetPath, {
       scripts: { items: ["my-script"] },
     });
@@ -507,7 +549,7 @@ describe("pullProject", () => {
     expect(pulledContent).toBe("// updated\n");
   });
 
-  it("스크립트 서브디렉터리 포함 재귀 풀", async () => {
+  it("pulls script directory recursively including subdirectories", async () => {
     const syncYamlContent = makeSyncYaml(targetPath, {
       scripts: { items: ["complex-script"] },
     });
@@ -542,7 +584,7 @@ describe("pullProject", () => {
   // 추가: 스코프 컴포넌트 (project:name 형식) 소스 경로 해석
   // -------------------------------------------------------------------------
 
-  it("scoped 컴포넌트 (project:name) 소스 경로를 projects/ 아래로 해석", async () => {
+  it("resolves scoped component `project:name` to `projects/` source path", async () => {
     const syncYamlContent = makeSyncYaml(targetPath, {
       skills: { items: [{ component: "test-proj:scoped-skill" }] },
     });
@@ -570,7 +612,7 @@ describe("pullProject", () => {
   // 추가: 새 소스 파일 생성 (소스에 없는 경우)
   // -------------------------------------------------------------------------
 
-  it("소스에 없는 컴포넌트도 배포 경로에서 복사해 소스 생성", async () => {
+  it("creates new source file when component exists only in deployed target", async () => {
     const syncYamlContent = makeSyncYaml(targetPath, {
       commands: { items: ["new-cmd"] },
     });

--- a/tools/pull.test.ts
+++ b/tools/pull.test.ts
@@ -549,6 +549,26 @@ describe("pullProject", () => {
     expect(pulledContent).toBe("// updated\n");
   });
 
+  it("pulls single-file script (non-directory) without ENOTDIR crash", async () => {
+    const syncYamlContent = makeSyncYaml(targetPath, {
+      scripts: { items: ["deploy.sh"] },
+    });
+    await setupProject("test-proj", syncYamlContent);
+
+    await writeFile(path.join(rootDir, "scripts", "deploy.sh"), "#!/bin/bash\n# original\n");
+
+    // Deployed as a single file (not a directory)
+    await writeFile(
+      path.join(targetPath, ".claude", "scripts", "deploy.sh"),
+      "#!/bin/bash\n# updated\n",
+    );
+
+    await pullProject(makeOptions());
+
+    const pulledContent = await readFile(path.join(rootDir, "scripts", "deploy.sh"));
+    expect(pulledContent).toBe("#!/bin/bash\n# updated\n");
+  });
+
   it("preserves source-only `*.test.ts` files during directory pull", async () => {
     const syncYamlContent = makeSyncYaml(targetPath, {
       skills: { items: ["test-skill"] },

--- a/tools/pull.test.ts
+++ b/tools/pull.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import fs from "fs/promises";
 import path from "path";
 import os from "os";
-import { existsSync } from "fs";
 import { stringify as stringifyYaml } from "yaml";
 
 import { pullProject, parseCliArgs, type PullOptions } from "./pull.ts";
@@ -19,15 +18,6 @@ async function writeFile(filePath: string, content: string): Promise<void> {
 
 async function readFile(filePath: string): Promise<string> {
   return fs.readFile(filePath, "utf8");
-}
-
-async function exists(p: string): Promise<boolean> {
-  try {
-    await fs.stat(p);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 /**
@@ -400,7 +390,36 @@ describe("pullProject", () => {
   });
 
   // -------------------------------------------------------------------------
-  // 9. 플랫폼 경로 역변환
+  // 9. Gemini commands TOML 형식 미지원 경고
+  // -------------------------------------------------------------------------
+
+  it("--platform gemini --category commands: TOML 미지원 경고 출력, 소스 파일 미변경", async () => {
+    const syncYamlContent = makeSyncYaml(targetPath, {
+      commands: { items: ["test-cmd"] },
+    });
+    await setupProject("test-proj", syncYamlContent);
+
+    // Source command file (pre-existing in oh-my-toong source)
+    await writeFile(path.join(rootDir, "commands", "test-cmd.md"), "# Original Command\n");
+
+    // No deployed file in .gemini/commands/ — guard skips before existsSync check
+
+    let output = "";
+    output = await captureStderr(async () => {
+      await pullProject(makeOptions({ platform: "gemini", categoryFilter: "commands" }));
+    });
+
+    // Should warn about TOML format incompatibility
+    expect(output).toContain("[WARN]");
+    expect(output).toContain("toml");
+
+    // Source file should NOT be modified
+    const sourceContent = await readFile(path.join(rootDir, "commands", "test-cmd.md"));
+    expect(sourceContent).toBe("# Original Command\n");
+  });
+
+  // -------------------------------------------------------------------------
+  // 10. 플랫폼 경로 역변환
   // -------------------------------------------------------------------------
 
   it("gemini 플랫폼 풀 시 .gemini/ 경로를 .claude/로 역변환", async () => {

--- a/tools/pull.test.ts
+++ b/tools/pull.test.ts
@@ -549,6 +549,39 @@ describe("pullProject", () => {
     expect(pulledContent).toBe("// updated\n");
   });
 
+  it("preserves source-only `*.test.ts` files during directory pull", async () => {
+    const syncYamlContent = makeSyncYaml(targetPath, {
+      skills: { items: ["test-skill"] },
+    });
+    await setupProject("test-proj", syncYamlContent);
+
+    // Source has SKILL.md + a test file (not present in deployed)
+    await writeFile(path.join(rootDir, "skills", "test-skill", "SKILL.md"), "# Original Skill\n");
+    await writeFile(path.join(rootDir, "skills", "test-skill", "skill.test.ts"), "// original test\n");
+    // Source also has an orphan non-excluded file that should be removed
+    await writeFile(path.join(rootDir, "skills", "test-skill", "old-helper.ts"), "// orphan\n");
+
+    // Deployed has SKILL.md only (sync excluded *.test.ts before deploying)
+    await writeFile(
+      path.join(targetPath, ".claude", "skills", "test-skill", "SKILL.md"),
+      "# Updated Skill\n",
+    );
+
+    await pullProject(makeOptions());
+
+    // SKILL.md should be updated from deployed
+    const pulledSkill = await readFile(path.join(rootDir, "skills", "test-skill", "SKILL.md"));
+    expect(pulledSkill).toBe("# Updated Skill\n");
+
+    // *.test.ts should be preserved (excluded from orphan cleanup)
+    const testFileContent = await readFile(path.join(rootDir, "skills", "test-skill", "skill.test.ts"));
+    expect(testFileContent).toBe("// original test\n");
+
+    // old-helper.ts (non-excluded orphan) should be removed
+    const { existsSync } = await import("fs");
+    expect(existsSync(path.join(rootDir, "skills", "test-skill", "old-helper.ts"))).toBe(false);
+  });
+
   it("pulls script directory recursively including subdirectories", async () => {
     const syncYamlContent = makeSyncYaml(targetPath, {
       scripts: { items: ["complex-script"] },

--- a/tools/pull.test.ts
+++ b/tools/pull.test.ts
@@ -1,0 +1,571 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+import { existsSync } from "fs";
+import { stringify as stringifyYaml } from "yaml";
+
+import { pullProject, parseCliArgs, type PullOptions } from "./pull.ts";
+import type { SyncYaml } from "./lib/types.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function writeFile(filePath: string, content: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, "utf8");
+}
+
+async function readFile(filePath: string): Promise<string> {
+  return fs.readFile(filePath, "utf8");
+}
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await fs.stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Capture stderr output from process.stderr.write during a callback.
+ */
+async function captureStderr(fn: () => Promise<void>): Promise<string> {
+  const chunks: string[] = [];
+  const original = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (chunk: string | Uint8Array) => {
+    chunks.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+    return true;
+  };
+  try {
+    await fn();
+  } finally {
+    process.stderr.write = original;
+  }
+  return chunks.join("");
+}
+
+/**
+ * Build a minimal sync.yaml YAML string.
+ */
+function makeSyncYaml(targetPath: string, sections: Partial<SyncYaml>): string {
+  const yaml: Record<string, unknown> = { path: targetPath, ...sections };
+  return stringifyYaml(yaml);
+}
+
+// ---------------------------------------------------------------------------
+// Suite: parseCliArgs
+// ---------------------------------------------------------------------------
+
+describe("parseCliArgs", () => {
+  it("첫 번째 위치 인수를 projectName으로 파싱", () => {
+    const result = parseCliArgs(["my-project"]);
+    expect(result.projectName).toBe("my-project");
+    expect(result.platform).toBe("claude");
+    expect(result.dryRun).toBe(false);
+  });
+
+  it("--dry-run 플래그 파싱", () => {
+    const result = parseCliArgs(["my-project", "--dry-run"]);
+    expect(result.dryRun).toBe(true);
+  });
+
+  it("--platform 플래그 파싱", () => {
+    const result = parseCliArgs(["my-project", "--platform", "gemini"]);
+    expect(result.platform).toBe("gemini");
+  });
+
+  it("--category 플래그 파싱", () => {
+    const result = parseCliArgs(["my-project", "--category", "skills"]);
+    expect(result.categoryFilter).toBe("skills");
+  });
+
+  it("--component 플래그 파싱", () => {
+    const result = parseCliArgs(["my-project", "--category", "skills", "--component", "oracle"]);
+    expect(result.componentFilter).toBe("oracle");
+  });
+
+  it("projectName 없으면 빈 문자열 반환", () => {
+    const result = parseCliArgs(["--dry-run"]);
+    expect(result.projectName).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: pullProject - 통합 테스트
+// ---------------------------------------------------------------------------
+
+describe("pullProject", () => {
+  let tmpDir: string;
+  let rootDir: string;
+  let targetPath: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "pull-test-"));
+    rootDir = path.join(tmpDir, "root");
+    targetPath = path.join(tmpDir, "target");
+    await fs.mkdir(rootDir, { recursive: true });
+    await fs.mkdir(targetPath, { recursive: true });
+    // Minimal config.yaml so getRootDir-like logic works
+    await writeFile(path.join(rootDir, "config.yaml"), "use-platforms: [claude]\n");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeOptions(overrides: Partial<PullOptions> = {}): PullOptions {
+    return {
+      projectName: "test-proj",
+      platform: "claude",
+      dryRun: false,
+      rootDir,
+      ...overrides,
+    };
+  }
+
+  async function setupProject(projectName: string, yamlContent: string): Promise<void> {
+    await writeFile(path.join(rootDir, "projects", projectName, "sync.yaml"), yamlContent);
+  }
+
+  // -------------------------------------------------------------------------
+  // 1. 전체 풀 테스트
+  // -------------------------------------------------------------------------
+
+  it("스킬과 에이전트를 대상에서 소스로 전체 풀", async () => {
+    const syncYamlContent = makeSyncYaml(targetPath, {
+      skills: { items: ["test-skill"] },
+      agents: { items: ["test-agent"] },
+    });
+    await setupProject("test-proj", syncYamlContent);
+
+    // Source files (pre-existing in oh-my-toong source)
+    await writeFile(path.join(rootDir, "skills", "test-skill", "SKILL.md"), "# Original Skill\n");
+    await writeFile(path.join(rootDir, "agents", "test-agent.md"), "---\nname: test-agent\n---\n# Original Agent\n");
+
+    // Deployed files in target
+    await writeFile(
+      path.join(targetPath, ".claude", "skills", "test-skill", "SKILL.md"),
+      "# Updated Skill\n",
+    );
+    await writeFile(
+      path.join(targetPath, ".claude", "agents", "test-agent.md"),
+      "---\nname: test-agent\n---\n# Updated Agent\n",
+    );
+
+    await pullProject(makeOptions());
+
+    // Source files should be updated to match deployed versions
+    const pulledSkill = await readFile(path.join(rootDir, "skills", "test-skill", "SKILL.md"));
+    expect(pulledSkill).toBe("# Updated Skill\n");
+
+    const pulledAgent = await readFile(path.join(rootDir, "agents", "test-agent.md"));
+    expect(pulledAgent).toBe("---\nname: test-agent\n---\n# Updated Agent\n");
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Dry-run 테스트
+  // -------------------------------------------------------------------------
+
+  it("dry-run 모드에서 파일 변경 없음, 출력에 컴포넌트 포함", async () => {
+    const syncYamlContent = makeSyncYaml(targetPath, {
+      skills: { items: ["dry-skill"] },
+    });
+    await setupProject("test-proj", syncYamlContent);
+
+    await writeFile(path.join(rootDir, "skills", "dry-skill", "SKILL.md"), "# Original\n");
+    await writeFile(
+      path.join(targetPath, ".claude", "skills", "dry-skill", "SKILL.md"),
+      "# Deployed\n",
+    );
+
+    let output = "";
+    output = await captureStderr(async () => {
+      await pullProject(makeOptions({ dryRun: true }));
+    });
+
+    // Source file should NOT be changed
+    const sourceContent = await readFile(path.join(rootDir, "skills", "dry-skill", "SKILL.md"));
+    expect(sourceContent).toBe("# Original\n");
+
+    // Output should mention the component
+    expect(output).toContain("[DRY-RUN]");
+    expect(output).toContain("dry-skill");
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. 존재하지 않는 프로젝트 이름
+  // -------------------------------------------------------------------------
+
+  it("존재하지 않는 프로젝트 이름이면 종료 코드 1로 실패", async () => {
+    let exitCode: number | undefined;
+    const originalExit = process.exit.bind(process);
+    (process as unknown as { exit: (code?: number) => never }).exit = (code?: number) => {
+      exitCode = code;
+      throw new Error("process.exit called");
+    };
+
+    try {
+      await captureStderr(async () => {
+        await pullProject(makeOptions({ projectName: "nonexistent-project" }));
+      });
+    } catch {
+      // Expected
+    } finally {
+      (process as unknown as { exit: (code?: number) => never }).exit = originalExit;
+    }
+
+    expect(exitCode).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. 카테고리 필터 테스트
+  // -------------------------------------------------------------------------
+
+  it("--category skills 필터: 스킬만 풀, 에이전트는 미변경", async () => {
+    const syncYamlContent = makeSyncYaml(targetPath, {
+      skills: { items: ["filter-skill"] },
+      agents: { items: ["filter-agent"] },
+    });
+    await setupProject("test-proj", syncYamlContent);
+
+    // Original source files
+    await writeFile(path.join(rootDir, "skills", "filter-skill", "SKILL.md"), "# Original Skill\n");
+    await writeFile(
+      path.join(rootDir, "agents", "filter-agent.md"),
+      "---\nname: filter-agent\n---\n# Original Agent\n",
+    );
+
+    // Deployed files
+    await writeFile(
+      path.join(targetPath, ".claude", "skills", "filter-skill", "SKILL.md"),
+      "# Updated Skill\n",
+    );
+    await writeFile(
+      path.join(targetPath, ".claude", "agents", "filter-agent.md"),
+      "---\nname: filter-agent\n---\n# Updated Agent\n",
+    );
+
+    await pullProject(makeOptions({ categoryFilter: "skills" }));
+
+    // Skill should be updated
+    const pulledSkill = await readFile(path.join(rootDir, "skills", "filter-skill", "SKILL.md"));
+    expect(pulledSkill).toBe("# Updated Skill\n");
+
+    // Agent should NOT be updated
+    const agentContent = await readFile(path.join(rootDir, "agents", "filter-agent.md"));
+    expect(agentContent).toBe("---\nname: filter-agent\n---\n# Original Agent\n");
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. 컴포넌트 필터 테스트
+  // -------------------------------------------------------------------------
+
+  it("--category skills --component target-skill: 해당 스킬만 풀", async () => {
+    const syncYamlContent = makeSyncYaml(targetPath, {
+      skills: { items: ["target-skill", "other-skill"] },
+    });
+    await setupProject("test-proj", syncYamlContent);
+
+    await writeFile(path.join(rootDir, "skills", "target-skill", "SKILL.md"), "# Original Target\n");
+    await writeFile(path.join(rootDir, "skills", "other-skill", "SKILL.md"), "# Original Other\n");
+
+    await writeFile(
+      path.join(targetPath, ".claude", "skills", "target-skill", "SKILL.md"),
+      "# Updated Target\n",
+    );
+    await writeFile(
+      path.join(targetPath, ".claude", "skills", "other-skill", "SKILL.md"),
+      "# Updated Other\n",
+    );
+
+    await pullProject(makeOptions({ categoryFilter: "skills", componentFilter: "target-skill" }));
+
+    const targetContent = await readFile(path.join(rootDir, "skills", "target-skill", "SKILL.md"));
+    expect(targetContent).toBe("# Updated Target\n");
+
+    // other-skill should NOT be updated
+    const otherContent = await readFile(path.join(rootDir, "skills", "other-skill", "SKILL.md"));
+    expect(otherContent).toBe("# Original Other\n");
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. --component without --category 에러
+  // -------------------------------------------------------------------------
+
+  it("--component 지정 시 --category 없으면 오류 및 종료 코드 1", async () => {
+    // This is validated in import.meta.main, but we test the CLI arg combination
+    // by simulating the check. The main guard in pull.ts handles this before pullProject.
+    // We verify the parseCliArgs output allows the caller to detect the issue.
+    const result = parseCliArgs(["test-proj", "--component", "oracle"]);
+    expect(result.componentFilter).toBe("oracle");
+    expect(result.categoryFilter).toBeUndefined();
+    // The caller (import.meta.main) would exit(1) on this combination.
+    // We verify the error check works by testing it inline.
+    let exitCode: number | undefined;
+    const originalExit = process.exit.bind(process);
+    (process as unknown as { exit: (code?: number) => never }).exit = (code?: number) => {
+      exitCode = code;
+      throw new Error("process.exit called");
+    };
+
+    try {
+      await captureStderr(async () => {
+        // Simulate the import.meta.main guard
+        if (result.componentFilter && !result.categoryFilter) {
+          process.stderr.write("[ERROR] --component는 --category가 필요합니다\n");
+          process.exit(1);
+        }
+      });
+    } catch {
+      // Expected
+    } finally {
+      (process as unknown as { exit: (code?: number) => never }).exit = originalExit;
+    }
+
+    expect(exitCode).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. 배포된 컴포넌트 누락 경고
+  // -------------------------------------------------------------------------
+
+  it("동기화 목록에 있지만 배포 경로에 없는 컴포넌트 경고 후 계속 진행", async () => {
+    const syncYamlContent = makeSyncYaml(targetPath, {
+      skills: { items: ["missing-skill", "present-skill"] },
+    });
+    await setupProject("test-proj", syncYamlContent);
+
+    await writeFile(path.join(rootDir, "skills", "missing-skill", "SKILL.md"), "# Missing\n");
+    await writeFile(path.join(rootDir, "skills", "present-skill", "SKILL.md"), "# Original Present\n");
+
+    // Only present-skill exists in deployed target
+    await writeFile(
+      path.join(targetPath, ".claude", "skills", "present-skill", "SKILL.md"),
+      "# Updated Present\n",
+    );
+
+    let output = "";
+    output = await captureStderr(async () => {
+      await pullProject(makeOptions());
+    });
+
+    // Should warn about missing component
+    expect(output).toContain("[WARN]");
+    expect(output).toContain("missing-skill");
+
+    // Should still pull the present one
+    const presentContent = await readFile(path.join(rootDir, "skills", "present-skill", "SKILL.md"));
+    expect(presentContent).toBe("# Updated Present\n");
+
+    // missing-skill source should be unchanged
+    const missingContent = await readFile(path.join(rootDir, "skills", "missing-skill", "SKILL.md"));
+    expect(missingContent).toBe("# Missing\n");
+  });
+
+  // -------------------------------------------------------------------------
+  // 8. 플랫폼 카테고리 지원 여부
+  // -------------------------------------------------------------------------
+
+  it("--platform gemini --category agents: gemini는 agents 미지원이므로 스킵", async () => {
+    const syncYamlContent = makeSyncYaml(targetPath, {
+      agents: { items: ["gemini-agent"] },
+      skills: { items: ["gemini-skill"] },
+    });
+    await setupProject("test-proj", syncYamlContent);
+
+    await writeFile(path.join(rootDir, "agents", "gemini-agent.md"), "---\nname: gemini-agent\n---\n# Agent\n");
+    await writeFile(path.join(rootDir, "skills", "gemini-skill", "SKILL.md"), "# Original\n");
+
+    // Deployed gemini skills (no agents for gemini)
+    await writeFile(
+      path.join(targetPath, ".gemini", "skills", "gemini-skill", "SKILL.md"),
+      "# Updated Gemini\n",
+    );
+
+    let output = "";
+    output = await captureStderr(async () => {
+      await pullProject(makeOptions({ platform: "gemini", categoryFilter: "agents" }));
+    });
+
+    // Agent source should NOT be modified
+    const agentContent = await readFile(path.join(rootDir, "agents", "gemini-agent.md"));
+    expect(agentContent).toBe("---\nname: gemini-agent\n---\n# Agent\n");
+
+    // No pull output for agents (silently skipped)
+    expect(output).not.toContain("gemini-agent");
+  });
+
+  // -------------------------------------------------------------------------
+  // 9. 플랫폼 경로 역변환
+  // -------------------------------------------------------------------------
+
+  it("gemini 플랫폼 풀 시 .gemini/ 경로를 .claude/로 역변환", async () => {
+    const syncYamlContent = makeSyncYaml(targetPath, {
+      skills: { items: ["path-skill"] },
+    });
+    await setupProject("test-proj", syncYamlContent);
+
+    await writeFile(path.join(rootDir, "skills", "path-skill", "SKILL.md"), "# Original\n");
+
+    // Deployed file references .gemini/ paths
+    await writeFile(
+      path.join(targetPath, ".gemini", "skills", "path-skill", "SKILL.md"),
+      "See .gemini/agents/oracle.md for details.\n",
+    );
+
+    await pullProject(makeOptions({ platform: "gemini" }));
+
+    const pulledContent = await readFile(path.join(rootDir, "skills", "path-skill", "SKILL.md"));
+    // .gemini/ should be replaced with .claude/
+    expect(pulledContent).toContain(".claude/agents/oracle.md");
+    expect(pulledContent).not.toContain(".gemini/");
+  });
+
+  // -------------------------------------------------------------------------
+  // 10. 에이전트 인젝션된 프론트매터 제거
+  // -------------------------------------------------------------------------
+
+  it("add-skills로 인젝션된 프론트매터 skills 필드 제거", async () => {
+    const syncYamlContent = makeSyncYaml(targetPath, {
+      agents: {
+        items: [
+          {
+            component: "inject-agent",
+            "add-skills": ["testing"],
+          },
+        ],
+      },
+    });
+    await setupProject("test-proj", syncYamlContent);
+
+    // Source agent without skills in frontmatter
+    await writeFile(
+      path.join(rootDir, "agents", "inject-agent.md"),
+      "---\nname: inject-agent\ndescription: test\n---\n# Inject Agent\n",
+    );
+
+    // Deployed agent with skills injected
+    await writeFile(
+      path.join(targetPath, ".claude", "agents", "inject-agent.md"),
+      "---\nname: inject-agent\ndescription: test\nskills:\n  - testing\n---\n# Inject Agent\n",
+    );
+
+    await pullProject(makeOptions());
+
+    const pulledContent = await readFile(path.join(rootDir, "agents", "inject-agent.md"));
+    // skills field should be stripped because source had no skills
+    expect(pulledContent).not.toContain("skills:");
+    expect(pulledContent).toContain("name: inject-agent");
+    expect(pulledContent).toContain("# Inject Agent");
+  });
+
+  // -------------------------------------------------------------------------
+  // 11. 스크립트 파일 및 디렉터리 풀
+  // -------------------------------------------------------------------------
+
+  it("스크립트 단일 파일 풀 (파일 타입)", async () => {
+    const syncYamlContent = makeSyncYaml(targetPath, {
+      scripts: { items: ["my-script"] },
+    });
+    await setupProject("test-proj", syncYamlContent);
+
+    await fs.mkdir(path.join(rootDir, "scripts", "my-script"), { recursive: true });
+    await writeFile(path.join(rootDir, "scripts", "my-script", "index.ts"), "// original\n");
+
+    // Deployed as directory
+    await writeFile(
+      path.join(targetPath, ".claude", "scripts", "my-script", "index.ts"),
+      "// updated\n",
+    );
+
+    await pullProject(makeOptions());
+
+    const pulledContent = await readFile(path.join(rootDir, "scripts", "my-script", "index.ts"));
+    expect(pulledContent).toBe("// updated\n");
+  });
+
+  it("스크립트 서브디렉터리 포함 재귀 풀", async () => {
+    const syncYamlContent = makeSyncYaml(targetPath, {
+      scripts: { items: ["complex-script"] },
+    });
+    await setupProject("test-proj", syncYamlContent);
+
+    await fs.mkdir(path.join(rootDir, "scripts", "complex-script", "lib"), { recursive: true });
+    await writeFile(path.join(rootDir, "scripts", "complex-script", "index.ts"), "// original\n");
+    await writeFile(path.join(rootDir, "scripts", "complex-script", "lib", "helper.ts"), "// original helper\n");
+
+    // Deployed with updated content in both files
+    await writeFile(
+      path.join(targetPath, ".claude", "scripts", "complex-script", "index.ts"),
+      "// updated\n",
+    );
+    await writeFile(
+      path.join(targetPath, ".claude", "scripts", "complex-script", "lib", "helper.ts"),
+      "// updated helper\n",
+    );
+
+    await pullProject(makeOptions());
+
+    const indexContent = await readFile(path.join(rootDir, "scripts", "complex-script", "index.ts"));
+    expect(indexContent).toBe("// updated\n");
+
+    const helperContent = await readFile(
+      path.join(rootDir, "scripts", "complex-script", "lib", "helper.ts"),
+    );
+    expect(helperContent).toBe("// updated helper\n");
+  });
+
+  // -------------------------------------------------------------------------
+  // 추가: 스코프 컴포넌트 (project:name 형식) 소스 경로 해석
+  // -------------------------------------------------------------------------
+
+  it("scoped 컴포넌트 (project:name) 소스 경로를 projects/ 아래로 해석", async () => {
+    const syncYamlContent = makeSyncYaml(targetPath, {
+      skills: { items: [{ component: "test-proj:scoped-skill" }] },
+    });
+    await setupProject("test-proj", syncYamlContent);
+
+    await writeFile(
+      path.join(rootDir, "projects", "test-proj", "skills", "scoped-skill", "SKILL.md"),
+      "# Original Scoped\n",
+    );
+
+    await writeFile(
+      path.join(targetPath, ".claude", "skills", "scoped-skill", "SKILL.md"),
+      "# Updated Scoped\n",
+    );
+
+    await pullProject(makeOptions());
+
+    const pulledContent = await readFile(
+      path.join(rootDir, "projects", "test-proj", "skills", "scoped-skill", "SKILL.md"),
+    );
+    expect(pulledContent).toBe("# Updated Scoped\n");
+  });
+
+  // -------------------------------------------------------------------------
+  // 추가: 새 소스 파일 생성 (소스에 없는 경우)
+  // -------------------------------------------------------------------------
+
+  it("소스에 없는 컴포넌트도 배포 경로에서 복사해 소스 생성", async () => {
+    const syncYamlContent = makeSyncYaml(targetPath, {
+      commands: { items: ["new-cmd"] },
+    });
+    await setupProject("test-proj", syncYamlContent);
+
+    // Source does NOT exist yet
+    await writeFile(
+      path.join(targetPath, ".claude", "commands", "new-cmd.md"),
+      "# New Command\n",
+    );
+
+    await pullProject(makeOptions());
+
+    const pulledContent = await readFile(path.join(rootDir, "commands", "new-cmd.md"));
+    expect(pulledContent).toBe("# New Command\n");
+  });
+});

--- a/tools/pull.ts
+++ b/tools/pull.ts
@@ -24,6 +24,7 @@ import {
   reversePlatformPaths,
   stripInjectedFrontmatter,
 } from "./lib/pull-utils.ts";
+import { DEFAULT_EXCLUDE, isExcluded } from "./lib/sync-directory.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -161,6 +162,74 @@ async function copyDirectory(
         await fs.mkdir(path.dirname(sourceEntry), { recursive: true });
         await fs.copyFile(deployedEntry, sourceEntry);
       }
+    }
+  }
+}
+
+/**
+ * Removes files in sourceDir that are not present in deployedDir, unless they
+ * match an exclusion pattern. Also removes empty directories after cleanup.
+ */
+async function removeOrphans(sourceDir: string, deployedDir: string, exclude: string[]): Promise<void> {
+  // Collect relative file paths in source
+  async function collectFiles(dir: string, rel = ""): Promise<string[]> {
+    const results: string[] = [];
+    let entries: import("fs").Dirent[];
+    try {
+      entries = (await fs.readdir(dir, { withFileTypes: true })) as import("fs").Dirent[];
+    } catch {
+      return results;
+    }
+    for (const entry of entries) {
+      const relPath = rel ? `${rel}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        results.push(...(await collectFiles(path.join(dir, entry.name), relPath)));
+      } else if (entry.isFile()) {
+        results.push(relPath);
+      }
+    }
+    return results;
+  }
+
+  const sourceFiles = await collectFiles(sourceDir);
+  const deployedFiles = new Set(await collectFiles(deployedDir));
+
+  // Delete source orphans (not in deployed and not excluded)
+  for (const relPath of sourceFiles) {
+    if (!deployedFiles.has(relPath) && !isExcluded(path.basename(relPath), exclude)) {
+      await fs.unlink(path.join(sourceDir, relPath));
+    }
+  }
+
+  // Remove empty directories in source (deepest first)
+  async function collectDirs(dir: string, rel = ""): Promise<string[]> {
+    const results: string[] = [];
+    let entries: import("fs").Dirent[];
+    try {
+      entries = (await fs.readdir(dir, { withFileTypes: true })) as import("fs").Dirent[];
+    } catch {
+      return results;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        const relPath = rel ? `${rel}/${entry.name}` : entry.name;
+        results.push(...(await collectDirs(path.join(dir, entry.name), relPath)));
+        results.push(relPath);
+      }
+    }
+    return results;
+  }
+
+  const sourceDirs = await collectDirs(sourceDir);
+  for (const relDir of sourceDirs) {
+    const absDir = path.join(sourceDir, relDir);
+    try {
+      const contents = await fs.readdir(absDir);
+      if (contents.length === 0) {
+        await fs.rmdir(absDir);
+      }
+    } catch {
+      // Directory may have already been removed
     }
   }
 }
@@ -303,11 +372,12 @@ export async function pullProject(options: PullOptions): Promise<void> {
 
         await copyFile(deployedPath, sourcePath, deployedContent);
       } else {
-        // Directory-based: wipe then recursive copy (mirror, not additive)
-        if (existsSync(sourcePath)) {
-          await fs.rm(sourcePath, { recursive: true, force: true });
-        }
+        // Directory-based: copy deployed files to source, then remove orphans
+        // (preserving source files that match exclusion patterns like *.test.ts)
         await copyDirectory(deployedPath, sourcePath, platform);
+        if (existsSync(sourcePath)) {
+          await removeOrphans(sourcePath, deployedPath, DEFAULT_EXCLUDE);
+        }
       }
 
       process.stderr.write(`[${category}] ${componentName}: ${deployedPath} ${arrow} ${sourcePath}\n`);

--- a/tools/pull.ts
+++ b/tools/pull.ts
@@ -333,10 +333,21 @@ export async function pullProject(options: PullOptions): Promise<void> {
 
         await writeContent(sourcePath, deployedContent);
       } else {
-        // Directory-based: copy deployed files to source, then remove orphans
-        // (preserving source files that match exclusion patterns like *.test.ts)
-        await copyDirectory(deployedPath, sourcePath, platform);
-        await removeOrphans(sourcePath, deployedPath, DEFAULT_EXCLUDE);
+        // Non-file-based categories (skills, scripts): could be file or directory
+        const stat = await fs.stat(deployedPath);
+        if (stat.isDirectory()) {
+          // Directory: copy deployed files to source, then remove orphans
+          // (preserving source files that match exclusion patterns like *.test.ts)
+          await copyDirectory(deployedPath, sourcePath, platform);
+          await removeOrphans(sourcePath, deployedPath, DEFAULT_EXCLUDE);
+        } else {
+          // Single file (e.g., scripts/deploy.sh): read, transform if .md, write
+          let content = await fs.readFile(deployedPath, "utf8");
+          if (deployedPath.endsWith(".md")) {
+            content = reversePlatformPaths(content, platform);
+          }
+          await writeContent(sourcePath, content);
+        }
       }
 
       process.stderr.write(`[${category}] ${componentName}: ${deployedPath} ${arrow} ${sourcePath}\n`);

--- a/tools/pull.ts
+++ b/tools/pull.ts
@@ -16,18 +16,14 @@ import { parse as parseYaml } from "yaml";
 import type { SyncYaml, SyncItem, Category, Platform } from "./lib/types.ts";
 import { getRootDir } from "./lib/config.ts";
 import { CATEGORIES, SUPPORTED_CATEGORIES } from "./sync.ts";
+import { resolvePlatforms } from "./lib/resolver.ts";
 import {
+  FILE_BASED_CATEGORIES,
   resolveDeployedPath,
   resolveSourcePath,
   reversePlatformPaths,
   stripInjectedFrontmatter,
 } from "./lib/pull-utils.ts";
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const FILE_BASED_CATEGORIES: Set<Category> = new Set(["agents", "commands", "rules"]);
 
 // ---------------------------------------------------------------------------
 // Types
@@ -148,11 +144,14 @@ async function copyDirectory(
     if (entry.isDirectory()) {
       await copyDirectory(deployedEntry, sourceEntry, platform);
     } else if (entry.isFile()) {
-      let content = await fs.readFile(deployedEntry, "utf8");
       if (entry.name.endsWith(".md")) {
+        let content = await fs.readFile(deployedEntry, "utf8");
         content = reversePlatformPaths(content, platform);
+        await copyFile(deployedEntry, sourceEntry, content);
+      } else {
+        await fs.mkdir(path.dirname(sourceEntry), { recursive: true });
+        await fs.copyFile(deployedEntry, sourceEntry);
       }
-      await copyFile(deployedEntry, sourceEntry, content);
     }
   }
 }
@@ -245,6 +244,18 @@ export async function pullProject(options: PullOptions): Promise<void> {
         continue;
       }
 
+      // Check format compatibility: gemini commands use .toml format which cannot be reversed
+      if (platform === "gemini" && category === "commands") {
+        process.stderr.write(`[WARN] gemini 커맨드 .toml 형식 미지원 (스킵): ${componentName}\n`);
+        continue;
+      }
+
+      // Check platform cascade: skip items not targeting the current platform
+      const itemPlatforms = await resolvePlatforms(syncItem, section.platforms, syncYaml.platforms, category);
+      if (!itemPlatforms.includes(platform)) {
+        continue;
+      }
+
       // Resolve paths
       const deployedPath = resolveDeployedPath(targetPath, platform, category, componentName);
       const sourcePathBase = resolveSourcePath(componentRef, category, rootDir, projectName);
@@ -257,15 +268,6 @@ export async function pullProject(options: PullOptions): Promise<void> {
       if (!existsSync(deployedPath)) {
         process.stderr.write(`[WARN] 배포된 컴포넌트 없음 (스킵): ${deployedPath}\n`);
         continue;
-      }
-
-      // Check format compatibility: gemini commands in .toml format are unsupported
-      if (platform === "gemini" && category === "commands") {
-        const deployedStat = await fs.stat(deployedPath).catch(() => null);
-        if (deployedStat && deployedStat.isFile() && deployedPath.endsWith(".toml")) {
-          process.stderr.write(`[WARN] gemini 커맨드 .toml 형식 미지원 (스킵): ${deployedPath}\n`);
-          continue;
-        }
       }
 
       // Log or perform the pull

--- a/tools/pull.ts
+++ b/tools/pull.ts
@@ -24,7 +24,7 @@ import {
   reversePlatformPaths,
   stripInjectedFrontmatter,
 } from "./lib/pull-utils.ts";
-import { DEFAULT_EXCLUDE, isExcluded } from "./lib/sync-directory.ts";
+import { DEFAULT_EXCLUDE, isExcluded, collectFiles, collectDirs } from "./lib/sync-directory.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -133,7 +133,7 @@ export function parseCliArgs(args: string[]): {
 // File copy helpers
 // ---------------------------------------------------------------------------
 
-async function copyFile(srcPath: string, destPath: string, content: string): Promise<void> {
+async function writeContent(destPath: string, content: string): Promise<void> {
   await fs.mkdir(path.dirname(destPath), { recursive: true });
   await fs.writeFile(destPath, content, "utf8");
 }
@@ -157,9 +157,8 @@ async function copyDirectory(
       if (entry.name.endsWith(".md")) {
         let content = await fs.readFile(deployedEntry, "utf8");
         content = reversePlatformPaths(content, platform);
-        await copyFile(deployedEntry, sourceEntry, content);
+        await writeContent(sourceEntry, content);
       } else {
-        await fs.mkdir(path.dirname(sourceEntry), { recursive: true });
         await fs.copyFile(deployedEntry, sourceEntry);
       }
     }
@@ -171,26 +170,6 @@ async function copyDirectory(
  * match an exclusion pattern. Also removes empty directories after cleanup.
  */
 async function removeOrphans(sourceDir: string, deployedDir: string, exclude: string[]): Promise<void> {
-  // Collect relative file paths in source
-  async function collectFiles(dir: string, rel = ""): Promise<string[]> {
-    const results: string[] = [];
-    let entries: import("fs").Dirent[];
-    try {
-      entries = (await fs.readdir(dir, { withFileTypes: true })) as import("fs").Dirent[];
-    } catch {
-      return results;
-    }
-    for (const entry of entries) {
-      const relPath = rel ? `${rel}/${entry.name}` : entry.name;
-      if (entry.isDirectory()) {
-        results.push(...(await collectFiles(path.join(dir, entry.name), relPath)));
-      } else if (entry.isFile()) {
-        results.push(relPath);
-      }
-    }
-    return results;
-  }
-
   const sourceFiles = await collectFiles(sourceDir);
   const deployedFiles = new Set(await collectFiles(deployedDir));
 
@@ -202,24 +181,6 @@ async function removeOrphans(sourceDir: string, deployedDir: string, exclude: st
   }
 
   // Remove empty directories in source (deepest first)
-  async function collectDirs(dir: string, rel = ""): Promise<string[]> {
-    const results: string[] = [];
-    let entries: import("fs").Dirent[];
-    try {
-      entries = (await fs.readdir(dir, { withFileTypes: true })) as import("fs").Dirent[];
-    } catch {
-      return results;
-    }
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        const relPath = rel ? `${rel}/${entry.name}` : entry.name;
-        results.push(...(await collectDirs(path.join(dir, entry.name), relPath)));
-        results.push(relPath);
-      }
-    }
-    return results;
-  }
-
   const sourceDirs = await collectDirs(sourceDir);
   for (const relDir of sourceDirs) {
     const absDir = path.join(sourceDir, relDir);
@@ -370,14 +331,12 @@ export async function pullProject(options: PullOptions): Promise<void> {
           deployedContent = stripInjectedFrontmatter(deployedContent, sourceContent, syncItem);
         }
 
-        await copyFile(deployedPath, sourcePath, deployedContent);
+        await writeContent(sourcePath, deployedContent);
       } else {
         // Directory-based: copy deployed files to source, then remove orphans
         // (preserving source files that match exclusion patterns like *.test.ts)
         await copyDirectory(deployedPath, sourcePath, platform);
-        if (existsSync(sourcePath)) {
-          await removeOrphans(sourcePath, deployedPath, DEFAULT_EXCLUDE);
-        }
+        await removeOrphans(sourcePath, deployedPath, DEFAULT_EXCLUDE);
       }
 
       process.stderr.write(`[${category}] ${componentName}: ${deployedPath} ${arrow} ${sourcePath}\n`);

--- a/tools/pull.ts
+++ b/tools/pull.ts
@@ -268,6 +268,10 @@ export async function pullProject(options: PullOptions): Promise<void> {
       // Resolve paths
       const deployedPath = resolveDeployedPath(targetPath, platform, category, componentName);
       const sourcePath = resolveSourcePath(componentRef, category, rootDir, projectName);
+      if (typeof sourcePath === "object" && "error" in sourcePath) {
+        process.stderr.write(`[WARN] ${category}/${componentRef}: ${sourcePath.error}\n`);
+        continue;
+      }
 
       // Check deployed path exists
       if (!existsSync(deployedPath)) {

--- a/tools/pull.ts
+++ b/tools/pull.ts
@@ -86,12 +86,21 @@ export function parseCliArgs(args: string[]): {
         process.stderr.write("[ERROR] --platform 플래그에 값이 필요합니다 (예: --platform gemini)\n");
         process.exit(1);
       }
+      const validPlatforms = Object.keys(SUPPORTED_CATEGORIES);
+      if (!validPlatforms.includes(value)) {
+        process.stderr.write(`[ERROR] 유효하지 않은 platform: ${value} (허용: ${validPlatforms.join(", ")})\n`);
+        process.exit(1);
+      }
       platform = value as Platform;
       i++;
     } else if (arg === "--category") {
       const value = args[i + 1];
       if (!value || value.startsWith("--")) {
         process.stderr.write("[ERROR] --category 플래그에 값이 필요합니다 (예: --category skills)\n");
+        process.exit(1);
+      }
+      if (!CATEGORIES.includes(value as Category)) {
+        process.stderr.write(`[ERROR] 유효하지 않은 category: ${value} (허용: ${CATEGORIES.join(", ")})\n`);
         process.exit(1);
       }
       categoryFilter = value as Category;
@@ -258,11 +267,7 @@ export async function pullProject(options: PullOptions): Promise<void> {
 
       // Resolve paths
       const deployedPath = resolveDeployedPath(targetPath, platform, category, componentName);
-      const sourcePathBase = resolveSourcePath(componentRef, category, rootDir, projectName);
-      // File-based categories use .md suffix in source (mirrors resolveDeployedPath behavior)
-      const sourcePath = FILE_BASED_CATEGORIES.has(category)
-        ? `${sourcePathBase}.md`
-        : sourcePathBase;
+      const sourcePath = resolveSourcePath(componentRef, category, rootDir, projectName);
 
       // Check deployed path exists
       if (!existsSync(deployedPath)) {
@@ -294,7 +299,10 @@ export async function pullProject(options: PullOptions): Promise<void> {
 
         await copyFile(deployedPath, sourcePath, deployedContent);
       } else {
-        // Directory-based: recursive copy
+        // Directory-based: wipe then recursive copy (mirror, not additive)
+        if (existsSync(sourcePath)) {
+          await fs.rm(sourcePath, { recursive: true, force: true });
+        }
         await copyDirectory(deployedPath, sourcePath, platform);
       }
 

--- a/tools/pull.ts
+++ b/tools/pull.ts
@@ -1,0 +1,339 @@
+/**
+ * oh-my-toong Pull Orchestrator
+ *
+ * CLI entry point for pulling deployed component files back to oh-my-toong source.
+ * Inverse of sync.ts: reads a project's sync.yaml and copies from target to source.
+ *
+ * Usage:
+ *   bun run tools/pull.ts <project-name> [--platform <name>] [--category <name>] [--component <name>] [--dry-run]
+ */
+
+import fs from "fs/promises";
+import path from "path";
+import { existsSync } from "fs";
+import { parse as parseYaml } from "yaml";
+
+import type { SyncYaml, SyncItem, Category, Platform } from "./lib/types.ts";
+import { getRootDir } from "./lib/config.ts";
+import { CATEGORIES, SUPPORTED_CATEGORIES } from "./sync.ts";
+import {
+  resolveDeployedPath,
+  resolveSourcePath,
+  reversePlatformPaths,
+  stripInjectedFrontmatter,
+} from "./lib/pull-utils.ts";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const FILE_BASED_CATEGORIES: Set<Category> = new Set(["agents", "commands", "rules"]);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type PullOptions = {
+  projectName: string;
+  platform: Platform;
+  categoryFilter?: Category;
+  componentFilter?: string;
+  dryRun: boolean;
+  rootDir: string;
+};
+
+// ---------------------------------------------------------------------------
+// CLI helpers
+// ---------------------------------------------------------------------------
+
+export function printUsage(): void {
+  process.stderr.write(
+    [
+      "Usage: bun tools/pull.ts <project-name> [options]",
+      "",
+      "Arguments:",
+      "  <project-name>         Directory name under projects/ (required)",
+      "",
+      "Options:",
+      "  --platform <name>      Target platform (default: claude)",
+      "  --category <name>      Pull only this category",
+      "  --component <name>     Pull only this component (requires --category)",
+      "  --dry-run              Preview changes without writing files",
+      "  --help                 Show this help message",
+      "",
+    ].join("\n"),
+  );
+}
+
+export function parseCliArgs(args: string[]): {
+  projectName: string;
+  platform: Platform;
+  categoryFilter?: Category;
+  componentFilter?: string;
+  dryRun: boolean;
+} {
+  let projectName = "";
+  let platform: Platform = "claude";
+  let categoryFilter: Category | undefined;
+  let componentFilter: string | undefined;
+  let dryRun = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg === "--dry-run") {
+      dryRun = true;
+    } else if (arg === "--platform") {
+      const value = args[i + 1];
+      if (!value || value.startsWith("--")) {
+        process.stderr.write("[ERROR] --platform 플래그에 값이 필요합니다 (예: --platform gemini)\n");
+        process.exit(1);
+      }
+      platform = value as Platform;
+      i++;
+    } else if (arg === "--category") {
+      const value = args[i + 1];
+      if (!value || value.startsWith("--")) {
+        process.stderr.write("[ERROR] --category 플래그에 값이 필요합니다 (예: --category skills)\n");
+        process.exit(1);
+      }
+      categoryFilter = value as Category;
+      i++;
+    } else if (arg === "--component") {
+      const value = args[i + 1];
+      if (!value || value.startsWith("--")) {
+        process.stderr.write("[ERROR] --component 플래그에 값이 필요합니다 (예: --component oracle)\n");
+        process.exit(1);
+      }
+      componentFilter = value;
+      i++;
+    } else if (arg === "--help") {
+      printUsage();
+      process.exit(0);
+    } else if (arg.startsWith("--")) {
+      process.stderr.write(`[WARN] 알 수 없는 플래그: ${arg}\n`);
+    } else if (!projectName) {
+      projectName = arg;
+    }
+
+    i++;
+  }
+
+  return { projectName, platform, categoryFilter, componentFilter, dryRun };
+}
+
+// ---------------------------------------------------------------------------
+// File copy helpers
+// ---------------------------------------------------------------------------
+
+async function copyFile(srcPath: string, destPath: string, content: string): Promise<void> {
+  await fs.mkdir(path.dirname(destPath), { recursive: true });
+  await fs.writeFile(destPath, content, "utf8");
+}
+
+/**
+ * Recursively copy a directory, applying reversePlatformPaths to .md files.
+ */
+async function copyDirectory(
+  deployedDir: string,
+  sourceDir: string,
+  platform: Platform,
+): Promise<void> {
+  await fs.mkdir(sourceDir, { recursive: true });
+  const entries = await fs.readdir(deployedDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const deployedEntry = path.join(deployedDir, entry.name);
+    const sourceEntry = path.join(sourceDir, entry.name);
+    if (entry.isDirectory()) {
+      await copyDirectory(deployedEntry, sourceEntry, platform);
+    } else if (entry.isFile()) {
+      let content = await fs.readFile(deployedEntry, "utf8");
+      if (entry.name.endsWith(".md")) {
+        content = reversePlatformPaths(content, platform);
+      }
+      await copyFile(deployedEntry, sourceEntry, content);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core pull logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Main pull orchestration function.
+ * Reads a project's sync.yaml and pulls deployed files back to oh-my-toong source.
+ */
+export async function pullProject(options: PullOptions): Promise<void> {
+  const { projectName, platform, categoryFilter, componentFilter, dryRun, rootDir } = options;
+
+  const syncYamlPath = path.join(rootDir, "projects", projectName, "sync.yaml");
+
+  // Validate project exists
+  if (!existsSync(syncYamlPath)) {
+    process.stderr.write(`[ERROR] Project not found: projects/${projectName}/sync.yaml\n`);
+    process.exit(1);
+  }
+
+  // Parse sync.yaml
+  let syncYaml: SyncYaml;
+  try {
+    const rawText = await fs.readFile(syncYamlPath, "utf8");
+    const parsed = parseYaml(rawText);
+    if (parsed == null || typeof parsed !== "object") {
+      process.stderr.write(`[ERROR] YAML이 비어 있거나 유효한 객체가 아님: ${syncYamlPath}\n`);
+      process.exit(1);
+    }
+    syncYaml = parsed as SyncYaml;
+  } catch (err) {
+    process.stderr.write(`[ERROR] YAML 파싱 실패: ${syncYamlPath}: ${err}\n`);
+    process.exit(1);
+  }
+
+  const targetPath = syncYaml.path;
+  if (!targetPath) {
+    process.stderr.write(`[ERROR] path가 정의되지 않음: ${syncYamlPath}\n`);
+    process.exit(1);
+  }
+
+  if (dryRun) {
+    process.stderr.write("[WARN] ========== DRY-RUN 모드 (실제 변경 없음) ==========\n");
+  }
+
+  // Iterate categories
+  for (const category of CATEGORIES) {
+    // Check platform supports this category
+    const supported = SUPPORTED_CATEGORIES[platform];
+    if (!supported || !supported.has(category)) {
+      continue;
+    }
+
+    // Apply category filter
+    if (categoryFilter && category !== categoryFilter) {
+      continue;
+    }
+
+    const section = syncYaml[category as keyof SyncYaml] as
+      | { platforms?: Platform[]; items?: SyncItem[] }
+      | undefined;
+
+    if (!section || !Array.isArray(section.items) || section.items.length === 0) {
+      continue;
+    }
+
+    for (const item of section.items) {
+      // Normalize item to get componentRef and componentName
+      let componentRef: string;
+      let syncItem: SyncItem;
+
+      if (typeof item === "string") {
+        componentRef = item;
+        syncItem = item;
+      } else {
+        componentRef = item.component;
+        syncItem = item;
+      }
+
+      // Extract just the component name (strip project prefix for matching)
+      const componentName = componentRef.includes(":")
+        ? componentRef.slice(componentRef.indexOf(":") + 1)
+        : componentRef;
+
+      // Apply component filter (match against parsed component name)
+      if (componentFilter && componentName !== componentFilter) {
+        continue;
+      }
+
+      // Resolve paths
+      const deployedPath = resolveDeployedPath(targetPath, platform, category, componentName);
+      const sourcePathBase = resolveSourcePath(componentRef, category, rootDir, projectName);
+      // File-based categories use .md suffix in source (mirrors resolveDeployedPath behavior)
+      const sourcePath = FILE_BASED_CATEGORIES.has(category)
+        ? `${sourcePathBase}.md`
+        : sourcePathBase;
+
+      // Check deployed path exists
+      if (!existsSync(deployedPath)) {
+        process.stderr.write(`[WARN] 배포된 컴포넌트 없음 (스킵): ${deployedPath}\n`);
+        continue;
+      }
+
+      // Check format compatibility: gemini commands in .toml format are unsupported
+      if (platform === "gemini" && category === "commands") {
+        const deployedStat = await fs.stat(deployedPath).catch(() => null);
+        if (deployedStat && deployedStat.isFile() && deployedPath.endsWith(".toml")) {
+          process.stderr.write(`[WARN] gemini 커맨드 .toml 형식 미지원 (스킵): ${deployedPath}\n`);
+          continue;
+        }
+      }
+
+      // Log or perform the pull
+      const arrow = "→";
+      if (dryRun) {
+        process.stderr.write(`[DRY-RUN] [${category}] ${componentName}: ${deployedPath} ${arrow} ${sourcePath}\n`);
+        continue;
+      }
+
+      // Perform file copy
+      if (FILE_BASED_CATEGORIES.has(category)) {
+        // File-based: read, transform, write
+        let deployedContent = await fs.readFile(deployedPath, "utf8");
+        deployedContent = reversePlatformPaths(deployedContent, platform);
+
+        // For agents: strip injected frontmatter if add-skills/add-hooks present
+        if (category === "agents") {
+          let sourceContent = "";
+          if (existsSync(sourcePath)) {
+            sourceContent = await fs.readFile(sourcePath, "utf8");
+          }
+          deployedContent = stripInjectedFrontmatter(deployedContent, sourceContent, syncItem);
+        }
+
+        await copyFile(deployedPath, sourcePath, deployedContent);
+      } else {
+        // Directory-based: recursive copy
+        await copyDirectory(deployedPath, sourcePath, platform);
+      }
+
+      process.stderr.write(`[${category}] ${componentName}: ${deployedPath} ${arrow} ${sourcePath}\n`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+if (import.meta.main) {
+  const args = process.argv.slice(2);
+  const { projectName, platform, categoryFilter, componentFilter, dryRun } = parseCliArgs(args);
+
+  if (!projectName) {
+    process.stderr.write("[ERROR] <project-name>이 필요합니다\n");
+    printUsage();
+    process.exit(1);
+  }
+
+  if (componentFilter && !categoryFilter) {
+    process.stderr.write("[ERROR] --component는 --category가 필요합니다\n");
+    process.exit(1);
+  }
+
+  const rootDir = getRootDir();
+  if (!rootDir) {
+    process.stderr.write("[ERROR] config.yaml를 찾을 수 없음. 실행 위치를 확인하세요.\n");
+    process.exit(1);
+  }
+
+  await pullProject({
+    projectName,
+    platform,
+    categoryFilter,
+    componentFilter,
+    dryRun,
+    rootDir,
+  });
+
+  process.exit(0);
+}

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -51,14 +51,14 @@ export type AdapterMap = Map<Platform, PlatformAdapter>;
 // ---------------------------------------------------------------------------
 
 /** All categories handled by syncCategory. */
-const CATEGORIES: Category[] = ["agents", "commands", "skills", "scripts", "rules"];
+export const CATEGORIES: Category[] = ["agents", "commands", "skills", "scripts", "rules"];
 
 /**
  * Platform×category capability map.
  * Only combinations listed here proceed through backup+wipe+dispatch.
  * Unsupported combos (e.g., codex+agents) are skipped entirely.
  */
-const SUPPORTED_CATEGORIES: Record<string, Set<Category>> = {
+export const SUPPORTED_CATEGORIES: Record<string, Set<Category>> = {
   claude: new Set(["agents", "commands", "skills", "scripts", "rules"]),
   gemini: new Set(["commands", "skills", "scripts"]),
   codex: new Set(["skills", "scripts"]),


### PR DESCRIPTION
## 📌 Summary

`sync`(소스→타겟 배포)의 역방향인 `pull` 기능 구현. 타겟 프로젝트에 배포된 컴포넌트 파일을 sync.yaml 매핑 기반으로 oh-my-toong 소스 저장소로 풀백하는 CLI 도구.

---

## 🔧 Changes

### pull 유틸리티 모듈 (`tools/lib/pull-utils.ts`)

- `resolveDeployedPath`: 플랫폼별 디렉토리 레이아웃(`.claude/`, `.gemini/` 등)을 고려한 배포 파일 경로 생성
- `resolveSourcePath`: 컴포넌트 참조를 소스 경로로 역변환 (project-local 우선 탐색 + global 폴백, resolver.ts의 `resolveComponentPath` 의미론 미러링)
- `reversePlatformPaths`: 배포 시 치환된 플랫폼 경로를 `.claude/` 원본으로 복원
- `stripInjectedFrontmatter`: sync가 에이전트에 주입한 `add-skills`/`add-hooks` frontmatter 제거

sync의 역방향 해석이 필요한 4개 유틸리티를 별도 모듈로 분리하여 pull.ts 오케스트레이터의 복잡도를 낮춤.

**영향 범위**
신규 모듈. 기존 sync 흐름에 영향 없음. `resolver.ts`의 `tryResolveInDir`을 import하여 경로 해석 로직의 단일 소스 유지.

### pull CLI 오케스트레이터 (`tools/pull.ts`)

- `parseCliArgs`: `--platform`, `--category`, `--component`, `--dry-run` CLI 플래그 파싱 및 enum 검증
- `pullProject`: sync.yaml 읽기 → 카테고리/아이템 순회 → 플랫폼 cascade 체크 → 경로 해석 → 파일 복사 오케스트레이션
- `copyDirectory`: 디렉토리 재귀 복사 + `.md` 파일 플랫폼 경로 역변환
- `removeOrphans`: 배포 디렉토리에 없는 소스 파일 정리 (sync 제외 패턴 매칭 파일은 보존)

sync.ts의 `CATEGORIES`, `SUPPORTED_CATEGORIES`, `resolvePlatforms`를 직접 import하여 카테고리/플랫폼 정의의 단일 소스를 유지.

**영향 범위**
신규 파일. Makefile에 `make pull PROJ=<name>` / `make pull-dry PROJ=<name>` 타겟 추가. `sync-directory.ts`에서 `DEFAULT_EXCLUDE`, `isExcluded`, `collectFiles`, `collectDirs`를 export하여 pull에서 재사용.

### 기존 모듈 변경

- `tools/sync.ts`: `CATEGORIES`, `SUPPORTED_CATEGORIES` export 추가 (로직 변경 없음)
- `tools/lib/resolver.ts`: `tryResolveInDir` export 추가 (로직 변경 없음)
- `tools/lib/sync-directory.ts`: `DEFAULT_EXCLUDE`, `isExcluded`, `collectFiles`, `collectDirs` export 추가 + `DEFAULT_EXCLUDE` 상수 추출

모두 가시성(export) 변경만으로 기존 동작에 영향 없음.

**영향 범위**
export 추가만. 기존 sync 동작 무변경.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. resolveSourcePath의 project-local 우선 탐색

**배경 및 문제 상황:**
sync의 `resolveComponentPath`는 project sync.yaml의 unscoped ref(예: `- oracle`)에 대해 `projects/{project}/skills/oracle/`을 먼저 검색한 후 global `skills/oracle/`로 폴백한다. pull이 이 의미론을 미러링하지 않으면 project-local 오버라이드가 있는 컴포넌트를 pull할 때 글로벌 소스가 프로젝트 로컬 내용으로 오염된다.

**해결 방안:**
`resolveSourcePath`에서 `projectDirName`이 제공되고 ref가 unscoped일 때, `tryResolveInDir`로 project-local 경로를 먼저 탐색. 파일이 존재하면 그 경로를 반환하고, 없으면 global로 폴백.

**구현 세부사항:**
resolver.ts의 `tryResolveInDir`을 export하여 pull-utils.ts에서 직접 재사용. 동일한 4단계 파일 탐색 체인(`.md` → `index.md` → `SKILL.md` → bare directory)을 공유하여 해석 로직의 divergence를 방지함.

**선택과 트레이드오프:**
pull-utils.ts가 resolver.ts에 의존하게 되지만, 해석 로직의 단일 소스 유지가 별도 구현 대비 divergence 위험을 줄여준다. 초기 구현에서 `tryResolveExisting`으로 로직을 복사했다가 코드 리뷰에서 지적받아 공유로 전환함.

### 2. 디렉토리 pull의 smart merge 전략

**배경 및 문제 상황:**
sync의 `syncDirectory`는 `DEFAULT_EXCLUDE = ["*.test.ts"]`로 테스트 파일을 배포에서 제외한다. 초기 pull 구현은 소스 디렉토리를 `fs.rm`으로 전체 삭제 후 배포 디렉토리를 복사하는 destructive mirror였으나, 이 경우 sync가 제외한 소스 전용 파일(테스트 등)이 영구 유실된다.

**해결 방안:**
destructive mirror를 additive copy + selective orphan removal로 교체. 배포 파일을 먼저 소스에 덮어쓰고, `removeOrphans`가 배포에 없는 소스 파일 중 제외 패턴에 매칭되지 않는 것만 삭제.

**구현 세부사항:**
`sync-directory.ts`의 `DEFAULT_EXCLUDE`, `isExcluded`, `collectFiles`, `collectDirs`를 export하여 pull에서 재사용. orphan 판별: `sourceFiles - deployedFiles - excludedFiles`. 빈 디렉토리는 deepest-first로 정리.

**선택과 트레이드오프:**
sync와 pull이 동일한 `DEFAULT_EXCLUDE`를 공유하므로 제외 패턴 변경 시 양방향에 자동 반영된다. 다만, sync가 어댑터별로 다른 제외 패턴을 사용하는 경우(현재는 모두 `["*.test.ts"]`)에는 pull도 어댑터별 분기가 필요할 수 있다 — 현재로서는 YAGNI.

---

## ✅ Checklist

### pull CLI 기본 동작
- [ ] `make pull PROJ=<name>`으로 프로젝트의 배포 파일을 소스로 복사
  - `tools/pull.ts`, `Makefile`
- [ ] `--dry-run` 모드에서 실제 파일 변경 없이 예정 작업을 출력
  - `tools/pull.ts`
- [ ] `--platform`, `--category`, `--component` 필터가 동작
  - `tools/pull.ts`

### 경로 해석 정확성
- [ ] project-local 오버라이드가 있는 unscoped ref를 project-local 경로로 해석
  - `tools/lib/pull-utils.ts`, `tools/lib/pull-utils.test.ts`
- [ ] cross-project 참조 시 에러 객체 반환 후 다음 아이템으로 계속 진행 (전체 중단 없음)
  - `tools/lib/pull-utils.ts`, `tools/pull.ts`

### 파일 변환
- [ ] 비-claude 플랫폼 경로(`.gemini/`, `.codex/`)가 `.claude/`로 역변환
  - `tools/lib/pull-utils.ts`
- [ ] 에이전트의 주입된 frontmatter(`add-skills`/`add-hooks`)가 제거되어 소스 원본 상태 복원
  - `tools/lib/pull-utils.ts`

### 디렉토리 pull 안전성
- [ ] 디렉토리 카테고리 pull 시 `*.test.ts` 같은 sync 제외 파일이 보존
  - `tools/pull.ts`, `tools/pull.test.ts`
- [ ] 배포에 없는 비제외 소스 파일(orphan)은 삭제
  - `tools/pull.ts`

### 호환성 가드
- [ ] gemini commands의 TOML 형식 미지원 감지 및 스킵
  - `tools/pull.ts`, `tools/pull.test.ts`

---

## 📎 References
- 없음