### PR TITLE
refactor: code-review 스킬 자기-반성적 강화 및 역할 경계 정렬

### DIFF
--- a/agents/chunk-reviewer.md
+++ b/agents/chunk-reviewer.md
@@ -12,13 +12,6 @@ You are the chunk-reviewer agent. Follow the orchestrate-review skill exactly.
 
 **Identity**: Code Review Chairman for this chunk. Per the loaded `orchestrate-review` skill, you orchestrate multi-AI workers and aggregate per-model results into a structured report — you do NOT review code yourself, do NOT compute a combined verdict, and do NOT add your own opinions. The combined verdict is computed by the upstream `code-review` skill (Step 8) that dispatched you.
 
-**Premises forwarded to your workers (NOT self-directives)**:
-The dispatch prompt you forward to workers contains two non-negotiable premises that govern *worker* behavior:
-1. Workers run inside a git worktree with the target branch checked out and may read the actual files freely.
-2. Workers must trace dependencies, callers, callees, and runtime context across files — diff-only review is insufficient.
-
-Your role remains Chairman per the loaded `orchestrate-review` skill — you do NOT read source files yourself, do NOT execute the diff command, and do NOT augment worker findings. These premises shape what your workers do, not what you do.
-
 **Input**: A completed implementation chunk and the original plan or acceptance criteria.
 
 **Output**: Structured aggregation per `orchestrate-review` SKILL §"Aggregation Output Format" (Chunk Analysis / Strengths / Issues / Recommendations, with per-issue Per-Model entries). Do NOT compute a combined verdict — that is the orchestrator's responsibility per `code-review` SKILL Step 8. Do NOT add Chairman opinions; faithfully report consensus and dissent across reviewers.

--- a/agents/chunk-reviewer.md
+++ b/agents/chunk-reviewer.md
@@ -12,9 +12,12 @@ You are the chunk-reviewer agent. Follow the orchestrate-review skill exactly.
 
 **Identity**: Code review orchestrator. You aggregate multi-AI review signals and synthesize them into a unified verdict against the original plan and coding standards.
 
-**Operating Premises (non-negotiable)**:
-1. You operate inside a git worktree with the target branch already checked out. The working directory reflects the post-change state — read the actual files freely.
-2. Diff-only review is insufficient. Always trace dependencies, callers, callees, and runtime context across files. The diff is the delta; the unit of review is the system the diff produces.
+**Premises forwarded to your workers (NOT self-directives)**:
+The dispatch prompt you forward to workers contains two non-negotiable premises that govern *worker* behavior:
+1. Workers run inside a git worktree with the target branch checked out and may read the actual files freely.
+2. Workers must trace dependencies, callers, callees, and runtime context across files — diff-only review is insufficient.
+
+Your role remains Chairman per the loaded `orchestrate-review` skill — you do NOT read source files yourself, do NOT execute the diff command, and do NOT augment worker findings. These premises shape what your workers do, not what you do.
 
 **Input**: A completed implementation chunk and the original plan or acceptance criteria.
 

--- a/agents/chunk-reviewer.md
+++ b/agents/chunk-reviewer.md
@@ -10,7 +10,7 @@ skills: orchestrate-review
 
 You are the chunk-reviewer agent. Follow the orchestrate-review skill exactly.
 
-**Identity**: Code review orchestrator. You aggregate multi-AI review signals into a structured per-reviewer report against the original plan and coding standards. You do NOT compute a combined verdict — that is the orchestrator's responsibility per the loaded `orchestrate-review` skill.
+**Identity**: Code Review Chairman for this chunk. Per the loaded `orchestrate-review` skill, you orchestrate multi-AI workers and aggregate per-model results into a structured report — you do NOT review code yourself, do NOT compute a combined verdict, and do NOT add your own opinions. The combined verdict is computed by the upstream `code-review` skill (Step 8) that dispatched you.
 
 **Premises forwarded to your workers (NOT self-directives)**:
 The dispatch prompt you forward to workers contains two non-negotiable premises that govern *worker* behavior:

--- a/agents/chunk-reviewer.md
+++ b/agents/chunk-reviewer.md
@@ -21,9 +21,4 @@ Your role remains Chairman per the loaded `orchestrate-review` skill — you do 
 
 **Input**: A completed implementation chunk and the original plan or acceptance criteria.
 
-**Output**: Structured review with:
-- **Plan Conformance**: Whether implementation matches the original plan
-- **Standards Violations**: Coding standard issues found
-- **Multi-AI Signals**: Aggregated findings across review sources
-- **Per-Reviewer Verdicts**: Each dispatched model's verdict listed separately (do NOT compute a combined verdict — orchestrator decides per `code-review` SKILL Step 8)
-- **Consensus & Dissent**: Where models agree and where they diverge, faithfully reported (do NOT add Chairman opinions)
+**Output**: Structured aggregation per `orchestrate-review` SKILL §"Aggregation Output Format" (Chunk Analysis / Strengths / Issues / Recommendations, with per-issue Per-Model entries). Do NOT compute a combined verdict — that is the orchestrator's responsibility per `code-review` SKILL Step 8. Do NOT add Chairman opinions; faithfully report consensus and dissent across reviewers.

--- a/agents/chunk-reviewer.md
+++ b/agents/chunk-reviewer.md
@@ -12,6 +12,10 @@ You are the chunk-reviewer agent. Follow the orchestrate-review skill exactly.
 
 **Identity**: Code review orchestrator. You aggregate multi-AI review signals and synthesize them into a unified verdict against the original plan and coding standards.
 
+**Operating Premises (non-negotiable)**:
+1. You operate inside a git worktree with the target branch already checked out. The working directory reflects the post-change state — read the actual files freely.
+2. Diff-only review is insufficient. Always trace dependencies, callers, callees, and runtime context across files. The diff is the delta; the unit of review is the system the diff produces.
+
 **Input**: A completed implementation chunk and the original plan or acceptance criteria.
 
 **Output**: Structured review with:

--- a/agents/chunk-reviewer.md
+++ b/agents/chunk-reviewer.md
@@ -10,7 +10,7 @@ skills: orchestrate-review
 
 You are the chunk-reviewer agent. Follow the orchestrate-review skill exactly.
 
-**Identity**: Code review orchestrator. You aggregate multi-AI review signals and synthesize them into a unified verdict against the original plan and coding standards.
+**Identity**: Code review orchestrator. You aggregate multi-AI review signals into a structured per-reviewer report against the original plan and coding standards. You do NOT compute a combined verdict — that is the orchestrator's responsibility per the loaded `orchestrate-review` skill.
 
 **Premises forwarded to your workers (NOT self-directives)**:
 The dispatch prompt you forward to workers contains two non-negotiable premises that govern *worker* behavior:
@@ -25,5 +25,5 @@ Your role remains Chairman per the loaded `orchestrate-review` skill — you do 
 - **Plan Conformance**: Whether implementation matches the original plan
 - **Standards Violations**: Coding standard issues found
 - **Multi-AI Signals**: Aggregated findings across review sources
-- **Verdict**: Pass / Conditional Pass / Fail with required changes
-- **Required Actions**: Specific fixes needed before acceptance
+- **Per-Reviewer Verdicts**: Each dispatched model's verdict listed separately (do NOT compute a combined verdict — orchestrator decides per `code-review` SKILL Step 8)
+- **Consensus & Dissent**: Where models agree and where they diverge, faithfully reported (do NOT add Chairman opinions)

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -203,6 +203,8 @@ This skill assumes the orchestrator is already running inside a worktree dedicat
 **PR ID 추출 규칙**: 사용자가 URL(`https://github.com/<org>/<repo>/pull/<N>`) 형식으로 호출하면, 아래 bash로 진입하기 *전에* trailing path segment에서 numeric `<N>`을 추출해 `<number>` 자리에 substitute하라. URL을 그대로 substitute하면 `git fetch origin pull/<URL>/head`가 invalid refspec으로 실패하고 `git checkout -B pr-<URL>`이 invalid 브랜치명으로 실패한다.
 
 ```bash
+set -euo pipefail
+
 # 0. Safety guards (Premise 1 enforcement) — abort BEFORE any state change
 # -uno: untracked files are preserved by checkout; only check tracked modifications
 if [ -n "$(git status --porcelain -uno)" ]; then
@@ -218,8 +220,12 @@ if [ "$(git rev-parse --git-dir 2>/dev/null)" = "$(git rev-parse --git-common-di
   exit 1
 fi
 
-# 1. Get base branch name
+# 1. Get base branch name (abort if gh fails or returns empty)
 BASE_REF=$(gh pr view <number> --json baseRefName --jq '.baseRefName')
+if [ -z "$BASE_REF" ]; then
+  echo "Error: gh pr view returned empty baseRefName — aborting before any fetch" >&2
+  exit 1
+fi
 
 # 2. Fetch base branch first, then PR ref last so FETCH_HEAD points to PR head
 #    (rerun-safe — force-push on the PR is picked up on re-review)

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -12,7 +12,7 @@ Orchestrates chunk-reviewer agents against diffs. Handles input parsing, context
 
 These two premises are non-negotiable. They are forwarded to every chunk-reviewer dispatch and they govern every decision in this skill.
 
-1. **Worktree environment** — This review runs inside a git worktree dedicated to the PR/branch under review. Checkout has zero cost to the user's primary working directory. Therefore: **always check out the target ref and explore the codebase at the post-change state**. Do not pretend the file system is read-only or stuck at base.
+1. **Worktree environment** — This review runs inside a git worktree dedicated to the PR/branch under review. Checkout has zero cost to the user's primary working directory. Therefore: **ensure the working directory reflects the post-change state of the target ref before any analysis** — by checking it out (PR mode) or by verifying the caller already arrived on it (other modes). Do not pretend the file system is read-only or stuck at base.
 
 2. **No diff-only review** — A diff is a delta. The unit of review is the *system the diff produces*. Always trace dependencies, callers, callees, interfaces, configurations, and runtime context across files. If you cannot explain how the changed code behaves end-to-end against the surrounding system, you have not reviewed it.
 
@@ -191,14 +191,24 @@ Determine range and setup for subsequent steps:
 | Input | Setup | Range |
 |-------|-------|-------|
 | `pr <number or URL>` | Fetch and check out PR ref into the worktree (see below) | `origin/<baseRefName>...pr-<number>` |
-| `<base> <target>` | Worktree must already be on `<target>` (caller's responsibility per Premise 1) | `<base>...<target>` |
-| (none) | Detect default branch (`origin/main` or `origin/master`); worktree is on the target branch | `<default>...HEAD` |
+| `<base> <target>` | Verify HEAD is `<target>` via `git rev-parse --abbrev-ref HEAD`; verify clean tree via `git status --porcelain`. Abort if mismatch or dirty. | `<base>...<target>` |
+| (none) | Detect default branch (`origin/main` or `origin/master`). Verify HEAD is the target branch via `git rev-parse --abbrev-ref HEAD`; verify clean tree via `git status --porcelain`. Abort if mismatch or dirty. | `<default>...HEAD` |
 
 ### PR Mode: Worktree Checkout (per Premise 1)
 
 This skill assumes the orchestrator is already running inside a worktree dedicated to this review (the caller is responsible for creating the worktree). Therefore: **fetch the PR ref AND check it out**. The working directory must reflect the post-change state of the PR so that all subsequent code reading (Phase 1a, Phase 2 verification, chunk-reviewer Step 2) sees the actual code under review.
 
 ```bash
+# 0. Safety guards (Premise 1 enforcement) — abort BEFORE any state change
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Error: working directory has uncommitted changes — refusing to checkout over the user's work" >&2
+  exit 1
+fi
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Error: not running inside a git work tree (Premise 1 violation)" >&2
+  exit 1
+fi
+
 # 1. Get base branch name
 BASE_REF=$(gh pr view <number> --json baseRefName --jq '.baseRefName')
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -195,8 +195,8 @@ Determine range and setup for subsequent steps:
 | Input | Setup | Range |
 |-------|-------|-------|
 | `pr <number or URL>` | Fetch and check out PR ref into the worktree (see below) | `origin/<baseRefName>...pr-<number>` |
-| `<base> <target>` | Verify HEAD is `<target>` via `git rev-parse --abbrev-ref HEAD`; verify clean tree via `git status --porcelain`. Abort if mismatch or dirty. | `<base>...<target>` |
-| (none) | Detect default branch (`origin/main` or `origin/master`). Verify HEAD is the target branch via `git rev-parse --abbrev-ref HEAD`; verify clean tree via `git status --porcelain`. Abort if mismatch or dirty. | `<default>...HEAD` |
+| `<base> <target>` | Verify HEAD is `<target>` via `git rev-parse --abbrev-ref HEAD`; verify clean tree via `git status --porcelain -uno`. Abort if mismatch or dirty. | `<base>...<target>` |
+| (none) | Detect default branch (`origin/main` or `origin/master`). Verify HEAD is the target branch via `git rev-parse --abbrev-ref HEAD`; verify clean tree via `git status --porcelain -uno`. Abort if mismatch or dirty. | `<default>...HEAD` |
 
 ### PR Mode: Worktree Checkout (per Premise 1)
 
@@ -206,7 +206,8 @@ This skill assumes the orchestrator is already running inside a worktree dedicat
 
 ```bash
 # 0. Safety guards (Premise 1 enforcement) — abort BEFORE any state change
-if [ -n "$(git status --porcelain)" ]; then
+# -uno: untracked files are preserved by checkout; only check tracked modifications
+if [ -n "$(git status --porcelain -uno)" ]; then
   echo "Error: working directory has uncommitted changes — refusing to checkout over the user's work" >&2
   exit 1
 fi
@@ -215,7 +216,7 @@ fi
 # while --git-common-dir points to the shared .git directory; they differ.
 # In a primary clone they are equal — refuse so we never checkout over the user's main work tree.
 if [ "$(git rev-parse --git-dir 2>/dev/null)" = "$(git rev-parse --git-common-dir 2>/dev/null)" ]; then
-  echo "Error: refusing to run in primary repo — create a dedicated linked worktree first (Premise 1)" >&2
+  echo "Error: refusing to run in primary repo — create a dedicated linked worktree first (Premise 1). Hint: 'git worktree add ../review-pr-<N> -b review/pr-<N>'" >&2
   exit 1
 fi
 
@@ -224,7 +225,7 @@ BASE_REF=$(gh pr view <number> --json baseRefName --jq '.baseRefName')
 
 # 2. Fetch base branch first, then PR ref last so FETCH_HEAD points to PR head
 #    (rerun-safe — force-push on the PR is picked up on re-review)
-git fetch origin ${BASE_REF}
+git fetch origin "${BASE_REF}"
 git fetch origin pull/<number>/head
 
 # 3. Reset local pr-<N> to the freshly fetched PR head (FETCH_HEAD) and check it out
@@ -469,9 +470,9 @@ If any of (1)–(5) is missing, the pattern is a masking pattern → P1.
 
 ### Project-Rule Violations (also P1, even without masking)
 
-This project's `.claude/rules/coding-discipline.md` defines explicit written rules. Violations are P1 by definition because the rule itself declares the change unwanted.
+The five enumerated rules below are P1 by definition — each rule declares the named pattern unwanted. This section is self-contained: project-rule-based P1 entries must cite a specific rule (1–5) listed here.
 
-The following violations are P1 (this list is the *source of truth at this commit*; if `coding-discipline.md` adds rules later, this section must be updated in the same PR — do not silently re-classify):
+The following violations are P1 (this list is the *source of truth* — closed enumeration; do not silently re-classify):
 
 1. **Speculative addition** — feature, abstraction, configuration, or option that was not requested by the user, spec, or issue.
 2. **Single-use abstraction** — wrapper class, helper function, or interface introduced for a code path that has exactly one caller.
@@ -481,7 +482,7 @@ The following violations are P1 (this list is the *source of truth at this commi
 
 For each P1 issue under this section, the reviewer must cite the specific rule (1–5) and quote the violating code.
 
-**Closed list discipline**: this enumeration is closed. Reviewers cannot create new P1-from-rule entries from un-enumerated reasoning. If a new rule emerges, it goes into `coding-discipline.md` first, then this section in the same PR.
+**Closed list discipline**: this enumeration is closed. Reviewers cannot create new P1-from-rule entries from un-enumerated reasoning. New rules require explicit addition to this list.
 
 ### Phase 2: Critique Synthesis
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -449,11 +449,39 @@ Workers **propose** P-levels with supporting evidence. The orchestrator **adjudi
 | P-Level | Impact Delta | Probability | Maintainability |
 |---------|-------------|-------------|-----------------|
 | **P0** (must-fix) | Outage, data loss, or security breach | Triggered during normal operation | System inoperable if unfixed |
-| **P1** (should-fix) | **Demonstrable defect**: partial failure, incorrect behavior, data corruption, or security weakness in the current code | **Occurs under realistic conditions** that exist today -- not hypothetical future states | Fix corrects an actual bug or closes a real vulnerability |
-| **P2** (consider-fix) | **(a)** Bug exists but trigger probability is unrealistic today, OR **(b)** No bug today but code will predictably fail as the system grows/evolves, OR **(c)** No bug but maintainability significantly improves | Low probability today, or projected under realistic growth/change | Significant improvement to resilience, debuggability, or long-term health |
+| **P1** (should-fix) | **Demonstrable defect**: partial failure, incorrect behavior, data corruption, security weakness, **suppression/masking of error diagnostics**, or **violation of an enumerated project-rule (see §Project-Rule Violations below)** in the current code | **Occurs under realistic conditions** that exist today -- not hypothetical future states | Fix corrects an actual bug or closes a real vulnerability |
+| **P2** (consider-fix) | **(a)** Bug exists but trigger probability is unrealistic today, OR **(b)** No bug today but code will predictably fail as the system grows/evolves, OR **(c)** No bug but maintainability significantly improves. *Note*: Masking patterns that suppress evidence of a present-day defect are P1, NOT P2(a)/P2(c), even when the masked defect's trigger looks rare or the fix is framed as maintainability. | Low probability today, or projected under realistic growth/change | Significant improvement to resilience, debuggability, or long-term health |
 | **P3** (optional) | No correctness issue, no projected failure | N/A | Readability, consistency, or style improvement only |
 
-**P1 vs P2 Decision Gate:** "Is there a defect in the current code, AND does it manifest under conditions that exist today?" Both must be yes for P1. If the defect's trigger is unrealistic → P2(a). If no defect today but predictable future failure → P2(b). If no defect and no projected failure but significant maintainability gain → P2(c).
+**P1 vs P2 Decision Gate:** "Is there a defect in the current code, AND does it manifest under conditions that exist today?" Both must be yes for P1. If the defect's trigger is unrealistic → P2(a). If no defect today but predictable future failure → P2(b). If no defect and no projected failure but significant maintainability gain → P2(c). **For masking patterns, the relevant "trigger" is the moment the underlying primary-path defect would have surfaced; if the patch routes around that defect, the trigger condition is met today.**
+
+### Masking Carve-out (NOT P1)
+
+A fallback or alternate path is NOT a masking pattern when ALL of the following hold:
+
+1. **Scoped** to a known external/version boundary (e.g., `bun` version difference, `gh` API change, OS-specific path, third-party library breaking change).
+2. **Documented** in a code comment that names the specific external defect, version constraint, or boundary it works around.
+3. **Tested** on both primary and fallback paths.
+4. **Preserves** failure evidence — the original error is still logged or reported, not swallowed or downgraded.
+5. **Does not replace** fixing a primary contract that the project itself controls.
+
+If any of (1)–(5) is missing, the pattern is a masking pattern → P1.
+
+### Project-Rule Violations (also P1, even without masking)
+
+This project's `.claude/rules/coding-discipline.md` defines explicit written rules. Violations are P1 by definition because the rule itself declares the change unwanted.
+
+The following violations are P1 (this list is the *source of truth at this commit*; if `coding-discipline.md` adds rules later, this section must be updated in the same PR — do not silently re-classify):
+
+1. **Speculative addition** — feature, abstraction, configuration, or option that was not requested by the user, spec, or issue.
+2. **Single-use abstraction** — wrapper class, helper function, or interface introduced for a code path that has exactly one caller.
+3. **Unrequested flexibility** — config option, environment variable, or branching logic added to support hypothetical future scenarios.
+4. **Impossible-scenario error handling** — guard, validation, or fallback for a state that cannot occur given the surrounding contract (e.g., null-check on a value just constructed by `new`).
+5. **Backwards-compatibility shim without removal date** — fallback for an old format/API that has no documented removal target. Either set a removal date or remove the old path now.
+
+For each P1 issue under this section, the reviewer must cite the specific rule (1–5) and quote the violating code.
+
+**Closed list discipline**: this enumeration is closed. Reviewers cannot create new P1-from-rule entries from un-enumerated reasoning. If a new rule emerges, it goes into `coding-discipline.md` first, then this section in the same PR.
 
 ### Phase 2: Critique Synthesis
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -8,6 +8,16 @@ disable-model-invocation: true
 
 Orchestrates chunk-reviewer agents against diffs. Handles input parsing, context gathering, chunking, and result synthesis.
 
+## Premises (apply to orchestrator AND chunk-reviewer)
+
+These two premises are non-negotiable. They are forwarded to every chunk-reviewer dispatch and they govern every decision in this skill.
+
+1. **Worktree environment** — This review runs inside a git worktree dedicated to the PR/branch under review. Checkout has zero cost to the user's primary working directory. Therefore: **always check out the target ref and explore the codebase at the post-change state**. Do not pretend the file system is read-only or stuck at base.
+
+2. **No diff-only review** — A diff is a delta. The unit of review is the *system the diff produces*. Always trace dependencies, callers, callees, interfaces, configurations, and runtime context across files. If you cannot explain how the changed code behaves end-to-end against the surrounding system, you have not reviewed it.
+
+These premises must be reflected in the chunk-reviewer dispatch prompt — see Step 5.
+
 ## Input Modes
 
 ```bash
@@ -85,79 +95,94 @@ digraph role_separation {
 
 **RULE**: You CAN and SHOULD read code to verify findings and enrich the walkthrough. You CANNOT run the raw diff command or modify files.
 
-## Step 0: Requirements Context
+## Step 0: Intent and Context Acquisition
 
-Three-question gate — adapt by input mode:
+**Intent acquisition is non-negotiable.** Either intent is confirmed (from artifacts, interview, or both), or the user explicitly defers to a code-quality-only review. There is no third option — proceeding without intent and without explicit deferral is forbidden. Reviewing without intent produces wrong severities, missed scope creep, and false positives born from misunderstanding the author's goal.
 
-**PR mode:**
-1. Auto-extract PR metadata:
-   `gh pr view <number> --json title,body,labels,comments,reviews`
-2. Scan PR body and comments for references to related documents (previous PRs, issues, Jira tickets, design docs, external URLs, review threads, etc.):
-   - GitHub refs (`#123`) → fetch context via `gh pr view` or `gh issue view`
-   - Non-fetchable references (Jira, Notion, Confluence, etc.) → note for user inquiry
-3. If description is substantial (>1 sentence): proceed with auto-extracted context, confirm with user: "Extracted requirements from PR description: [summary]. Anything to add?"
-4. If description is thin AND no linked references found: ask user "Do you have core requirements or a spec for this PR?"
-5. If non-fetchable external references found, ask user: "The PR references these external documents: [links]. Please share relevant context if available. (If not, review will proceed with available information)"
+### Acquisition order
 
-**Branch comparison mode:**
-Ask user: "What was implemented on this branch? If there are original requirements/spec, please share."
+1. **PR/branch artifacts** — PR title, description, labels, commit history, code review comments and threads
+2. **Linked references (recursive)** — every link found in the artifacts above, followed transitively until the trail ends
+3. **Codebase signals** — CLAUDE.md, README, ADRs, related history in changed paths
+4. **User interview** — only for what the artifacts cannot reveal
 
-**Auto-detect mode:**
-1. Infer from commit messages (`git log --oneline`)
-2. Ask user: "Do you have requirements/spec for the recent work? (If not, review will focus on code quality)"
+### Acquire all reachable references
 
-**User deferral** ("없어", "그냥 리뷰해줘", "skip"):
-→ Set {REQUIREMENTS} = "N/A - code quality review only"
-→ Proceed without blocking
+PR descriptions, commits, and comments routinely link to richer context (issue trackers, design docs, chat threads). **Follow every link recursively** — a linked ticket may itself link to a doc which links to a discussion thread; keep following until the trail ends.
 
-**Vague Answer Handling:**
-- Explicit deferral ("없어", "skip", "그냥 해줘") → Treat as N/A and proceed
-- Vague answer → Refine with follow-up question:
+Do not name specific tools. Use whatever fetch capability the environment provides for each link type. If a link cannot be fetched directly (no credential, no MCP for that platform, network unreachable), do not skip it — mark it for the user interview step.
+
+Sources to consult per input mode:
+
+| Input mode | Sources |
+|------------|---------|
+| PR | `gh pr view --json title,body,labels,comments,reviews`, `gh pr view --comments`, linked issues, `gh issue view <n>`, every external link found in the chain, commit messages on the PR branch |
+| Branch comparison | Commit messages, branch name conventions, any linked tickets discovered in commits, related issues |
+| Auto-detect | Recent commit messages on HEAD, any linked tickets found there |
+
+### User interview — only for what artifacts cannot reveal
+
+After exhausting fetchable sources, ask the user about:
+- **Intent** — what problem is this PR solving and why was this approach chosen
+- **Alternatives** — what was considered and rejected, and why
+- **Constraints** — deadlines, dependencies, compatibility commitments, hidden requirements
+- **Concerns** — known risks, untested paths, areas the author is uncertain about
+
+DO NOT interview the user about codebase facts (file locations, patterns, architecture, who calls what). Use Read/Grep/Glob and the explore agent for those — they are reachable from the working directory.
+
+### Intent Block Gate (hard exit condition)
+
+Before exiting Step 0, the state must be one of:
+
+| State | Action |
+|-------|--------|
+| **Intent confirmed** — author's goal, approach, and constraints are understood from artifacts and/or interview | Proceed to Step 1 |
+| **User explicit deferral** — user says "skip", "그냥 리뷰해줘", "없어", "code quality only", or unambiguous equivalent | Set {REQUIREMENTS} = "N/A — code-quality-only review (user deferred)" and proceed |
+| **Neither** — artifacts thin and user not yet asked, OR user gave vague answers without explicit deferral | **BLOCK**. Do not proceed. Continue interview until one of the two states above is reached. |
+
+There is no "I tried hard enough, just review" path. The block IS the safety mechanism.
+
+### Vague answer refinement
+
+When the user gives a vague answer that is not an explicit deferral, refine ONCE with a specific follow-up:
 
 | User says | Follow-up |
 |-----------|-----------|
-| "대충 있어" / "뭐 좀 있긴 한데" | "Where can I find them? (PR description, Notion, Jira, etc.)" |
-| "그냥 성능 개선이야" | "What specific metrics were you trying to improve? (latency, throughput, memory, etc.)" |
-| "여러 가지 고쳤어" | "What are the 1-2 most important changes? I'll identify the rest from code." |
+| "대충 있어" / "뭐 좀 있긴 한데" | "어디서 찾을 수 있나요? 링크나 문서 위치를 알려주세요." |
+| "그냥 성능 개선이야" | "어떤 지표를 개선하려 했나요? (latency, throughput, memory 등)" |
+| "여러 가지 고쳤어" | "가장 중요한 1-2개만 알려주세요. 나머지는 코드에서 식별하겠습니다." |
 
-Rule: 2 consecutive vague answers → Declare "I'll identify the context directly from the code" and proceed. No infinite questioning.
+If refinement still yields a vague answer, surface the block explicitly to the user:
 
-**Question Method:**
+> "의도를 명확히 잡기 어렵습니다. 둘 중 하나를 선택해주세요: (1) [구체적 질문]에 답하여 의도 확정, 또는 (2) 'skip / 코드 품질만 리뷰' 명시적 deferral. 둘 중 하나를 명시하기 전까지 리뷰는 시작하지 않습니다."
+
+This is not adversarial — it is refusing to silently produce a worse review.
+
+### Question discipline
 
 | Situation | Method |
 |-----------|--------|
 | 2-4 structured choices (review scope, severity threshold) | AskUserQuestion tool |
-| Free-form / subjective (intent, context, concerns) | Plain text question |
+| Free-form / subjective (intent, alternatives, constraints, concerns) | Plain text question |
 
-**Question Quality Standard:**
+**One question per message.** Never bundle. Wait for the answer before the next question.
+
+**Question quality** — every question must include either a specific anchor (a summary the user can correct) or a default action in parentheses (so progress is possible without an answer):
 
 | BAD | GOOD |
 |-----|------|
-| "요구사항이 있나요?" | "Do you have core requirements or a spec for this PR? (If not, review will focus on code quality)" |
-| "어떤 부분을 볼까요?" | "23 files changed. Any specific area to focus on? (If not, I'll review everything)" |
-| "테스트 있나요?" | "Do you have test coverage standards? (e.g., 80% line coverage, mandatory scenarios, etc.)" |
+| "요구사항이 있나요?" | "PR 본문과 연결된 이슈에서 [요약]을 추출했습니다. 보완할 부분이 있나요?" |
+| "어떤 부분을 볼까요?" | "23개 파일이 변경됐습니다. 집중할 영역이 있나요? (없으면 전체 리뷰)" |
 
-Rule: Every question must include a default action in parentheses. Ensure progress is possible even without user response.
+### Project Context
 
-**One Question Per Message:**
-One question at a time. Proceed to the next question only after receiving an answer. Never bundle multiple questions in a single message.
+Include project context when interpolating the chunk-reviewer prompt template in Step 5. Describe what kind of software this is, who uses it, how it runs, and what depends on it — based on CLAUDE.md, README.md, and the artifacts gathered above.
 
-**Project Context:**
+If available context is insufficient to characterize the project, ask the user once: "What kind of software is this? (e.g., personal CLI tool, internal team service, public-facing API, shared library, etc.)"
 
-Include project context when interpolating the chunk-reviewer prompt template in Step 5. Describe what kind of software this is, who uses it, how it runs, and what depends on it — based on CLAUDE.md, README.md, and other available information.
+### Step 0 Exit Condition
 
-If the available context is insufficient to characterize the project, ask the user: "What kind of software is this? (e.g., personal CLI tool, internal team service, public-facing API, shared library, etc.)"
-
-**Step 0 Exit Condition:**
-Proceed to Step 1 when any of the following are met:
-- Requirements captured (PR description, user input, or spec reference)
-- User explicitly deferred ("skip", "없어", "그냥 리뷰해줘")
-- 2-strike vague limit reached → proceed with code-quality-only review
-
-**Context Brokering:**
-- DO NOT ask user about codebase facts (file locations, patterns, architecture)
-- USE explore/oracle in Step 6 Phase 1 for codebase context
-- ONLY ask user about: requirements, intent, specific concerns
+Proceed to Step 1 only when the Intent Block Gate state is **Intent confirmed** or **User explicit deferral**. Any other state → continue at Step 0.
 
 ## Step 1: Input Parsing
 
@@ -165,26 +190,31 @@ Determine range and setup for subsequent steps:
 
 | Input | Setup | Range |
 |-------|-------|-------|
-| `pr <number or URL>` | Fetch PR ref locally (see below) | `origin/<baseRefName>...pr-<number>` |
-| `<base> <target>` | (none — branches already local) | `<base>...<target>` |
-| (none) | Detect default branch (`origin/main` or `origin/master`) | `<default>...HEAD` |
+| `pr <number or URL>` | Fetch and check out PR ref into the worktree (see below) | `origin/<baseRefName>...pr-<number>` |
+| `<base> <target>` | Worktree must already be on `<target>` (caller's responsibility per Premise 1) | `<base>...<target>` |
+| (none) | Detect default branch (`origin/main` or `origin/master`); worktree is on the target branch | `<default>...HEAD` |
 
-### PR Mode: Local Ref Setup (NO checkout)
+### PR Mode: Worktree Checkout (per Premise 1)
 
-Fetch the PR ref and base branch without switching the current branch:
+This skill assumes the orchestrator is already running inside a worktree dedicated to this review (the caller is responsible for creating the worktree). Therefore: **fetch the PR ref AND check it out**. The working directory must reflect the post-change state of the PR so that all subsequent code reading (Phase 1a, Phase 2 verification, chunk-reviewer Step 2) sees the actual code under review.
 
 ```bash
 # 1. Get base branch name
 BASE_REF=$(gh pr view <number> --json baseRefName --jq '.baseRefName')
 
-# 2. Fetch PR ref and base branch (no checkout — user's working directory untouched)
+# 2. Fetch PR ref and base branch
 git fetch origin pull/<number>/head:pr-<number>
 git fetch origin ${BASE_REF}
+
+# 3. Check out the PR ref so the working directory matches the PR state
+git checkout pr-<number>
 ```
+
+If the working directory is dirty (uncommitted changes) or the caller is not in a worktree, abort and report — do not silently checkout over the user's work. The worktree premise is the safety net; without it, the safety net is gone.
 
 All range formats use **three-dot syntax** (`A...B`), which is equivalent to `git diff $(git merge-base A B)..B`. This shows only changes introduced by the target since the common ancestor — not changes on the base branch. This prevents false positives when `origin/main` has moved ahead after branching.
 
-All subsequent steps use `{range}` from this table. All diff commands use `git diff {range} -- <files>` for path-filtered output.
+All subsequent steps use `{range}` from this table. All diff commands use `git diff {range} -- <files>` for path-filtered output. After checkout, code reading via Read/Grep/Glob reflects the **post-change** state, which is the intended behavior — diff shows the delta, the working directory shows the result.
 
 ## Early Exit
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -359,7 +359,6 @@ The orchestrator constructs this command string but does NOT execute it. The com
    - {PROJECT_CONTEXT} ← Step 0 project context
    - {FILE_LIST} ← Step 2 file list
    - {DIFF_COMMAND} ← diff command string: `git diff {range}` (single chunk) or `git diff {range} -- <chunk-files>` (multi-chunk). Orchestrator constructs this string but does NOT execute it.
-   - {CLAUDE_MD} ← Step 2 CLAUDE.md content (or empty)
    - {COMMIT_HISTORY} ← Step 2 commit history
    - {EVIDENCE_RESULTS} ← Step 3 evidence summary (Source: Step 3. Fallback: "Evidence verification unavailable — no build/test/lint commands discovered")
 3. Dispatch `chunk-reviewer` agent(s) via Task tool (`subagent_type: "chunk-reviewer"`) with interpolated prompt
@@ -470,17 +469,17 @@ If any of (1)–(5) is missing, the pattern is a masking pattern → P1.
 
 ### Project-Rule Violations (also P1, even without masking)
 
-The five enumerated rules below are P1 by definition — each rule declares the named pattern unwanted. This section is self-contained: project-rule-based P1 entries must cite a specific rule (1–5) listed here.
+**Simplicity First — minimum code that solves the problem, nothing speculative.** The five enumerated patterns below are P1 by definition; each one declares the named pattern unwanted, so the rule itself states the change should not have been made. This section is self-contained: project-rule-based P1 entries must cite a specific rule (1–5) listed here and quote the violating code.
 
 The following violations are P1 (this list is the *source of truth* — closed enumeration; do not silently re-classify):
 
-1. **Speculative addition** — feature, abstraction, configuration, or option that was not requested by the user, spec, or issue.
-2. **Single-use abstraction** — wrapper class, helper function, or interface introduced for a code path that has exactly one caller.
-3. **Unrequested flexibility** — config option, environment variable, or branching logic added to support hypothetical future scenarios.
-4. **Impossible-scenario error handling** — guard, validation, or fallback for a state that cannot occur given the surrounding contract (e.g., null-check on a value just constructed by `new`).
-5. **Backwards-compatibility shim without removal date** — fallback for an old format/API that has no documented removal target. Either set a removal date or remove the old path now.
+1. **Speculative addition** — *No features beyond what was asked.* Any feature, abstraction, configuration, or option that was not requested by the user, spec, or issue.
+2. **Single-use abstraction** — *No abstractions for single-use code.* Any wrapper class, helper function, or interface introduced for a code path that has exactly one caller.
+3. **Unrequested flexibility** — *No "flexibility" or "configurability" that wasn't requested.* Any config option, environment variable, or branching logic added to support hypothetical future scenarios.
+4. **Impossible-scenario error handling** — *No error handling for impossible scenarios.* Any guard, validation, or fallback for a state that cannot occur given the surrounding contract (e.g., null-check on a value just constructed by `new`).
+5. **Backwards-compatibility shim without removal date** — Any fallback for an old format/API that has no documented removal target. Either set a removal date or remove the old path now.
 
-For each P1 issue under this section, the reviewer must cite the specific rule (1–5) and quote the violating code.
+**Self-check**: "Would a senior engineer say this is overcomplicated?" If yes, the change is in violation territory.
 
 **Closed list discipline**: this enumeration is closed. Reviewers cannot create new P1-from-rule entries from un-enumerated reasoning. New rules require explicit addition to this list.
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -146,11 +146,13 @@ There is no "I tried hard enough, just review" path. The block IS the safety mec
 
 When the user gives a vague answer that is not an explicit deferral, refine ONCE with a specific follow-up:
 
+각 follow-up 메시지는 deferral 옵션을 함께 안내하여 사용자가 "skip / 그냥 리뷰해줘 / 없어" 어휘를 몰라도 escape 가능하도록 한다.
+
 | User says | Follow-up |
 |-----------|-----------|
-| "대충 있어" / "뭐 좀 있긴 한데" | "어디서 찾을 수 있나요? 링크나 문서 위치를 알려주세요." |
-| "그냥 성능 개선이야" | "어떤 지표를 개선하려 했나요? (latency, throughput, memory 등)" |
-| "여러 가지 고쳤어" | "가장 중요한 1-2개만 알려주세요. 나머지는 코드에서 식별하겠습니다." |
+| "대충 있어" / "뭐 좀 있긴 한데" | "어디서 찾을 수 있나요? 링크나 문서 위치를 알려주세요. (답하기 어려우면 'skip'으로 코드 품질만 리뷰 가능)" |
+| "그냥 성능 개선이야" | "어떤 지표를 개선하려 했나요? (latency, throughput, memory 등 — 답하기 어려우면 'skip'으로 코드 품질만 리뷰 가능)" |
+| "여러 가지 고쳤어" | "가장 중요한 1-2개만 알려주세요. 나머지는 코드에서 식별하겠습니다. (답하기 어려우면 'skip'으로 코드 품질만 리뷰 가능)" |
 
 If refinement still yields a vague answer, surface the block explicitly to the user:
 
@@ -204,20 +206,26 @@ if [ -n "$(git status --porcelain)" ]; then
   echo "Error: working directory has uncommitted changes — refusing to checkout over the user's work" >&2
   exit 1
 fi
-if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  echo "Error: not running inside a git work tree (Premise 1 violation)" >&2
+# Distinguish primary repo from linked worktree.
+# In a linked worktree, --git-dir points inside .git/worktrees/<wt>,
+# while --git-common-dir points to the shared .git directory; they differ.
+# In a primary clone they are equal — refuse so we never checkout over the user's main work tree.
+if [ "$(git rev-parse --git-dir 2>/dev/null)" = "$(git rev-parse --git-common-dir 2>/dev/null)" ]; then
+  echo "Error: refusing to run in primary repo — create a dedicated linked worktree first (Premise 1)" >&2
   exit 1
 fi
 
 # 1. Get base branch name
 BASE_REF=$(gh pr view <number> --json baseRefName --jq '.baseRefName')
 
-# 2. Fetch PR ref and base branch
-git fetch origin pull/<number>/head:pr-<number>
+# 2. Fetch PR ref idempotently (rerun-safe — force-update local pr-<N> on
+#    re-review after force-push) and base branch
+git fetch origin pull/<number>/head
 git fetch origin ${BASE_REF}
 
-# 3. Check out the PR ref so the working directory matches the PR state
-git checkout pr-<number>
+# 3. Reset local pr-<N> to the freshly fetched ref and check it out so the
+#    working directory matches the PR state
+git checkout -B pr-<number> FETCH_HEAD
 ```
 
 If the working directory is dirty (uncommitted changes) or the caller is not in a worktree, abort and report — do not silently checkout over the user's work. The worktree premise is the safety net; without it, the safety net is gone.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -14,6 +14,8 @@ These two premises are non-negotiable. They are forwarded to every chunk-reviewe
 
 1. **Worktree environment** — This review runs inside a git worktree dedicated to the PR/branch under review. Checkout has zero cost to the user's primary working directory. Therefore: **ensure the working directory reflects the post-change state of the target ref before any analysis** — by checking it out (PR mode) or by verifying the caller already arrived on it (other modes). Do not pretend the file system is read-only or stuck at base.
 
+   Note: 비-PR 모드(branch comparison, auto-detect)는 checkout이 발생하지 않으므로 PR 모드의 `--git-dir` 가드는 의도적으로 적용되지 않는다 — 비-PR 모드는 verify-only(HEAD 일치 + clean tree)로 위 "post-change state" 요건을 충족한다. 두 path의 비대칭은 결함이 아니라 설계.
+
 2. **No diff-only review** — A diff is a delta. The unit of review is the *system the diff produces*. Always trace dependencies, callers, callees, interfaces, configurations, and runtime context across files. If you cannot explain how the changed code behaves end-to-end against the surrounding system, you have not reviewed it.
 
 These premises must be reflected in the chunk-reviewer dispatch prompt — see Step 5.
@@ -199,6 +201,8 @@ Determine range and setup for subsequent steps:
 ### PR Mode: Worktree Checkout (per Premise 1)
 
 This skill assumes the orchestrator is already running inside a worktree dedicated to this review (the caller is responsible for creating the worktree). Therefore: **fetch the PR ref AND check it out**. The working directory must reflect the post-change state of the PR so that all subsequent code reading (Phase 1a, Phase 2 verification, chunk-reviewer Step 2) sees the actual code under review.
+
+**PR ID 추출 규칙**: 사용자가 URL(`https://github.com/<org>/<repo>/pull/<N>`) 형식으로 호출하면, 아래 bash로 진입하기 *전에* trailing path segment에서 numeric `<N>`을 추출해 `<number>` 자리에 substitute하라. URL을 그대로 substitute하면 `git fetch origin pull/<URL>/head`가 invalid refspec으로 실패하고 `git checkout -B pr-<URL>`이 invalid 브랜치명으로 실패한다.
 
 ```bash
 # 0. Safety guards (Premise 1 enforcement) — abort BEFORE any state change

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -12,9 +12,7 @@ Orchestrates chunk-reviewer agents against diffs. Handles input parsing, context
 
 These two premises are non-negotiable. They are forwarded to every chunk-reviewer dispatch and they govern every decision in this skill.
 
-1. **Worktree environment** — This review runs inside a git worktree dedicated to the PR/branch under review. Checkout has zero cost to the user's primary working directory. Therefore: **ensure the working directory reflects the post-change state of the target ref before any analysis** — by checking it out (PR mode) or by verifying the caller already arrived on it (other modes). Do not pretend the file system is read-only or stuck at base.
-
-   Note: 비-PR 모드(branch comparison, auto-detect)는 checkout이 발생하지 않으므로 PR 모드의 `--git-dir` 가드는 의도적으로 적용되지 않는다 — 비-PR 모드는 verify-only(HEAD 일치 + clean tree)로 위 "post-change state" 요건을 충족한다. 두 path의 비대칭은 결함이 아니라 설계.
+1. **Post-change state** — The working directory reflects the post-change state of the target ref. PR mode achieves this by checking out the PR head into a dedicated linked worktree (see Step 1). Non-PR modes (branch comparison, auto-detect) achieve this by verifying HEAD-match + clean-tree on the current working directory (also Step 1). Either way: read code freely from the working directory — the diff is the delta, the working directory is the result. Do not pretend the file system is read-only or stuck at base.
 
 2. **No diff-only review** — A diff is a delta. The unit of review is the *system the diff produces*. Always trace dependencies, callers, callees, interfaces, configurations, and runtime context across files. If you cannot explain how the changed code behaves end-to-end against the surrounding system, you have not reviewed it.
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -218,13 +218,13 @@ fi
 # 1. Get base branch name
 BASE_REF=$(gh pr view <number> --json baseRefName --jq '.baseRefName')
 
-# 2. Fetch PR ref idempotently (rerun-safe — force-update local pr-<N> on
-#    re-review after force-push) and base branch
-git fetch origin pull/<number>/head
+# 2. Fetch base branch first, then PR ref last so FETCH_HEAD points to PR head
+#    (rerun-safe — force-push on the PR is picked up on re-review)
 git fetch origin ${BASE_REF}
+git fetch origin pull/<number>/head
 
-# 3. Reset local pr-<N> to the freshly fetched ref and check it out so the
-#    working directory matches the PR state
+# 3. Reset local pr-<N> to the freshly fetched PR head (FETCH_HEAD) and check it out
+#    so the working directory matches the PR state
 git checkout -B pr-<number> FETCH_HEAD
 ```
 

--- a/skills/orchestrate-review/scripts/chunk-reviewer-prompt.md
+++ b/skills/orchestrate-review/scripts/chunk-reviewer-prompt.md
@@ -2,11 +2,19 @@
 
 > This template provides data for the chunk-review multi-model dispatch. Review instructions are in prompts/reviewer.md.
 
+## Review Premises (non-negotiable)
+
+1. **You are running inside a git worktree with the PR/target branch checked out.** The working directory reflects the post-change state of the code under review. Use Read/Grep/Glob freely against the actual files — the diff is the delta, the working directory is the result.
+
+2. **Diff-only review is insufficient.** A diff is a delta. The unit of review is the *system the diff produces*. You MUST trace dependencies, callers, callees, interfaces, configurations, and runtime context across files before assessing any change. If you cannot explain how the changed code behaves end-to-end against the surrounding system, you have not reviewed it.
+
+These premises override any reflex to "review just what is in the diff."
+
 ## Review Scope
 
-**Review ONLY these files:** {FILE_LIST}
+**Findings target ONLY these files:** {FILE_LIST}
 
-Do NOT review files outside this list. Cross-references to other files are acceptable for context, but findings must be limited to the files listed above.
+Findings must be limited to files in the list above. Cross-references and exploration into surrounding files are not just acceptable — they are required (per Premise 2). Files outside the list are reference material that you read to understand the change; you do not file findings against them.
 
 ## What Was Implemented
 

--- a/skills/orchestrate-review/scripts/chunk-reviewer-prompt.md
+++ b/skills/orchestrate-review/scripts/chunk-reviewer-prompt.md
@@ -48,6 +48,38 @@ Execute the following command to obtain the diff for review. You MUST run this c
 {DIFF_COMMAND}
 ```
 
+## Severity Augmentation
+
+This project applies two augmentations to the standard P0-P3 rubric. Apply these ON TOP of the built-in severity definitions in your system prompt — these augmentations OVERRIDE the built-in rubric where they conflict.
+
+### Masking Carve-out (NOT P1)
+
+A fallback or alternate path is NOT a masking pattern when ALL of the following hold:
+
+1. **Scoped** to a known external/version boundary (e.g., `bun` version difference, `gh` API change, OS-specific path, third-party library breaking change).
+2. **Documented** in a code comment that names the specific external defect, version constraint, or boundary it works around.
+3. **Tested** on both primary and fallback paths.
+4. **Preserves** failure evidence — the original error is still logged or reported, not swallowed or downgraded.
+5. **Does not replace** fixing a primary contract that the project itself controls.
+
+If any of (1)–(5) is missing, the pattern is a masking pattern → P1.
+
+### Project-Rule Violations (also P1, even without masking)
+
+The five enumerated rules below are P1 by definition — each rule declares the named pattern unwanted. This section is self-contained: project-rule-based P1 entries must cite a specific rule (1–5) listed here.
+
+The following violations are P1 (this list is the *source of truth* — closed enumeration; do not silently re-classify):
+
+1. **Speculative addition** — feature, abstraction, configuration, or option that was not requested by the user, spec, or issue.
+2. **Single-use abstraction** — wrapper class, helper function, or interface introduced for a code path that has exactly one caller.
+3. **Unrequested flexibility** — config option, environment variable, or branching logic added to support hypothetical future scenarios.
+4. **Impossible-scenario error handling** — guard, validation, or fallback for a state that cannot occur given the surrounding contract (e.g., null-check on a value just constructed by `new`).
+5. **Backwards-compatibility shim without removal date** — fallback for an old format/API that has no documented removal target. Either set a removal date or remove the old path now.
+
+For each P1 issue under this section, the reviewer must cite the specific rule (1–5) and quote the violating code.
+
+**Closed list discipline**: this enumeration is closed. Reviewers cannot create new P1-from-rule entries from un-enumerated reasoning. New rules require explicit addition to this list.
+
 ## Project Guidelines
 
 {CLAUDE_MD}

--- a/skills/orchestrate-review/scripts/chunk-reviewer-prompt.md
+++ b/skills/orchestrate-review/scripts/chunk-reviewer-prompt.md
@@ -4,7 +4,7 @@
 
 ## Review Premises (non-negotiable)
 
-1. **You are running inside a git worktree with the PR/target branch checked out.** The working directory reflects the post-change state of the code under review. Use Read/Grep/Glob freely against the actual files — the diff is the delta, the working directory is the result.
+1. **The working directory reflects the post-change state of the target ref.** The reviewed code is the working directory; use Read/Grep/Glob freely against the actual files — the diff is the delta, the working directory is the result.
 
 2. **Diff-only review is insufficient.** A diff is a delta. The unit of review is the *system the diff produces*. You MUST trace dependencies, callers, callees, interfaces, configurations, and runtime context across files before assessing any change. If you cannot explain how the changed code behaves end-to-end against the surrounding system, you have not reviewed it.
 

--- a/skills/orchestrate-review/scripts/chunk-reviewer-prompt.md
+++ b/skills/orchestrate-review/scripts/chunk-reviewer-prompt.md
@@ -52,6 +52,8 @@ Execute the following command to obtain the diff for review. You MUST run this c
 
 This project applies two augmentations to the standard P0-P3 rubric. Apply these ON TOP of the built-in severity definitions in your system prompt — these augmentations OVERRIDE the built-in rubric where they conflict.
 
+> Canonical policy lives in `skills/code-review/SKILL.md §Severity Augmentation`. The text below is mirrored here for worker self-containment; edit the canonical file first.
+
 ### Masking Carve-out (NOT P1)
 
 A fallback or alternate path is NOT a masking pattern when ALL of the following hold:
@@ -66,23 +68,19 @@ If any of (1)–(5) is missing, the pattern is a masking pattern → P1.
 
 ### Project-Rule Violations (also P1, even without masking)
 
-The five enumerated rules below are P1 by definition — each rule declares the named pattern unwanted. This section is self-contained: project-rule-based P1 entries must cite a specific rule (1–5) listed here.
+**Simplicity First — minimum code that solves the problem, nothing speculative.** The five enumerated patterns below are P1 by definition; each one declares the named pattern unwanted, so the rule itself states the change should not have been made. This section is self-contained: project-rule-based P1 entries must cite a specific rule (1–5) listed here and quote the violating code.
 
-The following violations are P1 (this list is the *source of truth* — closed enumeration; do not silently re-classify):
+The following violations are P1 (closed enumeration; do not silently re-classify — the canonical list is `code-review/SKILL.md §Project-Rule Violations`):
 
-1. **Speculative addition** — feature, abstraction, configuration, or option that was not requested by the user, spec, or issue.
-2. **Single-use abstraction** — wrapper class, helper function, or interface introduced for a code path that has exactly one caller.
-3. **Unrequested flexibility** — config option, environment variable, or branching logic added to support hypothetical future scenarios.
-4. **Impossible-scenario error handling** — guard, validation, or fallback for a state that cannot occur given the surrounding contract (e.g., null-check on a value just constructed by `new`).
-5. **Backwards-compatibility shim without removal date** — fallback for an old format/API that has no documented removal target. Either set a removal date or remove the old path now.
+1. **Speculative addition** — *No features beyond what was asked.* Any feature, abstraction, configuration, or option that was not requested by the user, spec, or issue.
+2. **Single-use abstraction** — *No abstractions for single-use code.* Any wrapper class, helper function, or interface introduced for a code path that has exactly one caller.
+3. **Unrequested flexibility** — *No "flexibility" or "configurability" that wasn't requested.* Any config option, environment variable, or branching logic added to support hypothetical future scenarios.
+4. **Impossible-scenario error handling** — *No error handling for impossible scenarios.* Any guard, validation, or fallback for a state that cannot occur given the surrounding contract (e.g., null-check on a value just constructed by `new`).
+5. **Backwards-compatibility shim without removal date** — Any fallback for an old format/API that has no documented removal target. Either set a removal date or remove the old path now.
 
-For each P1 issue under this section, the reviewer must cite the specific rule (1–5) and quote the violating code.
+**Self-check**: "Would a senior engineer say this is overcomplicated?" If yes, the change is in violation territory.
 
 **Closed list discipline**: this enumeration is closed. Reviewers cannot create new P1-from-rule entries from un-enumerated reasoning. New rules require explicit addition to this list.
-
-## Project Guidelines
-
-{CLAUDE_MD}
 
 ## Commit History
 
@@ -101,5 +99,4 @@ For each P1 issue under this section, the reviewer must cite the specific rule (
 | {EVIDENCE_RESULTS} | Optional | Step 3 Evidence Verification (may be 'unavailable' message) |
 | {FILE_LIST} | Required | Step 2 git diff --name-only |
 | {DIFF_COMMAND} | Required | Step 4 — constructed from range + chunk file list |
-| {CLAUDE_MD} | Optional | Step 2 CLAUDE.md collection |
 | {COMMIT_HISTORY} | Required | Step 2 git log output |

--- a/skills/orchestrate-review/scripts/prompts/gemini.md
+++ b/skills/orchestrate-review/scripts/prompts/gemini.md
@@ -3,7 +3,7 @@ CRITICAL: YOU MUST FOLLOW THESE RULES. NO EXCEPTIONS. FAILURE TO COMPLY IS A REV
 0. **Premises (non-negotiable):**
    - You are running inside a git worktree with the PR/target branch already checked out. The working directory reflects the post-change state. Use Read/Grep/Glob freely against the actual files.
    - **Diff-only review is insufficient.** A diff is a delta; the unit of review is the system the diff produces. You MUST trace dependencies, callers, callees, interfaces, configurations, and runtime context across files. Reviewing on the diff alone is a review failure.
-1. Execute the diff command FIRST (Step 1), then **MUST** explore related code for context (Step 2 is mandatory, not optional).
+1. Execute the diff command FIRST (Step 1), then **you MUST** explore related code for context (Step 2 is mandatory, not optional).
 2. Report issues ONLY for files in the diff — related files are reference material, not review targets.
 3. Do NOT edit or write any files.
 4. Follow ALL Steps (1-8) sequentially. Do NOT skip any step. Do NOT stop early.
@@ -228,6 +228,10 @@ Produce your review in exactly this structure:
 - P0/P1: All 6 fields are mandatory.
 - P2/P3: Probability and Maintainability may be `[N/A]`.
 - Fix is always mandatory (P3 may use a single line).
+
+## Severity Augmentation Override
+
+If the review data contains a `## Severity Augmentation` section, treat its rules as authoritative — apply them ON TOP of the built-in P0-P3 rubric below. When a project augmentation rule conflicts with the built-in rubric, the augmentation OVERRIDES the built-in.
 
 ## Severity Definitions (P0-P3)
 

--- a/skills/orchestrate-review/scripts/prompts/gemini.md
+++ b/skills/orchestrate-review/scripts/prompts/gemini.md
@@ -3,7 +3,7 @@
 CRITICAL: YOU MUST FOLLOW THESE RULES. NO EXCEPTIONS. FAILURE TO COMPLY IS A REVIEW FAILURE.
 
 0. **Premises (non-negotiable):**
-   - You are running inside a git worktree with the PR/target branch already checked out. The working directory reflects the post-change state. Use Read/Grep/Glob freely against the actual files.
+   - The working directory reflects the post-change state of the target ref. Use Read/Grep/Glob freely against the actual files.
    - **Diff-only review is insufficient.** A diff is a delta; the unit of review is the system the diff produces. You MUST trace dependencies, callers, callees, interfaces, configurations, and runtime context across files. Reviewing on the diff alone is a review failure.
 1. Execute the diff command FIRST (Step 1), then **you MUST** explore related code for context (Step 2 is mandatory, not optional).
 2. Report issues ONLY for files in the diff — related files are reference material, not review targets.

--- a/skills/orchestrate-review/scripts/prompts/gemini.md
+++ b/skills/orchestrate-review/scripts/prompts/gemini.md
@@ -1,6 +1,9 @@
 CRITICAL: YOU MUST FOLLOW THESE RULES. NO EXCEPTIONS. FAILURE TO COMPLY IS A REVIEW FAILURE.
 
-1. Execute the diff command FIRST (Step 1), then freely explore related code for context.
+0. **Premises (non-negotiable):**
+   - You are running inside a git worktree with the PR/target branch already checked out. The working directory reflects the post-change state. Use Read/Grep/Glob freely against the actual files.
+   - **Diff-only review is insufficient.** A diff is a delta; the unit of review is the system the diff produces. You MUST trace dependencies, callers, callees, interfaces, configurations, and runtime context across files. Reviewing on the diff alone is a review failure.
+1. Execute the diff command FIRST (Step 1), then **MUST** explore related code for context (Step 2 is mandatory, not optional).
 2. Report issues ONLY for files in the diff — related files are reference material, not review targets.
 3. Do NOT edit or write any files.
 4. Follow ALL Steps (1-8) sequentially. Do NOT skip any step. Do NOT stop early.
@@ -15,7 +18,7 @@ You are a Senior Code Reviewer performing an independent code review. Your revie
 
 ## Chain-of-Thought Analysis Method
 
-Execute Steps 1 through 8 sequentially. Step 1 obtains the diff. Step 2 explores context. Steps 3-8 analyze and assess. Do not skip steps.
+Execute Steps 1 through 8 sequentially. Step 1 obtains the diff. Step 2 traces dependencies and runtime context across the codebase. Steps 3-8 analyze and assess. Do not skip steps.
 
 ### Step 1: Obtain the Diff (MANDATORY)
 
@@ -28,21 +31,25 @@ Before starting any analysis, locate the `## Diff Command` section in the review
 ✓ Step 1 complete. Proceed to Step 2.
 ---
 
-### Step 2: Context Exploration
+### Step 2: Dependency and Runtime-Context Tracing (MANDATORY)
 
-Read files referenced in the diff to understand the full picture:
-- Interfaces, base classes, and types that changed code implements or extends
-- Functions and methods that changed code calls or is called by
-- Configuration and constants that changed code depends on
-- **Execution context of callers**: Before assessing any method, trace who calls it and under what execution model. A method's correctness depends on how it is invoked — the same code may be safe under single-threaded sequential execution and broken under concurrent access. Verify:
+This step is a duty, not an option. The premises above forbid diff-only review. The working directory is the checked-out post-change state — read the actual files and trace the system the diff produces.
+
+For every non-trivial change unit, trace:
+- **Static dependencies** — interfaces, base classes, and types the changed code implements or extends; functions and methods it calls or is called by; configuration and constants it depends on.
+- **Call-flow** — for each public/exported symbol that changed, trace at least one full caller chain from an entry point (controller, scheduled job, message consumer, CLI handler) down to the change. Note who else calls the changed symbol.
+- **Execution context of callers** — a method's correctness depends on how it is invoked. The same code may be safe under single-threaded sequential execution and broken under concurrent access. For each caller, verify:
   - Threading model: Is the caller single-threaded, multi-threaded, or event-loop-based?
   - Dispatch model: Is this called synchronously, via async event handler, message consumer, scheduled task, or thread pool?
   - Ordering guarantees: If message-driven, does the messaging infrastructure (queue routing, consumer assignment, acknowledgment strategy) guarantee ordering or exclusive processing?
   - Transaction boundaries: Where do transactions start and end in the call chain? Does the caller's TX scope match the callee's expectations?
+- **Data flow** — for each new or modified data path, trace input source → transformation → output destination across files.
 
 **Before claiming a concurrency, ordering, or data consistency issue, you MUST verify the actual execution model of the caller — not just the code pattern of the callee.** A race condition that is structurally impossible under the actual execution model is not an issue.
 
-This step builds understanding — no findings yet.
+If you find yourself proposing findings without having traced these axes, you have skipped Step 2. Go back.
+
+This step builds understanding — no findings are filed yet, but the artifacts of this tracing (which files you read, which call chains you traced) directly inform every later step.
 
 ---
 ✓ Step 2 complete. Proceed to Step 3.

--- a/skills/orchestrate-review/scripts/prompts/gemini.md
+++ b/skills/orchestrate-review/scripts/prompts/gemini.md
@@ -1,3 +1,5 @@
+<!-- TWIN FILE — sibling: prompts/reviewer.md. Sections marked common to both must be edited in lockstep. Consider extracting if drift becomes a maintenance problem. -->
+
 CRITICAL: YOU MUST FOLLOW THESE RULES. NO EXCEPTIONS. FAILURE TO COMPLY IS A REVIEW FAILURE.
 
 0. **Premises (non-negotiable):**
@@ -163,7 +165,7 @@ FINAL REMINDER: Now produce the COMPLETE output in the exact format specified be
 Evaluate every change against these categories: **Code Quality** (separation of concerns, error handling, type safety, DRY, edge cases), **Architecture** (design decisions, scalability, performance, security), **Testing** (tests verify logic not mocks, edge cases covered, integration tests where needed), **Requirements** (plan requirements met, matches spec, no scope creep), **Production Readiness** (migration strategy, backward compatibility, documentation).
 
 **Testing — additional checks:**
-- Are there changed production paths with no test coverage? (If `{EVIDENCE_RESULTS}` contains a Test Coverage Mapping table, use it; otherwise assess from the diff alone)
+- Are there changed production paths with no test coverage? (If `{EVIDENCE_RESULTS}` contains a Test Coverage Mapping table, use it; otherwise read the changed files in the worktree and identify untested paths — never assess from the diff alone, per Premise 0.)
 
 **MANDATORY: Your response MUST include ALL of the following sections. Missing any section is a FAILURE:**
 1. ### Chunk Analysis (with per-file/per-symbol entries)
@@ -402,9 +404,9 @@ When reviewing a chunk (subset of a larger diff):
 2. **Focus on your chunk** -- review thoroughly within your assigned files.
 3. **Flag cross-file suspicions** -- if you see patterns that might conflict with files outside your chunk (e.g., interface changes, shared state mutations, inconsistent error conventions), note them under the `#### Cross-File Concerns` subsection within Issues.
 
-## CLAUDE.md Compliance
+## Project Convention Compliance
 
-If CLAUDE.md content is provided, verify the diff adheres to its conventions. Flag violations as Issues with the relevant CLAUDE.md rule cited.
+Per Premise 1, you are inside the worktree. Before producing findings, read any project-level convention or policy documents present in the worktree (e.g., agent base prompts, contributor guides, coding standards). Verify the diff adheres to those conventions and flag violations citing the specific document and rule.
 
 ## Critical Rules
 

--- a/skills/orchestrate-review/scripts/prompts/reviewer.md
+++ b/skills/orchestrate-review/scripts/prompts/reviewer.md
@@ -3,7 +3,7 @@
 CRITICAL: You MUST obey these rules. No exceptions.
 
 0. **Premises (non-negotiable):**
-   - You are running inside a git worktree with the PR/target branch already checked out. The working directory reflects the post-change state. Use Read/Grep/Glob freely against the actual files.
+   - The working directory reflects the post-change state of the target ref. Use Read/Grep/Glob freely against the actual files.
    - **Diff-only review is insufficient.** A diff is a delta; the unit of review is the system the diff produces. You MUST trace dependencies, callers, callees, interfaces, configurations, and runtime context across files. Reviewing on the diff alone is a review failure.
 1. Execute the diff command FIRST (Step 1), then **you MUST** explore related code for context (Step 2 is mandatory, not optional).
 2. Report issues ONLY for files in the diff — related files are reference material, not review targets.

--- a/skills/orchestrate-review/scripts/prompts/reviewer.md
+++ b/skills/orchestrate-review/scripts/prompts/reviewer.md
@@ -1,3 +1,5 @@
+<!-- TWIN FILE — sibling: prompts/gemini.md. Sections marked common to both must be edited in lockstep. Consider extracting if drift becomes a maintenance problem. -->
+
 CRITICAL: You MUST obey these rules. No exceptions.
 
 0. **Premises (non-negotiable):**
@@ -157,7 +159,7 @@ Evaluate every change against ALL five categories:
 - Integration tests where needed?
 - Do tests exercise the changed code paths (not just exist alongside)?
 - Are assertions checking meaningful outcomes (not just no-exception)?
-- Are there changed production paths with no test coverage? (If `{EVIDENCE_RESULTS}` contains a Test Coverage Mapping table, use it; otherwise assess from the diff alone)
+- Are there changed production paths with no test coverage? (If `{EVIDENCE_RESULTS}` contains a Test Coverage Mapping table, use it; otherwise read the changed files in the worktree and identify untested paths — never assess from the diff alone, per Premise 0.)
 
   Test fixtures containing credential patterns (mock API keys, etc.) = P3, not P1.
 
@@ -405,9 +407,9 @@ When reviewing a chunk (subset of a larger diff):
 2. **Focus on your chunk** -- review thoroughly within your assigned files.
 3. **Flag cross-file suspicions** -- if you see patterns that might conflict with files outside your chunk (e.g., interface changes, shared state mutations, inconsistent error conventions), note them under the `#### Cross-File Concerns` subsection within Issues.
 
-## CLAUDE.md Compliance
+## Project Convention Compliance
 
-If CLAUDE.md content is provided, verify the diff adheres to its conventions. Flag violations as Issues with the relevant CLAUDE.md rule cited.
+Per Premise 1, you are inside the worktree. Before producing findings, read any project-level convention or policy documents present in the worktree (e.g., agent base prompts, contributor guides, coding standards). Verify the diff adheres to those conventions and flag violations citing the specific document and rule.
 
 ## Critical Rules
 

--- a/skills/orchestrate-review/scripts/prompts/reviewer.md
+++ b/skills/orchestrate-review/scripts/prompts/reviewer.md
@@ -3,7 +3,7 @@ CRITICAL: You MUST obey these rules. No exceptions.
 0. **Premises (non-negotiable):**
    - You are running inside a git worktree with the PR/target branch already checked out. The working directory reflects the post-change state. Use Read/Grep/Glob freely against the actual files.
    - **Diff-only review is insufficient.** A diff is a delta; the unit of review is the system the diff produces. You MUST trace dependencies, callers, callees, interfaces, configurations, and runtime context across files. Reviewing on the diff alone is a review failure.
-1. Execute the diff command FIRST (Step 1), then **MUST** explore related code for context (Step 2 is mandatory, not optional).
+1. Execute the diff command FIRST (Step 1), then **you MUST** explore related code for context (Step 2 is mandatory, not optional).
 2. Report issues ONLY for files in the diff — related files are reference material, not review targets.
 3. Do NOT edit or write any files.
 4. Follow ALL Steps (1-8) sequentially. Do NOT skip any step. Do NOT stop early.
@@ -231,6 +231,10 @@ Produce your review in exactly this structure:
 - P0/P1: All 6 fields are mandatory.
 - P2/P3: Probability and Maintainability may be `[N/A]`.
 - Fix is always mandatory (P3 may use a single line).
+
+## Severity Augmentation Override
+
+If the review data contains a `## Severity Augmentation` section, treat its rules as authoritative — apply them ON TOP of the built-in P0-P3 rubric below. When a project augmentation rule conflicts with the built-in rubric, the augmentation OVERRIDES the built-in.
 
 ## Severity Definitions (P0-P3)
 

--- a/skills/orchestrate-review/scripts/prompts/reviewer.md
+++ b/skills/orchestrate-review/scripts/prompts/reviewer.md
@@ -1,6 +1,9 @@
 CRITICAL: You MUST obey these rules. No exceptions.
 
-1. Execute the diff command FIRST (Step 1), then freely explore related code for context.
+0. **Premises (non-negotiable):**
+   - You are running inside a git worktree with the PR/target branch already checked out. The working directory reflects the post-change state. Use Read/Grep/Glob freely against the actual files.
+   - **Diff-only review is insufficient.** A diff is a delta; the unit of review is the system the diff produces. You MUST trace dependencies, callers, callees, interfaces, configurations, and runtime context across files. Reviewing on the diff alone is a review failure.
+1. Execute the diff command FIRST (Step 1), then **MUST** explore related code for context (Step 2 is mandatory, not optional).
 2. Report issues ONLY for files in the diff — related files are reference material, not review targets.
 3. Do NOT edit or write any files.
 4. Follow ALL Steps (1-8) sequentially. Do NOT skip any step. Do NOT stop early.
@@ -14,7 +17,7 @@ You are a Senior Code Reviewer performing an independent code review. Your revie
 
 ## Chain-of-Thought Analysis Method
 
-Execute Steps 1 through 8 sequentially. Step 1 obtains the diff. Step 2 explores context. Steps 3-8 analyze and assess. Do not skip steps.
+Execute Steps 1 through 8 sequentially. Step 1 obtains the diff. Step 2 traces dependencies and runtime context across the codebase. Steps 3-8 analyze and assess. Do not skip steps.
 
 ### Step 1: Obtain the Diff (MANDATORY)
 
@@ -23,21 +26,25 @@ Before starting any analysis, locate the `## Diff Command` section in the review
 - You MUST execute the command. Do NOT skip this step.
 - If the command fails or returns empty output, report the failure and stop. Do NOT fabricate or guess the diff.
 
-### Step 2: Context Exploration
+### Step 2: Dependency and Runtime-Context Tracing (MANDATORY)
 
-Read files referenced in the diff to understand the full picture:
-- Interfaces, base classes, and types that changed code implements or extends
-- Functions and methods that changed code calls or is called by
-- Configuration and constants that changed code depends on
-- **Execution context of callers**: Before assessing any method, trace who calls it and under what execution model. A method's correctness depends on how it is invoked — the same code may be safe under single-threaded sequential execution and broken under concurrent access. Verify:
+This step is a duty, not an option. The premises above forbid diff-only review. The working directory is the checked-out post-change state — read the actual files and trace the system the diff produces.
+
+For every non-trivial change unit, trace:
+- **Static dependencies** — interfaces, base classes, and types the changed code implements or extends; functions and methods it calls or is called by; configuration and constants it depends on.
+- **Call-flow** — for each public/exported symbol that changed, trace at least one full caller chain from an entry point (controller, scheduled job, message consumer, CLI handler) down to the change. Note who else calls the changed symbol.
+- **Execution context of callers** — a method's correctness depends on how it is invoked. The same code may be safe under single-threaded sequential execution and broken under concurrent access. For each caller, verify:
   - Threading model: Is the caller single-threaded, multi-threaded, or event-loop-based?
   - Dispatch model: Is this called synchronously, via async event handler, message consumer, scheduled task, or thread pool?
   - Ordering guarantees: If message-driven, does the messaging infrastructure (queue routing, consumer assignment, acknowledgment strategy) guarantee ordering or exclusive processing?
   - Transaction boundaries: Where do transactions start and end in the call chain? Does the caller's TX scope match the callee's expectations?
+- **Data flow** — for each new or modified data path, trace input source → transformation → output destination across files.
 
 **Before claiming a concurrency, ordering, or data consistency issue, you MUST verify the actual execution model of the caller — not just the code pattern of the callee.** A race condition that is structurally impossible under the actual execution model is not an issue.
 
-This step builds understanding — no findings yet.
+If you find yourself proposing findings without having traced these axes, you have skipped Step 2. Go back.
+
+This step builds understanding — no findings are filed yet, but the artifacts of this tracing (which files you read, which call chains you traced) directly inform every later step.
 
 ### Step 3: Change Identification
 

--- a/skills/orchestrate-review/scripts/template-consistency.test.ts
+++ b/skills/orchestrate-review/scripts/template-consistency.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..", "..");
+const SKILL_MD = join(REPO_ROOT, "skills", "code-review", "SKILL.md");
+const TEMPLATE_MD = join(
+  REPO_ROOT,
+  "skills",
+  "orchestrate-review",
+  "scripts",
+  "chunk-reviewer-prompt.md"
+);
+
+/**
+ * Extract placeholder names from SKILL.md Step 5's "Interpolate placeholders" bullet list.
+ *
+ * The block starts at the line containing "Interpolate placeholders with context from"
+ * and ends at the next line beginning with "##" or "###" (or the next numbered list item
+ * that is not a placeholder bullet).
+ *
+ * Bullet format: `   - {NAME} ←`
+ */
+function extractSkillPlaceholders(content: string): Set<string> {
+  const lines = content.split("\n");
+
+  // Find the line index that starts the placeholder block
+  const startIndex = lines.findIndex((line) =>
+    line.includes("Interpolate placeholders with context from")
+  );
+  if (startIndex === -1) {
+    throw new Error(
+      "SKILL.md: Could not locate 'Interpolate placeholders with context from' marker in Step 5. " +
+        "The section may have been renamed — update the parser in template-consistency.test.ts."
+    );
+  }
+
+  const placeholders = new Set<string>();
+
+  // Scan forward from the start marker until we hit the next heading or numbered step
+  for (let i = startIndex + 1; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Stop at the next heading (## or ###) or at the next top-level numbered step
+    if (/^#{1,6}\s/.test(line)) break;
+    // Stop when we hit the closing step line (e.g. "3. Dispatch ...")
+    if (/^\d+\.\s/.test(line)) break;
+
+    // Match bullet lines: optional spaces + "- {NAME} ←"
+    const match = line.match(/^\s+-\s+(\{[A-Z_]+\})\s+←/);
+    if (match) {
+      placeholders.add(match[1]);
+    }
+  }
+
+  return placeholders;
+}
+
+/**
+ * Extract placeholder names from the "## Field Reference" table in chunk-reviewer-prompt.md.
+ *
+ * Table format:
+ *   | {NAME} | ... |
+ *
+ * Only rows whose first column is a `{PLACEHOLDER}` token are extracted (skips the header row).
+ */
+function extractTemplateFieldReferences(content: string): Set<string> {
+  const lines = content.split("\n");
+
+  // Find the "## Field Reference" heading
+  const headingIndex = lines.findIndex((line) =>
+    /^##\s+Field Reference/.test(line)
+  );
+  if (headingIndex === -1) {
+    throw new Error(
+      "chunk-reviewer-prompt.md: Could not locate '## Field Reference' heading. " +
+        "The section may have been renamed — update the parser in template-consistency.test.ts."
+    );
+  }
+
+  const placeholders = new Set<string>();
+
+  // Scan forward from the heading until the next top-level heading or end of file
+  for (let i = headingIndex + 1; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Stop at the next heading of the same or higher level
+    if (/^#{1,2}\s/.test(line)) break;
+
+    // Match table rows whose first column is {PLACEHOLDER}
+    // Format: | {NAME} | ... |
+    const match = line.match(/^\|\s*(\{[A-Z_]+\})\s*\|/);
+    if (match) {
+      placeholders.add(match[1]);
+    }
+  }
+
+  return placeholders;
+}
+
+describe("dispatch template placeholder consistency", () => {
+  it("SKILL.md Step 5 and chunk-reviewer-prompt.md Field Reference declare the same placeholder set", () => {
+    // Arrange
+    const skillContent = readFileSync(SKILL_MD, "utf-8");
+    const templateContent = readFileSync(TEMPLATE_MD, "utf-8");
+
+    const skillPlaceholders = extractSkillPlaceholders(skillContent);
+    const templatePlaceholders = extractTemplateFieldReferences(templateContent);
+
+    // Guard: parsers must not silently return empty sets (format regression detection)
+    expect(skillPlaceholders.size).toBeGreaterThan(
+      0,
+      `SKILL.md Step 5 placeholder parser returned 0 results — ` +
+        `the source format likely changed. Review the parser in template-consistency.test.ts.`
+    );
+    expect(templatePlaceholders.size).toBeGreaterThan(
+      0,
+      `chunk-reviewer-prompt.md Field Reference parser returned 0 results — ` +
+        `the source format likely changed. Review the parser in template-consistency.test.ts.`
+    );
+
+    // Act: compute symmetric difference
+    const onlyInSkill = [...skillPlaceholders].filter(
+      (p) => !templatePlaceholders.has(p)
+    );
+    const onlyInTemplate = [...templatePlaceholders].filter(
+      (p) => !skillPlaceholders.has(p)
+    );
+
+    // Assert: sets must be equal
+    const mismatchLines: string[] = [];
+    if (onlyInSkill.length > 0) {
+      mismatchLines.push(
+        `Declared in SKILL.md Step 5 but MISSING from chunk-reviewer-prompt.md Field Reference: ${onlyInSkill.join(", ")}`
+      );
+    }
+    if (onlyInTemplate.length > 0) {
+      mismatchLines.push(
+        `Declared in chunk-reviewer-prompt.md Field Reference but MISSING from SKILL.md Step 5: ${onlyInTemplate.join(", ")}`
+      );
+    }
+
+    expect(mismatchLines.length).toBe(
+      0,
+      `Placeholder sets are out of sync:\n${mismatchLines.join("\n")}\n\n` +
+        `SKILL.md Step 5 declares: ${[...skillPlaceholders].sort().join(", ")}\n` +
+        `Field Reference declares: ${[...templatePlaceholders].sort().join(", ")}`
+    );
+  });
+});


### PR DESCRIPTION
## 📌 Summary

code-review 스킬과 chunk-reviewer 에이전트를 자기-반성적으로 강화하여 자기-순환 참조를 제거하고 다중-AI 리뷰 표면(SKILL · data template · reviewer/gemini prompt) 사이의 어휘·룰·역할을 정렬합니다. 11개 커밋에 걸쳐 워크트리 안전망(모든 모드 일관 적용), Intent Block Gate(의도 미확정 시 hard block), Severity Augmentation cascade(Masking carve-out + closed-enumeration P1 룰 5개), Chairman·워커 역할 분리(verdict 권한을 upstream code-review skill Step 8로 명시 위임)를 도입합니다.

---

## 🔧 Changes

### Identity·역할 경계 정렬

- `agents/chunk-reviewer.md` Identity를 "Code Review Chairman"으로 핀고정 (이전: "Code review orchestrator" — self가 verdict 계산 주체를 동시에 지칭하던 자기-순환)
- verdict 권한 출처를 "upstream code-review skill (Step 8)"로 명시
- 워커 지향 premises를 "Operating Premises"(self-directive처럼 읽힘)에서 "Premises forwarded to your workers (NOT self-directives)"로 재분류
- Output 형식 정의를 inline 열거에서 canonical reference(`orchestrate-review` SKILL §"Aggregation Output Format")로 단일 위임

orchestrate-review SKILL.md의 NON-NEGOTIABLE 역할 정의(`Role Declaration:8`)와 chunk-reviewer 에이전트 Identity가 동일 source-of-truth를 참조하도록 정렬.

**영향 범위**
`agents/chunk-reviewer.md` 단일 파일. 행동 변경: 미존재(이미 의도였던 Chairman 역할의 명시화). 다운스트림 영향: chunk-reviewer 호출자(현재는 code-review skill Step 5)가 "워커에게 forward할 premises"를 정확히 식별 가능.

---

### Intent Block Gate · 인터뷰 규율

- Step 0를 "Intent and Context Acquisition"으로 재구성하고 hard exit 게이트 신설 (3-state: Intent confirmed / 사용자 explicit deferral / **BLOCK**)
- 모호한 답변에 대한 1-refinement 규율 + deferral hint 자동 안내 ("답하기 어려우면 'skip'으로 코드 품질만 리뷰 가능")
- Acquisition order 명시: PR/branch artifacts → linked references (recursive) → codebase signals → user interview
- 인터뷰는 codebase 사실(파일 위치·아키텍처)이 아닌 PREFERENCES·DECISIONS만 묻도록 Context Brokering 규약화

**영향 범위**
`skills/code-review/SKILL.md` Step 0. 행동 변경: 의도 미확정 + 사용자 미답변 상태에서 silent pass 봉쇄. 사용자 측 부담: 모호한 답변 시 1번 더 질문받을 수 있음 (대신 deferral 한 단어로 즉시 진행 가능).

---

### Severity Augmentation cascade

- SKILL.md `Severity Rubric`에 두 augmentation 추가:
  - **Masking Carve-out**: fallback/alternate path가 P1이 아닌 5개 조건 (scoped/documented/tested/preserves-evidence/non-replacement)
  - **Project-Rule Violations**: P1로 정의되는 5개 closed-enumeration 룰 (Speculative addition / Single-use abstraction / Unrequested flexibility / Impossible-scenario error handling / Backwards-compatibility shim without removal date)
- 동일 룰 본문이 chunk-reviewer-prompt.md(워커 dispatch data layer)에도 주입
- reviewer.md/gemini.md(워커 system prompt)에 "Severity Augmentation Override" 정렬 지시 추가 — data layer의 Augmentation이 built-in P0-P3 rubric을 OVERRIDE한다는 precedence만 선언, 룰 본문 미포함
- closed enumeration discipline 명시: "Reviewers cannot create new P1-from-rule entries from un-enumerated reasoning"

**영향 범위**
4개 파일(SKILL.md / chunk-reviewer-prompt.md / reviewer.md / gemini.md). 모든 워커가 동일 룰을 system+data 두 layer에서 받음. 다른 프로젝트가 orchestrate-review 스킬을 sync할 때 본문이 자동 동봉되는 부수 효과 있음 (Review Point 2에서 논의).

---

### 워크트리 안전망 (모든 모드)

- PR/branch-comparison/auto-detect 세 모드 모두에 post-change-state assertion 강제
- PR 모드: 능동 checkout + dirty-tree abort(`git status --porcelain -uno`) + primary-vs-linked-worktree 식별(`git rev-parse --git-dir` ≟ `--git-common-dir`)
- 비-PR 모드(branch-comparison/auto-detect): verify-only (`HEAD == target` + clean tree) — caller-arrived 패턴 보존
- 비대칭이 결함이 아니라 설계임을 SKILL.md `Premises:17` 주석에 명시
- PR fetch 순서를 base-first → PR head-last로 교환하여 FETCH_HEAD가 PR head를 가리키도록 보정 (rerun-safe)
- URL 형식 호출 시 trailing path segment에서 numeric `<N>` 추출 규칙 명시

**영향 범위**
`skills/code-review/SKILL.md` Premises 섹션 + Step 1 + Step 1 Worktree Checkout 블록. 행동 변경: dirty 작업 위에 silent checkout 발생하던 위험 차단. caller가 wrong branch에 도착한 비-PR 모드 호출 시 명시 abort.

---

### Worker prompt Step 2 의무화

- reviewer.md/gemini.md의 Step 2를 "Context Exploration (optional)"에서 "Dependency and Runtime-Context Tracing (MANDATORY)"로 재정의
- 4개 추적 축 명시: Static dependencies / Call-flow / Execution context of callers / Data flow
- "If you find yourself proposing findings without having traced these axes, you have skipped Step 2. Go back."

**영향 범위**
워커 system prompt 2종. diff-only 리뷰로 인한 false positive·false negative 비율 감소 의도. 워커 응답 시간 다소 증가 가능.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. Closed enumeration 규율의 권한·한계

**배경 및 문제 상황:**
다중-AI 워커가 자유롭게 P1 룰을 신설할 수 있으면 (1) 모델별 격차가 누적되어 동일 코드를 모델마다 다르게 등급 부여하고, (2) "프로젝트 룰에 X가 더해져야 한다"는 무한 확장이 일어나며, (3) 한 워커가 임의 추론으로 P1을 부여한 finding이 오케스트레이터 adjudication에서 어떻게 처리될지 사양이 없음. 직전 self-review에서 Gemini가 `set -euo pipefail` 누락을 Rule 4("impossible-scenario error handling")로 인용했는데, Rule 4는 "필요 없는 가드를 추가하는 것"을 P1로 정의하는 반대 방향 룰이라 카테고리 에러였음 — 이런 오용을 차단할 메커니즘이 없으면 자기-개선 변경마다 워커들이 룰을 자기 입맛대로 재해석할 수 있음.

**해결 방안:**
P1 룰을 5개로 명시 폐쇄(Speculative addition / Single-use abstraction / Unrequested flexibility / Impossible-scenario error handling / Backwards-compatibility shim without removal date)하고, "Reviewers cannot create new P1-from-rule entries from un-enumerated reasoning. New rules require explicit addition to this list" 규율을 명시. 워커는 P1을 룰로 부여할 때 (1)–(5) 중 하나를 인용하고 위반 코드를 quote해야 하며, un-enumerated reasoning은 P1이 아닌 다른 등급에서 다룸.

**구현 세부사항:**
- SKILL.md `Severity Rubric:471` ~ `Severity Rubric:485`에 5개 룰 본문 + closed list discipline 명시
- chunk-reviewer-prompt.md에 동일 본문 verbatim 주입 (워커가 dispatch 시점에 룰을 받음)
- reviewer.md/gemini.md의 "Severity Augmentation Override"가 data layer의 룰을 built-in rubric 위로 priority 정렬

**선택과 트레이드오프:**
- **채택**: 5개 룰 closed list — 일관성·예측성 우선
- **거부**: open-ended P1 룰 (모델별 무한 재해석)
- **거부**: 룰 없이 "워커 judgment에 맡김" (직전 self-review의 Gemini 오용 사례가 이 path의 위험을 입증)
- **알려진 위험**: 닫힌 리스트가 너무 좁아 정당한 P1을 P2로 mask할 가능성. 본 PR의 첫 리뷰에서 closed enumeration이 부적절한 P1 인용을 차단한 효력은 입증됐지만, 반대로 정당한 P1을 차단한 사례는 아직 없음 — 시간이 지나며 false negative가 누적되는지 모니터링 필요
- **열린 질문**: 5번째 룰 추가 절차는? PR 한 번에 룰만 추가하는 changeset이 좋은지, 룰을 적용한 코드 리뷰와 함께 추가하는 게 좋은지

### 2. Severity Augmentation 이중 주입·접합점 사양

**배경 및 문제 상황:**
워커가 Severity Augmentation을 어디에서 받아야 하는가? (a) system prompt(reviewer.md/gemini.md)에 hardcode — 룰 변경 시 모든 워커 prompt 수정 필요; (b) data prompt(chunk-reviewer-prompt.md)에만 주입 — 워커가 system prompt의 built-in P0-P3 rubric을 우선시할 위험; (c) 둘 다. 이번에 전체 워커 시스템(Claude/Codex/Gemini)에 cross-model 일관성을 보장하면서 룰 변경의 single point of truth를 확보하는 게 핵심 요건.

**해결 방안:**
**이중 주입**을 채택. data layer(chunk-reviewer-prompt.md)에는 룰 본문 verbatim 주입, system layer(reviewer.md/gemini.md)에는 "Override 정렬 지시"만 추가하여 "data prompt에 Severity Augmentation 섹션이 있으면 built-in P0-P3 rubric을 OVERRIDE한다"는 precedence를 선언. orchestrator(SKILL.md)에는 adjudication 기준으로 동일 본문 보유.

**구현 세부사항:**
- SKILL.md(orchestrator adjudication 기준): 룰 본문 보유
- chunk-reviewer-prompt.md(워커 data): 룰 본문 보유 (Step 5 interpolation에서 워커에게 전달)
- reviewer.md/gemini.md(워커 system): Override 정렬 지시만 (룰 본문 미포함)

**관련 코드:**
```markdown
# reviewer.md/gemini.md (system prompt) - 추가된 Override 지시
## Severity Augmentation Override

If the review data contains a `## Severity Augmentation` section,
treat its rules as authoritative — apply them ON TOP of the built-in
P0-P3 rubric below. When a project augmentation rule conflicts with
the built-in rubric, the augmentation OVERRIDES the built-in.
```

**선택과 트레이드오프:**
- **채택**: 이중 주입 (system Override + data 본문) — 워커가 어느 layer를 우선시하더라도 결과 일치
- **거부**: data 단일 주입 — built-in rubric이 우선시될 위험
- **거부**: system 단일 주입 — 워커 prompt 변경 시 룰 syncing 부담 + 프로젝트 간 룰 다름을 표현 어려움
- **알려진 부담**: 룰 본문이 SKILL.md(orchestrator)와 chunk-reviewer-prompt.md(워커 data) 두 곳에 verbatim 중복. 미래 한쪽만 갱신되면 silent inconsistency 발생 — 직전 self-review에서 P2(maintainability) finding으로 잡혔음
- **열린 질문**: `{SEVERITY_AUGMENTATION}` placeholder 도입을 follow-up PR로 처리할지, 본 PR에 포함할지? 또한 chunk-reviewer-prompt.md가 generic orchestrate-review 스킬에 위치하면서 oh-my-toong 특화 룰을 hardcode하는 것이 다른 프로젝트가 sync할 때 정당한가? (현재는 단일 사용자라 즉시 영향 없지만 미래 위험)

### 3. Worktree 가드 비대칭 (PR 모드 vs 비-PR 모드)

**배경 및 문제 상황:**
세 모드(PR/branch-comparison/auto-detect)가 worktree 안전성에 대해 서로 다른 가정을 가짐. PR 모드는 능동 checkout이 필요하므로 caller의 working tree를 덮을 위험 → primary-vs-linked-worktree 식별 가드 필수. 비-PR 모드는 caller가 이미 target branch에 도착했다고 가정(caller-arrived 패턴) → checkout 불필요, verify만 필요. 만약 모든 모드에 동일 가드를 적용하면 비-PR caller-arrived 패턴이 깨지고, 모든 모드에 active checkout을 적용하면 auto-detect에서 caller의 임의 브랜치를 강제 변경하는 위험이 발생.

**해결 방안:**
모드별 가드를 명시 분리. PR 모드: dirty-tree abort + primary-vs-linked-worktree 식별 + active checkout. 비-PR 모드: verify-only(HEAD == target + clean tree). 비대칭이 결함이 아니라 설계임을 SKILL.md Premises 섹션에 주석으로 명시.

**구현 세부사항:**
- PR 모드 식별 로직: `git rev-parse --git-dir` ≟ `git rev-parse --git-common-dir` 비교 — linked worktree에서는 `--git-dir`가 `.git/worktrees/<wt>`를, `--git-common-dir`가 공유 `.git`을 가리키므로 다름. primary clone에서는 같음. 같으면 abort하고 hint 출력 (`git worktree add ../review-pr-<N> -b review/pr-<N>`)
- 비-PR 모드 verify-only: `git rev-parse --abbrev-ref HEAD` + `git status --porcelain -uno`. mismatch 또는 dirty 시 abort.

**관련 코드:**
```bash
# PR Mode primary-vs-linked-worktree 식별
if [ "$(git rev-parse --git-dir 2>/dev/null)" \
   = "$(git rev-parse --git-common-dir 2>/dev/null)" ]; then
  echo "Error: refusing to run in primary repo —
        create a dedicated linked worktree first ..." >&2
  exit 1
fi
```

**선택과 트레이드오프:**
- **채택**: 비대칭 가드 (PR active, 비-PR verify-only)
- **거부**: 모든 모드 primary 가드 일률 적용 — caller-arrived 패턴(비-PR)을 깨뜨림
- **거부**: 모든 모드 active checkout — auto-detect에서 caller의 의도치 않은 브랜치 변경
- **알려진 부담**: 미래 편집자가 "왜 PR만 가드가 다르냐"고 의아할 수 있음 → Premises 내 명시 주석으로 완화
- **열린 질문**: 비-PR 모드의 verify-only가 실제로 충분히 안전한가? 사용자가 wrong branch에 도착한 채 호출 → mismatch abort로 차단되지만, 사용자가 우연히 target과 동일한 이름의 다른 분기에 있는 시나리오(예: stale local main)에 verify가 실효성을 잃지 않는가?

### 4. Chairman·워커 역할 분리 · 자기-순환 참조 제거

**배경 및 문제 상황:**
변경 전 `agents/chunk-reviewer.md` line 13은 self를 "Code review orchestrator"로 묘사하면서 verdict 계산 주체도 자기 자신이라고 시사했고(자기-순환 참조), 워커-지향 premises가 "Operating Premises"라는 헤더 하에 위치해 LLM이 헤더-anchor에 따라 self-directive로 해석할 위험이 있었음. 결과: chunk-reviewer agent가 가끔 직접 코드를 읽거나 verdict를 자체 계산하는 등 Chairman boundary를 넘는 행동을 보임.

**해결 방안:**
Identity를 외부 source-of-truth(`orchestrate-review` SKILL.md `Role Declaration`)에 명시 위임하고, verdict 권한 출처를 "upstream code-review skill (Step 8)"로 별도 명시. 워커 지향 premises를 "Premises forwarded to your workers (NOT self-directives)"로 재라벨링하여 LLM의 헤더-anchor 해석 함정을 차단. Output 형식은 inline 열거를 canonical section reference로 단일 위임.

**구현 세부사항:**
- agents/chunk-reviewer.md line 11-20에 Identity·Premises 분리 명시
- line 24의 Output을 `orchestrate-review` SKILL §"Aggregation Output Format"으로 단일 위임 — drift 위험 감소
- "Your role remains Chairman ... — you do NOT read source files yourself, do NOT execute the diff command, and do NOT augment worker findings. These premises shape what your workers do, not what you do." 명시

**선택과 트레이드오프:**
- **채택**: Identity·Output 정의를 외부(orchestrate-review SKILL.md)에 위임
- **거부**: agents/chunk-reviewer.md에 inline 본문 — drift 위험. 직전 self-review에서 Output 열거의 parenthetical에 "Per-Model Verdicts" 누락 P2 finding이 inline drift의 증거
- **알려진 부담**: orchestrate-review SKILL.md `Role Declaration`이 변경되면 chunk-reviewer 행동이 silent change. 즉 "Chairman boundaries" 변경은 chunk-reviewer 호출자에게 영향이 있다는 사실을 명시할 메커니즘이 부재
- **열린 질문**: orchestrate-review SKILL.md의 Chairman boundaries 변경 시 chunk-reviewer agent에 어떤 알림이 필요한가? 또는 inline reference에 git-blame 의존성을 명시하는 주석이 필요한가?

---

## ✅ Checklist

### 자동화 검증

- [ ] `make validate` 통과 (schema + component validation, sync.yaml 참조 무결성 포함)
  - `Makefile`
- [ ] `make test` 통과 (1241 bun + 5 shell tests, 0 fail)
  - `Makefile`
  - `tools/run-tests.sh`

### 자기-순환 참조 부재

- [ ] `agents/chunk-reviewer.md`의 Identity가 self가 아닌 외부(`orchestrate-review` SKILL.md)에 위임됨
  - `agents/chunk-reviewer.md`
- [ ] verdict 권한 출처가 명시되어 있음 ("upstream code-review skill Step 8")
  - `agents/chunk-reviewer.md`
- [ ] 워커 지향 premises가 "Premises forwarded to your workers (NOT self-directives)"로 명시 분류됨
  - `agents/chunk-reviewer.md`

### Severity Augmentation 4-표면 일관성

- [ ] SKILL.md(오케스트레이터 adjudication)에 Masking Carve-out 5개 조건 + Project-Rule Violations 5개 룰 본문 존재
  - `skills/code-review/SKILL.md`
- [ ] chunk-reviewer-prompt.md(워커 data layer)에 동일 룰 본문 verbatim 주입
  - `skills/orchestrate-review/scripts/chunk-reviewer-prompt.md`
- [ ] reviewer.md/gemini.md(워커 system layer)에 Severity Augmentation Override 정렬 지시 존재
  - `skills/orchestrate-review/scripts/prompts/reviewer.md`
  - `skills/orchestrate-review/scripts/prompts/gemini.md`
- [ ] closed enumeration discipline 명시 ("Reviewers cannot create new P1-from-rule entries from un-enumerated reasoning")
  - `skills/code-review/SKILL.md`
  - `skills/orchestrate-review/scripts/chunk-reviewer-prompt.md`

### 워크트리 가드

- [ ] PR 모드에 dirty-tree abort + primary-vs-linked-worktree 식별 가드 존재
  - `skills/code-review/SKILL.md`
- [ ] branch-comparison 모드에 HEAD verify + clean-tree 가드 존재
  - `skills/code-review/SKILL.md`
- [ ] auto-detect 모드에 HEAD verify + clean-tree 가드 존재
  - `skills/code-review/SKILL.md`
- [ ] Premises 섹션에 모드 비대칭이 설계임이 명시됨
  - `skills/code-review/SKILL.md`

### Intent Block Gate

- [ ] Step 0 exit 조건이 3-state(Intent confirmed / explicit deferral / BLOCK)로 정의됨
  - `skills/code-review/SKILL.md`
- [ ] vague answer refinement에 deferral hint 자동 안내 포함
  - `skills/code-review/SKILL.md`

---

## 📎 References

- `skills/orchestrate-review/SKILL.md` (Chairman role declaration · Aggregation Output Format)
- `skills/code-review/SKILL.md` Premises · Severity Rubric (in-tree)