### PR TITLE
feat(humanizer): 마크업, 구조, 번역체 AI 흔적 9개 패턴 추가

### DIFF
--- a/skills/humanizer/SKILL.md
+++ b/skills/humanizer/SKILL.md
@@ -40,13 +40,13 @@ These are not single-word matches — scan for whole-document layout signals.
 
 | Code | Detection signal | Severity |
 |------|------------------|----------|
-| K17 | em-dash(—) in Korean text: 3+ → P2, 10+ → P1 | P2/P1 |
+| K17 | **any** em-dash (—) in Korean text | **P1** |
 | K18 | **any** middle-dot (·) occurrence — including "남·녀", "동·서양" | **P1** |
 | K19 | "이것이 X의 핵심이다" definition-closing translated from "This is the X" | P2 |
 | K20 | mid-paragraph `>` blockquote inserted only to define a term | P2 |
 | K21 | 100% consistent Korean(English) bilingual notation across the document | P2 |
 | E18 | `*italic*` asterisk emphasis used in Korean text (Korean uses **bold**) | P3 |
-| C7 | tables in a single document: 5–6 → P2, 7+ → P1 | P2/P1 |
+| C7 | tables used where prose would fit (qualitative misuse) | **P1** |
 | C8 | "한 줄 요약 → 본문 → 헷갈렸던 지점 → 참고자료" lecture-slide closure | P2 |
 | C9 | uniform tone/tension/sentence-length throughout — no fatigue toward the end | P2 |
 
@@ -400,13 +400,13 @@ Removing AI patterns is half the job. Clean but lifeless writing still reads as 
 
 ---
 
-### K17. Em-dash overuse in Korean [P2]
+### K17. Em-dash (—) in Korean — any occurrence [P1]
 
-**Detection signal:** Three or more em-dashes (—) in a single Korean document, especially when used as English-style appositive ("~다 — 이것이 ~의 핵심이다") rather than ranges or interruptions.
+**Detection signal:** Any em-dash (—) appearing in a Korean text, especially when used as English-style appositive ("~다 — 이것이 ~의 핵심이다") rather than as a range marker.
 
-**Problem:** Korean writers natively use colon(:), parentheses, or line breaks for parenthetical exposition. Frequent em-dash use is a residue from English-trained models copying English typographic habits into Korean. One em-dash per long document can be natural; a chapter-length note with em-dash on nearly every page is a strong AI signature.
+**Problem:** Korean writers natively use colon(:), parentheses, or line breaks for parenthetical exposition. Em-dash use in running Korean prose is a residue from English-trained models copying English typographic habits. Like K18 (middle-dot), em-dash belongs to narrow registers (newspaper headlines, range notation) — its appearance in blog/study-note prose is the signal, not the count.
 
-**Counting rule:** Count em-dashes across the whole document, not per paragraph. 3+ in a single Korean piece is P2. 10+ is P1.
+**Severity rule:** Em-dash (—) appears anywhere in Korean prose → **P1**. No threshold counting, no grading.
 
 **Replacements:**
 - `~다 — 이것이 X의 핵심이다.` → `~다. 이것이 X의 핵심이다.` (period + new sentence) or simply delete the second clause if redundant
@@ -778,16 +778,13 @@ Removing AI patterns is half the job. Clean but lifeless writing still reads as 
 
 ---
 
-### C7. Table overuse [P2]
+### C7. Table overuse [P1]
 
-**Detection signal:** A document with 5+ tables, especially when tables are used to encode information that has no natural rows/columns (e.g., a "list of three concepts" rendered as a table).
+**Detection signal:** A document where tables are used to encode information that could naturally be prose — "term: description" pairs, "list of three concepts," ordered preferences, "A is for X, B is for Y" pairings. The signal is *qualitative misuse*, not a count threshold.
 
-**Problem:** LLMs compulsively tabulate. Anything remotely comparable — pros vs cons, terms vs descriptions, before vs after, "three reasons" — gets a table. Native human writing usually has at most 1–2 tables per chapter-length piece, and reserves them for genuinely tabular data (multi-attribute comparison, lookup tables).
+**Problem:** LLMs compulsively tabulate. Anything remotely comparable — pros vs cons, terms vs descriptions, before vs after, "three reasons" — gets converted to a table. Native human writing reserves tables for genuinely tabular data (multi-attribute comparison, lookup tables with ≥3 heterogeneous columns) and lets the rest flow as prose.
 
-**Counting rule:**
-- ≤4 tables in a chapter-length document: usually fine
-- 5–6 tables: P2, review whether at least two could be prose
-- 7+ tables: P1, almost certainly LLM-generated
+**Severity rule:** A document containing tables that should be prose → **P1**. Judgment is qualitative — apply when the writer was tabulating from compulsion rather than fit.
 
 **Rule for rewrite:**
 - Keep tables that have ≥3 columns of genuinely heterogeneous attributes

--- a/skills/humanizer/SKILL.md
+++ b/skills/humanizer/SKILL.md
@@ -34,6 +34,22 @@ Scan this list FIRST during pattern detection. See full catalog below for detail
 | E13 | Great question!, I hope this helps, Let's dive in, Here's the thing |
 | E16 | curly quotes ("\u201c...\u201d") → straight quotes ("...") |
 
+### Markup & Structure Traces (P1–P3)
+
+These are not single-word matches — scan for whole-document layout signals.
+
+| Code | Detection signal | Severity |
+|------|------------------|----------|
+| K17 | em-dash(—) in Korean text: 3+ → P2, 10+ → P1 | P2/P1 |
+| K18 | **any** middle-dot (·) occurrence — including "남·녀", "동·서양" | **P1** |
+| K19 | "이것이 X의 핵심이다" definition-closing translated from "This is the X" | P2 |
+| K20 | mid-paragraph `>` blockquote inserted only to define a term | P2 |
+| K21 | 100% consistent Korean(English) bilingual notation across the document | P2 |
+| E18 | `*italic*` asterisk emphasis used in Korean text (Korean uses **bold**) | P3 |
+| C7 | tables in a single document: 5–6 → P2, 7+ → P1 | P2/P1 |
+| C8 | "한 줄 요약 → 본문 → 헷갈렸던 지점 → 참고자료" lecture-slide closure | P2 |
+| C9 | uniform tone/tension/sentence-length throughout — no fatigue toward the end | P2 |
+
 ---
 
 ## Execution Process
@@ -384,6 +400,112 @@ Removing AI patterns is half the job. Clean but lifeless writing still reads as 
 
 ---
 
+### K17. Em-dash overuse in Korean [P2]
+
+**Detection signal:** Three or more em-dashes (—) in a single Korean document, especially when used as English-style appositive ("~다 — 이것이 ~의 핵심이다") rather than ranges or interruptions.
+
+**Problem:** Korean writers natively use colon(:), parentheses, or line breaks for parenthetical exposition. Frequent em-dash use is a residue from English-trained models copying English typographic habits into Korean. One em-dash per long document can be natural; a chapter-length note with em-dash on nearly every page is a strong AI signature.
+
+**Counting rule:** Count em-dashes across the whole document, not per paragraph. 3+ in a single Korean piece is P2. 10+ is P1.
+
+**Replacements:**
+- `~다 — 이것이 X의 핵심이다.` → `~다. 이것이 X의 핵심이다.` (period + new sentence) or simply delete the second clause if redundant
+- `A — B` (appositive) → `A(B)` or `A. B는 ~`
+- `A — 그래서 B` → `A. 그래서 B` or `A이고, 그래서 B`
+
+**Before:**
+> 메시지 전달이지만 영속성·보장 수준·소비자 모델이 다르다. — 이런 식의 부연이 한국어 글에 어울리지 않는다.
+
+**After:**
+> 메시지 전달이지만 영속성, 보장 수준, 소비자 모델이 다르다. 이런 식의 부연은 한국어 글에 잘 안 어울린다.
+
+---
+
+### K18. Middle-dot (·) — any occurrence [P1]
+
+**Detection signal:** Any middle-dot (·) character used as a separator in the text — enumeration, compound nouns, or paired terms. "A·B·C", "영속성·보장 수준·소비자 모델", "큐·스트림·이벤트 버스", "남·녀", "동·서양", "국·공립".
+
+**Why this matters:** Korean writers in any normal register — blog, study notes, technical writing, essay, SNS — **do not use middle-dot in running prose**. Even traditionally hyphenated pairs ("남녀", "동서양", "국공립") are written without the middle dot in everyday text. Middle dot is corpus-specific punctuation belonging to newspaper headlines, government documents, Wikipedia, and academic publication metadata — exactly the kind of text overrepresented in LLM training data. **Any middle-dot occurrence is a definitive AI signature.**
+
+**Severity rule:**
+- Middle-dot (·) appears anywhere in the text → **P1**. No exceptions. No grading by context.
+
+**Rule for rewrite:**
+- `A·B·C` → `A, B, C` or `A와 B, 그리고 C`
+- `영속성·보장 수준·소비자 모델` → `영속성과 보장 수준, 소비자 모델` (split into a clause)
+- `남·녀`, `동·서양`, `국·공립` → `남녀`, `동서양`, `국공립` (drop the dot, fuse)
+- If the middle-dot list is also followed by em-dash, additionally apply K17
+
+**Before:**
+> 메시지 전달이지만 영속성·보장 수준·소비자 모델이 다르다 — 그래서 큐는 1:1, 스트림은 n:n에 어울린다.
+
+**After:**
+> 메시지를 전달하는 도구지만 영속성, 보장 수준, 소비자 모델이 각각 다르다. 그래서 큐는 1:1 작업 분배에, 스트림은 n:n 분배에 어울린다.
+
+**Before:**
+> 이번 글에서는 큐·스트림·이벤트 버스를 비교한다.
+
+**After:**
+> 이번 글에서는 큐, 스트림, 이벤트 버스를 비교한다.
+
+**Note on edge cases:** If you are intentionally humanizing newspaper-style copy, government documents, or academic abstracts where middle dot is a register convention, this rule may produce false positives. In that case, the humanization itself is likely inappropriate for the source register — middle dot is not the only signal that will fire.
+
+---
+
+### K19. "이것이 ~다" definition closing (translated from "This is the X") [P2]
+
+**Detection expressions:** "~ — 이것이 X의 핵심이다", "~. 이것이 ~의 핵심 역할이다", "이것이 X다", "이것이 X의 본질이다"
+
+**Problem:** Direct translation of English "This is the core of X" / "This is X" closing patterns. Native Korean writers rarely close a paragraph by referring back with "이것이" — they tend to drop the demonstrative ("X의 핵심이다") or use a different rhythm ("바로 그 점이 ~", "그래서 ~", or no closing at all).
+
+**Distinction from K3:** K3 covers hedging endings ("~라고 할 수 있습니다"). K19 covers *definitional* endings where a preceding clause is referred back to and labeled — a translated rhetorical move, not a hedge.
+
+**Before:**
+> 메시지를 일단 받아두고 나중에 처리할 수 있게 한다 — 이것이 메시지 브로커의 핵심 역할이다.
+
+**After:**
+> 메시지를 일단 받아두고 나중에 처리하게 해주는 것이 메시지 브로커가 하는 일이다.
+
+또는: `메시지 브로커는 들어온 메시지를 받아뒀다가 나중에 처리하게 해준다.`
+
+---
+
+### K20. Mid-paragraph blockquote term definition [P2]
+
+**Detection signal:** A `>` blockquote inserted in the middle of running prose for the sole purpose of defining a term, with the format `> term: definition.` or `> **term**: definition.`
+
+**Problem:** LLMs love to break the flow of explanation to drop in a textbook-style term definition as a quote block. Native writers either (a) define inline in parentheses, (b) handle definitions in a separate glossary section, or (c) embed the definition in the surrounding sentence.
+
+**Note:** Genuine *quotations* in blockquotes are fine. K20 only applies when the blockquote is the *writer's own* term definition wedged into prose.
+
+**Before:**
+> 큐는 작업을 보내고 응답을 기다리지 않는다.
+>
+> > fire-and-forget: 작업을 던지고 결과를 기다리지 않는 비동기 패턴.
+>
+> 그래서 큐는 fire-and-forget에 어울린다.
+
+**After:**
+> 큐는 작업을 보내고 응답을 기다리지 않는다(fire-and-forget). 그래서 ~ 패턴이 큐와 잘 맞는다.
+
+---
+
+### K21. Bilingual notation uniformity [P2]
+
+**Detection signal:** Every technical term in the document is given consistently in `한국어(English)` form — e.g., "멱등(idempotent)", "소비자 그룹(consumer group)" — with no omissions and the same bracketing format throughout.
+
+**Problem:** Native writers are inconsistent about bilingual notation. They give the English the first time a term appears, then drop it. Or they give the English only when the Korean translation is ambiguous. 100% consistency from start to finish — every technical term, every time, same format — is an LLM-uniformity tell.
+
+**Rule:** Keep bilingual notation only on **first mention** of each term, or only where the Korean alone is ambiguous. Drop it on subsequent uses.
+
+**Before:**
+> 멱등(idempotent)한 처리가 필요하다. 멱등(idempotent)성을 보장하지 않으면 ~ . 멱등(idempotent) 키를 활용해 ~.
+
+**After:**
+> 멱등(idempotent)한 처리가 필요하다. 멱등성을 보장하지 않으면 ~. 멱등 키를 써서 ~.
+
+---
+
 ## English AI Pattern Catalog
 
 ### E1. Importance inflation [P1]
@@ -584,6 +706,22 @@ Removing AI patterns is half the job. Clean but lifeless writing still reads as 
 
 ---
 
+### E18. Italic asterisk emphasis in Korean text [P3]
+
+**Detection signal:** `*phrase*` single-asterisk italic emphasis appearing in Korean prose for emphasis (not for genuine titles or foreign-word styling).
+
+**Problem:** Korean writers using markdown overwhelmingly reach for `**bold**` for emphasis. `*italic*` emphasis is an English-language markdown habit — italic doesn't render as visually emphatic on Hangul as it does on Latin script, so native Korean markdown convention favors bold. LLMs trained heavily on English markdown leak `*italic*` into Korean output.
+
+**Rule:** Convert `*phrase*` to `**phrase**` in Korean prose unless the italic is genuinely for a foreign-word/title convention (e.g., titles of works).
+
+**Before:**
+> 여러 클라이언트가 동시에 메시지를 기다리고 있을 때 *먼저 요청한 클라이언트*가 메시지를 가져간다.
+
+**After:**
+> 여러 클라이언트가 동시에 메시지를 기다리고 있을 때 **먼저 요청한 클라이언트**가 메시지를 가져간다.
+
+---
+
 ## Common Patterns
 
 ### C1. Synonym cycling (Elegant Variation) [P2]
@@ -637,6 +775,75 @@ Removing AI patterns is half the job. Clean but lifeless writing still reads as 
 **Problem:** AI forces "Introduction → Body → Conclusion" regardless of text type. Even short texts get introductions and conclusions.
 
 **Rule:** Remove introduction/conclusion if they don't fit the text's length and purpose. "결론적으로" in text under 500 characters is almost always unnecessary.
+
+---
+
+### C7. Table overuse [P2]
+
+**Detection signal:** A document with 5+ tables, especially when tables are used to encode information that has no natural rows/columns (e.g., a "list of three concepts" rendered as a table).
+
+**Problem:** LLMs compulsively tabulate. Anything remotely comparable — pros vs cons, terms vs descriptions, before vs after, "three reasons" — gets a table. Native human writing usually has at most 1–2 tables per chapter-length piece, and reserves them for genuinely tabular data (multi-attribute comparison, lookup tables).
+
+**Counting rule:**
+- ≤4 tables in a chapter-length document: usually fine
+- 5–6 tables: P2, review whether at least two could be prose
+- 7+ tables: P1, almost certainly LLM-generated
+
+**Rule for rewrite:**
+- Keep tables that have ≥3 columns of genuinely heterogeneous attributes
+- Convert tables that are just "term: description" (2 columns) to a definition list or inline prose
+- Convert tables that exist only to encode "A is for X, B is for Y" pairs to a single sentence
+
+**Before:**
+```
+| 패턴 | 설명 |
+|------|------|
+| 큐 | 1:1 작업 분배 |
+| 스트림 | n:n 데이터 분배 |
+```
+
+**After:**
+> 큐는 1:1 작업 분배에, 스트림은 n:n 데이터 분배에 어울린다.
+
+---
+
+### C8. Lecture-slide meta-structure [P2]
+
+**Detection signal:** The document follows a complete "한 줄 요약 → 본문 → 헷갈렸던 지점 → 참고자료" or "TL;DR → Body → Pitfalls → References" structure where every section is present, evenly weighted, and rhetorically self-contained.
+
+**Problem:** Real human study notes are uneven. People scribble heavy notes on one section and skip the framing entirely on another. They forget the "한 줄 요약" or write it as an afterthought. The "헷갈렸던 지점" section, if present, is messy — half-formed sentences, asides, "왜인지 모르겠는데", maybe an unrelated tangent. When all four sections are present, polished, and each ends with a clean conclusion, the structure itself is the AI tell, regardless of content quality.
+
+**Particularly suspicious:**
+- "헷갈렸던 지점" / "Things I got confused about" written in clean, organized sentences — humans usually write these messily
+- Every section has its own intro-body-outro micro-arc
+- "참고자료" section listed without any personal commentary on what was useful
+
+**Rule for rewrite:**
+- Pick which structural section actually carries the writer's energy, expand it
+- Compress or delete the sections that exist only for completeness
+- Rewrite "헷갈렸던 지점" with one specific stuck moment rather than a polished list
+- If "한 줄 요약" wasn't earned (the body doesn't actually deliver a 한 줄's worth of insight), delete it
+
+---
+
+### C9. Uniform tone and tension throughout [P2]
+
+**Detection signal:** The document maintains identical register, sentence-length distribution, and rhetorical posture from the first paragraph to the last. No fatigue, no acceleration, no sections where the writer obviously cared more or less.
+
+**Problem:** Humans get tired. Early sections of a long note are often careful, well-structured, with longer sentences. Later sections tend to compress: shorter sentences, more telegraphic phrasing, occasionally rougher punctuation, the occasional aside or even a frustrated tone. LLM output, by contrast, holds the *same* rhythm and register from the opening line to the closing line of an 8-section document.
+
+**Distinct from C5 (uniform paragraph length):** C5 is about paragraph word counts. C9 is about *whole-document tension* — the writer's energy curve. A document can have varied paragraph lengths and still register as C9 if every paragraph has the same "voice temperature."
+
+**How to spot:**
+- Compare paragraph 1 and the second-to-last paragraph aloud — do they sound like the same person at the same energy level?
+- Check if any section has noticeably shorter sentences than others (fatigue marker)
+- Check if any section has tangents, asides, or partial sentences (humanity markers)
+- If none of these vary across the document, flag C9
+
+**Rule for rewrite (Blog/Essay only):**
+- Introduce rhythm variation in the latter half: shorten sentences, drop the occasional connective, allow one fragment
+- Add a single human aside or self-correction somewhere past the midpoint
+- For technical docs, C9 is acceptable — do not flag
 
 ---
 

--- a/skills/humanizer/test-scenarios.md
+++ b/skills/humanizer/test-scenarios.md
@@ -340,14 +340,14 @@ at most once와 at least once의 차이가 처음에는 헷갈렸다. at most on
 
 | Pattern | Severity | Instance |
 |---------|----------|----------|
-| K17 | P2 | em-dash(—) appears 4 times across document (3+ → P2 per K17 rule) |
+| K17 | P1 | em-dash(—) present in Korean prose (any occurrence → P1) |
 | K18 | P1 | "영속성·보장 수준·소비자 모델" middle-dot enumeration (any middle-dot = P1) |
 | K18 | P1 | "로그·이벤트", "캐시·세션", "알림·브로드캐스트" middle-dot in table cells (any middle-dot = P1) |
 | K19 | P2 | "~할 수 있게 한다 — 이것이 메시지 브로커의 핵심 역할이다" |
 | K20 | P2 | `> fire-and-forget: ~` mid-paragraph blockquote term definition |
 | K21 | P2 | "멱등(idempotent)" repeated 4 times with identical bracketing |
 | E18 | P3 | `*먼저 요청한 클라이언트*` italic asterisk in Korean prose |
-| C7 | P2 | 5 tables in a single chapter note (5–6 → P2 per C7 rule) |
+| C7 | P1 | Tables used for "term: description" and "A is for X" pairings that could be prose |
 | C8 | P2 | Complete "한 줄 요약 → 본문 → 헷갈렸던 지점 → 참고자료" structure |
 | C9 | P2 | Uniform tension/sentence rhythm across all sections |
 
@@ -358,14 +358,14 @@ at most once와 at least once의 차이가 처음에는 헷갈렸다. at most on
 
 **PASS criteria:**
 1. Agent flags all 9 new pattern codes (K17, K18, K19, K20, K21, E18, C7, C8, C9)
-2. Agent does NOT mechanically flag every middle-dot or every em-dash — counts occurrences first
+2. Agent flags em-dash (K17) and middle-dot (K18) on first occurrence — no threshold counting required
 3. Agent correctly identifies C8 even though each individual section looks reasonable — the *combination* is the tell
 4. Agent does NOT flag this as K2/K10 false positive (content is concrete, not modifier-inflated)
 5. Audit report distinguishes whole-document signals (C7, C8, C9) from local signals (K19, K20)
 
 **Notes for the rewriter (if mode=rewrite):**
-- Reduce em-dashes to ≤2 in the whole document
-- Convert at least 2 of the 5 tables to prose (likely C7 candidates: 1:1 vs n:n in the queue-vs-stream table, the selection-criteria table, the fan-out vs consumer-group table)
+- Remove all em-dashes (replace with periods, parentheses, or commas)
+- Convert tables whose content is just "term: description" or "A is for X" pairings into prose (likely candidates: queue-vs-stream, selection-criteria, fan-out vs consumer-group). Leave any genuinely multi-attribute lookup tables intact.
 - Convert `> fire-and-forget` blockquote to inline parenthetical
 - Drop "멱등(idempotent)" bilingual on 2nd, 3rd, 4th mentions
 - Rewrite "헷갈렸던 지점" with one specific stuck moment, messier, in first person

--- a/skills/humanizer/test-scenarios.md
+++ b/skills/humanizer/test-scenarios.md
@@ -256,3 +256,118 @@ Additionally, the intricate interplay between edge computing and serviceless pat
 3. 60% statistic preserved
 4. "serviceless" concept preserved accurately
 5. Mixed-language flow maintained naturally
+
+---
+
+## Scenario 7: Korean Study Notes — Markup & Structure AI Traces
+
+**Type:** Application + variation (newly added markup/structure patterns)
+**Content type:** Blog/Essay (personal study notes)
+**Mode:** audit
+
+**Purpose:** Verify the skill detects K17–K21, E18, C7–C9 — the markup, translation, and document-structure traces that single-word keyword scanning misses.
+
+**Input text:**
+```
+## 한 줄 요약
+
+메시지 큐와 스트림은 둘 다 메시지 전달이지만 영속성·보장 수준·소비자 모델이 다르다 — 그래서 용도가 갈린다.
+
+## 본문
+
+### 1. 메시지 브로커란
+
+들어온 메시지를 일단 받아두고 나중에 처리할 수 있게 한다 — 이것이 메시지 브로커의 핵심 역할이다.
+
+> fire-and-forget: 작업을 던지고 결과를 기다리지 않는 비동기 패턴.
+
+그래서 큐는 fire-and-forget에 어울린다.
+
+### 2. 큐 vs 스트림
+
+| 항목 | 큐 | 스트림 |
+|------|-----|--------|
+| 모델 | 1:1 | n:n |
+| 영속성 | 짧음 | 김 |
+| 재처리 | 어려움 | 쉬움 |
+
+여러 클라이언트가 동시에 메시지를 기다릴 때 *먼저 요청한 클라이언트*가 가져간다.
+
+### 3. 전달 보장 수준
+
+| 수준 | 의미 |
+|------|------|
+| at most once | 중복 없음, 유실 가능 |
+| at least once | 유실 없음, 중복 가능 |
+| exactly once | 둘 다 없음 |
+
+at least once는 멱등(idempotent)한 처리를 전제로 한다. 멱등(idempotent)성을 보장하지 않으면 중복 처리 사고가 난다. 멱등(idempotent) 키를 활용해 중복을 거른다.
+
+### 4. Kafka vs Redis
+
+| 항목 | Kafka | Redis |
+|------|-------|-------|
+| 영속성 | 디스크 | 메모리 |
+| 처리량 | 높음 | 매우 높음 |
+| 사용 사례 | 로그·이벤트 | 캐시·세션 |
+
+### 5. fan-out vs 소비자 그룹
+
+| 항목 | fan-out | 소비자 그룹 |
+|------|---------|------------|
+| 의미 | 모두에게 전달 | 그룹 내 1명 |
+| 용도 | 알림·브로드캐스트 | 작업 분배 |
+
+### 6. 선택 기준
+
+| 상황 | 선택 |
+|------|------|
+| 작업 분배 | 큐 |
+| 이벤트 스트림 | 스트림 |
+| 실시간 알림 | fan-out |
+
+## 헷갈렸던 지점
+
+at most once와 at least once의 차이가 처음에는 헷갈렸다. at most once는 "한 번 이하 — 즉 유실 가능"이고, at least once는 "한 번 이상 — 즉 중복 가능"이다. 결국 멱등(idempotent)성으로 해결한다.
+
+## 참고자료
+
+- Kafka 공식 문서
+- Designing Data-Intensive Applications
+```
+
+**Expected detections (focus on new patterns):**
+
+| Pattern | Severity | Instance |
+|---------|----------|----------|
+| K17 | P1 | em-dash(—) 10+ times across document |
+| K18 | P1 | "영속성·보장 수준·소비자 모델" middle-dot enumeration (any middle-dot = P1) |
+| K18 | P1 | "로그·이벤트", "캐시·세션", "알림·브로드캐스트" middle-dot in table cells (any middle-dot = P1) |
+| K19 | P2 | "~할 수 있게 한다 — 이것이 메시지 브로커의 핵심 역할이다" |
+| K20 | P2 | `> fire-and-forget: ~` mid-paragraph blockquote term definition |
+| K21 | P2 | "멱등(idempotent)" repeated 4 times with identical bracketing |
+| E18 | P3 | `*먼저 요청한 클라이언트*` italic asterisk in Korean prose |
+| C7 | P1 | 6 tables in a single chapter note |
+| C8 | P2 | Complete "한 줄 요약 → 본문 → 헷갈렸던 지점 → 참고자료" structure |
+| C9 | P2 | Uniform tension/sentence rhythm across all sections |
+
+**Also expected (pre-existing patterns):**
+- K2: none (no "혁신적", "체계적" — content is reasonably specific)
+- K1: none (no opening cliché)
+- K10: none (no closing cliché — "참고자료" is structural, not "결론적으로")
+
+**PASS criteria:**
+1. Agent flags all 9 new pattern codes (K17, K18, K19, K20, K21, E18, C7, C8, C9)
+2. Agent does NOT mechanically flag every middle-dot or every em-dash — counts occurrences first
+3. Agent correctly identifies C8 even though each individual section looks reasonable — the *combination* is the tell
+4. Agent does NOT flag this as K2/K10 false positive (content is concrete, not modifier-inflated)
+5. Audit report distinguishes whole-document signals (C7, C8, C9) from local signals (K19, K20)
+
+**Notes for the rewriter (if mode=rewrite):**
+- Reduce em-dashes to ≤2 in the whole document
+- Convert at least 3 of the 6 tables to prose (likely C7 candidates: 1:1 vs n:n, selection criteria, fan-out vs consumer-group)
+- Convert `> fire-and-forget` blockquote to inline parenthetical
+- Drop "멱등(idempotent)" bilingual on 2nd, 3rd, 4th mentions
+- Rewrite "헷갈렸던 지점" with one specific stuck moment, messier, in first person
+- Convert `*italic*` to `**bold**`
+- Break tone uniformity in the later sections — shorter sentences, one aside

--- a/skills/humanizer/test-scenarios.md
+++ b/skills/humanizer/test-scenarios.md
@@ -340,14 +340,14 @@ at most once와 at least once의 차이가 처음에는 헷갈렸다. at most on
 
 | Pattern | Severity | Instance |
 |---------|----------|----------|
-| K17 | P1 | em-dash(—) 10+ times across document |
+| K17 | P2 | em-dash(—) appears 4 times across document (3+ → P2 per K17 rule) |
 | K18 | P1 | "영속성·보장 수준·소비자 모델" middle-dot enumeration (any middle-dot = P1) |
 | K18 | P1 | "로그·이벤트", "캐시·세션", "알림·브로드캐스트" middle-dot in table cells (any middle-dot = P1) |
 | K19 | P2 | "~할 수 있게 한다 — 이것이 메시지 브로커의 핵심 역할이다" |
 | K20 | P2 | `> fire-and-forget: ~` mid-paragraph blockquote term definition |
 | K21 | P2 | "멱등(idempotent)" repeated 4 times with identical bracketing |
 | E18 | P3 | `*먼저 요청한 클라이언트*` italic asterisk in Korean prose |
-| C7 | P1 | 6 tables in a single chapter note |
+| C7 | P2 | 5 tables in a single chapter note (5–6 → P2 per C7 rule) |
 | C8 | P2 | Complete "한 줄 요약 → 본문 → 헷갈렸던 지점 → 참고자료" structure |
 | C9 | P2 | Uniform tension/sentence rhythm across all sections |
 
@@ -365,7 +365,7 @@ at most once와 at least once의 차이가 처음에는 헷갈렸다. at most on
 
 **Notes for the rewriter (if mode=rewrite):**
 - Reduce em-dashes to ≤2 in the whole document
-- Convert at least 3 of the 6 tables to prose (likely C7 candidates: 1:1 vs n:n, selection criteria, fan-out vs consumer-group)
+- Convert at least 2 of the 5 tables to prose (likely C7 candidates: 1:1 vs n:n in the queue-vs-stream table, the selection-criteria table, the fan-out vs consumer-group table)
 - Convert `> fire-and-forget` blockquote to inline parenthetical
 - Drop "멱등(idempotent)" bilingual on 2nd, 3rd, 4th mentions
 - Rewrite "헷갈렸던 지점" with one specific stuck moment, messier, in first person


### PR DESCRIPTION
## 📌 Summary

humanizer 스킬은 어휘 단위 키워드(K1~K16, E1~E17, C1~C6)에는 강하지만 마크업, 문서 구조, 번역체 측면의 LLM 시그니처를 잡지 못한다는 지적을 받았습니다. 이 PR은 한국어 카탈로그에 K17~K21, 영어 카탈로그에 E18, 공통 카탈로그에 C7~C9를 추가하여 9개 신규 룰을 신설하고, Cheatsheet에 별도 "Markup & Structure Traces (P1-P3)" 섹션을 만들었습니다.

---

## 🔧 Changes

### 한국어 카탈로그 K17~K21 추가

- K17: 한국어 텍스트에 em-dash가 등장하면 무조건 P1 (K18과 동일 정책)
- K18: 가운뎃점(·)이 어떤 컨텍스트에서 등장하든 무조건 P1
- K19: "이것이 X의 핵심이다" 정의 마무리 직역체
- K20: 본문 중간 `>` 인용블록을 용어 정의로 끼워넣는 패턴
- K21: "한국어(English)" 병기를 글 전체에 걸쳐 100% 균일하게 유지

기존 K1~K16은 단어 매칭 중심이었는데, 위 5개는 한국어 텍스트의 마크업과 번역체 시그니처를 검사합니다.

**영향 범위**
`skills/humanizer/SKILL.md`의 Korean AI Pattern Catalog (K16 다음). 기존 K1~K16 룰의 동작은 변경되지 않으며 신규 룰만 추가됩니다.

---

### 영어 카탈로그 E18 추가

- E18: 한국어 텍스트에서 `*phrase*` italic asterisk 강조 사용. 한국어 markdown은 `**bold**` 관습이라 italic은 영어권 마크다운 습관의 leakage 신호입니다.

**영향 범위**
`skills/humanizer/SKILL.md`의 English AI Pattern Catalog (E17 다음).

---

### 공통 카탈로그 C7~C9 추가

- C7: 표가 prose로 풀 수 있는 내용에 사용되면 P1 (카운트 임계가 아닌 정성적 misuse 판단)
- C8: 학습노트나 슬라이드형 메타 구조 완결성 (한 줄 요약 → 본문 → 헷갈렸던 지점 → 참고자료)
- C9: 글 전체 톤과 텐션 균일성. C5(paragraph length 균일)를 넘는 sentence rhythm 일관성

C8, C9는 어휘가 아닌 문서 전체 layout signal로 검사한다는 점에서 기존 C 룰과 구분됩니다.

**영향 범위**
`skills/humanizer/SKILL.md`의 Common Patterns (C6 다음).

---

### Cheatsheet "Markup & Structure Traces" 섹션 신설

- "Markup & Structure Traces (P1-P3)" 별도 섹션 추가
- 표 구조를 3열(Code / Detection signal / Severity)로 전환
- K17, C7 모두 K18과 동일하게 단일 P1 등급으로 통일하여 초기 (P2/P3) 표기 오류와 임계 분기 자체를 동시에 해소

**영향 범위**
`skills/humanizer/SKILL.md`의 Quick Reference Cheatsheet. 기존 "Korean Immediate Fix (P1)"과 "English Immediate Fix (P1)" 표는 그대로 유지됩니다.

---

### test scenario 추가

- Scenario 7 "Korean Study Notes — Markup & Structure AI Traces" 신설
- 메시지 브로커 학습노트 형태의 baseline 텍스트, 9개 신규 룰의 detection 기대값, PASS criteria 작성

**영향 범위**
`skills/humanizer/test-scenarios.md`. 기존 Scenario 1~6은 그대로 유지됩니다.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. K18(가운뎃점)을 무조건 P1으로 단순화한 판단

**배경 및 문제 상황:**
한국어에서 가운뎃점(·)은 신문 헤드라인, 공문, 학술 출판 메타데이터처럼 LLM 학습 코퍼스에 과대표상된 매체에서만 일상적으로 등장하는 punctuation입니다. 일반 블로그, 학습노트, SNS 톤에서는 사실상 쓰이지 않습니다. 처음에는 단독 사용 P2 + em-dash 콤보 P1의 그라데이션 룰로 설계했으나, 결정성과 단순성 측면에서 부족했고 사용자도 "가운뎃점 있으면 무조건 P1"을 명시적으로 요구했습니다.

**해결 방안:**
K18 severity rule을 단일 P1으로 단순화. 고정 표현("남·녀", "동·서양", "국·공립") 예외도 제거하여 모든 가운뎃점 occurrence를 동일하게 처리.

**구현 세부사항:**
- 카탈로그 본문에 severity rule 한 줄만 명시 (등급 분기 제거)
- rewrite 규칙에 "남·녀 → 남녀"처럼 가운뎃점을 떼고 fuse하는 가이드 추가
- 신문이나 공문 텍스트를 humanize하는 경우의 false positive 가능성은 카탈로그 끝 note로 경고 처리

**선택과 트레이드오프:**
- 채택: 단일 P1 룰. audit 보고서에서 분기 없이 결정성이 높아짐. fixed expression false positive 가능성은 note 경고로 사용자 판단 영역에 둠.
- 거부: 그라데이션 룰. 미세 분류는 가능하지만 agent의 P1/P2 경계 망설임과 audit 보고서의 일관성 저하를 유발.

---

### 2. C8(메타 구조), C9(톤 균일성)의 "문서 전체 단위 신호" 정의

**배경 및 문제 상황:**
기존 카탈로그의 검출 방식은 키워드 매칭과 짧은 구문 패턴 중심이었습니다. 그러나 분석에서 드러난 가장 강한 AI 시그니처 중 일부는 단일 구문이 아니라 문서 전체에서 드러나는 신호였습니다. "한 줄 요약 → 본문 → 헷갈렸던 지점 → 참고자료" 같은 강의 슬라이드형 구조 완결성, 처음부터 끝까지 일정한 톤과 텐션이 대표적입니다. 키워드 기반 룰로는 잡을 수 없는 차원입니다.

**해결 방안:**
"Markup & Structure Traces" 별도 섹션을 신설하여 detection unit 자체를 문서 전체 layout signal로 정의. C8은 4-part lecture-slide closure의 완결성을, C9는 sentence rhythm과 voice temperature의 균일성을 검출 대상으로 둠.

**구현 세부사항:**
- C8 본문에 "특히 의심 지점" 가이드 명시: 깔끔하게 정리된 "헷갈렸던 지점" 섹션, 각 섹션 내부의 micro-arc, 참고자료에 commentary 없음
- C9 본문에 self-check 휴리스틱 추가 ("paragraph 1과 끝에서 두 번째 paragraph를 소리 내서 비교")
- C9는 Blog/Essay에만 적용하며 기술 문서에는 적용하지 않도록 명시

**선택과 트레이드오프:**
- 채택: 정성적 detection signal과 휴리스틱 가이드. 사람이 검출할 때 실제 쓰는 신호를 글로 풀어내어 agent가 따라할 수 있게 함.
- 한계: 정량 매칭이 아니라 false positive와 false negative를 정형 측정하기 어려움. 우선 test-scenarios.md Scenario 7로 baseline 검출만 확인.

---

### 3. K17, C7도 K18처럼 단일 P1으로 통일한 판단

**배경 및 문제 상황:**
초안에서는 K17(em-dash)에 "3+ → P2, 10+ → P1", C7(표)에 "5~6 → P2, 7+ → P1" 같은 카운트 임계 분기를 두었습니다. 그러나 두 가지 문제가 드러났습니다. 첫째, P1과 P2의 차이는 audit 보고서의 우선순위 표시 외 rewrite 단계에서 실용적 가치가 없습니다. 둘째, 임계값 분기는 시나리오 expected에 input 파생 카운트("em-dash 4 times", "5 tables")를 박는 비정규화를 유발했고, Codex 자동 리뷰가 그 비정규화의 정합성 오류를 catch했습니다.

**해결 방안:**
K17과 C7을 K18(가운뎃점)과 동일한 정책으로 통일. 임계 분기를 제거하고 "등장 시 무조건 P1" 또는 "정성적 misuse 판단 시 P1"으로 단일 등급화. Cheatsheet의 K17, C7 행도 같은 정책으로 정렬. Scenario 7 expected에서도 카운트 표기를 제거하고 정성적 검출 조건으로 전환.

**선택과 트레이드오프:**
- 채택: 단일 P1 룰. 룰의 결정성과 단순성이 임계 정밀도보다 큰 가치를 제공. expected에서 input 파생 카운트가 사라져 정합성 검증 부담도 함께 제거.
- 거부: 임계 분기 유지. 미세 분류는 가능하지만 expected 비정규화 부담과 audit 보고서의 분기 망설임을 유발.
- 한계: C7의 정성적 "tables used where prose would fit" 판단은 agent마다 일관성이 흔들릴 가능성. 향후 false positive/negative 발견 시 룰 본문의 "Rule for rewrite" 가이드를 보강할 여지를 남김.

---

## ✅ Checklist

### Korean Catalog

- [ ] K17~K21 5개 카탈로그 항목이 한국어 카탈로그 K16 다음에 추가되어 있다
  - `skills/humanizer/SKILL.md`
- [ ] K18 카탈로그 헤더에 `[P1]` 표기가 있고 severity rule 섹션에 단일 P1만 명시되어 있다
  - `skills/humanizer/SKILL.md`

### English Catalog

- [ ] E18 카탈로그 항목이 영어 카탈로그 E17 다음에 추가되어 있다
  - `skills/humanizer/SKILL.md`

### Common Patterns

- [ ] C7~C9 3개 카탈로그 항목이 Common Patterns C6 다음에 추가되어 있다
  - `skills/humanizer/SKILL.md`

### Cheatsheet

- [ ] "Markup & Structure Traces (P1-P3)" 섹션이 Cheatsheet에 존재한다
  - `skills/humanizer/SKILL.md`
- [ ] Markup & Structure Traces 표가 3열(Code / Detection signal / Severity) 구조다
  - `skills/humanizer/SKILL.md`

### Test Scenarios

- [ ] Scenario 7 "Korean Study Notes — Markup & Structure AI Traces"가 test-scenarios.md에 존재한다
  - `skills/humanizer/test-scenarios.md`
- [ ] Scenario 7의 Expected detections에 9개 신규 룰(K17~K21, E18, C7~C9)이 모두 포함되어 있다
  - `skills/humanizer/test-scenarios.md`

---

## 📎 References

- [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing)
