### PR TITLE
refactor: 프로젝트 로컬 .omt/ 상태를 글로벌 ~/.omt/로 마이그레이션

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,6 @@
 # node
 node_modules/
 
-# omt state directories (project root and test artifacts)
-.omt/
 /.gemini/
 /.codex/
 .opencode/

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 # node
 node_modules/
 
+# omt state directories (project root and test artifacts)
+.omt/
+
 /.gemini/
 /.codex/
 .opencode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 - `scripts/`: Deployed script packages (hud, chunk-review, spec-reviewer).
 - `tools/`: Internal sync/validation tooling (not deployed).
 - `projects/`: Project-specific overrides (e.g., `projects/<project>/skills/<skill>/SKILL.md`).
-- Local/runtime artifacts: `.omt/` (state) and `.claude/` are ignored by git.
+- Local/runtime artifacts: `~/.omt/{OMT_PROJECT}/` (state, in home directory) and `.claude/` are ignored by git.
 
 ## Build, Test, and Development Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ skills:
 
 **Ralph Loop**:
 - Iterative completion enforcement with oracle verification
-- State file at `.omt/ralph-state.json`
+- State file at `~/.omt/{OMT_PROJECT}/ralph-state.json` (resolved via `$OMT_DIR` env var)
 - Cancel with `/cancel-ralph`
 
 ## Coding Conventions

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -63,7 +63,7 @@ This project uses `make` to validate and sync configurations to your local envir
 - **Testing**: Test display names in Korean; method names in English.
 
 ### Workflow Principles
-1.  **Plan First**: Use `Prometheus` to generate a plan (`.omt/plans/*.md`) before any code is written.
+1.  **Plan First**: Use `Prometheus` to generate a plan (`~/.omt/{OMT_PROJECT}/plans/*.md`, via `$OMT_DIR`) before any code is written.
 2.  **Orchestrate**: Use `Sisyphus` to execute the plan. Sisyphus delegates the actual coding to `Sisyphus-Junior`.
 3.  **Verify**: Use `Oracle` or `Code-Reviewer` to validate changes.
 4.  **Ralph Loop**: A mechanism (`/ralph`) to enforce iterative work until a strict definition of done is met.

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ flowchart LR
         sisyphus["sisyphus"]
     end
 
-    spec -->|".omt/specs/{name}/"| prometheus
-    prometheus -->|".omt/plans/*.md"| sisyphus
+    spec -->|"~/.omt/{OMT_PROJECT}/specs/{name}/"| prometheus
+    prometheus -->|"~/.omt/{OMT_PROJECT}/plans/*.md"| sisyphus
     sisyphus -->|"검증된 코드"| Done((완료))
 ```
 
@@ -92,7 +92,7 @@ flowchart LR
 flowchart TB
     Start([사용자 요청]) --> Phase[단계 선택]
     Phase --> Step[단계 실행]
-    Step --> Save[.omt/specs/에 저장]
+    Step --> Save[~/.omt/{OMT_PROJECT}/specs/에 저장]
     Save --> Review{spec-reviewer<br/>피드백 필요?}
     Review -->|아니오| Next{다음 단계?}
     Review -->|예| Feedback[Multi-AI 피드백 수신]
@@ -129,7 +129,7 @@ flowchart TB
     Criteria -->|예| Metis[metis 상담]
     Criteria -->|아니오| Draft[기준 초안<br/>-> 사용자 확인]
     Draft --> Metis
-    Metis --> Write[.omt/plans/*.md에<br/>계획 작성]
+    Metis --> Write[~/.omt/{OMT_PROJECT}/plans/*.md에<br/>계획 작성]
     Write --> Handoff([/sisyphus로 전달])
 ```
 
@@ -294,7 +294,7 @@ oh-my-toong/
 ### 계획에서 실행까지
 
 ```
-1. /prometheus <task>     .omt/plans/*.md에 작업 계획 생성
+1. /prometheus <task>     ~/.omt/{OMT_PROJECT}/plans/*.md에 작업 계획 생성
          ↓
 2. /sisyphus              서브에이전트를 통해 계획 실행 조율
          ↓
@@ -305,7 +305,7 @@ oh-my-toong/
 
 oracle 검증을 통한 반복적 완료 강제. oracle이 작업이 정말로 완료되었음을 확인할 때까지 루프가 계속됩니다.
 
-- 상태 파일: `.omt/ralph-state.json`
+- 상태 파일: `~/.omt/{OMT_PROJECT}/ralph-state.json` (`$OMT_DIR` 환경 변수로 접근)
 - 취소: `/cancel-ralph`
 
 ### Ultrawork Mode

--- a/agents/momus.md
+++ b/agents/momus.md
@@ -8,6 +8,6 @@ tools: Read, Glob, Grep, Bash
 
 You are the Momus agent. Follow the momus skill exactly.
 
-**Input**: You will receive a file path to a work plan (e.g., `.omt/plans/plan-name.md`).
+**Input**: You will receive a file path to a work plan (e.g., `$OMT_DIR/plans/plan-name.md`).
 
 **Output**: Review the plan following the skill's process and provide your verdict.

--- a/agents/sisyphus-junior.md
+++ b/agents/sisyphus-junior.md
@@ -119,7 +119,7 @@ If no methodology skill is specified, implement directly following task requirem
 
 ## Plan File Rules
 
-**PLAN PATH**: `.omt/plans/{plan-name}.md`
+**PLAN PATH**: `$OMT_DIR/plans/{plan-name}.md`
 
 ⚠️ **SACRED AND READ-ONLY** ⚠️
 
@@ -156,7 +156,7 @@ Task NOT complete without:
 
 ## Notepad (for learnings)
 
-**NOTEPAD PATH**: `.omt/notepads/{plan-name}/`
+**NOTEPAD PATH**: `$OMT_DIR/notepads/{plan-name}/`
 - `learnings.md`: Patterns, conventions, successful approaches
 - `issues.md`: Problems, blockers, gotchas
 - `decisions.md`: Architectural choices and rationales

--- a/agents/spec-reviewer.md
+++ b/agents/spec-reviewer.md
@@ -155,7 +155,7 @@ Output: JOB_DIR path (one line on stdout).
 
 > **Important**: Write prompts in English for consistent cross-model communication.
 
-> **`--spec` flag**: Use `--spec <spec-name>` to auto-load context from `.omt/specs/<spec-name>/` (spec.md, records/*.md, shared context).
+> **`--spec` flag**: Use `--spec <spec-name>` to auto-load context from `$OMT_DIR/specs/<spec-name>/` (spec.md, records/*.md, shared context).
 
 ### Phase 2 — Collect (Bash, timeout: 180000)
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,4 @@
 [test]
 # Exclude deployed and backup directories — source tests live in lib/, scripts/, tools/
 # Skills tests have @lib/ dependencies that only resolve in deployed context
-exclude = [".claude/**", ".gemini/**", ".codex/**", ".opencode/**", ".sync-backup/**", "skills/**"]
+exclude = [".claude/**", ".gemini/**", ".codex/**", ".opencode/**", ".sync-backup/**", ".omt/**", "skills/**"]

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,4 @@
 [test]
 # Exclude deployed and backup directories — source tests live in lib/, scripts/, tools/
 # Skills tests have @lib/ dependencies that only resolve in deployed context
-exclude = [".claude/**", ".gemini/**", ".codex/**", ".opencode/**", ".sync-backup/**", ".omt/**", "skills/**"]
+exclude = [".claude/**", ".gemini/**", ".codex/**", ".opencode/**", ".sync-backup/**", "skills/**"]

--- a/commands/cancel-ralph.md
+++ b/commands/cancel-ralph.md
@@ -12,13 +12,13 @@ Execute these commands to fully cancel the Ralph Loop and clean up all associate
 
 ```bash
 # Remove all session-specific ralph state files
-rm -f $OMT_DIR/ralph-state-*.json 2>/dev/null || true
+rm -f "$OMT_DIR"/ralph-state-*.json 2>/dev/null || true
 
 # Check if ultrawork is linked to ralph and clean up if so
-if [ -f $OMT_DIR/ultrawork-state.json ]; then
-  is_linked=$(jq -r '.linked_to_ralph // false' $OMT_DIR/ultrawork-state.json 2>/dev/null)
+if [ -f "$OMT_DIR/ultrawork-state.json" ]; then
+  is_linked=$(jq -r '.linked_to_ralph // false' "$OMT_DIR/ultrawork-state.json" 2>/dev/null)
   if [ "$is_linked" = "true" ]; then
-    rm -f $OMT_DIR/ultrawork-state.json
+    rm -f "$OMT_DIR/ultrawork-state.json"
     rm -f ~/.claude/ultrawork-state.json
   fi
 fi
@@ -30,7 +30,7 @@ After running the cleanup commands, verify the cancellation was successful:
 
 ```bash
 # Should return no files
-ls $OMT_DIR/ralph-state-*.json 2>/dev/null || echo "ralph-state files removed"
+ls "$OMT_DIR"/ralph-state-*.json 2>/dev/null || echo "ralph-state files removed"
 ```
 
 ## POST-CANCELLATION

--- a/commands/cancel-ralph.md
+++ b/commands/cancel-ralph.md
@@ -11,17 +11,14 @@ The Ralph Loop has been cancelled. You MUST now execute the full cleanup procedu
 Execute these commands to fully cancel the Ralph Loop and clean up all associated state (for all sessions):
 
 ```bash
-# Navigate to state directory
-cd .omt
-
 # Remove all session-specific ralph state files
-rm -f ralph-state-*.json 2>/dev/null || true
+rm -f $OMT_DIR/ralph-state-*.json 2>/dev/null || true
 
 # Check if ultrawork is linked to ralph and clean up if so
-if [ -f ultrawork-state.json ]; then
-  is_linked=$(jq -r '.linked_to_ralph // false' ultrawork-state.json 2>/dev/null)
+if [ -f $OMT_DIR/ultrawork-state.json ]; then
+  is_linked=$(jq -r '.linked_to_ralph // false' $OMT_DIR/ultrawork-state.json 2>/dev/null)
   if [ "$is_linked" = "true" ]; then
-    rm -f ultrawork-state.json
+    rm -f $OMT_DIR/ultrawork-state.json
     rm -f ~/.claude/ultrawork-state.json
   fi
 fi
@@ -33,7 +30,7 @@ After running the cleanup commands, verify the cancellation was successful:
 
 ```bash
 # Should return no files
-ls -la .omt/ralph-state-*.json 2>/dev/null || echo "ralph-state files removed"
+ls $OMT_DIR/ralph-state-*.json 2>/dev/null || echo "ralph-state files removed"
 ```
 
 ## POST-CANCELLATION

--- a/docs/ORCHESTRATION.en.md
+++ b/docs/ORCHESTRATION.en.md
@@ -57,13 +57,13 @@ flowchart TD
 
     subgraph Design Phase
         Spec["/spec"] --> SpecReviewer[spec-reviewer]
-        SpecReviewer --> SpecFile[".omt/specs/*.md"]
+        SpecReviewer --> SpecFile["~/.omt/{OMT_PROJECT}/specs/*.md"]
     end
 
     subgraph Planning Phase
         Prometheus["/prometheus"] --> Metis[metis<br/>Gap Analysis]
         Metis --> Prometheus
-        Prometheus --> PlanFile[".omt/plans/*.md"]
+        Prometheus --> PlanFile["~/.omt/{OMT_PROJECT}/plans/*.md"]
     end
 
     SpecFile -.->|informs| Prometheus
@@ -85,14 +85,14 @@ flowchart TD
 
 - **Role**: Creates comprehensive, testable specifications
 - **Constraint**: No phase completion without user confirmation
-- **Output**: `.omt/specs/{name}/spec.md`
+- **Output**: `~/.omt/{OMT_PROJECT}/specs/{name}/spec.md` (via `$OMT_DIR`)
 - **Key Feature**: Multi-AI feedback via spec-reviewer
 
 ### prometheus (The Planner)
 
 - **Role**: Strategic planning, requirements interviews
 - **Constraint**: **READ-ONLY**. NEVER writes code.
-- **Output**: `.omt/plans/{name}.md`
+- **Output**: `~/.omt/{OMT_PROJECT}/plans/{name}.md` (via `$OMT_DIR`)
 - **Workflow**: Interview -> Research -> Metis consultation -> Plan creation
 
 ### sisyphus (The Orchestrator)
@@ -134,7 +134,7 @@ When requirements are clear, use `/prometheus`:
 1. **Interview Mode**: Collects context through questions
 2. **Research**: Investigates codebase via explore/librarian agents
 3. **Metis Consultation**: MANDATORY gap analysis before plan creation
-4. **Plan Generation**: Writes structured plan to `.omt/plans/*.md`
+4. **Plan Generation**: Writes structured plan to `~/.omt/{OMT_PROJECT}/plans/*.md`
 
 ### Phase 3: Execution
 
@@ -151,8 +151,8 @@ With a plan ready, use `/sisyphus`:
 
 | Command | Purpose | Output |
 |---------|---------|--------|
-| `/spec <description>` | Create software specification | `.omt/specs/*.md` |
-| `/prometheus <task>` | Create work plan | `.omt/plans/*.md` |
+| `/spec <description>` | Create software specification | `~/.omt/{OMT_PROJECT}/specs/*.md` |
+| `/prometheus <task>` | Create work plan | `~/.omt/{OMT_PROJECT}/plans/*.md` |
 | `/sisyphus` | Execute plan via orchestration | Verified code changes |
 | `/ralph <task>` | Iterative completion with oracle verification | Task completion |
 | `/hud setup\|restore` | HUD setup and management | statusLine configuration |

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -57,13 +57,13 @@ flowchart TD
 
     subgraph 설계 단계
         Spec["/spec"] --> SpecReviewer[spec-reviewer]
-        SpecReviewer --> SpecFile[".omt/specs/*.md"]
+        SpecReviewer --> SpecFile["~/.omt/{OMT_PROJECT}/specs/*.md"]
     end
 
     subgraph 기획 단계
         Prometheus["/prometheus"] --> Metis[metis<br/>갭 분석]
         Metis --> Prometheus
-        Prometheus --> PlanFile[".omt/plans/*.md"]
+        Prometheus --> PlanFile["~/.omt/{OMT_PROJECT}/plans/*.md"]
     end
 
     SpecFile -.->|참조| Prometheus
@@ -85,14 +85,14 @@ flowchart TD
 
 - **역할**: 포괄적이고 테스트 가능한 명세 작성
 - **제약**: 사용자 확인 없이 단계 완료 불가
-- **출력**: `.omt/specs/{name}/spec.md`
+- **출력**: `~/.omt/{OMT_PROJECT}/specs/{name}/spec.md` (`$OMT_DIR` 경유)
 - **핵심 기능**: spec-reviewer를 통한 다중 AI 피드백
 
 ### prometheus (기획자)
 
 - **역할**: 전략적 기획, 요구사항 인터뷰
 - **제약**: **READ-ONLY**. 절대 코드 작성 안 함.
-- **출력**: `.omt/plans/{name}.md`
+- **출력**: `~/.omt/{OMT_PROJECT}/plans/{name}.md` (`$OMT_DIR` 경유)
 - **워크플로우**: 인터뷰 -> 조사 -> Metis 상담 -> 계획 작성
 
 ### sisyphus (오케스트레이터)
@@ -134,7 +134,7 @@ flowchart TD
 1. **인터뷰 모드**: 질문을 통해 컨텍스트 수집
 2. **조사**: explore/librarian 에이전트로 코드베이스 조사
 3. **Metis 상담**: 계획 작성 전 필수 갭 분석
-4. **계획 생성**: `.omt/plans/*.md`에 구조화된 계획 작성
+4. **계획 생성**: `~/.omt/{OMT_PROJECT}/plans/*.md`에 구조화된 계획 작성
 
 ### 3단계: 실행
 
@@ -151,8 +151,8 @@ flowchart TD
 
 | 명령어 | 용도 | 출력 |
 |--------|------|------|
-| `/spec <설명>` | 소프트웨어 명세 작성 | `.omt/specs/*.md` |
-| `/prometheus <작업>` | 작업 계획 생성 | `.omt/plans/*.md` |
+| `/spec <설명>` | 소프트웨어 명세 작성 | `~/.omt/{OMT_PROJECT}/specs/*.md` |
+| `/prometheus <작업>` | 작업 계획 생성 | `~/.omt/{OMT_PROJECT}/plans/*.md` |
 | `/sisyphus` | 조율을 통한 계획 실행 | 검증된 코드 변경 |
 | `/ralph <작업>` | oracle 검증과 함께 반복적 완료 | 작업 완료 |
 | `/hud setup\|restore` | HUD 설정 및 관리 | statusLine 설정 |

--- a/hooks/keyword-detector.sh
+++ b/hooks/keyword-detector.sh
@@ -46,6 +46,19 @@ get_project_root() {
 # Get project root
 PROJECT_ROOT=$(get_project_root "$DIRECTORY")
 
+# Compute OMT_DIR if not already set by session-start.sh
+if [ -z "$OMT_DIR" ]; then
+  _omt_git_common=$(git -C "$PROJECT_ROOT" rev-parse --git-common-dir 2>/dev/null)
+  _omt_pname=""
+  if [ -n "$_omt_git_common" ] && [ "$_omt_git_common" != ".git" ]; then
+    _omt_pname=$(basename "$(dirname "$_omt_git_common")")
+  else
+    _omt_pname=$(basename "$PROJECT_ROOT")
+  fi
+  OMT_DIR="$HOME/.omt/${_omt_pname// /-}"
+  mkdir -p "$OMT_DIR"
+fi
+
 # Extract the prompt text - try multiple JSON paths
 PROMPT=""
 if command -v jq &> /dev/null; then
@@ -124,12 +137,8 @@ truncate_prompt_text() {
 # Function to create ralph state file
 # Uses SESSION_ID for session-specific file naming
 create_ralph_state() {
-  local dir="$1"
-  local prompt="$2"
+  local prompt="$1"
   local timestamp=$(date -Iseconds 2>/dev/null || date +"%Y-%m-%dT%H:%M:%S")
-
-  # Create local .omt directory
-  mkdir -p "$dir/.omt" 2>/dev/null
 
   if command -v jq &> /dev/null; then
     jq -n \
@@ -142,11 +151,11 @@ create_ralph_state() {
         completion_promise: "DONE",
         prompt: $prompt,
         started_at: $started_at
-      }' > "$dir/.omt/ralph-state-${SESSION_ID}.json" 2>/dev/null
+      }' > "$OMT_DIR/ralph-state-${SESSION_ID}.json" 2>/dev/null
   else
     # Fallback: basic escaping when jq is unavailable
     local escaped_prompt=$(printf '%s' "$prompt" | sed 's/\\/\\\\/g; s/"/\\"/g; s/	/\\t/g' | tr '\n' ' ')
-    cat > "$dir/.omt/ralph-state-${SESSION_ID}.json" 2>/dev/null << RALPH_STATE_EOF
+    cat > "$OMT_DIR/ralph-state-${SESSION_ID}.json" 2>/dev/null << RALPH_STATE_EOF
 {
   "active": true,
   "iteration": 0,
@@ -165,7 +174,7 @@ if echo "$PROMPT_LOWER" | grep -qE '\bralph\b'; then
   RALPH_CONTEXT_PROMPT=$(truncate_prompt_text "$PROMPT_CLEAN" "$RALPH_CONTEXT_PROMPT_MAX")
 
   # Create ralph state file
-  create_ralph_state "$PROJECT_ROOT" "$RALPH_STATE_PROMPT"
+  create_ralph_state "$RALPH_STATE_PROMPT"
 
   # Build ralph activation JSON safely using jq --arg to escape prompt
   if command -v jq &> /dev/null; then

--- a/hooks/keyword-detector.sh
+++ b/hooks/keyword-detector.sh
@@ -47,17 +47,9 @@ get_project_root() {
 PROJECT_ROOT=$(get_project_root "$DIRECTORY")
 
 # Compute OMT_DIR if not already set by session-start.sh
-if [ -z "$OMT_DIR" ]; then
-  _omt_git_common=$(git -C "$PROJECT_ROOT" rev-parse --git-common-dir 2>/dev/null)
-  _omt_pname=""
-  if [ -n "$_omt_git_common" ] && [ "$_omt_git_common" != ".git" ]; then
-    _omt_pname=$(basename "$(dirname "$_omt_git_common")")
-  else
-    _omt_pname=$(basename "$PROJECT_ROOT")
-  fi
-  OMT_DIR="$HOME/.omt/${_omt_pname// /-}"
-  mkdir -p "$OMT_DIR"
-fi
+SCRIPT_DIR_KD="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR_KD/lib/omt-dir.sh"
+compute_omt_dir "$PROJECT_ROOT"
 
 # Extract the prompt text - try multiple JSON paths
 PROMPT=""

--- a/hooks/keyword-detector_test.sh
+++ b/hooks/keyword-detector_test.sh
@@ -16,7 +16,9 @@ setup_test_env() {
     TEST_TMP_DIR=$(mktemp -d)
     # Create .git directory so get_project_root() can find project root
     mkdir -p "$TEST_TMP_DIR/.git"
-    mkdir -p "$TEST_TMP_DIR/.omt"
+    # Set OMT_DIR so hook uses this path directly (bypasses fallback computation)
+    export OMT_DIR="$TEST_TMP_DIR/.omt"
+    mkdir -p "$OMT_DIR"
     # Set HOME to test dir for global state files
     export HOME_BACKUP="$HOME"
     export HOME="$TEST_TMP_DIR"
@@ -25,6 +27,7 @@ setup_test_env() {
 
 teardown_test_env() {
     export HOME="$HOME_BACKUP"
+    unset OMT_DIR
     if [[ -d "$TEST_TMP_DIR" ]]; then
         rm -rf "$TEST_TMP_DIR"
     fi

--- a/hooks/lib/logging.sh
+++ b/hooks/lib/logging.sh
@@ -178,18 +178,11 @@ omt_log_init() {
     OMT_PROJECT_ROOT="$project_root"
 
     # Compute OMT_DIR if not already set by session-start.sh
+    local _log_script_dir
+    _log_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "$_log_script_dir/omt-dir.sh"
+    compute_omt_dir "$OMT_PROJECT_ROOT"
     local _log_omt_dir="$OMT_DIR"
-    if [[ -z "$_log_omt_dir" ]]; then
-        local _log_git_common
-        _log_git_common=$(git -C "$OMT_PROJECT_ROOT" rev-parse --git-common-dir 2>/dev/null)
-        local _log_pname=""
-        if [[ -n "$_log_git_common" ]] && [[ "$_log_git_common" != ".git" ]]; then
-            _log_pname=$(basename "$(dirname "$_log_git_common")")
-        else
-            _log_pname=$(basename "$OMT_PROJECT_ROOT")
-        fi
-        _log_omt_dir="$HOME/.omt/${_log_pname// /-}"
-    fi
 
     # Create log directory
     local log_dir="${_log_omt_dir}/logs"

--- a/hooks/lib/logging.sh
+++ b/hooks/lib/logging.sh
@@ -177,8 +177,22 @@ omt_log_init() {
     OMT_HOOK_NAME="$hook_name"
     OMT_PROJECT_ROOT="$project_root"
 
+    # Compute OMT_DIR if not already set by session-start.sh
+    local _log_omt_dir="$OMT_DIR"
+    if [[ -z "$_log_omt_dir" ]]; then
+        local _log_git_common
+        _log_git_common=$(git -C "$OMT_PROJECT_ROOT" rev-parse --git-common-dir 2>/dev/null)
+        local _log_pname=""
+        if [[ -n "$_log_git_common" ]] && [[ "$_log_git_common" != ".git" ]]; then
+            _log_pname=$(basename "$(dirname "$_log_git_common")")
+        else
+            _log_pname=$(basename "$OMT_PROJECT_ROOT")
+        fi
+        _log_omt_dir="$HOME/.omt/${_log_pname// /-}"
+    fi
+
     # Create log directory
-    local log_dir="$OMT_PROJECT_ROOT/.omt/logs"
+    local log_dir="${_log_omt_dir}/logs"
     mkdir -p "$log_dir" 2>/dev/null
 
     # Set log file path (with optional session ID suffix)

--- a/hooks/lib/logging_test.sh
+++ b/hooks/lib/logging_test.sh
@@ -22,6 +22,10 @@ setup_test_env() {
     ORIGINAL_HOME="$HOME"
     ORIGINAL_OMT_HOOK_LOG_ENABLED="${OMT_HOOK_LOG_ENABLED:-}"
     ORIGINAL_OMT_HOOK_LOG_LEVEL="${OMT_HOOK_LOG_LEVEL:-}"
+    ORIGINAL_OMT_DIR="${OMT_DIR:-}"
+
+    # Set OMT_DIR so logging lib uses this path directly (bypasses fallback computation)
+    export OMT_DIR="$TEST_TMP_DIR/.omt"
 
     # Create temporary home directory for isolated tests
     TEST_HOME=$(mktemp -d)
@@ -46,6 +50,11 @@ teardown_test_env() {
         export OMT_HOOK_LOG_LEVEL="$ORIGINAL_OMT_HOOK_LOG_LEVEL"
     else
         unset OMT_HOOK_LOG_LEVEL 2>/dev/null || true
+    fi
+    if [[ -n "$ORIGINAL_OMT_DIR" ]]; then
+        export OMT_DIR="$ORIGINAL_OMT_DIR"
+    else
+        unset OMT_DIR 2>/dev/null || true
     fi
 
     if [[ -d "$TEST_TMP_DIR" ]]; then
@@ -417,7 +426,7 @@ test_log_file_location_uses_project_root() {
     omt_log_info "test message"
 
     local expected_log="$TEST_TMP_DIR/.omt/logs/test-hook.log"
-    assert_file_exists "$expected_log" "Log should be at PROJECT_ROOT/.omt/logs/" || return 1
+    assert_file_exists "$expected_log" "Log should be at OMT_DIR/logs/" || return 1
 }
 
 # =============================================================================

--- a/hooks/lib/omt-dir.sh
+++ b/hooks/lib/omt-dir.sh
@@ -24,7 +24,7 @@ compute_omt_dir() {
 
   local _omt_root="$1"
   local _omt_git_common
-  _omt_git_common=$(git -C "$_omt_root" rev-parse --git-common-dir 2>/dev/null) || true
+  _omt_git_common=$(git -C "$_omt_root" rev-parse --git-common-dir 2>/dev/null) || _omt_git_common=""
 
   local _omt_name=""
   if [ -n "$_omt_git_common" ] && [ "$_omt_git_common" != ".git" ]; then
@@ -42,7 +42,7 @@ compute_omt_dir() {
     esac
   elif [ "$_omt_git_common" = ".git" ]; then
     # Standard repo: use the actual toplevel directory name
-    _omt_name=$(basename "$(git -C "$_omt_root" rev-parse --show-toplevel 2>/dev/null)") || true
+    _omt_name=$(basename "$(git -C "$_omt_root" rev-parse --show-toplevel 2>/dev/null)") || _omt_name=""
   else
     # No git: fall back to the project root basename
     _omt_name=$(basename "$_omt_root")

--- a/hooks/lib/omt-dir.sh
+++ b/hooks/lib/omt-dir.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# =============================================================================
+# oh-my-toong OMT_DIR Computation Library
+# Shared function for deriving OMT_DIR from a project root path.
+# Compatible with macOS Bash 3.2.
+# =============================================================================
+
+# compute_omt_dir <project-root>
+#
+# Sets OMT_DIR to "$HOME/.omt/<project-name>" and creates the directory.
+# If OMT_DIR is already set, returns immediately (no-op).
+#
+# Project name derivation (matches session-start.sh canonical logic):
+#   - Worktree: basename of the main repo directory (from --git-common-dir)
+#   - Standard repo: basename of --show-toplevel
+#   - No git: basename of <project-root>
+#
+# Arguments:
+#   $1  absolute path to the project root
+compute_omt_dir() {
+  if [ -n "$OMT_DIR" ]; then
+    return 0
+  fi
+
+  local _omt_root="$1"
+  local _omt_git_common
+  _omt_git_common=$(git -C "$_omt_root" rev-parse --git-common-dir 2>/dev/null)
+
+  local _omt_name=""
+  if [ -n "$_omt_git_common" ] && [ "$_omt_git_common" != ".git" ]; then
+    # Worktree: --git-common-dir returns an absolute path like /path/to/repo/.git
+    _omt_name=$(basename "$(dirname "$_omt_git_common")")
+  elif [ "$_omt_git_common" = ".git" ]; then
+    # Standard repo: use the actual toplevel directory name
+    _omt_name=$(basename "$(git -C "$_omt_root" rev-parse --show-toplevel 2>/dev/null)")
+  else
+    # No git: fall back to the project root basename
+    _omt_name=$(basename "$_omt_root")
+  fi
+
+  # Final fallback if name is still empty
+  if [ -z "$_omt_name" ]; then
+    _omt_name=$(basename "$_omt_root")
+  fi
+
+  # Sanitize: replace spaces with hyphens
+  OMT_DIR="$HOME/.omt/${_omt_name// /-}"
+  mkdir -p "$OMT_DIR"
+}

--- a/hooks/lib/omt-dir.sh
+++ b/hooks/lib/omt-dir.sh
@@ -18,21 +18,31 @@
 # Arguments:
 #   $1  absolute path to the project root
 compute_omt_dir() {
-  if [ -n "$OMT_DIR" ]; then
+  if [ -n "${OMT_DIR:-}" ]; then
     return 0
   fi
 
   local _omt_root="$1"
   local _omt_git_common
-  _omt_git_common=$(git -C "$_omt_root" rev-parse --git-common-dir 2>/dev/null)
+  _omt_git_common=$(git -C "$_omt_root" rev-parse --git-common-dir 2>/dev/null) || true
 
   local _omt_name=""
   if [ -n "$_omt_git_common" ] && [ "$_omt_git_common" != ".git" ]; then
-    # Worktree: --git-common-dir returns an absolute path like /path/to/repo/.git
-    _omt_name=$(basename "$(dirname "$_omt_git_common")")
+    # Worktree: --git-common-dir may return absolute or relative path
+    # Resolve relative path against _omt_root using cd && pwd (Bash 3.2 compatible)
+    case "$_omt_git_common" in
+      /*)
+        # Already absolute
+        _omt_name=$(basename "$(dirname "$_omt_git_common")")
+        ;;
+      *)
+        # Relative: resolve against _omt_root
+        _omt_name=$(basename "$(dirname "$(cd "$_omt_root/$_omt_git_common" && pwd)")")
+        ;;
+    esac
   elif [ "$_omt_git_common" = ".git" ]; then
     # Standard repo: use the actual toplevel directory name
-    _omt_name=$(basename "$(git -C "$_omt_root" rev-parse --show-toplevel 2>/dev/null)")
+    _omt_name=$(basename "$(git -C "$_omt_root" rev-parse --show-toplevel 2>/dev/null)") || true
   else
     # No git: fall back to the project root basename
     _omt_name=$(basename "$_omt_root")

--- a/hooks/persistent-mode/decision.test.ts
+++ b/hooks/persistent-mode/decision.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
 import { makeDecision, DecisionContext } from './decision.ts';
 import { mkdir, writeFile, rm } from 'fs/promises';
 import { join } from 'path';
@@ -7,8 +7,10 @@ import { tmpdir } from 'os';
 describe('makeDecision', () => {
   const testDir = join(tmpdir(), 'persistent-mode-decision-test-' + Date.now());
   const projectRoot = join(testDir, 'project');
-  const omtDir = join(projectRoot, '.omt');
+  const omtDir = join(testDir, 'omt');
   const stateDir = join(omtDir, 'state');
+
+  const savedOmtDir = process.env.OMT_DIR;
 
   beforeAll(async () => {
     await mkdir(stateDir, { recursive: true });
@@ -19,9 +21,18 @@ describe('makeDecision', () => {
   });
 
   beforeEach(async () => {
+    process.env.OMT_DIR = omtDir;
     // Clean up state files between tests
     await rm(omtDir, { recursive: true, force: true });
     await mkdir(stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (savedOmtDir === undefined) {
+      delete process.env.OMT_DIR;
+    } else {
+      process.env.OMT_DIR = savedOmtDir;
+    }
   });
 
   const createContext = (overrides: Partial<DecisionContext> = {}): DecisionContext => ({

--- a/hooks/persistent-mode/decision.ts
+++ b/hooks/persistent-mode/decision.ts
@@ -6,6 +6,8 @@ import {
 } from './state.ts';
 import { analyzeTranscript } from './transcript-detector.ts';
 import { generateAttemptId, ensureDir } from './utils.ts';
+import { join } from 'path';
+import { getOmtDir } from '@lib/omt-dir';
 
 export interface DecisionContext {
   projectRoot: string;
@@ -136,7 +138,7 @@ Do NOT stop until all tasks are completed.
 
 export function makeDecision(context: DecisionContext): HookOutput {
   const { projectRoot, sessionId, lastAssistantMessage, incompleteTodoCount } = context;
-  const stateDir = `${projectRoot}/.omt/state`;
+  const stateDir = join(getOmtDir(), 'state');
   const attemptId = generateAttemptId(sessionId, projectRoot);
 
   // Ensure state directory exists

--- a/hooks/persistent-mode/decision.ts
+++ b/hooks/persistent-mode/decision.ts
@@ -145,14 +145,14 @@ export function makeDecision(context: DecisionContext): HookOutput {
   ensureDir(stateDir);
 
   // Priority 1: Ralph Loop with Oracle Verification
-  const ralphState = readRalphState(projectRoot, sessionId);
+  const ralphState = readRalphState(sessionId);
 
   // Analyze last assistant message for completion markers
   const transcript = analyzeTranscript(lastAssistantMessage);
   if (ralphState && ralphState.active) {
     // Branch 1: Max iteration check (escape hatch, regardless of tasks)
     if (ralphState.iteration >= ralphState.max_iterations) {
-      cleanupRalphState(projectRoot, sessionId);
+      cleanupRalphState(sessionId);
       cleanupBlockCountFiles(stateDir, attemptId);
       return formatContinueOutput();
     }
@@ -165,7 +165,7 @@ export function makeDecision(context: DecisionContext): HookOutput {
         ...ralphState,
         iteration: newIteration,
       };
-      updateRalphState(projectRoot, sessionId, updatedState);
+      updateRalphState(sessionId, updatedState);
 
       const message = buildRalphContinuationMessage(
         newIteration,
@@ -178,7 +178,7 @@ export function makeDecision(context: DecisionContext): HookOutput {
 
     // Branch 3: VERIFIED_COMPLETE detected → cleanup → exit (regardless of DONE)
     if (transcript.hasOracleApproval) {
-      cleanupRalphState(projectRoot, sessionId);
+      cleanupRalphState(sessionId);
       cleanupBlockCountFiles(stateDir, attemptId);
       return formatContinueOutput();
     }
@@ -187,7 +187,7 @@ export function makeDecision(context: DecisionContext): HookOutput {
     if (transcript.hasCompletionPromise) {
       const newIteration = ralphState.iteration + 1;
       const updatedState: RalphState = { ...ralphState, iteration: newIteration };
-      updateRalphState(projectRoot, sessionId, updatedState);
+      updateRalphState(sessionId, updatedState);
       const message = buildOracleVerificationMessage(newIteration, ralphState.max_iterations, ralphState.prompt);
       return formatBlockOutput(message);
     }
@@ -195,7 +195,7 @@ export function makeDecision(context: DecisionContext): HookOutput {
     // Branch 5: No DONE detected → increment iteration → DONE reminder
     const newIteration = ralphState.iteration + 1;
     const updatedState: RalphState = { ...ralphState, iteration: newIteration };
-    updateRalphState(projectRoot, sessionId, updatedState);
+    updateRalphState(sessionId, updatedState);
     const message = buildNoDoneMessage(newIteration, ralphState.max_iterations, ralphState.prompt, ralphState.completion_promise || 'DONE');
     return formatBlockOutput(message);
   }

--- a/hooks/persistent-mode/index.test.ts
+++ b/hooks/persistent-mode/index.test.ts
@@ -17,6 +17,7 @@ describe('main entry point', () => {
   const originalCwd = process.cwd;
   const originalLog = console.log;
   const originalError = console.error;
+  const savedOmtDir = process.env.OMT_DIR;
 
   let capturedOutput: string[] = [];
   let capturedErrors: string[] = [];
@@ -32,6 +33,7 @@ describe('main entry point', () => {
   });
 
   beforeEach(() => {
+    process.env.OMT_DIR = omtDir;
     capturedOutput = [];
     capturedErrors = [];
     console.log = (...args: unknown[]) => {
@@ -43,6 +45,11 @@ describe('main entry point', () => {
   });
 
   afterEach(() => {
+    if (savedOmtDir === undefined) {
+      delete process.env.OMT_DIR;
+    } else {
+      process.env.OMT_DIR = savedOmtDir;
+    }
     console.log = originalLog;
     console.error = originalError;
   });
@@ -243,6 +250,7 @@ describe('main entry point', () => {
     beforeEach(async () => {
       process.env.HOME = join(taskTestDir, 'home');
       process.env.OMT_LOG_LEVEL = 'DEBUG';
+      process.env.OMT_DIR = join(taskProjectRoot, '.omt');
     });
 
     afterEach(() => {
@@ -313,6 +321,7 @@ describe('main entry point', () => {
     beforeEach(async () => {
       // Set DEBUG log level to capture all logs
       process.env.OMT_LOG_LEVEL = 'DEBUG';
+      process.env.OMT_DIR = join(loggingProjectRoot, '.omt');
       // Clean up logs directory before each test
       try {
         await rm(logsDir, { recursive: true, force: true });

--- a/hooks/persistent-mode/index.ts
+++ b/hooks/persistent-mode/index.ts
@@ -4,6 +4,7 @@ import { makeDecision, DecisionContext } from './decision.ts';
 import { readTasksFromDirectory, countIncompleteTasks } from '@lib/task-reader';
 import { join } from 'path';
 import { initLogger, logStart, logEnd, logInfo, logDebug, logError } from '@lib/logging';
+import { getOmtDir } from '@lib/omt-dir';
 
 export async function main(): Promise<void> {
   try {
@@ -15,7 +16,7 @@ export async function main(): Promise<void> {
     const projectRoot = getProjectRoot(input.directory);
 
     // Initialize logging
-    initLogger('persistent-mode', projectRoot, input.sessionId);
+    initLogger('persistent-mode', getOmtDir(), input.sessionId);
     logStart();
     logInfo(`stop hook invoked, sessionId=${input.sessionId}`);
 

--- a/hooks/persistent-mode/state.test.ts
+++ b/hooks/persistent-mode/state.test.ts
@@ -16,7 +16,6 @@ import { tmpdir } from 'os';
 
 describe('Ralph state management', () => {
   const testDir = join(tmpdir(), 'state-test-ralph-' + Date.now());
-  const projectRoot = join(testDir, 'project');
   const omtDir = join(testDir, 'omt');
   const sessionId = 'test-session';
 
@@ -47,7 +46,7 @@ describe('Ralph state management', () => {
 
   describe('readRalphState', () => {
     it('should return null when state file does not exist', () => {
-      const result = readRalphState(projectRoot, 'nonexistent');
+      const result = readRalphState('nonexistent');
 
       expect(result).toBeNull();
     });
@@ -65,7 +64,7 @@ describe('Ralph state management', () => {
         JSON.stringify(state)
       );
 
-      const result = readRalphState(projectRoot, sessionId);
+      const result = readRalphState(sessionId);
 
       expect(result).not.toBeNull();
       expect(result?.active).toBe(true);
@@ -86,7 +85,7 @@ describe('Ralph state management', () => {
         JSON.stringify(state)
       );
 
-      const result = readRalphState(projectRoot, sessionId);
+      const result = readRalphState(sessionId);
 
       expect(result).toBeNull();
     });
@@ -97,7 +96,7 @@ describe('Ralph state management', () => {
         'invalid json {'
       );
 
-      const result = readRalphState(projectRoot, sessionId);
+      const result = readRalphState(sessionId);
 
       expect(result).toBeNull();
     });
@@ -114,7 +113,7 @@ describe('Ralph state management', () => {
         oracle_feedback: ['Feedback 1'],
       };
 
-      updateRalphState(projectRoot, sessionId, state);
+      updateRalphState(sessionId, state);
 
       const content = await readFile(
         join(omtDir, `ralph-state-${sessionId}.json`),
@@ -136,7 +135,7 @@ describe('Ralph state management', () => {
         prompt: 'New task',
       };
 
-      updateRalphState(projectRoot, sessionId, state);
+      updateRalphState(sessionId, state);
 
       const stateFile = join(newOmtDir, `ralph-state-${sessionId}.json`);
       expect(existsSync(stateFile)).toBe(true);
@@ -148,13 +147,13 @@ describe('Ralph state management', () => {
       const stateFile = join(omtDir, `ralph-state-${sessionId}.json`);
       await writeFile(stateFile, '{}');
 
-      cleanupRalphState(projectRoot, sessionId);
+      cleanupRalphState(sessionId);
 
       expect(existsSync(stateFile)).toBe(false);
     });
 
     it('should not throw when file does not exist', () => {
-      expect(() => cleanupRalphState(projectRoot, 'nonexistent')).not.toThrow();
+      expect(() => cleanupRalphState('nonexistent')).not.toThrow();
     });
   });
 });

--- a/hooks/persistent-mode/state.test.ts
+++ b/hooks/persistent-mode/state.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
 import {
   readRalphState,
   updateRalphState,
@@ -12,13 +12,15 @@ import type { RalphState } from './types.ts';
 import { mkdir, rm, writeFile, readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
-import { tmpdir, homedir } from 'os';
+import { tmpdir } from 'os';
 
 describe('Ralph state management', () => {
   const testDir = join(tmpdir(), 'state-test-ralph-' + Date.now());
   const projectRoot = join(testDir, 'project');
-  const omtDir = join(projectRoot, '.omt');
+  const omtDir = join(testDir, 'omt');
   const sessionId = 'test-session';
+
+  const savedOmtDir = process.env.OMT_DIR;
 
   beforeAll(async () => {
     await mkdir(omtDir, { recursive: true });
@@ -29,9 +31,18 @@ describe('Ralph state management', () => {
   });
 
   beforeEach(async () => {
+    process.env.OMT_DIR = omtDir;
     // Clean up state files before each test
     const stateFile = join(omtDir, `ralph-state-${sessionId}.json`);
     try { await rm(stateFile, { force: true }); } catch {}
+  });
+
+  afterEach(() => {
+    if (savedOmtDir === undefined) {
+      delete process.env.OMT_DIR;
+    } else {
+      process.env.OMT_DIR = savedOmtDir;
+    }
   });
 
   describe('readRalphState', () => {
@@ -115,7 +126,8 @@ describe('Ralph state management', () => {
     });
 
     it('should create directory if it does not exist', async () => {
-      const newProjectRoot = join(testDir, 'new-project');
+      const newOmtDir = join(testDir, 'new-omt');
+      process.env.OMT_DIR = newOmtDir;
       const state: RalphState = {
         active: true,
         iteration: 1,
@@ -124,9 +136,9 @@ describe('Ralph state management', () => {
         prompt: 'New task',
       };
 
-      updateRalphState(newProjectRoot, sessionId, state);
+      updateRalphState(projectRoot, sessionId, state);
 
-      const stateFile = join(newProjectRoot, '.omt', `ralph-state-${sessionId}.json`);
+      const stateFile = join(newOmtDir, `ralph-state-${sessionId}.json`);
       expect(existsSync(stateFile)).toBe(true);
     });
   });

--- a/hooks/persistent-mode/state.ts
+++ b/hooks/persistent-mode/state.ts
@@ -5,7 +5,7 @@ import { getOmtDir } from '@lib/omt-dir';
 
 const MAX_BLOCK_COUNT = 5;
 
-export function readRalphState(_projectRoot: string, sessionId: string): RalphState | null {
+export function readRalphState(sessionId: string): RalphState | null {
   const path = join(getOmtDir(), `ralph-state-${sessionId}.json`);
   const content = readFileOrNull(path);
   if (!content) return null;
@@ -18,12 +18,12 @@ export function readRalphState(_projectRoot: string, sessionId: string): RalphSt
   }
 }
 
-export function updateRalphState(_projectRoot: string, sessionId: string, state: RalphState): void {
+export function updateRalphState(sessionId: string, state: RalphState): void {
   const path = join(getOmtDir(), `ralph-state-${sessionId}.json`);
   writeFileSafe(path, JSON.stringify(state, null, 2));
 }
 
-export function cleanupRalphState(_projectRoot: string, sessionId: string): void {
+export function cleanupRalphState(sessionId: string): void {
   deleteFile(join(getOmtDir(), `ralph-state-${sessionId}.json`));
 }
 

--- a/hooks/persistent-mode/state.ts
+++ b/hooks/persistent-mode/state.ts
@@ -5,7 +5,7 @@ import { getOmtDir } from '@lib/omt-dir';
 
 const MAX_BLOCK_COUNT = 5;
 
-export function readRalphState(projectRoot: string, sessionId: string): RalphState | null {
+export function readRalphState(_projectRoot: string, sessionId: string): RalphState | null {
   const path = join(getOmtDir(), `ralph-state-${sessionId}.json`);
   const content = readFileOrNull(path);
   if (!content) return null;
@@ -18,12 +18,12 @@ export function readRalphState(projectRoot: string, sessionId: string): RalphSta
   }
 }
 
-export function updateRalphState(projectRoot: string, sessionId: string, state: RalphState): void {
+export function updateRalphState(_projectRoot: string, sessionId: string, state: RalphState): void {
   const path = join(getOmtDir(), `ralph-state-${sessionId}.json`);
   writeFileSafe(path, JSON.stringify(state, null, 2));
 }
 
-export function cleanupRalphState(projectRoot: string, sessionId: string): void {
+export function cleanupRalphState(_projectRoot: string, sessionId: string): void {
   deleteFile(join(getOmtDir(), `ralph-state-${sessionId}.json`));
 }
 

--- a/hooks/persistent-mode/state.ts
+++ b/hooks/persistent-mode/state.ts
@@ -1,10 +1,12 @@
 import { RalphState } from './types.ts';
 import { readFileOrNull, writeFileSafe, deleteFile, ensureDir } from './utils.ts';
+import { join } from 'path';
+import { getOmtDir } from '@lib/omt-dir';
 
 const MAX_BLOCK_COUNT = 5;
 
 export function readRalphState(projectRoot: string, sessionId: string): RalphState | null {
-  const path = `${projectRoot}/.omt/ralph-state-${sessionId}.json`;
+  const path = join(getOmtDir(), `ralph-state-${sessionId}.json`);
   const content = readFileOrNull(path);
   if (!content) return null;
 
@@ -17,12 +19,12 @@ export function readRalphState(projectRoot: string, sessionId: string): RalphSta
 }
 
 export function updateRalphState(projectRoot: string, sessionId: string, state: RalphState): void {
-  const path = `${projectRoot}/.omt/ralph-state-${sessionId}.json`;
+  const path = join(getOmtDir(), `ralph-state-${sessionId}.json`);
   writeFileSafe(path, JSON.stringify(state, null, 2));
 }
 
 export function cleanupRalphState(projectRoot: string, sessionId: string): void {
-  deleteFile(`${projectRoot}/.omt/ralph-state-${sessionId}.json`);
+  deleteFile(join(getOmtDir(), `ralph-state-${sessionId}.json`));
 }
 
 // Block counting for stuck agent escape hatch

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -69,14 +69,14 @@ PROJECT_NAME="${PROJECT_NAME// /-}"
 
 # Export OMT_PROJECT via Claude env file
 if [ -n "$CLAUDE_ENV_FILE" ]; then
-  echo "export OMT_PROJECT=$PROJECT_NAME" >> "$CLAUDE_ENV_FILE"
+  echo "export OMT_PROJECT=\"$PROJECT_NAME\"" >> "$CLAUDE_ENV_FILE"
 fi
 
 # Compute and export OMT_DIR (per-project working directory)
 OMT_DIR="$HOME/.omt/$PROJECT_NAME"
 mkdir -p "$OMT_DIR"
 if [ -n "$CLAUDE_ENV_FILE" ]; then
-  echo "export OMT_DIR=$OMT_DIR" >> "$CLAUDE_ENV_FILE"
+  echo "export OMT_DIR=\"$OMT_DIR\"" >> "$CLAUDE_ENV_FILE"
 fi
 
 MESSAGES=""

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -72,6 +72,13 @@ if [ -n "$CLAUDE_ENV_FILE" ]; then
   echo "export OMT_PROJECT=$PROJECT_NAME" >> "$CLAUDE_ENV_FILE"
 fi
 
+# Compute and export OMT_DIR (per-project working directory)
+OMT_DIR="$HOME/.omt/$PROJECT_NAME"
+mkdir -p "$OMT_DIR"
+if [ -n "$CLAUDE_ENV_FILE" ]; then
+  echo "export OMT_DIR=$OMT_DIR" >> "$CLAUDE_ENV_FILE"
+fi
+
 MESSAGES=""
 
 # Cleanup stale ralph-state files (older than 3 hours)
@@ -79,7 +86,7 @@ if command -v jq &> /dev/null; then
   STALE_THRESHOLD=10800  # 3 hours in seconds
   CURRENT_TIME=$(date +%s)
 
-  for state_file in "$PROJECT_ROOT"/.omt/ralph-state-*.json; do
+  for state_file in "$OMT_DIR"/ralph-state-*.json; do
     if [ -f "$state_file" ]; then
       STARTED_AT=$(jq -r '.started_at // ""' "$state_file" 2>/dev/null)
       if [ -n "$STARTED_AT" ] && [ "$STARTED_AT" != "null" ]; then
@@ -99,8 +106,8 @@ if command -v jq &> /dev/null; then
 fi
 
 # Check for active ralph loop state (session-specific)
-if [ -f "$PROJECT_ROOT/.omt/ralph-state-${SESSION_ID}.json" ]; then
-  RALPH_STATE=$(cat "$PROJECT_ROOT/.omt/ralph-state-${SESSION_ID}.json" 2>/dev/null)
+if [ -f "$OMT_DIR/ralph-state-${SESSION_ID}.json" ]; then
+  RALPH_STATE=$(cat "$OMT_DIR/ralph-state-${SESSION_ID}.json" 2>/dev/null)
 
   if command -v jq &> /dev/null; then
     IS_ACTIVE=$(echo "$RALPH_STATE" | jq -r '.active // false' 2>/dev/null)
@@ -136,7 +143,7 @@ if [ -d "$TODOS_DIR" ]; then
 fi
 
 # Check for incomplete todos in project directory
-for todo_path in "$PROJECT_ROOT/.omt/todos.json" "$DIRECTORY/.claude/todos.json"; do
+for todo_path in "$OMT_DIR/todos.json" "$DIRECTORY/.claude/todos.json"; do
   if [ -f "$todo_path" ]; then
     if command -v jq &> /dev/null; then
       COUNT=$(jq 'if type == "array" then [.[] | select(.status != "completed" and .status != "cancelled")] | length else 0 end' "$todo_path" 2>/dev/null || echo "0")

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -46,35 +46,19 @@ get_project_root() {
 # Get project root
 PROJECT_ROOT=$(get_project_root "$DIRECTORY")
 
-# Derive OMT_PROJECT name (main repo name, not worktree branch name)
-PROJECT_NAME=""
-if command -v git &> /dev/null; then
-  GIT_COMMON_DIR=$(git -C "$PROJECT_ROOT" rev-parse --git-common-dir 2>/dev/null)
-  if [ -n "$GIT_COMMON_DIR" ] && [ "$GIT_COMMON_DIR" != ".git" ]; then
-    # Worktree: git-common-dir returns absolute path like /path/to/repo/.git
-    PROJECT_NAME=$(basename "$(dirname "$GIT_COMMON_DIR")")
-  elif [ "$GIT_COMMON_DIR" = ".git" ]; then
-    # Standard repo: use toplevel directory name
-    PROJECT_NAME=$(basename "$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel 2>/dev/null)")
-  fi
-fi
-
-# Final fallback: use PROJECT_ROOT basename
-if [ -z "$PROJECT_NAME" ]; then
-  PROJECT_NAME=$(basename "$PROJECT_ROOT")
-fi
-
-# Sanitize: replace spaces with hyphens to prevent shell parsing issues
-PROJECT_NAME="${PROJECT_NAME// /-}"
+# Compute OMT_DIR via shared library
+SCRIPT_DIR_SS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=hooks/lib/omt-dir.sh
+source "$SCRIPT_DIR_SS/lib/omt-dir.sh"
+compute_omt_dir "$PROJECT_ROOT"
+PROJECT_NAME=$(basename "$OMT_DIR")
 
 # Export OMT_PROJECT via Claude env file
 if [ -n "$CLAUDE_ENV_FILE" ]; then
   echo "export OMT_PROJECT=\"$PROJECT_NAME\"" >> "$CLAUDE_ENV_FILE"
 fi
 
-# Compute and export OMT_DIR (per-project working directory)
-OMT_DIR="$HOME/.omt/$PROJECT_NAME"
-mkdir -p "$OMT_DIR"
+# Export OMT_DIR via Claude env file
 if [ -n "$CLAUDE_ENV_FILE" ]; then
   echo "export OMT_DIR=\"$OMT_DIR\"" >> "$CLAUDE_ENV_FILE"
 fi

--- a/hooks/session-start_test.sh
+++ b/hooks/session-start_test.sh
@@ -24,6 +24,12 @@ setup_test_env() {
     TEST_HOME=$(mktemp -d)
     mkdir -p "$TEST_HOME/.claude"
     export HOME="$TEST_HOME"
+
+    # Pre-compute TEST_OMT_DIR: mirrors session-start.sh OMT_DIR derivation.
+    # Since TEST_TMP_DIR has no real git repo, PROJECT_NAME = basename(TEST_TMP_DIR).
+    TEST_PROJECT_NAME=$(basename "$TEST_TMP_DIR")
+    TEST_OMT_DIR="$TEST_HOME/.omt/$TEST_PROJECT_NAME"
+    mkdir -p "$TEST_OMT_DIR"
 }
 
 teardown_test_env() {
@@ -100,7 +106,7 @@ test_session_start_extracts_session_id() {
 
 test_session_start_reads_session_specific_ralph_state() {
     # Create session-specific ralph state file
-    cat > "$TEST_TMP_DIR/.omt/ralph-state-test-session-abc.json" << 'EOF'
+    cat > "$TEST_OMT_DIR/ralph-state-test-session-abc.json" << 'EOF'
 {
   "active": true,
   "iteration": 3,
@@ -120,7 +126,7 @@ EOF
 
 test_session_start_ignores_other_sessions_ralph_state() {
     # Create ralph state file for DIFFERENT session
-    cat > "$TEST_TMP_DIR/.omt/ralph-state-other-session.json" << 'EOF'
+    cat > "$TEST_OMT_DIR/ralph-state-other-session.json" << 'EOF'
 {
   "active": true,
   "iteration": 5,
@@ -140,7 +146,7 @@ EOF
 
 test_session_start_uses_default_when_no_session_id() {
     # Create default ralph state file
-    cat > "$TEST_TMP_DIR/.omt/ralph-state-default.json" << 'EOF'
+    cat > "$TEST_OMT_DIR/ralph-state-default.json" << 'EOF'
 {
   "active": true,
   "iteration": 2,
@@ -170,7 +176,7 @@ test_session_start_no_verification_file_references() {
 
 test_session_start_reads_oracle_feedback_from_ralph_state() {
     # Create ralph state with oracle_feedback
-    cat > "$TEST_TMP_DIR/.omt/ralph-state-test-session-feedback.json" << 'EOF'
+    cat > "$TEST_OMT_DIR/ralph-state-test-session-feedback.json" << 'EOF'
 {
   "active": true,
   "iteration": 3,
@@ -201,7 +207,7 @@ EOF
 
 test_session_start_ignores_other_sessions_ultrawork_state() {
     # Create ultrawork state file for DIFFERENT session
-    cat > "$TEST_TMP_DIR/.omt/ultrawork-state-other-session.json" << 'EOF'
+    cat > "$TEST_OMT_DIR/ultrawork-state-other-session.json" << 'EOF'
 {
   "active": true,
   "started_at": "2024-01-01T00:00:00",
@@ -227,6 +233,78 @@ test_session_start_no_generic_ultrawork_state() {
         return 1
     else
         return 0
+    fi
+}
+
+# =============================================================================
+# Tests: OMT_DIR export and directory creation
+# =============================================================================
+
+test_session_start_exports_omt_dir_via_claude_env_file() {
+    # session-start.sh should export OMT_DIR into CLAUDE_ENV_FILE
+    local env_file
+    env_file=$(mktemp)
+
+    echo '{"cwd": "'"$TEST_TMP_DIR"'"}' | CLAUDE_ENV_FILE="$env_file" "$SCRIPT_DIR/session-start.sh" > /dev/null 2>&1 || true
+
+    if grep -q 'export OMT_DIR=' "$env_file"; then
+        rm -f "$env_file"
+        return 0
+    else
+        echo "ASSERTION FAILED: CLAUDE_ENV_FILE should contain 'export OMT_DIR='"
+        echo "  env_file contents: $(cat "$env_file")"
+        rm -f "$env_file"
+        return 1
+    fi
+}
+
+test_session_start_omt_dir_points_under_home_omt() {
+    # OMT_DIR exported should be under $HOME/.omt/
+    local env_file
+    env_file=$(mktemp)
+
+    echo '{"cwd": "'"$TEST_TMP_DIR"'"}' | CLAUDE_ENV_FILE="$env_file" "$SCRIPT_DIR/session-start.sh" > /dev/null 2>&1 || true
+
+    local exported_omt_dir
+    exported_omt_dir=$(grep 'export OMT_DIR=' "$env_file" | sed 's/export OMT_DIR=//' | head -1)
+
+    rm -f "$env_file"
+
+    if [[ "$exported_omt_dir" == "$TEST_HOME/.omt/"* ]]; then
+        return 0
+    else
+        echo "ASSERTION FAILED: OMT_DIR should be under \$HOME/.omt/"
+        echo "  Got: '$exported_omt_dir'"
+        echo "  Expected prefix: '$TEST_HOME/.omt/'"
+        return 1
+    fi
+}
+
+test_session_start_creates_omt_dir() {
+    # session-start.sh should create the OMT_DIR directory
+    local env_file
+    env_file=$(mktemp)
+
+    # Use a unique project dir so we can predict OMT_DIR
+    local proj_dir
+    proj_dir=$(mktemp -d)
+    mkdir -p "$proj_dir/.git"
+
+    echo '{"cwd": "'"$proj_dir"'"}' | CLAUDE_ENV_FILE="$env_file" "$SCRIPT_DIR/session-start.sh" > /dev/null 2>&1 || true
+
+    local exported_omt_dir
+    exported_omt_dir=$(grep 'export OMT_DIR=' "$env_file" | sed 's/export OMT_DIR=//' | head -1)
+
+    rm -f "$env_file"
+    rm -rf "$proj_dir"
+
+    if [[ -n "$exported_omt_dir" ]] && [[ -d "$exported_omt_dir" ]]; then
+        return 0
+    else
+        echo "ASSERTION FAILED: OMT_DIR directory should be created by session-start.sh"
+        echo "  OMT_DIR: '$exported_omt_dir'"
+        echo "  Exists: $([ -d "$exported_omt_dir" ] && echo yes || echo no)"
+        return 1
     fi
 }
 
@@ -274,6 +352,11 @@ main() {
     # Session-based ultrawork state tests
     run_test test_session_start_ignores_other_sessions_ultrawork_state
     run_test test_session_start_no_generic_ultrawork_state
+
+    # OMT_DIR export and directory creation
+    run_test test_session_start_exports_omt_dir_via_claude_env_file
+    run_test test_session_start_omt_dir_points_under_home_omt
+    run_test test_session_start_creates_omt_dir
 
     # Project root detection - session-start (from hooks/test/project_root_test.sh)
     run_test test_get_project_root_function_exists_in_session_start

--- a/hooks/session-start_test.sh
+++ b/hooks/session-start_test.sh
@@ -266,7 +266,7 @@ test_session_start_omt_dir_points_under_home_omt() {
     echo '{"cwd": "'"$TEST_TMP_DIR"'"}' | CLAUDE_ENV_FILE="$env_file" "$SCRIPT_DIR/session-start.sh" > /dev/null 2>&1 || true
 
     local exported_omt_dir
-    exported_omt_dir=$(grep 'export OMT_DIR=' "$env_file" | sed 's/export OMT_DIR=//' | head -1)
+    exported_omt_dir=$(grep 'export OMT_DIR=' "$env_file" | sed 's/export OMT_DIR=//' | sed 's/^"//;s/"$//' | head -1)
 
     rm -f "$env_file"
 
@@ -293,7 +293,7 @@ test_session_start_creates_omt_dir() {
     echo '{"cwd": "'"$proj_dir"'"}' | CLAUDE_ENV_FILE="$env_file" "$SCRIPT_DIR/session-start.sh" > /dev/null 2>&1 || true
 
     local exported_omt_dir
-    exported_omt_dir=$(grep 'export OMT_DIR=' "$env_file" | sed 's/export OMT_DIR=//' | head -1)
+    exported_omt_dir=$(grep 'export OMT_DIR=' "$env_file" | sed 's/export OMT_DIR=//' | sed 's/^"//;s/"$//' | head -1)
 
     rm -f "$env_file"
     rm -rf "$proj_dir"

--- a/hooks/stop-notify.sh
+++ b/hooks/stop-notify.sh
@@ -35,16 +35,9 @@ find_project_root() {
 PROJECT_ROOT=$(find_project_root "$CWD")
 
 # Compute OMT_DIR if not already set by session-start.sh
-if [[ -z "$OMT_DIR" ]]; then
-  _omt_git_common=$(git -C "$PROJECT_ROOT" rev-parse --git-common-dir 2>/dev/null)
-  _omt_pname=""
-  if [[ -n "$_omt_git_common" ]] && [[ "$_omt_git_common" != ".git" ]]; then
-    _omt_pname=$(basename "$(dirname "$_omt_git_common")")
-  else
-    _omt_pname=$(basename "$PROJECT_ROOT")
-  fi
-  OMT_DIR="$HOME/.omt/${_omt_pname// /-}"
-fi
+SCRIPT_DIR_SN="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR_SN/lib/omt-dir.sh"
+compute_omt_dir "$PROJECT_ROOT"
 
 # --- 조건 검사: ralph-state 활성 여부 ---
 RALPH_STATE_FILE="$OMT_DIR/ralph-state-${SESSION_ID}.json"

--- a/hooks/stop-notify.sh
+++ b/hooks/stop-notify.sh
@@ -34,8 +34,20 @@ find_project_root() {
 
 PROJECT_ROOT=$(find_project_root "$CWD")
 
+# Compute OMT_DIR if not already set by session-start.sh
+if [[ -z "$OMT_DIR" ]]; then
+  _omt_git_common=$(git -C "$PROJECT_ROOT" rev-parse --git-common-dir 2>/dev/null)
+  _omt_pname=""
+  if [[ -n "$_omt_git_common" ]] && [[ "$_omt_git_common" != ".git" ]]; then
+    _omt_pname=$(basename "$(dirname "$_omt_git_common")")
+  else
+    _omt_pname=$(basename "$PROJECT_ROOT")
+  fi
+  OMT_DIR="$HOME/.omt/${_omt_pname// /-}"
+fi
+
 # --- 조건 검사: ralph-state 활성 여부 ---
-RALPH_STATE_FILE="$PROJECT_ROOT/.omt/ralph-state-${SESSION_ID}.json"
+RALPH_STATE_FILE="$OMT_DIR/ralph-state-${SESSION_ID}.json"
 if [[ -f "$RALPH_STATE_FILE" ]]; then
   RALPH_ACTIVE=$(jq -r '.active // false' "$RALPH_STATE_FILE" 2>/dev/null)
   if [[ "$RALPH_ACTIVE" == "true" ]]; then

--- a/hooks/stop-notify_test.sh
+++ b/hooks/stop-notify_test.sh
@@ -1,0 +1,305 @@
+#!/bin/bash
+# =============================================================================
+# Stop Notify Hook Tests
+# Tests for OMT_DIR resolution and ralph-state gating logic
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Test utilities
+TESTS_PASSED=0
+TESTS_FAILED=0
+CURRENT_TEST=""
+
+setup_test_env() {
+    TEST_TMP_DIR=$(mktemp -d)
+    mkdir -p "$TEST_TMP_DIR/.git"
+
+    # Store and redirect HOME to isolate task-file checks
+    ORIGINAL_HOME="$HOME"
+    TEST_HOME=$(mktemp -d)
+    mkdir -p "$TEST_HOME/.claude"
+    export HOME="$TEST_HOME"
+
+    # Create a mock bin dir to intercept osascript
+    TEST_BIN_DIR=$(mktemp -d)
+    # Mock osascript: write a marker file and succeed silently
+    cat > "$TEST_BIN_DIR/osascript" << 'MOCK'
+#!/bin/bash
+touch "${OSASCRIPT_MARKER_FILE:-/dev/null}"
+exit 0
+MOCK
+    chmod +x "$TEST_BIN_DIR/osascript"
+
+    # Mock terminal-notifier absence: do not add it to PATH
+    export ORIGINAL_PATH="$PATH"
+    export PATH="$TEST_BIN_DIR:$PATH"
+
+    # Save OMT_DIR if it was set
+    ORIGINAL_OMT_DIR="${OMT_DIR:-}"
+    unset OMT_DIR
+}
+
+teardown_test_env() {
+    export HOME="$ORIGINAL_HOME"
+    export PATH="$ORIGINAL_PATH"
+
+    # Restore OMT_DIR
+    if [[ -n "$ORIGINAL_OMT_DIR" ]]; then
+        export OMT_DIR="$ORIGINAL_OMT_DIR"
+    else
+        unset OMT_DIR
+    fi
+
+    if [[ -d "$TEST_TMP_DIR" ]]; then
+        rm -rf "$TEST_TMP_DIR"
+    fi
+    if [[ -d "$TEST_HOME" ]]; then
+        rm -rf "$TEST_HOME"
+    fi
+    if [[ -d "$TEST_BIN_DIR" ]]; then
+        rm -rf "$TEST_BIN_DIR"
+    fi
+}
+
+run_test() {
+    local test_name="$1"
+    CURRENT_TEST="$test_name"
+
+    setup_test_env
+
+    if "$test_name"; then
+        echo "[PASS] $test_name"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "[FAIL] $test_name"
+        ((TESTS_FAILED++)) || true
+    fi
+
+    teardown_test_env
+}
+
+# Run the hook with JSON input piped to stdin.
+# Arguments:
+#   $1  session_id value (used as session_id in JSON)
+#   $2  cwd path (defaults to TEST_TMP_DIR)
+run_stop_notify() {
+    local session_id="${1:-test-session}"
+    local cwd="${2:-$TEST_TMP_DIR}"
+    echo "{\"session_id\": \"$session_id\", \"cwd\": \"$cwd\"}" | "$SCRIPT_DIR/stop-notify.sh"
+}
+
+# =============================================================================
+# Tests: OMT_DIR preset passthrough (compute_omt_dir is a no-op)
+# =============================================================================
+
+test_omt_dir_preset_is_respected() {
+    # When OMT_DIR is set before running the hook, compute_omt_dir must not
+    # overwrite it (the library's no-op guard must be honored).
+    local preset_dir="$TEST_TMP_DIR/my-preset-omt"
+    mkdir -p "$preset_dir"
+    export OMT_DIR="$preset_dir"
+
+    # Create a marker file to confirm we reached the notification stage
+    local marker="$TEST_TMP_DIR/notified"
+    export OSASCRIPT_MARKER_FILE="$marker"
+
+    run_stop_notify "s1" "$TEST_TMP_DIR" > /dev/null 2>&1 || true
+
+    # OMT_DIR must still be the preset value after the hook runs.
+    # We verify indirectly: ralph-state lookup uses preset_dir, not a fallback.
+    # Since no ralph-state exists, the hook should proceed to notification.
+    if [[ ! -f "$marker" ]]; then
+        echo "ASSERTION FAILED: osascript should have been called (notification stage reached)"
+        return 1
+    fi
+
+    # Confirm the preset_dir was used: no directory under HOME/.omt should have
+    # been created for this project (because OMT_DIR was already set).
+    local project_name
+    project_name=$(basename "$TEST_TMP_DIR")
+    if [[ -d "$TEST_HOME/.omt/$project_name" ]]; then
+        echo "ASSERTION FAILED: fallback OMT_DIR should not be created when OMT_DIR is preset"
+        return 1
+    fi
+
+    return 0
+}
+
+# =============================================================================
+# Tests: OMT_DIR fallback computation from git repo
+# =============================================================================
+
+test_omt_dir_fallback_computed_from_git_repo() {
+    # When OMT_DIR is unset, compute_omt_dir should derive it from the git
+    # repo's toplevel directory name and place it under $HOME/.omt/.
+    unset OMT_DIR
+
+    local marker="$TEST_TMP_DIR/notified"
+    export OSASCRIPT_MARKER_FILE="$marker"
+
+    # TEST_TMP_DIR has a .git directory (created in setup_test_env).
+    # The git repo basename is the dir name of TEST_TMP_DIR.
+    local project_name
+    project_name=$(basename "$TEST_TMP_DIR")
+    local expected_omt_dir="$TEST_HOME/.omt/$project_name"
+
+    run_stop_notify "s2" "$TEST_TMP_DIR" > /dev/null 2>&1 || true
+
+    # The hook should have created the expected OMT_DIR
+    if [[ ! -d "$expected_omt_dir" ]]; then
+        echo "ASSERTION FAILED: fallback OMT_DIR should be created at $expected_omt_dir"
+        return 1
+    fi
+
+    # Notification should still reach osascript (no ralph-state file present)
+    if [[ ! -f "$marker" ]]; then
+        echo "ASSERTION FAILED: osascript should have been called after fallback OMT_DIR computation"
+        return 1
+    fi
+
+    return 0
+}
+
+# =============================================================================
+# Tests: ralph-state active suppresses notification
+# =============================================================================
+
+test_ralph_state_active_suppresses_notification() {
+    # When ralph-state-{session}.json has "active": true, the hook must
+    # exit before reaching the notification stage.
+    local omt_dir="$TEST_TMP_DIR/.omt"
+    mkdir -p "$omt_dir"
+    export OMT_DIR="$omt_dir"
+
+    local session_id="session-active"
+    cat > "$omt_dir/ralph-state-${session_id}.json" << 'EOF'
+{"active": true, "iteration": 1, "max_iterations": 10, "completion_promise": "DONE"}
+EOF
+
+    local marker="$TEST_TMP_DIR/notified"
+    export OSASCRIPT_MARKER_FILE="$marker"
+
+    run_stop_notify "$session_id" "$TEST_TMP_DIR" > /dev/null 2>&1 || true
+
+    # osascript must NOT have been called
+    if [[ -f "$marker" ]]; then
+        echo "ASSERTION FAILED: osascript should NOT be called when ralph is active"
+        return 1
+    fi
+
+    return 0
+}
+
+# =============================================================================
+# Tests: ralph-state absent allows notification
+# =============================================================================
+
+test_ralph_state_absent_allows_notification() {
+    # When no ralph-state file exists, the hook must proceed to notification.
+    local omt_dir="$TEST_TMP_DIR/.omt"
+    mkdir -p "$omt_dir"
+    export OMT_DIR="$omt_dir"
+
+    # Ensure no state file exists
+    rm -f "$omt_dir/ralph-state-session-absent.json"
+
+    local marker="$TEST_TMP_DIR/notified"
+    export OSASCRIPT_MARKER_FILE="$marker"
+
+    run_stop_notify "session-absent" "$TEST_TMP_DIR" > /dev/null 2>&1 || true
+
+    # osascript MUST have been called
+    if [[ ! -f "$marker" ]]; then
+        echo "ASSERTION FAILED: osascript should be called when no ralph-state file exists"
+        return 1
+    fi
+
+    return 0
+}
+
+# =============================================================================
+# Tests: ralph-state active=false allows notification
+# =============================================================================
+
+test_ralph_state_inactive_allows_notification() {
+    # When ralph-state has "active": false, the hook must proceed to notification.
+    local omt_dir="$TEST_TMP_DIR/.omt"
+    mkdir -p "$omt_dir"
+    export OMT_DIR="$omt_dir"
+
+    local session_id="session-inactive"
+    cat > "$omt_dir/ralph-state-${session_id}.json" << 'EOF'
+{"active": false, "iteration": 5, "max_iterations": 10, "completion_promise": "DONE"}
+EOF
+
+    local marker="$TEST_TMP_DIR/notified"
+    export OSASCRIPT_MARKER_FILE="$marker"
+
+    run_stop_notify "$session_id" "$TEST_TMP_DIR" > /dev/null 2>&1 || true
+
+    # osascript MUST have been called
+    if [[ ! -f "$marker" ]]; then
+        echo "ASSERTION FAILED: osascript should be called when ralph-state has active=false"
+        return 1
+    fi
+
+    return 0
+}
+
+# =============================================================================
+# Tests: empty cwd causes early exit (no notification)
+# =============================================================================
+
+test_empty_cwd_causes_early_exit() {
+    # When cwd is absent from the JSON input, the hook exits early.
+    local omt_dir="$TEST_TMP_DIR/.omt"
+    mkdir -p "$omt_dir"
+    export OMT_DIR="$omt_dir"
+
+    local marker="$TEST_TMP_DIR/notified"
+    export OSASCRIPT_MARKER_FILE="$marker"
+
+    echo '{"session_id": "s-empty-cwd"}' | "$SCRIPT_DIR/stop-notify.sh" > /dev/null 2>&1 || true
+
+    # osascript must NOT have been called
+    if [[ -f "$marker" ]]; then
+        echo "ASSERTION FAILED: osascript should NOT be called when cwd is empty"
+        return 1
+    fi
+
+    return 0
+}
+
+# =============================================================================
+# Main Test Runner
+# =============================================================================
+
+main() {
+    echo "=========================================="
+    echo "Stop Notify Hook Tests"
+    echo "=========================================="
+
+    # OMT_DIR resolution
+    run_test test_omt_dir_preset_is_respected
+    run_test test_omt_dir_fallback_computed_from_git_repo
+
+    # ralph-state gating logic
+    run_test test_ralph_state_active_suppresses_notification
+    run_test test_ralph_state_absent_allows_notification
+    run_test test_ralph_state_inactive_allows_notification
+
+    # Early exit guard
+    run_test test_empty_cwd_causes_early_exit
+
+    echo "=========================================="
+    echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"
+    echo "=========================================="
+
+    if [[ $TESTS_FAILED -gt 0 ]]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -1170,12 +1170,12 @@ describe('parseYamlSimple', () => {
       'chunk-review:',
       '  context:',
       '    shared_context_dir: ~/my/context',
-      '    specs_dir: .omt/specs',
+      '    specs_dir: specs',
     ].join('\n'));
     const result = parseYamlSimple(configPath, chunkFallback, chunkReviewConfig, ['context']);
     expect(result['chunk-review'].context).toBeDefined();
     expect(result['chunk-review'].context.shared_context_dir).toBe('~/my/context');
-    expect(result['chunk-review'].context.specs_dir).toBe('.omt/specs');
+    expect(result['chunk-review'].context.specs_dir).toBe('specs');
   });
 
   test('extraSections: fallback context 값과 merge됨', () => {
@@ -1188,7 +1188,7 @@ describe('parseYamlSimple', () => {
     const fallbackWithContext = {
       'chunk-review': {
         ...chunkFallback['chunk-review'],
-        context: { shared_context_dir: '~/.omt/default', specs_dir: '.omt/specs' },
+        context: { shared_context_dir: '~/.omt/default', specs_dir: 'specs' },
       },
     };
     const result = parseYamlSimple(configPath, fallbackWithContext, chunkReviewConfig, ['context']);
@@ -1203,7 +1203,7 @@ describe('parseYamlSimple', () => {
       '  chairman:',
       '    role: gemini',
       '  context:',
-      '    specs_dir: .omt/specs',
+      '    specs_dir: specs',
     ].join('\n'));
     const result = parseYamlSimple(configPath, chunkFallback, chunkReviewConfig);
     expect(result['chunk-review'].chairman.role).toBe('gemini');

--- a/lib/job-utils.test.ts
+++ b/lib/job-utils.test.ts
@@ -688,8 +688,49 @@ describe('findProjectRoot', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  test('.git 마커로 프로젝트 루트 탐지', () => {
+    fs.mkdirSync(path.join(tmpDir, '.git'));
+    const subDir = path.join(tmpDir, 'src', 'lib');
+    fs.mkdirSync(subDir, { recursive: true });
+    expect(findProjectRoot(subDir)).toBe(tmpDir);
+  });
+
+  test('CLAUDE.md 마커로 프로젝트 루트 탐지', () => {
+    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), '');
+    const subDir = path.join(tmpDir, 'src');
+    fs.mkdirSync(subDir, { recursive: true });
+    expect(findProjectRoot(subDir)).toBe(tmpDir);
+  });
+
+  test('package.json 마커로 프로젝트 루트 탐지', () => {
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), '{}');
+    const subDir = path.join(tmpDir, 'lib');
+    fs.mkdirSync(subDir, { recursive: true });
+    expect(findProjectRoot(subDir)).toBe(tmpDir);
+  });
+
+  test('.omt 서픽스 제거 후 프로젝트 루트 탐지', () => {
+    fs.mkdirSync(path.join(tmpDir, '.git'));
+    const omtDir = path.join(tmpDir, '.omt');
+    fs.mkdirSync(omtDir);
+    expect(findProjectRoot(omtDir)).toBe(tmpDir);
+  });
+
+  test('.claude 서픽스 제거 후 프로젝트 루트 탐지', () => {
+    fs.mkdirSync(path.join(tmpDir, '.git'));
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir);
+    expect(findProjectRoot(claudeDir)).toBe(tmpDir);
+  });
+
+  test('.claude/scripts/foo/ 경로에서 regex로 프로젝트 루트 반환', () => {
+    // Regex fires first — no markers needed on disk
+    const scriptDir = path.join(tmpDir, '.claude', 'scripts', 'foo');
+    fs.mkdirSync(scriptDir, { recursive: true });
+    expect(findProjectRoot(scriptDir)).toBe(tmpDir);
+  });
+
   test('.claude/skills/<name>/scripts/ 경로에서 프로젝트 루트 반환', () => {
-    // tmpDir has no .omt or .git, so regex branch is reached
     const scriptDir = path.join(tmpDir, '.claude', 'skills', 'agent-council', 'scripts');
     fs.mkdirSync(scriptDir, { recursive: true });
     expect(findProjectRoot(scriptDir)).toBe(tmpDir);
@@ -702,7 +743,7 @@ describe('findProjectRoot', () => {
   });
 
   test('regex 미매칭 시 2단계 상위 경로 반환', () => {
-    // A path that doesn't match any platform pattern
+    // A path that doesn't match any platform pattern or markers
     const scriptDir = path.join(tmpDir, 'scripts', 'chunk-review');
     fs.mkdirSync(scriptDir, { recursive: true });
     expect(findProjectRoot(scriptDir)).toBe(tmpDir);

--- a/lib/job-utils.ts
+++ b/lib/job-utils.ts
@@ -243,27 +243,27 @@ export function generateJobId(): string {
 // ---------------------------------------------------------------------------
 
 export function findProjectRoot(scriptDir: string): string {
-  let current = scriptDir;
-  const root = path.parse(current).root;
-
-  while (current !== root) {
-    const omtDir = path.join(current, '.omt');
-    if (fs.existsSync(omtDir) && fs.statSync(omtDir).isDirectory()) {
-      return current;
-    }
-
-    const gitDir = path.join(current, '.git');
-    if (fs.existsSync(gitDir)) {
-      return current;
-    }
-
-    current = path.dirname(current);
-  }
-
+  // Regex fallback for deployed script paths — fires first before walk-up
   const normalized = scriptDir.replace(/\\/g, '/');
   const scriptsMatch = normalized.match(/^(.+?)\/\.(claude|gemini|codex|opencode)\/(scripts|skills\/[^/]+\/scripts)(?:\/|$)/);
   if (scriptsMatch) {
     return scriptsMatch[1];
+  }
+
+  // Strip .omt and .claude suffixes before walking up
+  let current = scriptDir.replace(/\/\.omt$/, '').replace(/\/\.claude$/, '');
+  const root = path.parse(current).root;
+
+  while (current !== root) {
+    if (
+      fs.existsSync(path.join(current, '.git')) ||
+      fs.existsSync(path.join(current, 'CLAUDE.md')) ||
+      fs.existsSync(path.join(current, 'package.json'))
+    ) {
+      return current;
+    }
+
+    current = path.dirname(current);
   }
 
   return path.resolve(scriptDir, '../..');

--- a/lib/logging.test.ts
+++ b/lib/logging.test.ts
@@ -40,38 +40,38 @@ describe('logging module', () => {
 
   describe('initLogger', () => {
     it('should create log directory and file path', () => {
-      const projectRoot = join(testDir, 'project1');
+      const omtDir = join(testDir, 'project1');
 
-      initLogger('test-component', projectRoot, 'session-123');
+      initLogger('test-component', omtDir, 'session-123');
 
       // Directory should exist after first log
       logInfo('test message');
-      const logDir = join(projectRoot, '.omt', 'logs');
+      const logDir = join(omtDir, 'logs');
       expect(existsSync(logDir)).toBe(true);
     });
 
     it('should use default when sessionId is not provided', async () => {
-      const projectRoot = join(testDir, 'project2');
+      const omtDir = join(testDir, 'project2');
 
-      initLogger('my-component', projectRoot);
+      initLogger('my-component', omtDir);
       logInfo('test');
 
-      const logPath = join(projectRoot, '.omt', 'logs', 'my-component-default.log');
+      const logPath = join(omtDir, 'logs', 'my-component-default.log');
       expect(existsSync(logPath)).toBe(true);
     });
 
     it('should sanitize sessionId with special characters', async () => {
-      const projectRoot = join(testDir, 'project3');
+      const omtDir = join(testDir, 'project3');
 
-      initLogger('comp', projectRoot, 'session/with:special*chars?');
+      initLogger('comp', omtDir, 'session/with:special*chars?');
       logInfo('test');
 
-      const logPath = join(projectRoot, '.omt', 'logs', 'comp-session-with-special-chars-.log');
+      const logPath = join(omtDir, 'logs', 'comp-session-with-special-chars-.log');
       expect(existsSync(logPath)).toBe(true);
     });
 
-    it('should not log when projectRoot is missing', async () => {
-      // @ts-expect-error - testing with undefined projectRoot
+    it('should not log when omtDir is missing', async () => {
+      // @ts-expect-error - testing with undefined omtDir
       initLogger('orphan', undefined);
       logInfo('should not be written');
 
@@ -79,7 +79,7 @@ describe('logging module', () => {
       expect(true).toBe(true);
     });
 
-    it('should not log when projectRoot is empty string', async () => {
+    it('should not log when omtDir is empty string', async () => {
       initLogger('orphan', '');
       logInfo('should not be written');
 
@@ -90,12 +90,12 @@ describe('logging module', () => {
 
   describe('log format', () => {
     it('should write logs in correct format: [timestamp] [LEVEL] [component] message', async () => {
-      const projectRoot = join(testDir, 'format-test');
+      const omtDir = join(testDir, 'format-test');
 
-      initLogger('format-comp', projectRoot, 'fmt-session');
+      initLogger('format-comp', omtDir, 'fmt-session');
       logInfo('test message');
 
-      const logPath = join(projectRoot, '.omt', 'logs', 'format-comp-fmt-session.log');
+      const logPath = join(omtDir, 'logs', 'format-comp-fmt-session.log');
       const content = await readFile(logPath, 'utf-8');
 
       // Should match format: [2024-01-15T10:30:00.000Z] [INFO] [format-comp] test message
@@ -112,13 +112,13 @@ describe('logging module', () => {
     });
 
     it('should default to INFO level', async () => {
-      const projectRoot = join(testDir, 'level-default');
+      const omtDir = join(testDir, 'level-default');
 
-      initLogger('level-comp', projectRoot, 'level-session');
+      initLogger('level-comp', omtDir, 'level-session');
       logDebug('debug message');
       logInfo('info message');
 
-      const logPath = join(projectRoot, '.omt', 'logs', 'level-comp-level-session.log');
+      const logPath = join(omtDir, 'logs', 'level-comp-level-session.log');
       const content = await readFile(logPath, 'utf-8');
 
       expect(content).not.toContain('debug message');
@@ -127,12 +127,12 @@ describe('logging module', () => {
 
     it('should respect OMT_LOG_LEVEL environment variable', async () => {
       process.env.OMT_LOG_LEVEL = 'DEBUG';
-      const projectRoot = join(testDir, 'level-env');
+      const omtDir = join(testDir, 'level-env');
 
-      initLogger('env-comp', projectRoot, 'env-session');
+      initLogger('env-comp', omtDir, 'env-session');
       logDebug('debug message');
 
-      const logPath = join(projectRoot, '.omt', 'logs', 'env-comp-env-session.log');
+      const logPath = join(omtDir, 'logs', 'env-comp-env-session.log');
       const content = await readFile(logPath, 'utf-8');
 
       expect(content).toContain('[DEBUG]');
@@ -141,15 +141,15 @@ describe('logging module', () => {
 
     it('should filter messages below configured level', async () => {
       process.env.OMT_LOG_LEVEL = 'WARN';
-      const projectRoot = join(testDir, 'level-filter');
+      const omtDir = join(testDir, 'level-filter');
 
-      initLogger('filter-comp', projectRoot, 'filter-session');
+      initLogger('filter-comp', omtDir, 'filter-session');
       logDebug('debug');
       logInfo('info');
       logWarn('warn');
       logError('error');
 
-      const logPath = join(projectRoot, '.omt', 'logs', 'filter-comp-filter-session.log');
+      const logPath = join(omtDir, 'logs', 'filter-comp-filter-session.log');
       const content = await readFile(logPath, 'utf-8');
 
       expect(content).not.toContain('[DEBUG]');
@@ -162,48 +162,48 @@ describe('logging module', () => {
   describe('log functions', () => {
     it('logDebug should write DEBUG level message', async () => {
       process.env.OMT_LOG_LEVEL = 'DEBUG';
-      const projectRoot = join(testDir, 'log-debug');
+      const omtDir = join(testDir, 'log-debug');
 
-      initLogger('debug-test', projectRoot, 'session');
+      initLogger('debug-test', omtDir, 'session');
       logDebug('debug message');
 
-      const logPath = join(projectRoot, '.omt', 'logs', 'debug-test-session.log');
+      const logPath = join(omtDir, 'logs', 'debug-test-session.log');
       const content = await readFile(logPath, 'utf-8');
 
       expect(content).toContain('[DEBUG]');
     });
 
     it('logInfo should write INFO level message', async () => {
-      const projectRoot = join(testDir, 'log-info');
+      const omtDir = join(testDir, 'log-info');
 
-      initLogger('info-test', projectRoot, 'session');
+      initLogger('info-test', omtDir, 'session');
       logInfo('info message');
 
-      const logPath = join(projectRoot, '.omt', 'logs', 'info-test-session.log');
+      const logPath = join(omtDir, 'logs', 'info-test-session.log');
       const content = await readFile(logPath, 'utf-8');
 
       expect(content).toContain('[INFO]');
     });
 
     it('logWarn should write WARN level message', async () => {
-      const projectRoot = join(testDir, 'log-warn');
+      const omtDir = join(testDir, 'log-warn');
 
-      initLogger('warn-test', projectRoot, 'session');
+      initLogger('warn-test', omtDir, 'session');
       logWarn('warn message');
 
-      const logPath = join(projectRoot, '.omt', 'logs', 'warn-test-session.log');
+      const logPath = join(omtDir, 'logs', 'warn-test-session.log');
       const content = await readFile(logPath, 'utf-8');
 
       expect(content).toContain('[WARN]');
     });
 
     it('logError should write ERROR level message', async () => {
-      const projectRoot = join(testDir, 'log-error');
+      const omtDir = join(testDir, 'log-error');
 
-      initLogger('error-test', projectRoot, 'session');
+      initLogger('error-test', omtDir, 'session');
       logError('error message');
 
-      const logPath = join(projectRoot, '.omt', 'logs', 'error-test-session.log');
+      const logPath = join(omtDir, 'logs', 'error-test-session.log');
       const content = await readFile(logPath, 'utf-8');
 
       expect(content).toContain('[ERROR]');
@@ -212,24 +212,24 @@ describe('logging module', () => {
 
   describe('logStart and logEnd', () => {
     it('logStart should write START marker', async () => {
-      const projectRoot = join(testDir, 'log-start');
+      const omtDir = join(testDir, 'log-start');
 
-      initLogger('start-test', projectRoot, 'session');
+      initLogger('start-test', omtDir, 'session');
       logStart();
 
-      const logPath = join(projectRoot, '.omt', 'logs', 'start-test-session.log');
+      const logPath = join(omtDir, 'logs', 'start-test-session.log');
       const content = await readFile(logPath, 'utf-8');
 
       expect(content).toContain('========== START ==========');
     });
 
     it('logEnd should write END marker', async () => {
-      const projectRoot = join(testDir, 'log-end');
+      const omtDir = join(testDir, 'log-end');
 
-      initLogger('end-test', projectRoot, 'session');
+      initLogger('end-test', omtDir, 'session');
       logEnd();
 
-      const logPath = join(projectRoot, '.omt', 'logs', 'end-test-session.log');
+      const logPath = join(omtDir, 'logs', 'end-test-session.log');
       const content = await readFile(logPath, 'utf-8');
 
       expect(content).toContain('========== END ==========');

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -116,12 +116,12 @@ function log(level: LogLevel, message: string): void {
  * Initialize logging for a component
  *
  * @param component - Name of the component (used in log messages and filename)
- * @param projectRoot - Project root directory (where .omt/logs will be created)
+ * @param omtDir - OMT working directory (where logs/ will be created)
  * @param sessionId - Optional session ID (defaults to 'default')
  */
-export function initLogger(component: string, projectRoot: string, sessionId?: string): void {
-  // Skip logging silently if projectRoot is missing
-  if (!projectRoot) {
+export function initLogger(component: string, omtDir: string, sessionId?: string): void {
+  // Skip logging silently if omtDir is missing
+  if (!omtDir) {
     initialized = false;
     return;
   }
@@ -129,8 +129,8 @@ export function initLogger(component: string, projectRoot: string, sessionId?: s
   componentName = component;
   const sanitizedSession = sanitizeSessionId(sessionId || 'default');
 
-  // Set log file path: .omt/logs/{component}-{sessionId}.log
-  const logDir = join(projectRoot, '.omt', 'logs');
+  // Set log file path: logs/{component}-{sessionId}.log
+  const logDir = join(omtDir, 'logs');
   logFile = join(logDir, `${component}-${sanitizedSession}.log`);
 
   initialized = true;

--- a/lib/omt-dir.test.ts
+++ b/lib/omt-dir.test.ts
@@ -1,0 +1,149 @@
+import { rm, mkdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { execSync } from 'child_process';
+import { join } from 'path';
+import { tmpdir, homedir } from 'os';
+import { basename, dirname } from 'path';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
+
+import { getOmtDir } from './omt-dir.ts';
+
+const testTmpBase = join(tmpdir(), 'omt-dir-test-' + Date.now());
+
+beforeAll(async () => {
+  await mkdir(testTmpBase, { recursive: true });
+});
+
+afterAll(async () => {
+  await rm(testTmpBase, { recursive: true, force: true });
+});
+
+describe('getOmtDir', () => {
+  let originalOmtDir: string | undefined;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalOmtDir = process.env.OMT_DIR;
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    if (originalOmtDir === undefined) {
+      delete process.env.OMT_DIR;
+    } else {
+      process.env.OMT_DIR = originalOmtDir;
+    }
+    process.chdir(originalCwd);
+  });
+
+  it('env var present: returns OMT_DIR and creates directory', () => {
+    const envDir = join(testTmpBase, 'from-env-var');
+    process.env.OMT_DIR = envDir;
+
+    const result = getOmtDir();
+
+    expect(result).toBe(envDir);
+    expect(existsSync(envDir)).toBe(true);
+  });
+
+  it('env var absent with git repo: returns $HOME/.omt/{repo-name}', () => {
+    delete process.env.OMT_DIR;
+
+    // Use this repo itself as a known git directory
+    const repoDir = join(import.meta.dir, '..');
+    process.chdir(repoDir);
+
+    const result = getOmtDir();
+
+    // Should be under $HOME/.omt/
+    expect(result.startsWith(`${homedir()}/.omt/`)).toBe(true);
+    expect(existsSync(result)).toBe(true);
+
+    // Derive expected name using the same logic as omt-dir.ts and session-start.sh
+    const gitCommonDir = execSync('git rev-parse --git-common-dir', {
+      cwd: repoDir,
+      encoding: 'utf-8',
+    }).trim();
+
+    let expectedName: string;
+    if (gitCommonDir !== '.git') {
+      // Worktree: use parent of git-common-dir
+      expectedName = basename(dirname(gitCommonDir));
+    } else {
+      const toplevel = execSync('git rev-parse --show-toplevel', {
+        cwd: repoDir,
+        encoding: 'utf-8',
+      }).trim();
+      expectedName = basename(toplevel);
+    }
+    expectedName = expectedName.replace(/ /g, '-');
+
+    expect(result).toBe(`${homedir()}/.omt/${expectedName}`);
+  });
+
+  it('env var absent without git: falls back to basename(cwd)', async () => {
+    delete process.env.OMT_DIR;
+
+    // Create a temp dir that is NOT a git repo
+    const nonGitDir = join(testTmpBase, 'non-git-dir');
+    await mkdir(nonGitDir, { recursive: true });
+    process.chdir(nonGitDir);
+
+    const result = getOmtDir();
+
+    const expectedName = basename(nonGitDir).replace(/ /g, '-');
+    expect(result).toBe(`${homedir()}/.omt/${expectedName}`);
+    expect(existsSync(result)).toBe(true);
+  });
+
+  it('path equivalence with session-start.sh logic: standard repo', () => {
+    delete process.env.OMT_DIR;
+
+    const repoDir = join(import.meta.dir, '..');
+    process.chdir(repoDir);
+
+    // Replicate session-start.sh lines 52-68 manually
+    let gitCommonDir: string;
+    try {
+      gitCommonDir = execSync('git rev-parse --git-common-dir', {
+        cwd: repoDir,
+        encoding: 'utf-8',
+      }).trim();
+    } catch {
+      gitCommonDir = '';
+    }
+
+    let shellProjectName: string;
+    if (gitCommonDir && gitCommonDir !== '.git') {
+      shellProjectName = basename(dirname(gitCommonDir));
+    } else if (gitCommonDir === '.git') {
+      const toplevel = execSync('git rev-parse --show-toplevel', {
+        cwd: repoDir,
+        encoding: 'utf-8',
+      }).trim();
+      shellProjectName = basename(toplevel);
+    } else {
+      shellProjectName = basename(repoDir);
+    }
+    shellProjectName = shellProjectName.replace(/ /g, '-');
+
+    const expectedPath = `${homedir()}/.omt/${shellProjectName}`;
+    const result = getOmtDir();
+
+    expect(result).toBe(expectedPath);
+  });
+
+  it('spaces in directory name are replaced with hyphens', async () => {
+    delete process.env.OMT_DIR;
+
+    // Create a non-git dir with spaces in name
+    const spacedDir = join(testTmpBase, 'my project name');
+    await mkdir(spacedDir, { recursive: true });
+    process.chdir(spacedDir);
+
+    const result = getOmtDir();
+
+    expect(result).toBe(`${homedir()}/.omt/my-project-name`);
+    expect(existsSync(result)).toBe(true);
+  });
+});

--- a/lib/omt-dir.test.ts
+++ b/lib/omt-dir.test.ts
@@ -1,5 +1,5 @@
 import { rm, mkdir } from 'fs/promises';
-import { existsSync } from 'fs';
+import { existsSync, readdirSync } from 'fs';
 import { execSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir, homedir } from 'os';
@@ -21,19 +21,38 @@ afterAll(async () => {
 describe('getOmtDir', () => {
   let originalOmtDir: string | undefined;
   let originalCwd: string;
+  let createdOmtDirs: string[] = [];
+  let preExistingDirs: Set<string>;
 
   beforeEach(() => {
     originalOmtDir = process.env.OMT_DIR;
     originalCwd = process.cwd();
+    createdOmtDirs = [];
+    const omtBase = `${homedir()}/.omt`;
+    preExistingDirs = new Set(
+      existsSync(omtBase)
+        ? readdirSync(omtBase).map(d => `${omtBase}/${d}`)
+        : []
+    );
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     if (originalOmtDir === undefined) {
       delete process.env.OMT_DIR;
     } else {
       process.env.OMT_DIR = originalOmtDir;
     }
     process.chdir(originalCwd);
+
+    for (const dir of createdOmtDirs) {
+      if (
+        dir.startsWith(`${homedir()}/.omt/`) &&
+        !preExistingDirs.has(dir) &&
+        existsSync(dir)
+      ) {
+        await rm(dir, { recursive: true, force: true });
+      }
+    }
   });
 
   it('env var present: returns OMT_DIR and creates directory', () => {
@@ -54,6 +73,7 @@ describe('getOmtDir', () => {
     process.chdir(repoDir);
 
     const result = getOmtDir();
+    createdOmtDirs.push(result);
 
     // Should be under $HOME/.omt/
     expect(result.startsWith(`${homedir()}/.omt/`)).toBe(true);
@@ -91,6 +111,7 @@ describe('getOmtDir', () => {
     process.chdir(nonGitDir);
 
     const result = getOmtDir();
+    createdOmtDirs.push(result);
 
     const expectedName = basename(nonGitDir).replace(/ /g, '-');
     expect(result).toBe(`${homedir()}/.omt/${expectedName}`);
@@ -131,6 +152,7 @@ describe('getOmtDir', () => {
 
     const expectedPath = `${homedir()}/.omt/${shellProjectName}`;
     const result = getOmtDir();
+    createdOmtDirs.push(result);
 
     expect(result).toBe(expectedPath);
   });
@@ -143,6 +165,7 @@ describe('getOmtDir', () => {
     process.chdir(subDir);
 
     const result = getOmtDir();
+    createdOmtDirs.push(result);
 
     // Derive expected name: resolve relative gitCommonDir against subDir
     const gitCommonDir = execSync('git rev-parse --git-common-dir', {
@@ -178,6 +201,7 @@ describe('getOmtDir', () => {
     process.chdir(spacedDir);
 
     const result = getOmtDir();
+    createdOmtDirs.push(result);
 
     expect(result).toBe(`${homedir()}/.omt/my-project-name`);
     expect(existsSync(result)).toBe(true);

--- a/lib/omt-dir.test.ts
+++ b/lib/omt-dir.test.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'fs';
 import { execSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir, homedir } from 'os';
-import { basename, dirname } from 'path';
+import { basename, dirname, resolve } from 'path';
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
 
 import { getOmtDir } from './omt-dir.ts';
@@ -67,8 +67,9 @@ describe('getOmtDir', () => {
 
     let expectedName: string;
     if (gitCommonDir !== '.git') {
-      // Worktree: use parent of git-common-dir
-      expectedName = basename(dirname(gitCommonDir));
+      // Worktree or subdirectory: resolve relative path against cwd
+      const resolved = resolve(repoDir, gitCommonDir);
+      expectedName = basename(dirname(resolved));
     } else {
       const toplevel = execSync('git rev-parse --show-toplevel', {
         cwd: repoDir,
@@ -115,7 +116,8 @@ describe('getOmtDir', () => {
 
     let shellProjectName: string;
     if (gitCommonDir && gitCommonDir !== '.git') {
-      shellProjectName = basename(dirname(gitCommonDir));
+      const resolved = resolve(repoDir, gitCommonDir);
+      shellProjectName = basename(dirname(resolved));
     } else if (gitCommonDir === '.git') {
       const toplevel = execSync('git rev-parse --show-toplevel', {
         cwd: repoDir,
@@ -131,6 +133,40 @@ describe('getOmtDir', () => {
     const result = getOmtDir();
 
     expect(result).toBe(expectedPath);
+  });
+
+  it('env var absent from git repo subdirectory: returns correct $HOME/.omt/{repo-name}', async () => {
+    delete process.env.OMT_DIR;
+
+    // Use a subdirectory of this repo — git rev-parse --git-common-dir returns relative "../.git"
+    const subDir = join(import.meta.dir, '..', 'lib');
+    process.chdir(subDir);
+
+    const result = getOmtDir();
+
+    // Derive expected name: resolve relative gitCommonDir against subDir
+    const gitCommonDir = execSync('git rev-parse --git-common-dir', {
+      cwd: subDir,
+      encoding: 'utf-8',
+    }).trim();
+
+    let expectedName: string;
+    if (gitCommonDir !== '.git') {
+      const resolved = resolve(subDir, gitCommonDir);
+      expectedName = basename(dirname(resolved));
+    } else {
+      const toplevel = execSync('git rev-parse --show-toplevel', {
+        cwd: subDir,
+        encoding: 'utf-8',
+      }).trim();
+      expectedName = basename(toplevel);
+    }
+    expectedName = expectedName.replace(/ /g, '-');
+
+    expect(result).toBe(`${homedir()}/.omt/${expectedName}`);
+    // Must not be the home directory itself (the bug: basename(dirname("../.git")) === "..")
+    expect(result).not.toBe(`${homedir()}/.omt/..`);
+    expect(existsSync(result)).toBe(true);
   });
 
   it('spaces in directory name are replaced with hyphens', async () => {

--- a/lib/omt-dir.ts
+++ b/lib/omt-dir.ts
@@ -11,7 +11,7 @@
 import { execSync } from 'child_process';
 import { mkdirSync } from 'fs';
 import { homedir } from 'os';
-import { basename, dirname } from 'path';
+import { basename, dirname, resolve } from 'path';
 
 /**
  * Returns the OMT working directory for the current project.
@@ -43,8 +43,9 @@ function deriveProjectName(cwd: string): string {
     let name: string;
 
     if (gitCommonDir !== '.git') {
-      // Worktree: git-common-dir returns absolute path like /path/to/repo/.git
-      name = basename(dirname(gitCommonDir));
+      // Worktree or subdirectory: resolve relative path against cwd
+      const resolved = resolve(cwd, gitCommonDir);
+      name = basename(dirname(resolved));
     } else {
       // Standard repo: use toplevel directory name
       const toplevel = execSync('git rev-parse --show-toplevel', {

--- a/lib/omt-dir.ts
+++ b/lib/omt-dir.ts
@@ -1,0 +1,63 @@
+/**
+ * OMT_DIR Resolution Module
+ * Provides the per-project OMT working directory path.
+ *
+ * Resolution order:
+ * 1. $OMT_DIR env var (set by session-start.sh)
+ * 2. Computed from git repo name + $HOME/.omt/{sanitized-name}
+ * 3. Fallback to basename(cwd) when not in a git repo
+ */
+
+import { execSync } from 'child_process';
+import { mkdirSync } from 'fs';
+import { homedir } from 'os';
+import { basename, dirname } from 'path';
+
+/**
+ * Returns the OMT working directory for the current project.
+ * Mirrors the PROJECT_NAME derivation logic in session-start.sh (lines 49-68).
+ * Creates the directory if it does not exist.
+ */
+export function getOmtDir(): string {
+  if (process.env.OMT_DIR) {
+    const dir = process.env.OMT_DIR;
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  const cwd = process.cwd();
+  const projectName = deriveProjectName(cwd);
+  const dir = `${homedir()}/.omt/${projectName}`;
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function deriveProjectName(cwd: string): string {
+  try {
+    const gitCommonDir = execSync('git rev-parse --git-common-dir', {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+
+    let name: string;
+
+    if (gitCommonDir !== '.git') {
+      // Worktree: git-common-dir returns absolute path like /path/to/repo/.git
+      name = basename(dirname(gitCommonDir));
+    } else {
+      // Standard repo: use toplevel directory name
+      const toplevel = execSync('git rev-parse --show-toplevel', {
+        cwd,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+      name = basename(toplevel);
+    }
+
+    return name.replace(/ /g, '-');
+  } catch {
+    // Not a git repo — fall back to basename of cwd
+    return basename(cwd).replace(/ /g, '-');
+  }
+}

--- a/scripts/chunk-review/job.ts
+++ b/scripts/chunk-review/job.ts
@@ -24,6 +24,7 @@ import {
 } from '@lib/job-utils';
 
 import { initLogger, logInfo, logStart, logEnd } from '@lib/logging';
+import { getOmtDir } from '@lib/omt-dir';
 
 import {
   type JobConfig,
@@ -53,7 +54,7 @@ const WORKER_PATH = path.join(SCRIPT_DIR, 'worker.ts');
 const SKILL_CONFIG_FILE = path.join(SCRIPT_DIR, 'chunk-review.config.yaml');
 const REPO_CONFIG_FILE = path.join(PROJECT_ROOT, 'chunk-review.config.yaml');
 
-const DEFAULT_JOBS_DIR = process.env.CHUNK_REVIEW_JOBS_DIR || path.join(PROJECT_ROOT, '.omt', 'jobs');
+const DEFAULT_JOBS_DIR = process.env.CHUNK_REVIEW_JOBS_DIR || path.join(getOmtDir(), 'jobs');
 
 // ---------------------------------------------------------------------------
 // JobConfig for chunk-review
@@ -111,7 +112,7 @@ function parseYamlSimple(configPath: string, fallback: Record<string, any>) {
 
 function initLoggerFromJobDir(jobDir: string): void {
   const jobId = path.basename(jobDir).replace(/^chunk-review-/, '');
-  initLogger('chunk-review-job', PROJECT_ROOT, jobId);
+  initLogger('chunk-review-job', getOmtDir(), jobId);
 }
 
 // ---------------------------------------------------------------------------
@@ -306,7 +307,7 @@ Notes:
 async function cmdStart(options: Record<string, unknown>, prompt: string): Promise<void> {
   const configPath = (options.config as string | undefined) || process.env.CHUNK_REVIEW_CONFIG || resolveDefaultConfigFile();
   const jobsDir =
-    (options['jobs-dir'] as string | undefined) || process.env.CHUNK_REVIEW_JOBS_DIR || path.join(PROJECT_ROOT, '.omt', 'jobs');
+    (options['jobs-dir'] as string | undefined) || process.env.CHUNK_REVIEW_JOBS_DIR || path.join(getOmtDir(), 'jobs');
 
   ensureDir(jobsDir);
   gcStaleJobs(jobsDir);
@@ -340,7 +341,7 @@ async function cmdStart(options: Record<string, unknown>, prompt: string): Promi
   if (members.length === 0) exitWithError('start: no members remaining after filtering');
 
   const jobId = generateJobId();
-  initLogger('chunk-review-job', PROJECT_ROOT, jobId);
+  initLogger('chunk-review-job', getOmtDir(), jobId);
   logStart();
   logInfo(`GC: stale jobs cleaned`);
   logInfo(`config: ${configPath}, chairman: ${chairmanRole}, members: ${members.length}`);

--- a/scripts/chunk-review/worker.ts
+++ b/scripts/chunk-review/worker.ts
@@ -5,6 +5,7 @@ import path from 'path';
 
 import { initLogger, logInfo, logError, logStart, logEnd } from '@lib/logging';
 import { findProjectRoot, exitWithError, parseArgs } from '@lib/job-utils';
+import { getOmtDir } from '@lib/omt-dir';
 import {
   splitCommand,
   atomicWriteJson,
@@ -56,9 +57,8 @@ function main() {
   const timeoutSec = options.timeout ? Number(options.timeout) : 0;
 
   // Initialize persistent logging
-  const projectRoot = findProjectRoot(import.meta.dirname);
   const jobId = jobDir ? path.basename(jobDir).replace(/^chunk-review-/, '') : 'unknown';
-  initLogger('chunk-review-worker', projectRoot, jobId);
+  initLogger('chunk-review-worker', getOmtDir(), jobId);
   logStart();
 
   // Parse --env args: collect KEY=VALUE pairs

--- a/scripts/hud/index.test.ts
+++ b/scripts/hud/index.test.ts
@@ -1,4 +1,5 @@
 import { jest, describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { tmpdir } from 'os';
 import type { StdinInput, RalphState, RateLimitData } from './types.ts';
 import type { TranscriptResult } from './transcript.ts';
 import * as stdinMod from './stdin.ts';
@@ -33,6 +34,7 @@ describe('main', () => {
   let mockFormatMinimalStatus: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
+    process.env.OMT_DIR = tmpdir();
     consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {});
 
     // Spy on all module functions
@@ -70,6 +72,7 @@ describe('main', () => {
   });
 
   afterEach(() => {
+    delete process.env.OMT_DIR;
     consoleLogSpy.mockRestore();
     mockReadStdin.mockRestore();
     mockInitLogger.mockRestore();
@@ -513,7 +516,7 @@ describe('main', () => {
 
       await main();
 
-      expect(mockInitLogger).toHaveBeenCalledWith('hud', '/my/project', 'test-session-123');
+      expect(mockInitLogger).toHaveBeenCalledWith('hud', tmpdir(), 'test-session-123');
     });
 
     it('uses default session ID when session_id is empty', async () => {
@@ -531,7 +534,7 @@ describe('main', () => {
 
       await main();
 
-      expect(mockInitLogger).toHaveBeenCalledWith('hud', '/my/project', 'default');
+      expect(mockInitLogger).toHaveBeenCalledWith('hud', tmpdir(), 'default');
     });
 
     it('calls logStart at entry point', async () => {

--- a/scripts/hud/index.ts
+++ b/scripts/hud/index.ts
@@ -4,6 +4,7 @@ import { parseTranscript } from './transcript.ts';
 import { fetchRateLimits } from './usage-api.ts';
 import { formatStatusLineV2, formatMinimalStatus } from './formatter.ts';
 import { initLogger, logInfo, logError, logStart, logEnd } from '@lib/logging';
+import { getOmtDir } from '../../lib/omt-dir';
 import type { HudDataV2 } from './types.ts';
 
 /**
@@ -34,7 +35,7 @@ export async function main(): Promise<void> {
     const sessionId = input.session_id || 'default';
 
     // Initialize logging
-    initLogger('hud', cwd, sessionId);
+    initLogger('hud', getOmtDir(), sessionId);
     logStart();
     logInfo(`Input: transcript_path=${input.transcript_path}, cwd=${cwd}`);
 

--- a/scripts/hud/state.test.ts
+++ b/scripts/hud/state.test.ts
@@ -7,13 +7,15 @@ import { tmpdir, homedir } from 'os';
 describe('state readers', () => {
   const testDir = join(tmpdir(), 'hud-state-test-' + Date.now());
   const projectDir = join(testDir, 'project');
-  const omtDir = join(projectDir, '.omt');
+  const omtDir = join(testDir, 'omt');
 
   beforeAll(async () => {
     await mkdir(omtDir, { recursive: true });
+    process.env.OMT_DIR = omtDir;
   });
 
   afterAll(async () => {
+    delete process.env.OMT_DIR;
     await rm(testDir, { recursive: true, force: true });
   });
 
@@ -59,10 +61,7 @@ describe('state readers', () => {
     });
 
     it('should return null when session-specific file does not exist', async () => {
-      const nonExistentDir = join(testDir, 'nonexistent');
-      await mkdir(nonExistentDir, { recursive: true });
-
-      const result = await readRalphState(nonExistentDir, 'non-existent-session');
+      const result = await readRalphState('', 'non-existent-session');
 
       expect(result).toBeNull();
     });

--- a/scripts/hud/state.ts
+++ b/scripts/hud/state.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { homedir } from 'os';
 import type { RalphState } from './types.ts';
 import { readTasksFromDirectory, countIncompleteTasks, getInProgressTask } from '@lib/task-reader';
+import { getOmtDir } from '../../lib/omt-dir';
 
 /**
  * Maximum age for state files to be considered "active".
@@ -40,9 +41,9 @@ async function readJsonFile<T>(path: string): Promise<T | null> {
  * Note: Global fallback (~/.claude/) was removed to prevent
  * state leakage between projects and parallel sessions.
  */
-async function findStateFile<T>(cwd: string, filename: string): Promise<T | null> {
+async function findStateFile<T>(filename: string): Promise<T | null> {
   // Project-local only (with stale check)
-  const localPath = join(cwd, '.omt', filename);
+  const localPath = join(getOmtDir(), filename);
   if (!await isStateFileStale(localPath)) {
     return readJsonFile<T>(localPath);
   }
@@ -50,8 +51,8 @@ async function findStateFile<T>(cwd: string, filename: string): Promise<T | null
   return null;
 }
 
-export async function readRalphState(cwd: string, sessionId: string = 'default'): Promise<RalphState | null> {
-  return findStateFile<RalphState>(cwd, `ralph-state-${sessionId}.json`);
+export async function readRalphState(_cwd: string, sessionId: string = 'default'): Promise<RalphState | null> {
+  return findStateFile<RalphState>(`ralph-state-${sessionId}.json`);
 }
 
 export async function readBackgroundTasks(): Promise<number> {

--- a/scripts/spec-reviewer/job.test.ts
+++ b/scripts/spec-reviewer/job.test.ts
@@ -64,11 +64,11 @@ describe('parseYamlSimple', () => {
       'spec-review:',
       '  context:',
       '    shared_context_dir: .omt/ctx',
-      '    specs_dir: .omt/specs',
+      '    specs_dir: specs',
     ].join('\n'));
     const result = parseYamlSimple(configPath, fallback);
     expect(result['spec-review'].context.shared_context_dir).toBe('.omt/ctx');
-    expect(result['spec-review'].context.specs_dir).toBe('.omt/specs');
+    expect(result['spec-review'].context.specs_dir).toBe('specs');
   });
 
   test('parses settings section with type coercion', () => {

--- a/scripts/spec-reviewer/job.ts
+++ b/scripts/spec-reviewer/job.ts
@@ -31,6 +31,8 @@ import {
   parseYamlSimple as frameworkParseYamlSimple,
 } from '@lib/generic-job';
 
+import { getOmtDir } from '@lib/omt-dir';
+
 // ---------------------------------------------------------------------------
 // Job configuration
 // ---------------------------------------------------------------------------
@@ -211,10 +213,10 @@ function gatherSpecContext(specName: string, config: Record<string, any>): { con
 
   const contextConfig = config['spec-review'].context || {};
   const sharedContextDirRaw = contextConfig.shared_context_dir || '~/.omt/${OMT_PROJECT}/context';
-  const specsDir = contextConfig.specs_dir || '.omt/specs';
+  const specsDir = contextConfig.specs_dir || 'specs';
 
   const contextDir = resolveContextDir(sharedContextDirRaw, projectRoot);
-  const specDir = path.join(projectRoot, specsDir, specName);
+  const specDir = path.join(getOmtDir(), specsDir, specName);
 
   const files: string[] = [];
 
@@ -297,7 +299,7 @@ Usage:
 
 Notes:
   - start returns immediately and runs reviewers in parallel via detached Node workers
-  - --spec auto-loads context from .omt/specs/<spec-name>/ (spec.md, records/*.md) + shared context
+  - --spec auto-loads context from $OMT_DIR/specs/<spec-name>/ (spec.md, records/*.md) + shared context
   - poll status with repeated short calls to update TODO/plan UIs in host agents
   - wait prints JSON by default and blocks until meaningful progress occurs, so you don't spam tool cells
 `);
@@ -330,7 +332,7 @@ function asWaitPayload(statusPayload: any): any {
 async function cmdStart(options: Record<string, unknown>, prompt: string): Promise<void> {
   const configPath = (options.config || process.env.SPEC_REVIEW_CONFIG || resolveDefaultConfigFile()) as string;
   const jobsDir =
-    (options['jobs-dir'] || process.env.SPEC_REVIEW_JOBS_DIR || path.join(PROJECT_ROOT, '.omt', 'jobs')) as string;
+    (options['jobs-dir'] || process.env.SPEC_REVIEW_JOBS_DIR || path.join(getOmtDir(), 'jobs')) as string;
 
   ensureDir(jobsDir);
   gcStaleJobs(jobsDir, JOB_CONFIG);
@@ -677,7 +679,7 @@ async function main(): Promise<void> {
     if (!jobDir) exitWithError('clean: missing jobDir');
     const defaultJobsDir = (options['jobs-dir'] as string | undefined)
       || process.env.SPEC_REVIEW_JOBS_DIR
-      || path.join(PROJECT_ROOT, '.omt', 'jobs');
+      || path.join(getOmtDir(), 'jobs');
     _cmdClean(options, jobDir, JOB_CONFIG, defaultJobsDir);
     return;
   }

--- a/scripts/spec-reviewer/job.ts
+++ b/scripts/spec-reviewer/job.ts
@@ -213,7 +213,8 @@ function gatherSpecContext(specName: string, config: Record<string, any>): { con
 
   const contextConfig = config['spec-review'].context || {};
   const sharedContextDirRaw = contextConfig.shared_context_dir || '~/.omt/${OMT_PROJECT}/context';
-  const specsDir = contextConfig.specs_dir || 'specs';
+  // Strip legacy ".omt/" prefix to prevent double path (~/.omt/project/.omt/specs/)
+  const specsDir = (contextConfig.specs_dir || 'specs').replace(/^\.omt\//, '');
 
   const contextDir = resolveContextDir(sharedContextDirRaw, projectRoot);
   const specDir = path.join(getOmtDir(), specsDir, specName);

--- a/scripts/spec-reviewer/spec-reviewer.config.yaml
+++ b/scripts/spec-reviewer/spec-reviewer.config.yaml
@@ -48,4 +48,4 @@ spec-review:
   # Spec context configuration
   context:
     shared_context_dir: "~/.omt/${OMT_PROJECT}/context"   # All *.md files in this dir
-    specs_dir: ".omt/specs"                     # {specName}/spec.md and {specName}/records/*.md
+    specs_dir: "specs"                           # {specName}/spec.md and {specName}/records/*.md

--- a/scripts/spec-reviewer/worker.test.ts
+++ b/scripts/spec-reviewer/worker.test.ts
@@ -697,7 +697,7 @@ describe('runOnce - workerEnv injection', () => {
 describe('main - logging lifecycle', () => {
   const WORKER_PATH = path.join(import.meta.dirname, 'worker.ts');
 
-  test('creates a log file in .omt/logs/ after successful run', async () => {
+  test('creates a log file in logs/ after successful run', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'spec-review-log-test-'));
     try {
       const jobDir = path.join(tmpDir, 'job');
@@ -706,15 +706,15 @@ describe('main - logging lifecycle', () => {
       fs.writeFileSync(path.join(jobDir, 'prompt.txt'), 'test prompt', 'utf8');
 
       const proc = Bun.spawn(
-        ['bun', WORKER_PATH, '--job-dir', jobDir, '--member', 'claude', '--command', 'true', '--project-root', tmpDir],
-        { stdout: 'pipe', stderr: 'pipe' },
+        ['bun', WORKER_PATH, '--job-dir', jobDir, '--member', 'claude', '--command', 'true'],
+        { stdout: 'pipe', stderr: 'pipe', env: { ...process.env, OMT_DIR: tmpDir } },
       );
       const exitCode = await proc.exited;
       expect(exitCode).toBe(0);
 
-      // Log file should exist in tmpDir/.omt/logs/
+      // Log file should exist in tmpDir/logs/
       // jobId = basename('job').replace(/^spec-review-/, '') = 'job'
-      const logFile = path.join(tmpDir, '.omt', 'logs', 'spec-review-worker-job.log');
+      const logFile = path.join(tmpDir, 'logs', 'spec-review-worker-job.log');
       expect(fs.existsSync(logFile)).toBe(true);
       const content = fs.readFileSync(logFile, 'utf8');
       expect(content.includes('========== START ==========')).toBe(true);

--- a/scripts/spec-reviewer/worker.ts
+++ b/scripts/spec-reviewer/worker.ts
@@ -5,6 +5,7 @@ import path from 'path';
 
 import { initLogger, logInfo, logError, logStart, logEnd } from '@lib/logging';
 import { parseArgs, exitWithError } from '@lib/job-utils';
+import { getOmtDir } from '@lib/omt-dir';
 import {
   splitCommand,
   atomicWriteJson,
@@ -39,11 +40,8 @@ function main() {
   const timeoutSec = options.timeout ? Number(options.timeout) : 0;
 
   // Initialize persistent logging
-  const projectRoot = options['project-root']
-    ? String(options['project-root'])
-    : path.resolve(import.meta.dirname, '../../..');
   const jobId = jobDir ? path.basename(String(jobDir)).replace(/^spec-review-/, '') : 'unknown';
-  initLogger('spec-review-worker', projectRoot, jobId);
+  initLogger('spec-review-worker', getOmtDir(), jobId);
   logStart();
 
   // Parse --env args: collect KEY=VALUE pairs

--- a/skills/agent-council/scripts/job.ts
+++ b/skills/agent-council/scripts/job.ts
@@ -35,6 +35,8 @@ import {
   safeFileName,
 } from '@lib/generic-job';
 
+import { getOmtDir } from '@lib/omt-dir';
+
 // ---------------------------------------------------------------------------
 // Council JobConfig
 // ---------------------------------------------------------------------------
@@ -313,7 +315,7 @@ async function cmdStatus(options, jobDir) {
 async function cmdStart(options, prompt) {
   const configPath = options.config || process.env.COUNCIL_CONFIG || resolveDefaultConfigFile();
   const jobsDir =
-    options['jobs-dir'] || process.env.COUNCIL_JOBS_DIR || path.join(PROJECT_ROOT, '.omt', 'jobs');
+    options['jobs-dir'] || process.env.COUNCIL_JOBS_DIR || path.join(getOmtDir(), 'jobs');
 
   ensureDir(jobsDir);
   gcStaleJobs(jobsDir, COUNCIL_CONFIG);
@@ -448,7 +450,7 @@ async function main() {
     if (!jobDir) exitWithError('clean: missing jobDir');
     const defaultJobsDir = options['jobs-dir'] as string | undefined
       || process.env.COUNCIL_JOBS_DIR
-      || path.join(PROJECT_ROOT, '.omt', 'jobs');
+      || path.join(getOmtDir(), 'jobs');
     frameworkCmdClean(options, jobDir, COUNCIL_CONFIG, defaultJobsDir);
     return;
   }

--- a/skills/agent-council/scripts/worker.test.ts
+++ b/skills/agent-council/scripts/worker.test.ts
@@ -615,7 +615,7 @@ describe('main - --env passthrough', () => {
     }
   });
 
-  test('creates a log file in .omt/logs/ after successful run', async () => {
+  test('creates a log file in logs/ after successful run', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'council-log-test-'));
     try {
       const jobDir = path.join(tmpDir, 'job');
@@ -629,16 +629,15 @@ describe('main - --env passthrough', () => {
           '--job-dir', jobDir,
           '--member', 'test-member',
           '--command', 'true',
-          '--project-root', tmpDir,
         ],
-        { stdout: 'pipe', stderr: 'pipe' },
+        { stdout: 'pipe', stderr: 'pipe', env: { ...process.env, OMT_DIR: tmpDir } },
       );
       const exitCode = await proc.exited;
       expect(exitCode).toBe(0);
 
-      // Log file should exist in tmpDir/.omt/logs/
+      // Log file should exist in tmpDir/logs/
       // jobId = basename('job').replace(/^council-/, '') = 'job'
-      const logFile = path.join(tmpDir, '.omt', 'logs', 'council-job-worker-job.log');
+      const logFile = path.join(tmpDir, 'logs', 'council-job-worker-job.log');
       expect(fs.existsSync(logFile)).toBe(true);
       const content = fs.readFileSync(logFile, 'utf8');
       expect(content.includes('========== START ==========')).toBe(true);

--- a/skills/agent-council/scripts/worker.ts
+++ b/skills/agent-council/scripts/worker.ts
@@ -5,6 +5,7 @@ import path from 'path';
 
 import { initLogger, logInfo, logError, logStart, logEnd } from '@lib/logging';
 import { parseArgs, exitWithError } from '@lib/job-utils';
+import { getOmtDir } from '@lib/omt-dir';
 import {
   splitCommand,
   atomicWriteJson,
@@ -81,11 +82,8 @@ function main() {
   const timeoutSec = options.timeout ? Number(options.timeout) : 0;
 
   // Initialize persistent logging
-  const projectRoot = options['project-root']
-    ? String(options['project-root'])
-    : path.resolve(import.meta.dirname, '../../..');
   const jobId = jobDir ? path.basename(String(jobDir)).replace(/^council-/, '') : 'unknown';
-  initLogger('council-job-worker', projectRoot, jobId);
+  initLogger('council-job-worker', getOmtDir(), jobId);
   logStart();
 
   // Parse --env args: collect KEY=VALUE pairs

--- a/skills/make-pr/references/output-format.md
+++ b/skills/make-pr/references/output-format.md
@@ -120,4 +120,4 @@ PR description follows the structure below. Write entirely in Korean.
 
 - **Purpose**: Provide links to related documents, issues, PRs
 - **Include**: Related GitHub issues/PRs, external documentation URLs, git-tracked design documents
-- **Anti-patterns**: Agent-internal files (memory, plans, session notes, council records, files under `.omt/`) — never include content that reviewers cannot access
+- **Anti-patterns**: Agent-internal files (memory, plans, session notes, council records, files under `$OMT_DIR/`) — never include content that reviewers cannot access

--- a/skills/momus/SKILL.md
+++ b/skills/momus/SKILL.md
@@ -32,7 +32,7 @@ digraph input_handling {
 }
 ```
 
-**When you receive ONLY a file path** (e.g., `.omt/plans/feature.md`):
+**When you receive ONLY a file path** (e.g., `$OMT_DIR/plans/feature.md`):
 1. This IS valid input - the path tells you WHICH plan to review
 2. Read the file at that path using your file reading tools
 3. If file exists: proceed to review its content
@@ -151,7 +151,7 @@ Blockers (trigger REQUEST_CHANGES as [CERTAIN]):
 | Measurable success | Can you objectively verify completion? (not "works properly") |
 | Edge cases covered | Errors, empty states, invalid input addressed? |
 | Test strategy defined | Unit? Integration? Manual? Specific commands to run? |
-| Evidence paths defined | Do QA Scenarios include `.omt/evidence/` paths for evidence capture? |
+| Evidence paths defined | Do QA Scenarios include `$OMT_DIR/evidence/` paths for evidence capture? |
 | QA scenario specificity | Do scenarios use concrete selectors/endpoints, specific test data, and exact assertions? (not "verify it works") |
 
 ### 3. Context Completeness (90% confidence required)

--- a/skills/performance-optimizer/SKILL.md
+++ b/skills/performance-optimizer/SKILL.md
@@ -66,7 +66,7 @@ digraph perf_workflow {
     more_bottlenecks [label="More bottlenecks\nto improve?" shape=diamond];
 
     // Step 10: Final Report
-    report [label="Step 10: Generate Final Report\n(.omt/performance-reports/*.md)"];
+    report [label="Step 10: Generate Final Report\n($OMT_DIR/performance-reports/*.md)"];
 
     // End
     complete [label="Optimization\nComplete" shape=ellipse];
@@ -417,14 +417,14 @@ Good example:
 
 ## Output Location
 
-All performance optimization reports are stored in the `.omt/performance-reports/` directory.
+All performance optimization reports are stored in the `$OMT_DIR/performance-reports/` directory.
 
-**Naming Convention:** `.omt/performance-reports/{feature-name}-performance-report.md`
+**Naming Convention:** `$OMT_DIR/performance-reports/{feature-name}-performance-report.md`
 
 **Examples:**
-- `.omt/performance-reports/product-list-api-performance-report.md`
-- `.omt/performance-reports/order-processing-performance-report.md`
-- `.omt/performance-reports/search-api-performance-report.md`
+- `$OMT_DIR/performance-reports/product-list-api-performance-report.md`
+- `$OMT_DIR/performance-reports/order-processing-performance-report.md`
+- `$OMT_DIR/performance-reports/search-api-performance-report.md`
 
 ## Output Format
 

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -42,7 +42,7 @@ This is not a suggestion. This is your fundamental identity.
 
 1. Questions to clarify requirements
 2. Research via explore/librarian agents
-3. Work plans saved to `.omt/plans/*.md`
+3. Work plans saved to `$OMT_DIR/plans/*.md`
 
 </Critical_Constraints>
 
@@ -61,7 +61,7 @@ digraph prometheus_flow {
     "Clearance + AC complete?" [shape=diamond];
     "Metis consultation" [shape=box];
     "Metis verdict?" [shape=diamond];
-    "Write plan to .omt/plans/*.md" [shape=box];
+    "Write plan to $OMT_DIR/plans/*.md" [shape=box];
     "Momus review" [shape=box];
     "Momus verdict?" [shape=diamond];
     "Present full plan\nAsk user to finalize" [shape=box];
@@ -80,10 +80,10 @@ digraph prometheus_flow {
     "Clearance + AC complete?" -> "Metis consultation" [label="yes"];
     "Metis consultation" -> "Metis verdict?";
     "Metis verdict?" -> "Interview Mode" [label="REQUEST_CHANGES\n(resolve gaps, re-review)"];
-    "Metis verdict?" -> "Write plan to .omt/plans/*.md" [label="APPROVE"];
-    "Write plan to .omt/plans/*.md" -> "Momus review";
+    "Metis verdict?" -> "Write plan to $OMT_DIR/plans/*.md" [label="APPROVE"];
+    "Write plan to $OMT_DIR/plans/*.md" -> "Momus review";
     "Momus review" -> "Momus verdict?";
-    "Momus verdict?" -> "Write plan to .omt/plans/*.md" [label="REQUEST_CHANGES\n(revise plan, re-review)"];
+    "Momus verdict?" -> "Write plan to $OMT_DIR/plans/*.md" [label="REQUEST_CHANGES\n(revise plan, re-review)"];
     "Momus verdict?" -> "Present full plan\nAsk user to finalize" [label="APPROVE"];
     "Present full plan\nAsk user to finalize" -> "User approves?";
     "User approves?" -> "Interview Mode" [label="no, more changes"];
@@ -108,7 +108,7 @@ digraph prometheus_flow {
 | Interview questions | Yes | - |
 | Clearance checklist evaluation | Yes | - |
 | AC drafting & user confirmation | Yes | - |
-| Plan file writing (.omt/plans/) | Yes | - |
+| Plan file writing ($OMT_DIR/plans/) | Yes | - |
 | Codebase fact gathering | NEVER | explore |
 | Architecture feasibility check | NEVER | oracle |
 | External tech research | NEVER | librarian |
@@ -726,7 +726,7 @@ Invoke metis with this structure. On re-invocation after REQUEST_CHANGES, use th
 **After generating the plan**, invoke the momus skill to review the plan for quality. **Momus must pass (APPROVE or COMMENT) to proceed to user presentation. REQUEST_CHANGES blocks until resolved.**
 
 **Momus Review Flow:**
-1. Generate the plan to `.omt/plans/{name}.md`
+1. Generate the plan to `$OMT_DIR/plans/{name}.md`
 2. Invoke momus with the plan file path (see Invocation Format below)
 3. Receive Momus verdict (APPROVE / REQUEST_CHANGES / COMMENT)
 4. Act on verdict per the table below
@@ -737,7 +737,7 @@ Invoke metis with this structure. On re-invocation after REQUEST_CHANGES, use th
 Invoke momus with the plan file path only. Momus reads the file and reviews according to its own 4 Criteria. On re-invocation after REQUEST_CHANGES, send the same path — the plan file content is already updated. Momus is stateless and reviews each submission independently. If a finding was considered but intentionally not adopted, document the rationale in the relevant plan section (Work Objectives guardrails, TODO constraints).
 
 ```
-.omt/plans/[name].md
+$OMT_DIR/plans/[name].md
 ```
 
 All review context (interview summary) is already in the plan's Context section per the Plan Template Structure. No supplementary prompt needed.
@@ -762,7 +762,7 @@ All review context (interview summary) is already in the plan's Context section 
 
 After Momus approves the plan:
 
-1. **Present the full plan** — Show the complete content of `.omt/plans/{name}.md` to the user
+1. **Present the full plan** — Show the complete content of `$OMT_DIR/plans/{name}.md` to the user
 2. **Ask to finalize** — Ask the user if they want to proceed with this plan
 3. **Execution Bridge** — After the user approves, present execution options via AskUserQuestion:
 
@@ -790,7 +790,7 @@ This is the ONLY point where the user sees and confirms the plan. All internal q
 
 ### Plan Output
 
-**Output location:** `.omt/plans/{name}.md`
+**Output location:** `$OMT_DIR/plans/{name}.md`
 
 **Language:** Plans MUST be written in English. This ensures:
 - Consistency across all plan files
@@ -803,7 +803,7 @@ This is the ONLY point where the user sees and confirms the plan. All internal q
 
 ### Plan Template Structure
 
-Every plan saved to `.omt/plans/{name}.md` MUST follow this structure:
+Every plan saved to `$OMT_DIR/plans/{name}.md` MUST follow this structure:
 
 | Section | Contents |
 |---------|----------|
@@ -812,7 +812,7 @@ Every plan saved to `.omt/plans/{name}.md` MUST follow this structure:
 | **Work Objectives** | Core objective, Definition of Done, Must Have (non-negotiable requirements), Must NOT Have / Guardrails (explicit exclusions, scope boundaries) |
 | **TODOs** | Numbered tasks in checkbox format (`- [ ] N. Title`) -- each with: what to do, must NOT do, files, References (CRITICAL), acceptance criteria, parallelization fields, QA scenarios |
 | **Execution Strategy** | Wave visualization format, Dependency Matrix (abbreviated), Critical Path. Rules: minimum 2+ tasks per wave (except final wave, or waves constrained by dependencies), circular dependencies forbidden, wave count determined by dependency structure, every wave must contain at least one numbered TODO (no phantom/conceptual waves like "Verification & Merge"). Final Verification Wave is mandatory for Scoped+ intent and contains F1-F4 verification tasks dispatched for verification. |
-| **Verification Strategy** | Test decision (TDD/tests-after/none), framework, verification commands. Per-TODO QA Scenarios serve as the primary verification mechanism; final checklist aggregates them. **Zero Human Intervention** principle applies — all verification must be agent-executable with evidence artifacts saved to `.omt/evidence/{plan-name}/` |
+| **Verification Strategy** | Test decision (TDD/tests-after/none), framework, verification commands. Per-TODO QA Scenarios serve as the primary verification mechanism; final checklist aggregates them. **Zero Human Intervention** principle applies — all verification must be agent-executable with evidence artifacts saved to `$OMT_DIR/evidence/{plan-name}/` |
 | **Success Criteria** | Binary pass/fail end state. Verification commands (exact shell commands with expected output) + final checklist (checkbox items). Distinct from Verification Strategy (which defines methodology); Success Criteria defines the concrete done-state |
 
 **TODO Task Format:**
@@ -894,7 +894,7 @@ Smell-action table — common signs a TODO is not atomic:
 
 > Acceptance criteria requiring "user manually tests/confirms" are FORBIDDEN.
 
-Every QA scenario must be executable by an agent without human involvement. Verification evidence is saved as artifacts to `.omt/evidence/{plan-name}/` so that downstream verification agents can audit results independently.
+Every QA scenario must be executable by an agent without human involvement. Verification evidence is saved as artifacts to `$OMT_DIR/evidence/{plan-name}/` so that downstream verification agents can audit results independently.
 
 - **QA Scenarios** -- MANDATORY subsection under each TODO's acceptance criteria:
   - Each scenario uses a structured block format with 7 fields:
@@ -945,7 +945,7 @@ Every QA scenario must be executable by an agent without human involvement. Veri
   - Minimum 2 scenarios per TODO: happy path + failure/edge case (recommended 2-4)
   - **Evidence Convention**: Each QA scenario execution MUST save its output as an evidence artifact. Evidence path format:
     ```
-    .omt/evidence/{plan-name}/task-{N}-{scenario-slug}.{ext}
+    $OMT_DIR/evidence/{plan-name}/task-{N}-{scenario-slug}.{ext}
     ```
     Evidence type by domain:
     | Domain | Extension | Example |
@@ -1035,7 +1035,7 @@ Critical Path: Task 1 -> Task 5 -> Task 8 -> Task 11 -> Task 15 -> Task 21 -> Ta
         4. Assert `response.json` contains `"email":"test@example.com"`
       Expected: 201 Created with JSON body containing id (UUID), email ("test@example.com"), name ("Test User")
       Failure: Non-201 status code, or response body missing `id` field, or `email` !== "test@example.com"
-      Evidence: .omt/evidence/{plan-name}/task-3-create-user-201.json
+      Evidence: $OMT_DIR/evidence/{plan-name}/task-3-create-user-201.json
 
     Scenario: Validation failure — missing required field rejected
       Tool: curl
@@ -1046,7 +1046,7 @@ Critical Path: Task 1 -> Task 5 -> Task 8 -> Task 11 -> Task 15 -> Task 21 -> Ta
         3. Assert `response.json` contains `"error"` referencing `"email"`
       Expected: 400 Bad Request with error message referencing missing "email" field
       Failure: Non-400 status code, or error message does not mention "email" field
-      Evidence: .omt/evidence/{plan-name}/task-3-validation-failure.json
+      Evidence: $OMT_DIR/evidence/{plan-name}/task-3-validation-failure.json
 ```
 
 **Non-code TODO Example:**
@@ -1084,7 +1084,7 @@ Critical Path: Task 1 -> Task 5 -> Task 8 -> Task 11 -> Task 15 -> Task 21 -> Ta
           5. `grep "429" docs/api-reference.md`
         Expected: All grep commands return exit code 0 with matching content
         Failure: Any grep returns exit code 1 (section or header absent)
-        Evidence: .omt/evidence/{plan-name}/task-6-rate-limit-docs.txt
+        Evidence: $OMT_DIR/evidence/{plan-name}/task-6-rate-limit-docs.txt
 
       Scenario: Existing docs preserved
         Tool: git
@@ -1094,7 +1094,7 @@ Critical Path: Task 1 -> Task 5 -> Task 8 -> Task 11 -> Task 15 -> Task 21 -> Ta
           2. Verify that the diff output shows ONLY additions within the new `## Rate Limiting` section — no modifications or deletions in pre-existing sections
         Expected: Diff output contains only `+` lines (additions) under the `## Rate Limiting` heading; no `-` lines (deletions) or changes in other sections
         Failure: Diff shows modifications or deletions in any pre-existing section (Authentication, Error Handling, etc.)
-        Evidence: .omt/evidence/{plan-name}/task-6-existing-docs-preserved.txt
+        Evidence: $OMT_DIR/evidence/{plan-name}/task-6-existing-docs-preserved.txt
 ```
 
 **Final Verification Wave**
@@ -1115,7 +1115,7 @@ Template:
     - Read plan end-to-end
     - For each "Must Have": verify implementation exists
     - For each "Must NOT Have": search for forbidden patterns
-    - Check evidence files exist in .omt/evidence/
+    - Check evidence files exist in $OMT_DIR/evidence/
   Expected Output: Must Have [N/N] | Must NOT Have [N/N] | VERDICT
 
 - [ ] F2. Code Quality Review
@@ -1129,7 +1129,7 @@ Template:
   What to verify:
     - Execute EVERY QA scenario from EVERY task
     - Test cross-task integration
-    - Save evidence to .omt/evidence/{plan-name}/final-qa/
+    - Save evidence to $OMT_DIR/evidence/{plan-name}/final-qa/
   Expected Output: Scenarios [N/N pass] | Integration [N/N] | VERDICT
 
 - [ ] F4. Scope Fidelity Check
@@ -1173,7 +1173,7 @@ The Success Criteria section defines the binary pass/fail end state of the plan.
 
 - [ ] All TODOs marked completed
 - [ ] All QA scenarios pass
-- [ ] Evidence artifacts saved to `.omt/evidence/{plan-name}/`
+- [ ] Evidence artifacts saved to `$OMT_DIR/evidence/{plan-name}/`
 - [ ] No scope creep detected
 - [ ] Build + lint + tests green
 - [ ] Plan compliance verified

--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -71,7 +71,7 @@ Single-line edits, obvious typos, or changes with no functional behavior modific
 ## Self-Discovery Protocol
 
 When verification methods are NOT specified in the request:
-1. Search project files: `.omt/context`, `CLAUDE.md`, `package.json`, build config
+1. Search project files: `$OMT_DIR/context`, `CLAUDE.md`, `package.json`, build config
 2. Use `~/.omt/{project}/project-commands.md` cache (existing mechanism from stage1-commands.md)
 3. Fall back to default protocol (build → test → lint)
 

--- a/skills/sisyphus/SKILL.md
+++ b/skills/sisyphus/SKILL.md
@@ -324,7 +324,7 @@ digraph task_loop {
 - sisyphus-junior path: each junior completion → immediately invoke argus for QA
 - sisyphus-junior path: each argus approval → immediately invoke mnemosyne to commit
 - argus direct path: each argus approval → immediately mark completed (no mnemosyne — no code changes to commit)
-- After marking task completed, if a plan file exists in `.omt/plans/`, edit the plan file to mark `- [x]` on the corresponding TODO checkbox (direct sisyphus action, not delegated)
+- After marking task completed, if a plan file exists in `$OMT_DIR/plans/`, edit the plan file to mark `- [x]` on the corresponding TODO checkbox (direct sisyphus action, not delegated)
 
 ---
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -26,7 +26,7 @@ NO AREA COMPLETION WITHOUT:
 3. User explicitly declares "Area complete"
 4. All acceptance criteria testable
 5. No "TBD" or vague placeholders remaining
-6. Document saved to .omt/specs/
+6. Document saved to $OMT_DIR/specs/
 ```
 
 **Violating the letter of these rules IS violating the spirit.** No exceptions.
@@ -569,7 +569,7 @@ Even if AI already has sufficient information for a Step, it MUST:
 
 1. **Present results**: Show the Step's output/proposal to user (even if based on prior knowledge). Include potential risks of the proposed design (e.g., transaction scope expansion, coupling increase, blast radius of policy changes). Present risks as trade-offs with alternatives, not as blocking problems.
 2. **User confirmation**: Wait for explicit user approval of the Step content
-3. Save content to `.omt/specs/{spec-name}/{area-directory}/design.md`
+3. Save content to `$OMT_DIR/specs/{spec-name}/{area-directory}/design.md`
 4. Update progress status at document top
 5. **MANDATORY: Record decisions** to `{area-directory}/records/` (see Record Workflow below)
    - If decisions were made: Create record NOW. This is a BLOCKING gate — do NOT proceed to step 6 until record is saved.
@@ -852,7 +852,7 @@ A statement is a **recordable decision** if ANY of these apply:
 ### How to Record
 
 1. **Create record NOW — not later, not at Area completion, not in batches**: Record MUST be created at the Step where the decision was confirmed. Do NOT defer to next Step, do NOT batch with other decisions, do NOT wait for Area Checkpoint.
-2. **Save location**: `.omt/specs/{spec-name}/{area-directory}/records/{naming-pattern}.md`
+2. **Save location**: `$OMT_DIR/specs/{spec-name}/{area-directory}/records/{naming-pattern}.md`
 3. **Naming**: Area and Step based - automatically determined by current progress
 4. **Template**: Use `templates/record.md` format
 
@@ -883,7 +883,7 @@ When a concern is deferred via Emergent Concern Protocol Option (C):
 - **Follow-up needed**: Whether follow-up is required and recommended timing
 - **Impact on current spec**: Impact on the current spec, if any
 
-**Save location**: `.omt/specs/{spec-name}/{current-area}/records/{step}-deferred-{concern-name}.md`
+**Save location**: `$OMT_DIR/specs/{spec-name}/{current-area}/records/{step}-deferred-{concern-name}.md`
 
 **Wrapup integration**: Deferred concern records are listed in Wrapup as a separate "Deferred Concerns" section.
 
@@ -1129,7 +1129,7 @@ If Design Area was recommended but user deselected:
 
 ## Step-by-Step Persistence
 
-**Core Principle**: Save progress to `.omt/specs/{spec-name}/{area-directory}/design.md` whenever each Area is completed.
+**Core Principle**: Save progress to `$OMT_DIR/specs/{spec-name}/{area-directory}/design.md` whenever each Area is completed.
 
 ### When to Save
 
@@ -1186,7 +1186,7 @@ When the user requests "continue from here", "review this", etc.:
 
 ### Resume Workflow
 
-1. Check existing directories in `.omt/specs/{spec-name}/`:
+1. Check existing directories in `$OMT_DIR/specs/{spec-name}/`:
    - `requirements/` - Requirements completion
    - `solution-design/` - Solution Design completion
    - `{area-name}/` - Design Area completion (domain-model, data-schema, interface-contract, integration-pattern, ai-responsibility-contract, operations-plan, frontend-ux-surface, data-ml-pipeline, security-privacy)
@@ -1218,7 +1218,7 @@ When the user requests "continue from here", "review this", etc.:
 
 ## Output Location
 
-All specification documents are saved in the `.omt/specs/` directory.
+All specification documents are saved in the `$OMT_DIR/specs/` directory.
 
 ### Structure Rationale
 

--- a/skills/spec/references/wrapup.md
+++ b/skills/spec/references/wrapup.md
@@ -24,9 +24,9 @@ As a knowledge curator, extract information that shapes the **next specification
 #### 1.1 Gather Records
 
 - Collect: Read all records from:
-  - `.omt/specs/{spec-name}/requirements/records/`
-  - `.omt/specs/{spec-name}/solution-design/records/`
-  - `.omt/specs/{spec-name}/{area-name}/records/` (for each selected Design Area)
+  - `$OMT_DIR/specs/{spec-name}/requirements/records/`
+  - `$OMT_DIR/specs/{spec-name}/solution-design/records/`
+  - `$OMT_DIR/specs/{spec-name}/{area-name}/records/` (for each selected Design Area)
 - Organize: Group by category (architectural decisions, domain conventions, gotchas, etc.)
 
 #### 1.2 Extract Candidates

--- a/skills/spec/templates/record.md
+++ b/skills/spec/templates/record.md
@@ -91,4 +91,4 @@ Records are saved to the `records/` folder within each area directory.
 - `2-communication-pattern.md` - Integration Pattern, Step 2 decision
 - `1-metrics-selection.md` - Operations Plan, Step 1 decision
 
-**Location**: `.omt/specs/{spec-name}/{area-name}/records/`
+**Location**: `$OMT_DIR/specs/{spec-name}/{area-name}/records/`

--- a/tools/run-tests.sh
+++ b/tools/run-tests.sh
@@ -50,6 +50,7 @@ run_shell_tests() {
     test_files=$(find "$ROOT_DIR" \
         -path "*/node_modules" -prune -o \
         -path "*/.sync-backup" -prune -o \
+        -path "*/.omt" -prune -o \
         \( -name "*_test.sh" -o -name "test_*.sh" \) \
         -type f -print | sort)
 

--- a/tools/run-tests.sh
+++ b/tools/run-tests.sh
@@ -50,7 +50,6 @@ run_shell_tests() {
     test_files=$(find "$ROOT_DIR" \
         -path "*/node_modules" -prune -o \
         -path "*/.sync-backup" -prune -o \
-        -path "*/.omt" -prune -o \
         \( -name "*_test.sh" -o -name "test_*.sh" \) \
         -type f -print | sort)
 


### PR DESCRIPTION
## 📌 Summary

Worktree 삭제 시 프로젝트 내부 `.omt/` 디렉토리가 함께 소실되는 문제를 해결하기 위해, 모든 프로젝트 상태를 `~/.omt/{project-name}/`으로 이전하고 `$OMT_DIR` 환경 변수 기반의 중앙화된 경로 관리 체계를 도입했습니다.

---

## 🔧 Changes

### 경로 해석 공유 라이브러리

- `lib/omt-dir.ts` (TypeScript)와 `hooks/lib/omt-dir.sh` (Shell) 신규 작성
- 동일한 해석 로직: `$OMT_DIR` 환경 변수 → git worktree/standard repo → cwd basename 순 fallback
- Worktree에서 `git rev-parse --git-common-dir`이 상대경로를 반환하는 케이스 처리
- 프로젝트명의 공백을 하이픈으로 치환하여 셸 파싱 안전성 확보

**영향 범위**: 모든 hook/script의 상태 경로가 이 라이브러리를 통해 결정됨. 기존 `~/.omt/` 디렉토리가 없으면 자동 생성되므로 하위 호환성 문제 없음.

### 세션 시작 및 환경 변수 설정

- `session-start.sh`에서 `compute_omt_dir()`을 호출하고 `$CLAUDE_ENV_FILE`을 통해 `$OMT_DIR` export
- 기존 20줄의 인라인 프로젝트명 도출 로직을 공유 라이브러리 호출로 교체
- `$CLAUDE_ENV_FILE` export 값에 인용 누락 수정

**영향 범위**: 세션 시작 시 1회 실행. 모든 하위 hook/script가 `$OMT_DIR` 환경 변수를 참조.

### Shell Hook 마이그레이션

- `keyword-detector.sh`, `stop-notify.sh`, `logging.sh`: 인라인 경로 계산 → `source omt-dir.sh` + `compute_omt_dir()` 호출로 통합
- ralph-state, 로그 등 모든 상태 파일 경로를 `$OMT_DIR` 기반으로 전환

**영향 범위**: 3개 shell hook. 기존 동작 동일, 경로만 변경.

### TypeScript Hook/Script 마이그레이션

- `persistent-mode/state.ts`: 미사용 `projectRoot` 파라미터 완전 제거 (시그니처 단순화)
- `logging.ts`: `initLogger(component, projectRoot, sessionId)` → `initLogger(component, omtDir, sessionId)` 시그니처 변경, 5개 콜사이트 업데이트
- `chunk-review`, `spec-reviewer`, `hud`, `agent-council`: 모든 상태/작업 디렉토리를 `getOmtDir()` 기반으로 전환
- `spec-reviewer`: 레거시 `.omt/` 접두사가 붙은 config 값 방어 처리

**영향 범위**: TypeScript 스크립트 6개, hook 1개. `initLogger` 시그니처 변경으로 모든 콜사이트 수정 필요했음.

### 프롬프트 및 문서 경로 업데이트

- skills, agents, commands 전체에서 `.omt/plans/`, `.omt/specs/`, `.omt/ralph-state` 경로를 `$OMT_DIR/` 기반으로 교체
- `cancel-ralph.md`의 `cd .omt` 이중 중첩 버그 제거
- README, CLAUDE.md, GEMINI.md, AGENTS.md 업데이트
- `.gitignore`에서 `.omt/` 항목 제거 (프로젝트 내부에 더 이상 생성되지 않음)

**영향 범위**: 프롬프트/문서 15개+. AI 에이전트가 참조하는 경로가 변경되므로 sync 후 즉시 반영됨.

### 테스트 추가

- `lib/omt-dir.test.ts`: env var, git repo, worktree, non-git, 공백 디렉토리 등 6개 케이스
- `hooks/session-start_test.sh`: OMT_DIR export 및 디렉토리 생성 검증 3개 케이스
- `hooks/stop-notify_test.sh`: 신규 훅 테스트 305줄
- 기존 테스트: OMT_DIR 환경 설정 반영, pre-existing 디렉토리 보호 로직 추가

**영향 범위**: 테스트만. 전체 1339개 테스트 통과.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 상태 디렉토리 위치: 프로젝트 내부 vs 홈 디렉토리

**배경 및 문제 상황:**
oh-my-toong은 git worktree를 적극적으로 사용하는 환경입니다. 기존에는 프로젝트 루트의 `.omt/` 디렉토리에 ralph-state, 로그, plan, spec 등 모든 세션 상태를 저장했습니다. Worktree는 임시 작업 공간이므로 작업 완료 후 삭제하는데, 이때 `.omt/` 디렉토리가 함께 소실되어 진행 중인 상태가 유실되었습니다.

**해결 방안:**
모든 프로젝트 상태를 `~/.omt/{project-name}/`으로 이전. 프로젝트명은 git 메인 레포의 basename에서 도출하여, 동일 레포의 모든 worktree가 같은 상태 디렉토리를 공유합니다.

**구현 세부사항:**
`session-start.sh`에서 1회 계산 후 `$CLAUDE_ENV_FILE`을 통해 export. TypeScript 쪽은 `getOmtDir()`이 `$OMT_DIR` 환경 변수를 먼저 확인하고, 없으면 동일 로직으로 재계산합니다. 이 이중 경로 덕분에 세션 외부에서 스크립트를 직접 실행해도 동작합니다.

**선택과 트레이드오프:**
- XDG 표준(`~/.local/state/omt/`)도 검토했으나, macOS에서 관습적이지 않고 경로가 길어져 `~/.omt/`로 결정
- 프로젝트명 기반이라 서로 다른 경로에 동명 레포가 있으면 충돌 가능. 현재 사용 환경에서는 발생하지 않으므로 수용

### 2. Shell과 TypeScript 이중 구현

**배경 및 문제 상황:**
oh-my-toong의 hook은 shell(session-start, keyword-detector, stop-notify)과 TypeScript(persistent-mode, hud)가 혼재합니다. 경로 해석 로직이 양쪽 모두에 필요한데, shell hook에서 TypeScript를 호출하면 bun 기동 오버헤드가 세션 시작마다 발생합니다.

**해결 방안:**
`hooks/lib/omt-dir.sh`(shell)와 `lib/omt-dir.ts`(TypeScript)를 각각 작성하되, 동일한 해석 로직(git-common-dir → show-toplevel → basename fallback)을 유지합니다.

**구현 세부사항:**
Shell 버전은 macOS Bash 3.2 호환을 위해 `case` 문으로 절대/상대 경로를 분기하고, `cd && pwd`로 해석합니다. TypeScript 버전은 `path.resolve()`를 사용합니다. 두 구현의 동작 일치는 `omt-dir.test.ts`와 `session-start_test.sh`에서 각각 검증됩니다.

**선택과 트레이드오프:**
- 단일 구현(TypeScript only)으로 통합하면 유지보수가 쉽지만, shell hook마다 bun 기동이 추가됨
- 현재 구조에서 shell hook은 3개로 고정되어 있어, 이중 구현의 유지 비용이 낮다고 판단
- 두 구현이 분기하는 리스크는 테스트로 완화

---

## ✅ Checklist

### OMT_DIR 경로 해석
- [ ] `$OMT_DIR` 환경 변수가 설정되어 있으면 그 값을 그대로 사용한다
  - `lib/omt-dir.ts`, `hooks/lib/omt-dir.sh`
- [ ] git worktree에서 메인 레포 이름을 정확히 도출한다 (상대경로 포함)
  - `lib/omt-dir.test.ts`
- [ ] non-git 디렉토리에서 cwd basename으로 fallback한다
  - `lib/omt-dir.test.ts`

### 세션 시작
- [ ] `session-start.sh` 실행 후 `$OMT_DIR`이 `$CLAUDE_ENV_FILE`에 export된다
  - `hooks/session-start_test.sh`
- [ ] `$OMT_DIR` 디렉토리가 존재하지 않으면 자동 생성된다
  - `hooks/session-start_test.sh`

### Hook/Script 마이그레이션
- [ ] `keyword-detector.sh`, `stop-notify.sh`가 `$OMT_DIR` 경로로 상태 파일을 참조한다
  - `hooks/keyword-detector.sh`, `hooks/stop-notify.sh`
- [ ] `persistent-mode/state.ts`의 ralph state 함수가 `projectRoot` 파라미터 없이 동작한다
  - `hooks/persistent-mode/state.ts`, `hooks/persistent-mode/state.test.ts`
- [ ] spec-reviewer가 레거시 `.omt/` 접두사를 가진 config에서도 올바른 경로를 해석한다
  - `scripts/spec-reviewer/job.ts`

### 테스트
- [ ] 전체 테스트 스위트(1339개)가 통과한다
- [ ] 테스트가 `~/.omt/`의 pre-existing 디렉토리를 삭제하지 않는다
  - `lib/omt-dir.test.ts`

---

## 📎 References
- 없음