### PR TITLE
refactor: job 출력 정제 및 프레임워크 통합

### DIFF
--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 
-import type { JobConfig } from './generic-job.ts';
+import type { JobConfig, CmdResultsHooks } from './generic-job.ts';
 import {
   detectCliType,
   buildAugmentedCommand,
@@ -1347,4 +1347,163 @@ describe('cmdCollect', () => {
     const result = JSON.parse(output[0]);
     expect(result.overallState).toBe('done');
   }, 15000);
+});
+
+// ---------------------------------------------------------------------------
+// cmdResults
+// ---------------------------------------------------------------------------
+
+describe('cmdResults', () => {
+  let tmpDir: string;
+
+  function captureStdout(fn: () => void): string {
+    let captured = '';
+    const orig = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: any) => {
+      captured += String(chunk);
+      return true;
+    }) as any;
+    try {
+      fn();
+    } finally {
+      process.stdout.write = orig;
+    }
+    return captured;
+  }
+
+  function setupResultsFixture(
+    jobDir: string,
+    members: Record<string, { member: string; state: string; exitCode: number; output: string; stderr: string }>,
+    jobMeta?: Record<string, any>,
+  ) {
+    fs.mkdirSync(jobDir, { recursive: true });
+    fs.writeFileSync(path.join(jobDir, 'job.json'), JSON.stringify(jobMeta || { id: 'test' }));
+    const membersDir = path.join(jobDir, 'members');
+    fs.mkdirSync(membersDir, { recursive: true });
+    for (const [name, data] of Object.entries(members)) {
+      const dir = path.join(membersDir, name);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'status.json'), JSON.stringify({ member: data.member, state: data.state, exitCode: data.exitCode }));
+      fs.writeFileSync(path.join(dir, 'output.txt'), data.output);
+      fs.writeFileSync(path.join(dir, 'error.txt'), data.stderr);
+    }
+  }
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('--json 기본 출력 구조 검증', () => {
+    const jobDir = path.join(tmpDir, 'job-results-basic');
+    setupResultsFixture(jobDir, {
+      alice: { member: 'alice', state: 'done', exitCode: 0, output: 'hello', stderr: '' },
+    });
+
+    const raw = captureStdout(() => {
+      cmdResults({ json: true }, jobDir, chunkReviewConfig);
+    });
+
+    const result = JSON.parse(raw);
+    expect(result.jobDir).toBeDefined();
+    expect(result.id).toBe('test');
+    expect(Array.isArray(result.members)).toBe(true);
+    const member = result.members[0];
+    expect(member.member).toBe('alice');
+    expect(member.state).toBe('done');
+    expect(member.exitCode).toBe(0);
+    expect(member.message).toBeNull();
+    expect(member.output).toBe('hello');
+    expect(member.stderr).toBeUndefined();
+  });
+
+  test('hooks.extraTopLevel 커스텀 필드 추가', () => {
+    const jobDir = path.join(tmpDir, 'job-results-extratop');
+    setupResultsFixture(jobDir, {
+      alice: { member: 'alice', state: 'done', exitCode: 0, output: '', stderr: '' },
+    });
+
+    const hooks: CmdResultsHooks = {
+      extraTopLevel: () => ({ specName: 'test-spec', prompt: 'test prompt' }),
+    };
+
+    const raw = captureStdout(() => {
+      cmdResults({ json: true }, jobDir, chunkReviewConfig, hooks);
+    });
+
+    const result = JSON.parse(raw);
+    expect(result.specName).toBe('test-spec');
+    expect(result.prompt).toBe('test prompt');
+  });
+
+  test('hooks.extraMemberFields per-member 필드 추가', () => {
+    const jobDir = path.join(tmpDir, 'job-results-extramember');
+    setupResultsFixture(jobDir, {
+      alice: { member: 'alice', state: 'done', exitCode: 0, output: '', stderr: 'some error' },
+    });
+
+    const hooks: CmdResultsHooks = {
+      extraMemberFields: (r) => ({ stderr: r.stderr }),
+    };
+
+    const raw = captureStdout(() => {
+      cmdResults({ json: true }, jobDir, chunkReviewConfig, hooks);
+    });
+
+    const result = JSON.parse(raw);
+    expect(result.members[0].stderr).toBe('some error');
+  });
+
+  test('ANSI 코드가 output에서 제거됨', () => {
+    const jobDir = path.join(tmpDir, 'job-results-ansi-output');
+    setupResultsFixture(jobDir, {
+      alice: { member: 'alice', state: 'done', exitCode: 0, output: '\x1b[31mred\x1b[0m', stderr: '' },
+    });
+
+    const raw = captureStdout(() => {
+      cmdResults({ json: true }, jobDir, chunkReviewConfig);
+    });
+
+    const result = JSON.parse(raw);
+    expect(result.members[0].output).toBe('red');
+  });
+
+  test('hooks 미전달 시 기존 동작 유지', () => {
+    const jobDir = path.join(tmpDir, 'job-results-nohooks');
+    setupResultsFixture(jobDir, {
+      alice: { member: 'alice', state: 'done', exitCode: 0, output: 'out', stderr: 'err' },
+    });
+
+    const raw = captureStdout(() => {
+      cmdResults({ json: true }, jobDir, chunkReviewConfig);
+    });
+
+    const result = JSON.parse(raw);
+    const member = result.members[0];
+    expect(member.member).toBe('alice');
+    expect(member.output).toBe('out');
+    expect(member.stderr).toBeUndefined();
+    expect(member.specName).toBeUndefined();
+  });
+
+  test('ANSI 코드가 stderr에서도 제거됨', () => {
+    const jobDir = path.join(tmpDir, 'job-results-ansi-stderr');
+    setupResultsFixture(jobDir, {
+      alice: { member: 'alice', state: 'done', exitCode: 0, output: '', stderr: '\x1b[32mgreen\x1b[0m' },
+    });
+
+    const hooks: CmdResultsHooks = {
+      extraMemberFields: (r) => ({ stderr: r.stderr }),
+    };
+
+    const raw = captureStdout(() => {
+      cmdResults({ json: true }, jobDir, chunkReviewConfig, hooks);
+    });
+
+    const result = JSON.parse(raw);
+    expect(result.members[0].stderr).toBe('green');
+  });
 });

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -25,6 +25,7 @@ import {
   parseWaitCursor,
   formatWaitCursor,
   resolveBucketSize,
+  stripAnsi,
 } from './job-utils';
 
 // ---------------------------------------------------------------------------
@@ -46,6 +47,24 @@ export interface JobConfig {
   configTopLevelKey: string;
   /** optional feature flags for consumers */
   [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Hook interfaces for cmdResults / cmdWait extensibility
+// ---------------------------------------------------------------------------
+
+export interface CmdResultsHooks {
+  /** Extra top-level fields to add to JSON output (e.g., specName, prompt) */
+  extraTopLevel?: (jobDir: string, jobMeta: any) => Record<string, unknown>;
+  /** Extra per-member fields. Receives the raw member object (includes stderr, output, safeName, all status.json fields). */
+  extraMemberFields?: (rawMember: any) => Record<string, unknown>;
+}
+
+export interface CmdWaitHooks {
+  /** Transform the wait payload before output (e.g., add specName) */
+  transformPayload?: (payload: any) => any;
+  /** Override default timeout-ms (framework default: 600000). Set 0 for infinite. */
+  defaultTimeoutMs?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -580,6 +599,7 @@ export async function cmdWait(
   options: Record<string, unknown>,
   jobDir: string,
   config: JobConfig,
+  hooks?: CmdWaitHooks,
 ): Promise<void> {
   const resolvedJobDir = path.resolve(jobDir);
   const cursorFilePath = path.join(resolvedJobDir, '.wait_cursor');
@@ -595,9 +615,12 @@ export async function cmdWait(
   const intervalMs = Math.max(50, Math.trunc(Number(intervalMsRaw)));
   if (!Number.isFinite(intervalMs) || intervalMs <= 0) exitWithError(`wait: invalid --interval-ms: ${intervalMsRaw}`);
 
-  const timeoutMsRaw = options['timeout-ms'] != null ? options['timeout-ms'] : 600000;
+  const defaultTimeout = hooks?.defaultTimeoutMs ?? 600000;
+  const timeoutMsRaw = options['timeout-ms'] != null ? options['timeout-ms'] : defaultTimeout;
   const timeoutMs = Math.trunc(Number(timeoutMsRaw));
   if (!Number.isFinite(timeoutMs) || timeoutMs < 0) exitWithError(`wait: invalid --timeout-ms: ${timeoutMsRaw}`);
+
+  const applyHook = (p: any) => hooks?.transformPayload ? hooks.transformPayload(p) : p;
 
   let payload = await computeStatus(jobDir, config);
   const bucketSize = resolveBucketSize(options, payload.counts.total, prevCursor);
@@ -612,7 +635,7 @@ export async function cmdWait(
 
   if (!prevCursor) {
     fs.writeFileSync(cursorFilePath, cursor, 'utf8');
-    process.stdout.write(`${JSON.stringify({ ...asWaitPayload(payload, config), cursor }, null, 2)}\n`);
+    process.stdout.write(`${JSON.stringify({ ...applyHook(asWaitPayload(payload, config)), cursor }, null, 2)}\n`);
     return;
   }
 
@@ -630,7 +653,7 @@ export async function cmdWait(
     const nextCursor = formatWaitCursor(bucketSize, dispatchB, doneB, doneFlag);
     if (nextCursor !== prevCursorRaw) {
       fs.writeFileSync(cursorFilePath, nextCursor, 'utf8');
-      process.stdout.write(`${JSON.stringify({ ...asWaitPayload(payload, config), cursor: nextCursor }, null, 2)}\n`);
+      process.stdout.write(`${JSON.stringify({ ...applyHook(asWaitPayload(payload, config)), cursor: nextCursor }, null, 2)}\n`);
       return;
     }
   }
@@ -644,7 +667,7 @@ export async function cmdWait(
   const finalDoneBucket = Math.floor(finalDone / bucketSize);
   const finalCursor = formatWaitCursor(bucketSize, finalDispatchBucket, finalDoneBucket, finalDoneFlag);
   fs.writeFileSync(cursorFilePath, finalCursor, 'utf8');
-  process.stdout.write(`${JSON.stringify({ ...asWaitPayload(finalPayload, config), cursor: finalCursor }, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify({ ...applyHook(asWaitPayload(finalPayload, config)), cursor: finalCursor }, null, 2)}\n`);
 }
 
 // ---------------------------------------------------------------------------
@@ -655,6 +678,7 @@ export function cmdResults(
   options: Record<string, unknown>,
   jobDir: string,
   config: JobConfig,
+  hooks?: CmdResultsHooks,
 ): void {
   const resolvedJobDir = path.resolve(jobDir);
   const jobMeta = readJsonIfExists(path.join(resolvedJobDir, 'job.json')) as any;
@@ -668,8 +692,8 @@ export function cmdResults(
       const errorPath = path.join(entitiesRoot, entry, 'error.txt');
       const status = readJsonIfExists(statusPath) as any;
       if (!status) continue;
-      const output = fs.existsSync(outputPath) ? fs.readFileSync(outputPath, 'utf8') : '';
-      const stderr = fs.existsSync(errorPath) ? fs.readFileSync(errorPath, 'utf8') : '';
+      const output = fs.existsSync(outputPath) ? stripAnsi(fs.readFileSync(outputPath, 'utf8')) : '';
+      const stderr = fs.existsSync(errorPath) ? stripAnsi(fs.readFileSync(errorPath, 'utf8')) : '';
       reviewers.push({ safeName: entry, ...status, output, stderr });
     }
   }
@@ -681,11 +705,13 @@ export function cmdResults(
   }
 
   if (options.json) {
+    const extraTop = hooks?.extraTopLevel ? hooks.extraTopLevel(resolvedJobDir, jobMeta) : {};
     process.stdout.write(
       `${JSON.stringify(
         {
           jobDir: resolvedJobDir,
           id: jobMeta ? jobMeta.id : null,
+          ...extraTop,
           [config.entityPlural]: reviewers
             .map((r) => ({
               member: r.member,
@@ -693,6 +719,7 @@ export function cmdResults(
               exitCode: r.exitCode != null ? r.exitCode : null,
               message: r.message || null,
               output: r.output,
+              ...(hooks?.extraMemberFields ? hooks.extraMemberFields(r) : {}),
             }))
             .sort((a, b) => String(a.member).localeCompare(String(b.member))),
         },

--- a/lib/job-utils.test.ts
+++ b/lib/job-utils.test.ts
@@ -22,6 +22,7 @@ import {
   resolveBucketSize,
   generateJobId,
   findProjectRoot,
+  stripAnsi,
 } from './job-utils.ts';
 
 // ---------------------------------------------------------------------------
@@ -747,5 +748,39 @@ describe('findProjectRoot', () => {
     const scriptDir = path.join(tmpDir, 'scripts', 'chunk-review');
     fs.mkdirSync(scriptDir, { recursive: true });
     expect(findProjectRoot(scriptDir)).toBe(tmpDir);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripAnsi
+// ---------------------------------------------------------------------------
+
+describe('stripAnsi', () => {
+  test('SGR 색상 코드 제거', () => {
+    expect(stripAnsi('\x1b[31mred text\x1b[0m')).toBe('red text');
+  });
+
+  test('bold/underline 코드 제거', () => {
+    expect(stripAnsi('\x1b[1mbold\x1b[22m \x1b[4munderline\x1b[24m')).toBe('bold underline');
+  });
+
+  test('일반 텍스트 무변경', () => {
+    expect(stripAnsi('plain text')).toBe('plain text');
+  });
+
+  test('빈 문자열 처리', () => {
+    expect(stripAnsi('')).toBe('');
+  });
+
+  test('cursor 이동 시퀀스 제거', () => {
+    expect(stripAnsi('\x1b[2Jhello\x1b[H')).toBe('hello');
+  });
+
+  test('OSC 시퀀스 (BEL 종료) 제거', () => {
+    expect(stripAnsi('\x1b]0;title\x07content')).toBe('content');
+  });
+
+  test('OSC 8 하이퍼링크 (ST 종료) 제거', () => {
+    expect(stripAnsi('\x1b]8;;https://example.com\x1b\\link text\x1b]8;;\x1b\\')).toBe('link text');
   });
 });

--- a/lib/job-utils.ts
+++ b/lib/job-utils.ts
@@ -268,3 +268,14 @@ export function findProjectRoot(scriptDir: string): string {
 
   return path.resolve(scriptDir, '../..');
 }
+
+// ---------------------------------------------------------------------------
+// ANSI stripping
+// ---------------------------------------------------------------------------
+
+// Covers SGR sequences, OSC (BEL and ST terminated), and CSI via 0x9B
+const ANSI_PATTERN = /\x1b\[[0-9;]*[A-Za-z]|\x1b\].*?(\x07|\x1b\\)|\x9b[0-9;]*[A-Za-z]/g;
+
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_PATTERN, '');
+}

--- a/lib/worker-utils.test.ts
+++ b/lib/worker-utils.test.ts
@@ -482,3 +482,177 @@ describe('runOnce heartbeat', () => {
     await promise;
   });
 });
+
+// ---------------------------------------------------------------------------
+// runOnce 환경 변수 전파
+// ---------------------------------------------------------------------------
+
+function createCapturingSpawnFn() {
+  const captured: { env?: Record<string, string> } = {};
+  const mockSpawn = (program: string, args: string[], options: any) => {
+    captured.env = options?.env;
+    const child = new (require('events').EventEmitter)();
+    const stdin = { write: () => true, end: () => {}, on: () => stdin } as any;
+    (child as any).stdin = stdin;
+    (child as any).stdout = null;
+    (child as any).stderr = null;
+    (child as any).pid = 12345;
+    process.nextTick(() => {
+      child.emit('exit', 0, null);
+      process.nextTick(() => child.emit('close', 0, null));
+    });
+    return child as any;
+  };
+  return { mockSpawn, captured };
+}
+
+describe('runOnce 환경 변수 전파', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'worker-env-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeEnvTestOpts(overrides: Partial<RunOnceOpts> = {}): RunOnceOpts {
+    const memberDir = join(tmpDir, 'member');
+    mkdirSync(memberDir, { recursive: true });
+    return {
+      program: '/bin/sh',
+      args: ['-c', 'exit 0'],
+      prompt: 'test prompt',
+      member: 'test-member',
+      memberDir,
+      command: '/bin/sh -c "exit 0"',
+      timeoutSec: 10,
+      attempt: 0,
+      ...overrides,
+    };
+  }
+
+  it('NO_COLOR=1 전파 확인', async () => {
+    const { mockSpawn, captured } = createCapturingSpawnFn();
+    const opts = makeEnvTestOpts({ spawnFn: mockSpawn });
+    await runOnce(opts);
+    expect(captured.env?.NO_COLOR).toBe('1');
+  });
+
+  it('TERM=dumb 전파 확인', async () => {
+    const { mockSpawn, captured } = createCapturingSpawnFn();
+    const opts = makeEnvTestOpts({ spawnFn: mockSpawn });
+    await runOnce(opts);
+    expect(captured.env?.TERM).toBe('dumb');
+  });
+
+  it('FORCE_COLOR=0 전파 확인', async () => {
+    const { mockSpawn, captured } = createCapturingSpawnFn();
+    const opts = makeEnvTestOpts({ spawnFn: mockSpawn });
+    await runOnce(opts);
+    expect(captured.env?.FORCE_COLOR).toBe('0');
+  });
+
+  it('workerEnv가 NO_COLOR override 가능', async () => {
+    const { mockSpawn, captured } = createCapturingSpawnFn();
+    const opts = makeEnvTestOpts({ spawnFn: mockSpawn, workerEnv: { NO_COLOR: '' } });
+    await runOnce(opts);
+    expect(captured.env?.NO_COLOR).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// retry 시 output 정제
+// ---------------------------------------------------------------------------
+
+describe('retry 시 output 정제', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'worker-retry-output-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('attempt 1에서 output.txt에 attempt 마커 없음', async () => {
+    const subDir = join(tmpDir, 'no-marker');
+    const memberDir = join(subDir, 'member');
+    mkdirSync(memberDir, { recursive: true });
+
+    await runOnce({
+      program: '/bin/sh',
+      args: ['-c', 'echo "retry output"'],
+      prompt: 'test prompt',
+      member: 'test-member',
+      memberDir,
+      command: '/bin/sh -c \'echo "retry output"\'',
+      timeoutSec: 10,
+      attempt: 1,
+    });
+
+    const outputContent = readFileSync(join(memberDir, 'output.txt'), 'utf8');
+    expect(outputContent).not.toContain('--- attempt');
+  });
+
+  it('attempt 1에서 output.txt가 truncate됨 (이전 데이터 없음)', async () => {
+    const subDir = join(tmpDir, 'truncate-check');
+    const memberDir = join(subDir, 'member');
+    mkdirSync(memberDir, { recursive: true });
+
+    // Pre-write old data
+    writeFileSync(join(memberDir, 'output.txt'), 'old data\n');
+
+    await runOnce({
+      program: '/bin/sh',
+      args: ['-c', 'echo "new output"'],
+      prompt: 'test prompt',
+      member: 'test-member',
+      memberDir,
+      command: '/bin/sh -c \'echo "new output"\'',
+      timeoutSec: 10,
+      attempt: 1,
+    });
+
+    const outputContent = readFileSync(join(memberDir, 'output.txt'), 'utf8');
+    expect(outputContent).toContain('new output');
+    expect(outputContent).not.toContain('old data');
+  });
+
+  it('errOffset=0 for retry: non-retryable 패턴 감지 정상', async () => {
+    const subDir = join(tmpDir, 'eroffset-retry');
+    const memberDir = join(subDir, 'member');
+    mkdirSync(memberDir, { recursive: true });
+
+    // Write a counter file to make the script behave differently on each invocation
+    const counterFile = join(subDir, 'counter');
+    writeFileSync(counterFile, '0');
+
+    const script = `
+  COUNT=$(cat ${counterFile})
+  echo $((COUNT + 1)) > ${counterFile}
+  if [ "$COUNT" = "0" ]; then
+    echo "Connection refused: retryable error" >&2
+    exit 1
+  else
+    echo "TerminalQuotaError: quota exceeded" >&2
+    exit 1
+  fi
+`;
+
+    const result = await runWithRetry({
+      program: '/bin/sh',
+      args: ['-c', script],
+      prompt: 'test prompt',
+      member: 'test-member',
+      memberDir,
+      command: '/bin/sh script',
+      timeoutSec: 10,
+      sleepFn: noopSleep,
+    });
+
+    expect(result.state).toBe('non_retryable');
+  });
+});

--- a/lib/worker-utils.ts
+++ b/lib/worker-utils.ts
@@ -226,8 +226,8 @@ export function runOnce(opts: RunOnceOpts): Promise<Record<string, unknown>> {
       command, pid: null, attempt,
     });
 
-    const outStream = fs.createWriteStream(outPath, { flags: 'a' });
-    const errStream = fs.createWriteStream(errPath, { flags: 'a' });
+    const outStream = fs.createWriteStream(outPath, { flags: attempt > 0 ? 'w' : 'a' });
+    const errStream = fs.createWriteStream(errPath, { flags: attempt > 0 ? 'w' : 'a' });
     outStream.on('error', () => { /* ignore */ });
     errStream.on('error', () => { /* ignore */ });
 
@@ -235,7 +235,7 @@ export function runOnce(opts: RunOnceOpts): Promise<Record<string, unknown>> {
     try {
       child = spawnFn(program, [...args], {
         stdio: ['pipe', 'pipe', 'pipe'],
-        env: { ...process.env, ...workerEnv },
+        env: { ...process.env, NO_COLOR: '1', TERM: 'dumb', FORCE_COLOR: '0', ...workerEnv },
       });
     } catch (error: unknown) {
       const err = error as Error | undefined;
@@ -283,13 +283,6 @@ export function runOnce(opts: RunOnceOpts): Promise<Record<string, unknown>> {
       } catch { /* ignore */ }
     }, heartbeatIntervalMs);
     heartbeatHandle.unref();
-
-    // Write attempt separator before piping output (preserves previous attempts)
-    if (attempt > 0) {
-      const marker = `\n--- attempt ${attempt} ---\n`;
-      outStream.write(marker);
-      errStream.write(marker);
-    }
 
     if (child.stdout) child.stdout.pipe(outStream);
     if (child.stderr) child.stderr.pipe(errStream);
@@ -387,8 +380,9 @@ export async function runWithRetry(opts: RunWithRetryOpts): Promise<Record<strin
   const errPath = path.join(runOpts.memberDir, 'error.txt');
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    // Record current error.txt size so we only check NEW stderr from this attempt
-    const errOffset = (() => { try { return fs.statSync(errPath).size; } catch { return 0; } })();
+    // On retry (attempt > 0), runOnce truncates error.txt, so offset is always 0.
+    // On first attempt, record current size to check only NEW stderr.
+    const errOffset = attempt > 0 ? 0 : (() => { try { return fs.statSync(errPath).size; } catch { return 0; } })();
 
     result = await runOnce({ ...runOpts, attempt });
 

--- a/scripts/chunk-review/worker.test.ts
+++ b/scripts/chunk-review/worker.test.ts
@@ -417,7 +417,7 @@ describe('runWithRetry', () => {
     expect(delays[0] < BASE_DELAY_MS * 3).toBe(true);
   });
 
-  test('appends output with attempt marker on retry', async () => {
+  test('retry 시 output.txt가 truncate되어 최종 attempt만 남음', async () => {
     const markerFile = path.join(tmpDir, 'attempt-marker2');
     const result = await runWithRetry({
       program: 'sh',
@@ -431,8 +431,8 @@ describe('runWithRetry', () => {
     });
 
     const out = await waitForFileContent(paths.outPath, 'attempt2');
-    expect(out.includes('attempt1')).toBe(true);
-    expect(out.includes('--- attempt 1 ---')).toBe(true);
+    expect(out.includes('attempt1')).toBe(false);
+    expect(out.includes('--- attempt')).toBe(false);
     expect(out.includes('attempt2')).toBe(true);
   });
 
@@ -734,10 +734,10 @@ describe('runOnce - workerEnv injection', () => {
     // Existing env vars should be present
     expect(captured.options.env.PATH).toBe(process.env.PATH);
     expect(captured.options.env.HOME).toBe(process.env.HOME);
-    // No extra keys beyond what process.env has
-    const envKeys = Object.keys(captured.options.env);
-    const processEnvKeys = Object.keys(process.env);
-    expect(envKeys.sort()).toEqual(processEnvKeys.sort());
+    // Framework injects NO_COLOR, TERM, FORCE_COLOR for clean output
+    expect(captured.options.env.NO_COLOR).toBe('1');
+    expect(captured.options.env.TERM).toBe('dumb');
+    expect(captured.options.env.FORCE_COLOR).toBe('0');
   });
 
   test('merges multiple workerEnv vars into spawn env', async () => {

--- a/scripts/spec-reviewer/job.test.ts
+++ b/scripts/spec-reviewer/job.test.ts
@@ -4,6 +4,7 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { execFileSync } from 'child_process';
 
 import {
   buildUiPayload,
@@ -816,5 +817,108 @@ describe('findProjectRoot', () => {
     const re = /^(.+?)\/\.(claude|gemini|codex|opencode)\/scripts\//;
     const match = '/path/to/project/.other/scripts/spec-reviewer/job.ts'.match(re);
     expect(match).toBe(null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cmdResults
+// ---------------------------------------------------------------------------
+
+describe('cmdResults', () => {
+  const SCRIPT = path.join(import.meta.dirname, 'job.ts');
+  let tmpDir;
+
+  function setupResultsFixture(
+    jobDir: string,
+    members: Record<string, { member: string; state: string; exitCode: number; output: string; stderr: string }>,
+    opts?: { specName?: string; prompt?: string },
+  ) {
+    fs.mkdirSync(jobDir, { recursive: true });
+    fs.writeFileSync(path.join(jobDir, 'job.json'), JSON.stringify({
+      id: 'spec-review-test',
+      specName: opts?.specName || null,
+    }));
+    if (opts?.prompt) {
+      fs.writeFileSync(path.join(jobDir, 'prompt.txt'), opts.prompt);
+    }
+    const membersDir = path.join(jobDir, 'members');
+    fs.mkdirSync(membersDir, { recursive: true });
+    for (const [name, data] of Object.entries(members)) {
+      const dir = path.join(membersDir, name);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'status.json'), JSON.stringify({
+        member: data.member, state: data.state, exitCode: data.exitCode,
+      }));
+      if (data.output !== undefined) {
+        fs.writeFileSync(path.join(dir, 'output.txt'), data.output);
+      }
+      fs.writeFileSync(path.join(dir, 'error.txt'), data.stderr || '');
+    }
+  }
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('--json 출력에 specName, prompt, stderr 필드 포함', () => {
+    const jobDir = path.join(tmpDir, 'job-results-1');
+    setupResultsFixture(
+      jobDir,
+      {
+        claude: { member: 'claude', state: 'done', exitCode: 0, output: 'review output', stderr: 'some warning' },
+      },
+      { specName: 'auth-flow', prompt: 'review this spec' },
+    );
+    const raw = execFileSync(process.execPath, [SCRIPT, 'results', '--json', jobDir], { stdio: 'pipe' });
+    const parsed = JSON.parse(raw.toString());
+    expect(parsed.specName).toBe('auth-flow');
+    expect(parsed.prompt).toBe('review this spec');
+    expect(parsed.members[0].stderr).toBe('some warning');
+  });
+
+  test('--json members가 알파벳 순 정렬', () => {
+    const jobDir = path.join(tmpDir, 'job-results-2');
+    setupResultsFixture(jobDir, {
+      codex: { member: 'codex', state: 'done', exitCode: 0, output: 'codex output', stderr: '' },
+      alice: { member: 'alice', state: 'done', exitCode: 0, output: 'alice output', stderr: '' },
+    });
+    const raw = execFileSync(process.execPath, [SCRIPT, 'results', '--json', jobDir], { stdio: 'pipe' });
+    const parsed = JSON.parse(raw.toString());
+    expect(parsed.members[0].member).toBe('alice');
+    expect(parsed.members[1].member).toBe('codex');
+  });
+
+  test('non-JSON: output 비어있으면 stderr fallback 출력', () => {
+    const jobDir = path.join(tmpDir, 'job-results-3');
+    setupResultsFixture(jobDir, {
+      claude: { member: 'claude', state: 'error', exitCode: 1, output: '', stderr: 'fallback error content' },
+    });
+    const raw = execFileSync(process.execPath, [SCRIPT, 'results', jobDir], { stdio: 'pipe' });
+    expect(raw.toString().includes('fallback error content')).toBe(true);
+  });
+
+  test('non-JSON: output 있으면 output 출력, stderr 미포함', () => {
+    const jobDir = path.join(tmpDir, 'job-results-4');
+    setupResultsFixture(jobDir, {
+      claude: { member: 'claude', state: 'done', exitCode: 0, output: 'primary content', stderr: 'hidden stderr' },
+    });
+    const raw = execFileSync(process.execPath, [SCRIPT, 'results', jobDir], { stdio: 'pipe' });
+    const out = raw.toString();
+    expect(out.includes('primary content')).toBe(true);
+    expect(out.includes('hidden stderr')).toBe(false);
+  });
+
+  test('--json 출력에서 ANSI 코드 제거됨', () => {
+    const jobDir = path.join(tmpDir, 'job-results-5');
+    setupResultsFixture(jobDir, {
+      claude: { member: 'claude', state: 'done', exitCode: 0, output: '\x1b[31mclean output\x1b[0m', stderr: '' },
+    });
+    const raw = execFileSync(process.execPath, [SCRIPT, 'results', '--json', jobDir], { stdio: 'pipe' });
+    const parsed = JSON.parse(raw.toString());
+    expect(parsed.members[0].output).toBe('clean output');
   });
 });

--- a/scripts/spec-reviewer/job.ts
+++ b/scripts/spec-reviewer/job.ts
@@ -20,10 +20,13 @@ import {
 
 import {
   type JobConfig,
+  type CmdResultsHooks,
+  type CmdWaitHooks,
   computeStatus as _computeStatus,
   buildUiPayload as _buildUiPayload,
   spawnWorkers as _spawnWorkers,
   cmdResults as _cmdResults,
+  cmdWait as _cmdWait,
   cmdStop as _cmdStop,
   cmdClean as _cmdClean,
   cmdCollect as _cmdCollect,
@@ -307,28 +310,28 @@ Notes:
 }
 
 // ---------------------------------------------------------------------------
-// Wait payload (spec-review-specific — adds specName field)
+// Hook definitions for framework cmdResults / cmdWait
 // ---------------------------------------------------------------------------
 
-function asWaitPayload(statusPayload: any): any {
-  const membersArray = Array.isArray(statusPayload.members) ? statusPayload.members : [];
+const RESULTS_HOOKS: CmdResultsHooks = {
+  extraTopLevel: (jobDir, jobMeta) => ({
+    specName: jobMeta?.specName || null,
+    prompt: fs.existsSync(path.join(jobDir, 'prompt.txt'))
+      ? fs.readFileSync(path.join(jobDir, 'prompt.txt'), 'utf8')
+      : null,
+  }),
+  extraMemberFields: (member) => ({
+    stderr: member.stderr || '',
+  }),
+};
 
-  return {
-    jobDir: statusPayload.jobDir,
-    id: statusPayload.id,
-    chairmanRole: statusPayload.chairmanRole,
-    overallState: statusPayload.overallState,
-    counts: statusPayload.counts,
-    specName: statusPayload.specName,
-    members: membersArray.map((r: any) => ({
-      member: r.member,
-      state: r.state,
-      exitCode: r.exitCode != null ? r.exitCode : null,
-      message: r.message || null,
-    })),
-    ui: buildUiPayload(statusPayload),
-  };
-}
+const WAIT_HOOKS: CmdWaitHooks = {
+  defaultTimeoutMs: 0,
+  transformPayload: (payload) => {
+    const jobMeta = readJsonIfExists(path.join(path.resolve(payload.jobDir), 'job.json')) as any;
+    return { ...payload, specName: jobMeta?.specName || null };
+  },
+};
 
 async function cmdStart(options: Record<string, unknown>, prompt: string): Promise<void> {
   const configPath = (options.config || process.env.SPEC_REVIEW_CONFIG || resolveDefaultConfigFile()) as string;
@@ -477,144 +480,6 @@ async function cmdStatus(options: Record<string, unknown>, jobDir: string): Prom
 }
 
 // ---------------------------------------------------------------------------
-// cmdWait (spec-review-specific — adds specName to wait payload)
-// ---------------------------------------------------------------------------
-
-async function cmdWait(options: Record<string, unknown>, jobDir: string): Promise<void> {
-  // We override the wait payload to include specName, so we implement our own cmdWait
-  // rather than delegating to the framework's cmdWait.
-  const { parseWaitCursor, formatWaitCursor, resolveBucketSize, sleepMs } = await import('@lib/job-utils');
-
-  const resolvedJobDir = path.resolve(jobDir);
-  const cursorFilePath = path.join(resolvedJobDir, '.wait_cursor');
-  const prevCursorRaw =
-    options.cursor != null
-      ? String(options.cursor)
-      : fs.existsSync(cursorFilePath)
-        ? String(fs.readFileSync(cursorFilePath, 'utf8')).trim()
-        : '';
-  const prevCursor = parseWaitCursor(prevCursorRaw);
-
-  const intervalMsRaw = options['interval-ms'] != null ? options['interval-ms'] : 250;
-  const intervalMs = Math.max(50, Math.trunc(Number(intervalMsRaw)));
-  if (!Number.isFinite(intervalMs) || intervalMs <= 0) exitWithError(`wait: invalid --interval-ms: ${intervalMsRaw}`);
-
-  const timeoutMsRaw = options['timeout-ms'] != null ? options['timeout-ms'] : 0;
-  const timeoutMs = Math.trunc(Number(timeoutMsRaw));
-  if (!Number.isFinite(timeoutMs) || timeoutMs < 0) exitWithError(`wait: invalid --timeout-ms: ${timeoutMsRaw}`);
-
-  let payload = await computeStatus(jobDir);
-  const bucketSize = resolveBucketSize(options, payload.counts.total, prevCursor);
-
-  const doneCount = computeTerminalDoneCount(payload.counts);
-  const isDone = payload.overallState === 'done';
-  const total = Number(payload.counts.total || 0);
-  const queued = Number(payload.counts.queued || 0);
-  const dispatchBucket = queued === 0 && total > 0 ? 1 : 0;
-  const doneBucket = Math.floor(doneCount / bucketSize);
-  const cursor = formatWaitCursor(bucketSize, dispatchBucket, doneBucket, isDone);
-
-  if (!prevCursor) {
-    fs.writeFileSync(cursorFilePath, cursor, 'utf8');
-    process.stdout.write(`${JSON.stringify({ ...asWaitPayload(payload), cursor }, null, 2)}\n`);
-    return;
-  }
-
-  const start = Date.now();
-  while (cursor === prevCursorRaw) {
-    if (timeoutMs > 0 && Date.now() - start >= timeoutMs) break;
-    await sleepMs(intervalMs);
-    payload = await computeStatus(jobDir);
-    const d = computeTerminalDoneCount(payload.counts);
-    const doneFlag = payload.overallState === 'done';
-    const totalCount = Number(payload.counts.total || 0);
-    const queuedCount = Number(payload.counts.queued || 0);
-    const dispatchB = queuedCount === 0 && totalCount > 0 ? 1 : 0;
-    const doneB = Math.floor(d / bucketSize);
-    const nextCursor = formatWaitCursor(bucketSize, dispatchB, doneB, doneFlag);
-    if (nextCursor !== prevCursorRaw) {
-      fs.writeFileSync(cursorFilePath, nextCursor, 'utf8');
-      process.stdout.write(`${JSON.stringify({ ...asWaitPayload(payload), cursor: nextCursor }, null, 2)}\n`);
-      return;
-    }
-  }
-
-  const finalPayload = await computeStatus(jobDir);
-  const finalDone = computeTerminalDoneCount(finalPayload.counts);
-  const finalDoneFlag = finalPayload.overallState === 'done';
-  const finalTotal = Number(finalPayload.counts.total || 0);
-  const finalQueued = Number(finalPayload.counts.queued || 0);
-  const finalDispatchBucket = finalQueued === 0 && finalTotal > 0 ? 1 : 0;
-  const finalDoneBucket = Math.floor(finalDone / bucketSize);
-  const finalCursor = formatWaitCursor(bucketSize, finalDispatchBucket, finalDoneBucket, finalDoneFlag);
-  fs.writeFileSync(cursorFilePath, finalCursor, 'utf8');
-  process.stdout.write(`${JSON.stringify({ ...asWaitPayload(finalPayload), cursor: finalCursor }, null, 2)}\n`);
-}
-
-// ---------------------------------------------------------------------------
-// cmdResults (spec-review-specific — adds specName and prompt to JSON output)
-// ---------------------------------------------------------------------------
-
-function cmdResults(options: Record<string, unknown>, jobDir: string): void {
-  const resolvedJobDir = path.resolve(jobDir);
-  const jobMeta = readJsonIfExists(path.join(resolvedJobDir, 'job.json')) as any;
-  const membersRoot = path.join(resolvedJobDir, 'members');
-
-  const members: any[] = [];
-  if (fs.existsSync(membersRoot)) {
-    for (const entry of fs.readdirSync(membersRoot)) {
-      const statusPath = path.join(membersRoot, entry, 'status.json');
-      const outputPath = path.join(membersRoot, entry, 'output.txt');
-      const errorPath = path.join(membersRoot, entry, 'error.txt');
-      const status = readJsonIfExists(statusPath) as any;
-      if (!status) continue;
-      const output = fs.existsSync(outputPath) ? fs.readFileSync(outputPath, 'utf8') : '';
-      const stderr = fs.existsSync(errorPath) ? fs.readFileSync(errorPath, 'utf8') : '';
-      members.push({ safeName: entry, ...status, output, stderr });
-    }
-  }
-
-  if (options.json) {
-    process.stdout.write(
-      `${JSON.stringify(
-        {
-          jobDir: resolvedJobDir,
-          id: jobMeta ? jobMeta.id : null,
-          specName: jobMeta ? jobMeta.specName : null,
-          prompt: fs.existsSync(path.join(resolvedJobDir, 'prompt.txt'))
-            ? fs.readFileSync(path.join(resolvedJobDir, 'prompt.txt'), 'utf8')
-            : null,
-          members: members
-            .map((r) => ({
-              member: r.member,
-              state: r.state,
-              exitCode: r.exitCode != null ? r.exitCode : null,
-              message: r.message || null,
-              output: r.output,
-              stderr: r.stderr,
-            }))
-            .sort((a, b) => String(a.member).localeCompare(String(b.member))),
-        },
-        null,
-        2
-      )}\n`
-    );
-    return;
-  }
-
-  for (const r of members.sort((a, b) => String(a.member).localeCompare(String(b.member)))) {
-    process.stdout.write(`\n=== ${r.member} (${r.state}) ===\n`);
-    if (r.message) process.stdout.write(`${r.message}\n`);
-    process.stdout.write(r.output || '');
-    if (!r.output && r.stderr) {
-      process.stdout.write('\n');
-      process.stdout.write(r.stderr);
-    }
-    process.stdout.write('\n');
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -654,7 +519,7 @@ async function main(): Promise<void> {
   if (command === 'wait') {
     const jobDir = rest[0] as string;
     if (!jobDir) exitWithError('wait: missing jobDir');
-    await cmdWait(options, jobDir);
+    await _cmdWait(options, jobDir, JOB_CONFIG, WAIT_HOOKS);
     return;
   }
   if (command === 'collect') {
@@ -666,7 +531,7 @@ async function main(): Promise<void> {
   if (command === 'results') {
     const jobDir = rest[0] as string;
     if (!jobDir) exitWithError('results: missing jobDir');
-    cmdResults(options, jobDir);
+    _cmdResults(options, jobDir, JOB_CONFIG, RESULTS_HOOKS);
     return;
   }
   if (command === 'stop') {

--- a/scripts/spec-reviewer/worker.test.ts
+++ b/scripts/spec-reviewer/worker.test.ts
@@ -399,7 +399,7 @@ describe('runWithRetry', () => {
     expect(delays[0] < BASE_DELAY_MS * 3).toBe(true);
   });
 
-  test('appends output with attempt marker on retry', async () => {
+  test('retry 시 output.txt가 truncate되어 최종 attempt만 남음', async () => {
     const markerFile = path.join(tmpDir, 'attempt-marker2');
     const result = await runWithRetry({
       program: 'sh',
@@ -413,8 +413,8 @@ describe('runWithRetry', () => {
     });
 
     const out = fs.readFileSync(paths.outPath, 'utf8');
-    expect(out.includes('attempt1')).toBe(true);
-    expect(out.includes('--- attempt 1 ---')).toBe(true);
+    expect(out.includes('attempt1')).toBe(false);
+    expect(out.includes('--- attempt')).toBe(false);
     expect(out.includes('attempt2')).toBe(true);
   });
 

--- a/skills/agent-council/scripts/worker.test.ts
+++ b/skills/agent-council/scripts/worker.test.ts
@@ -347,7 +347,7 @@ describe('runWithRetry', () => {
     expect(result.attempt).toBe(0);
   });
 
-  test('appends output with attempt marker on retry', async () => {
+  test('retry 시 output.txt가 truncate되어 최종 attempt만 남음', async () => {
     const markerFile = path.join(tmpDir, 'attempt-marker2');
     // First attempt: echo "attempt1" and exit 1; second: echo "attempt2" and exit 0
     const script = `sh -c 'if [ -f "${markerFile}" ]; then echo attempt2 && exit 0; else touch "${markerFile}" && echo attempt1 && exit 1; fi'`;
@@ -363,9 +363,9 @@ describe('runWithRetry', () => {
     });
 
     const output = fs.readFileSync(paths.outPath, 'utf8');
-    // Should contain both attempts with marker separator
-    expect(output.includes('attempt1')).toBe(true);
-    expect(output.includes('--- attempt 1 ---')).toBe(true);
+    // Retry truncates: only final attempt output remains
+    expect(output.includes('attempt1')).toBe(false);
+    expect(output.includes('--- attempt')).toBe(false);
     expect(output.includes('attempt2')).toBe(true);
   });
 


### PR DESCRIPTION
## 📌 Summary
generic-job 프레임워크에 hook 기반 확장 포인트(`CmdResultsHooks`/`CmdWaitHooks`)를 도입하고, spec-reviewer의 ~200줄 커스텀 구현을 ~20줄 hook 위임으로 교체. 부수적으로 worker 출력의 ANSI 정제를 spawn 환경변수 + `stripAnsi` 이중 방어로 일원화.

---

## 🔧 Changes

### generic-job 프레임워크 확장

- `CmdResultsHooks` 인터페이스 추가 — `extraTopLevel`(job-level 필드 추가), `extraMemberFields`(per-member 필드 추가)
- `CmdWaitHooks` 인터페이스 추가 — `transformPayload`(wait 출력 변환), `defaultTimeoutMs`(기본 타임아웃 오버라이드)
- `cmdResults`/`cmdWait` 함수에 optional `hooks` 파라미터 추가
- `cmdResults`에서 output/stderr 읽기 시 `stripAnsi` 프레임워크 레벨 일괄 적용

hook이 `undefined`이면 no-op 처리되어 기존 소비자(chunk-review, agent-council)는 변경 없이 동작함.

**영향 범위**
`lib/generic-job.ts` — 하위 호환 유지. 기존 3개 소비자(spec-reviewer, chunk-review, agent-council) 중 spec-reviewer만 hook 주입, 나머지 2개는 코드 변경 없음.

### spec-reviewer hook 전환

- 자체 `cmdWait`/`cmdResults`/`asWaitPayload` 구현 삭제 (~110줄)
- `RESULTS_HOOKS`/`WAIT_HOOKS` 상수 정의로 교체 (~20줄)
- `main()`에서 프레임워크 `_cmdWait`/`_cmdResults`에 hook 주입하여 호출

**영향 범위**
`scripts/spec-reviewer/job.ts` — spec-reviewer의 `results`/`wait` 명령어 출력 포맷 유지. JSON 출력 필드(`specName`, `prompt`, `stderr`) 동일.

### ANSI 정제 이중 방어

- `runOnce` spawn 시 `NO_COLOR=1`, `TERM=dumb`, `FORCE_COLOR=0` 환경변수 주입
- `job-utils.ts`에 `stripAnsi` 유틸리티 추가 (SGR/OSC/CSI 시퀀스 제거)
- spawn 환경변수로 생성 차단 + `stripAnsi`로 잔여 시퀀스 제거의 2단계 방어

**영향 범위**
`lib/worker-utils.ts`, `lib/job-utils.ts` — 모든 job 소비자의 worker 출력에 적용. `workerEnv` 옵션으로 추가 환경변수 주입도 지원.

### retry truncation 시맨틱 변경

- 재시도 시 output/error 파일을 `'w'` 모드로 열어 이전 시도 내용 덮어쓰기 (기존: `'a'` 모드 + 구분 마커 append)
- `runWithRetry`의 `errOffset`을 재시도 시 0으로 설정하여 truncation과 동기화

**영향 범위**
`lib/worker-utils.ts` — 마지막 시도의 출력만 보존. 3개 소비자(chunk-review, spec-reviewer, agent-council) 테스트 모두 동기화.

### 테스트

- `cmdResults` hook 동작 테스트 신규 추가 (extraTopLevel, extraMemberFields, ANSI 스트리핑, no-hooks 호환)
- `stripAnsi` 유틸리티 테스트 신규 추가 (SGR, OSC, CSI, 하이퍼링크)
- `runOnce` 환경변수 전파/retry truncation 테스트 신규 추가
- spec-reviewer `cmdResults` 통합 테스트 (`execFileSync`로 실제 CLI 경로 검증)
- 기존 worker 테스트(chunk-review, spec-reviewer, agent-council) truncation 시맨틱으로 업데이트

**영향 범위**
테스트 파일만 — 총 1458 bun 테스트 + 4 shell 테스트 전체 통과.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. Optional hook 패턴 vs 상속/제네릭 기반 확장

**배경 및 문제 상황:**
spec-reviewer가 `cmdResults`/`cmdWait`의 JSON 출력에 `specName`, `prompt`, `stderr` 필드를 추가하기 위해 프레임워크 함수를 통째로 복제·수정한 상태였음. chunk-review와 agent-council도 향후 유사한 커스터마이징이 필요할 수 있어 확장 메커니즘이 필요.

**해결 방안:**
optional callback 인터페이스(`CmdResultsHooks`/`CmdWaitHooks`)를 도입하고, 프레임워크 함수가 hook이 `undefined`이면 기본 동작을 수행. 상속 기반(`class SpecReviewJob extends GenericJob`)이나 제네릭 기반(`cmdResults<T extends JobMeta>`)은 채택하지 않음.

**구현 세부사항:**
hook 함수의 파라미터 타입이 `any`로 되어 있음. 각 job마다 jobMeta/member 구조가 다르기 때문에 프레임워크 레벨에서 제네릭 타입을 강제하면 소비자마다 type assertion이 필요해져 noise가 증가함.

**선택과 트레이드오프:**
- 상속 기반은 `cmdResults`/`cmdWait` 외에도 `cmdStart`/`cmdStatus` 등이 있어 base class가 비대해지고, 현재 함수 단위 구성이 깨짐
- 제네릭은 `any` 대비 타입 안전성이 높지만, 3개 소비자 중 1개만 hook을 사용하는 현 상태에서 오버엔지니어링
- optional callback은 기존 소비자에 코드 변경 0줄이라는 실질적 이점이 있음. 향후 소비자가 늘면 그때 타입을 강화해도 늦지 않음

### 2. ANSI 정제의 이중 방어 전략

**배경 및 문제 상황:**
worker가 spawn하는 외부 CLI(claude, codex, gemini)의 출력에 ANSI escape 시퀀스가 포함되면, `cmdResults` JSON 출력이 깨지거나 소비자(chairman agent)가 잘못 파싱함. 각 CLI의 ANSI 출력 동작이 제각각이고, 환경변수를 존중하는지 보장할 수 없음.

**해결 방안:**
spawn 시점에 환경변수(`NO_COLOR=1`, `TERM=dumb`, `FORCE_COLOR=0`)로 ANSI 생성을 원천 차단하고, 결과 읽기 시점에 `stripAnsi` regex로 잔여 시퀀스를 제거하는 2단계 방어.

**구현 세부사항:**
`stripAnsi`는 SGR(`\x1b[...m`), OSC(`\x1b]...BEL/ST`), CSI(`0x9B`) 세 가지 패턴을 커버. OSC 브랜치의 `.*?`는 multiline에서 제한이 있으나, 환경변수 주입이 1차 방어이므로 safety net으로 충분.

**선택과 트레이드오프:**
- 환경변수만 사용하면 CLI가 이를 무시하는 경우(gemini CLI의 일부 버전 등) 방어 불가
- `stripAnsi`만 사용하면 복잡한 escape 시퀀스(256색, OSC 하이퍼링크 등) 파싱 실패 위험
- 이중 방어는 두 방법의 약점을 상호 보완. 비용은 regex 한 번 실행이므로 무시 가능

---

## ✅ Checklist

### 프레임워크 확장
- [ ] hook 미전달 시 기존 동작과 동일 (chunk-review, agent-council 영향 없음)
  - `lib/generic-job.ts`
- [ ] `cmdResults`에서 `extraTopLevel`/`extraMemberFields` hook이 JSON 출력에 정상 반영
  - `lib/generic-job.test.ts`
- [ ] `cmdWait`에서 `transformPayload`/`defaultTimeoutMs` hook이 정상 동작
  - `lib/generic-job.ts`

### spec-reviewer hook 전환
- [ ] `results --json` 출력에 `specName`, `prompt`, `stderr` 필드가 포함
  - `scripts/spec-reviewer/job.test.ts`
- [ ] `wait` 출력에 `specName` 필드가 포함
  - `scripts/spec-reviewer/job.ts`

### ANSI 정제
- [ ] spawn된 프로세스에 `NO_COLOR=1`, `TERM=dumb`, `FORCE_COLOR=0` 환경변수가 전달
  - `lib/worker-utils.test.ts`
- [ ] `stripAnsi`가 SGR, OSC(BEL/ST 종료), CSI 시퀀스를 모두 제거
  - `lib/job-utils.test.ts`

### retry truncation
- [ ] 재시도 시 이전 시도의 output/error가 덮어쓰기되어 마지막 시도만 남음
  - `lib/worker-utils.test.ts`
- [ ] 3개 소비자 테스트 모두 truncation 시맨틱으로 업데이트
  - `scripts/chunk-review/worker.test.ts`, `scripts/spec-reviewer/worker.test.ts`, `skills/agent-council/scripts/worker.test.ts`