### PR TITLE
refactor(prometheus): reference 트리거 MANDATORY 명시

### DIFF
--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -193,8 +193,10 @@ After loading context, classify the user's request. Classification determines in
 | **Greenfield** | Goal, Constraint, Success Criteria | 0.4, 0.3, 0.3 |
 | **Brownfield** | Goal, Constraint, Success Criteria, Context | 0.35, 0.25, 0.25, 0.15 |
 
-**All YES + Ambiguity ≤ 0.2** → Proceed to Acceptance Criteria Drafting (see [acceptance-criteria.md](acceptance-criteria.md)).
-After AC is confirmed → Metis consultation automatically (see [review-pipeline.md](review-pipeline.md)).
+Before conducting interviews → **MUST read [interview.md](interview.md)** — question types, vague answer handling, sequential interview rules.
+**All YES + Ambiguity ≤ 0.2** → Proceed to Acceptance Criteria Drafting (**MUST read [acceptance-criteria.md](acceptance-criteria.md)** — two-line AC format, Zero Human Intervention, verification thinking).
+After AC is confirmed → Metis consultation automatically (**MUST read [review-pipeline.md](review-pipeline.md)** — three-agent pipeline, verdict handling, Stage A/B/C presentation).
+After Metis APPROVE/COMMENT → **MUST read [plan-template.md](plan-template.md)** before writing the plan — structure, TODO 7-field format, AC 2-line format, QA scenarios, Final Verification Wave defined ONLY there.
 
 This checklist is internal — do not present it to the user.
 
@@ -275,7 +277,7 @@ The Planning-time Task Discipline is complementary (상보적) to the Pipeline S
 
 | When | Read |
 |------|------|
-| Conducting interviews, asking questions, handling user responses | [interview.md](interview.md) |
-| Drafting acceptance criteria, format, verification thinking | [acceptance-criteria.md](acceptance-criteria.md) |
-| Writing plan files, TODO format, QA scenarios, decomposition | [plan-template.md](plan-template.md) |
-| Running Metis/Oracle/Momus review pipeline, plan presentation | [review-pipeline.md](review-pipeline.md) |
+| **Before conducting interviews (MANDATORY)** | **[interview.md](interview.md)** |
+| **Before AC drafting (MANDATORY — two-line format, Zero Human Intervention)** | **[acceptance-criteria.md](acceptance-criteria.md)** |
+| **Before writing the plan (MANDATORY — structure/TODO format/AC/QA/Final Verification Wave defined ONLY here)** | **[plan-template.md](plan-template.md)** |
+| **Before invoking Metis/Oracle/Momus (MANDATORY — verdict handling, Stage A/B/C)** | **[review-pipeline.md](review-pipeline.md)** |


### PR DESCRIPTION
## 📌 Summary

prometheus skill의 reference file 4종(`interview.md` / `acceptance-criteria.md` / `plan-template.md` / `review-pipeline.md`)을 *언제 읽어야 하는지* 명시하는 본문 inline trigger에 비대칭이 있었습니다. `acceptance-criteria.md`와 `review-pipeline.md`는 workflow 본문에 `(see [...].md)` 형태로 inline mention이 있었지만, `plan-template.md`와 `interview.md`는 Reference Guides 표 한 채널로만 트리거되어 enforcement가 약했습니다.

실제 plan 생성 결과(prometheus invoke 후 산출된 plan)에서 plan-template.md 형식 위반 14건 (TODO checkbox 부재, Must NOT 누락, References 5분류 부재, AC 2-line 위반, Final Verification Wave 부재, 한국어 작성 등) 관찰. 같은 violation 패턴이 두 번 재현되어 reproducibility 확인.

4종 reference 모두 동일한 "MUST read" 패턴으로 trigger 균일화.

## 🔧 Changes

### 1. Workflow 본문 inline trigger를 4 reference 모두로 확장

기존 2줄(AC / review-pipeline만 inline mention)이 4줄로 확장. 각 reference의 workflow phase 시점에 `MUST read [...].md` 명시 + 해당 reference에서 정의되는 핵심 룰을 한 줄 요약.

**영향 범위**: `skills/prometheus/SKILL.md` (Clearance Checklist 섹션 직후, 본문 영역)

### 2. Reference Guides 표 4행 모두 bold + MANDATORY 강조

표의 모든 행에 동일한 `**Before X (MANDATORY — ...)**` 패턴 적용. 행 간 강조 강도 균일.

**영향 범위**: `skills/prometheus/SKILL.md` (Reference Guides 섹션)

### 3. Flowchart는 변경 없음

high-level workflow 시각화는 보존. reference read 트리거는 본문 + 표 두 채널로 명문화.

**영향 범위**: 없음 (의도적 보존)

## 💬 Review Points

### 1. Reference 트리거 비대칭이 enforcement gap의 root cause라는 진단

**배경 및 문제 상황**: prometheus skill을 invoke해도 plan-template.md 형식이 적용되지 않는 사례가 두 번 재현됨. AI가 SKILL.md를 받아도 별도 reference file을 *자발적으로 Read하지 않으면* 형식 details(TODO 체크박스, AC 2-line, Final Verification Wave, "Plans MUST be written in English" 룰 등)를 모름.

**해결 방안**: 메커니즘 강제(force-load) 없이 *trigger 채널 균일화*로 enforcement 회복. 깨진 channel(`plan-template.md` 본문 inline 부재, `interview.md` 본문 inline 부재) 두 곳을 sibling 패턴(AC/review-pipeline)에 맞춰 채움.

**구현 세부사항**: 4 reference 모두 본문 inline + 표 두 채널로 노출. 본문 트리거는 workflow 시점에 맞춰 배치 (interview → AC → review-pipeline → plan-template).

**선택과 트레이드오프**:
- 메커니즘 자체는 변경 없음. markdown link는 공식 Claude Code 스펙상 force-load 아님 — self-discipline 의존.
- 명시 톤 강화만으로 enforcement가 회복되는지는 *다음 prometheus invoke 결과*가 검증. 만약 동일 violation 재발 시 plan-template.md를 SKILL.md에 통합하는 더 강한 패치 격상 필요.

### 2. \`@\` force-load 옵션 폐기

**배경 및 문제 상황**: 초기 패치 옵션으로 \`@plan-template.md\` force-load를 검토. superpowers writing-skills 가이드가 "\`@\` force-loads, burns context"라며 명확한 메커니즘으로 단언.

**해결 방안**: claude-code-guide로 공식 스펙 확인 결과 — Claude Code 공식 문서에 \`@\` syntax 자체가 존재하지 않음. force-load 메커니즘은 community lore. 진짜 force-load는 \`\` !\`command\` \`\` dynamic shell injection만 (별도 비용 큼).

**구현 세부사항**: \`@plan-template.md\` 옵션 폐기. 기존 markdown link 유지하고 *명시 톤만 강화*.

**선택과 트레이드오프**: 메커니즘 강제력은 잃지만 공식 spec 부재를 우회한 fake mechanism 사용 회피. writing-skills 가이드의 \`@\` anti-pattern 자체가 공식 근거 없는 community lore라는 점은 별도 issue로 추적 가치.

### 3. Flowchart 보존 결정

**배경 및 문제 상황**: 초안에서는 flowchart에 "MUST read plan-template.md" 노드 추가 검토. 단일 노드만 추가하면 reference 4종 중 plan-template만 *역방향 비대칭* 발생.

**해결 방안**: 4 reference 모두 flowchart에 노드 추가하면 graph 비대화. 대신 *본문 + 표 두 채널의 균일성*에 집중. flowchart는 high-level workflow 시각화로 보존.

**선택과 트레이드오프**: 시각 channel(flowchart) 강조는 잃지만 4 reference 균일 처리 우선. graph 가독성 보존.

## ✅ Checklist

- [ ] \`interview.md\` / \`acceptance-criteria.md\` / \`plan-template.md\` / \`review-pipeline.md\` 4종 모두 본문 inline에 \`MUST read\` 표기가 등장
  - \`skills/prometheus/SKILL.md\` (Clearance Checklist 섹션 직후)
- [ ] Reference Guides 표 4행 모두 \`**Before X (MANDATORY — ...)**\` 패턴 + bold link 적용
  - \`skills/prometheus/SKILL.md\` (Reference Guides 섹션)
- [ ] Workflow flowchart의 노드/엣지 구성은 변경 전과 동일
  - \`skills/prometheus/SKILL.md\` (Workflow 섹션 dot graph)
- [ ] 기존 동작(intent classification, Clearance Checklist 6항목, Three-Agent pipeline) 룰은 변경 없음

## 📎 References

- 본 커밋: \`b1e35b0\`
- 공식 Claude Code Skills 문서: https://code.claude.com/docs/en/skills.md