### PR TITLE
refactor(prometheus): mandatory contract를 SKILL.md inline 통합

### DIFF
--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -193,7 +193,7 @@ After loading context, classify the user's request. Classification determines in
 | **Greenfield** | Goal, Constraint, Success Criteria | 0.4, 0.3, 0.3 |
 | **Brownfield** | Goal, Constraint, Success Criteria, Context | 0.35, 0.25, 0.25, 0.15 |
 
-Before conducting interviews → **MUST read [interview.md](interview.md)** — question types, vague answer handling, sequential interview rules.
+Before conducting interviews → follow `## Interview Mode (Mandatory Contract)` below (tool use vs user questions, sequential rule, vague answer handling, deferral handling, persistence, anti-patterns — all inline). [interview.md](interview.md) is lookup-only (examples + subagent prompt templates).
 **All YES + Ambiguity ≤ 0.2** → Proceed to Acceptance Criteria Drafting per `## Acceptance Criteria (Mandatory Contract)` below (two-line AC format, Zero Human Intervention, verification at consumer boundary, transparency, chaining template — all inline). [acceptance-criteria.md](acceptance-criteria.md) is lookup-only (per-tool examples).
 After AC is confirmed → Metis consultation automatically (**MUST read [review-pipeline.md](review-pipeline.md)** — three-agent pipeline, verdict handling, Stage A/B/C presentation).
 After Metis APPROVE/COMMENT → write plan per `## Plan Structure (Mandatory Contract)` below (defines structure, TODO 7-field format, AC 2-line format, QA scenarios, MECE/Atomicity, Final Verification Wave — all inline). [plan-template.md](plan-template.md) is lookup-only (worked examples).
@@ -270,6 +270,106 @@ The Planning-time Task Discipline is complementary (상보적) to the Pipeline S
 ### Reconciliation with Work-Principles Mandate
 
 `work-principles.md` mandates task creation before non-trivial work. This mandate applies equally during planning sessions. The platform's native task tool is the implementation vehicle, but discipline is the invariant, not the tool. Whether using the platform's native task-tracking tool, a checklist, or another tracking mechanism, the obligation — create tasks, track completion, never batch-complete — is non-negotiable.
+
+---
+
+## Interview Mode (Mandatory Contract)
+
+Interview rules are inline (not deferred to `interview.md`) so they cannot be partial-read away. The reference file is lookup-only (question categories, quality examples, subagent dispatch prompt templates).
+
+### Tool Use vs User Questions
+
+**The ONLY questions for users are about PREFERENCES, not FACTS.**
+
+| Question Type | Ask User? | Action |
+|---|---|---|
+| "Which project contains X?" | NO | Use explore first |
+| "What patterns exist in the codebase?" | NO | Use explore first |
+| "Where is X implemented?" | NO | Use explore first |
+| "What's the current architecture?" | NO | Use oracle |
+| "What's the tech stack?" | NO | Use explore first |
+| "What's your timeline?" | YES | AskUserQuestion |
+| "Should we prioritize speed or quality?" | YES | AskUserQuestion |
+| "What's the scope boundary?" | YES | AskUserQuestion |
+
+NEVER burden user with questions the codebase can answer. When user has no preference, select best practice autonomously.
+
+### Question Type Selection
+
+| Situation | Method |
+|---|---|
+| Decision with 2-4 clear options | AskUserQuestion (structured choices) |
+| Open-ended / subjective question | Plain text question |
+| Yes/No confirmation | Plain text question |
+| Complex trade-off | Markdown analysis + AskUserQuestion |
+
+**Do NOT force AskUserQuestion for open-ended questions.**
+
+### Sequential Interview Rule
+
+- **One question per message.** Wait for answer before next.
+- **Never bundle** multiple questions into a list, document, or compound prompt.
+- After each answer, evaluate Clearance Checklist (internal). If any item NO, continue interviewing.
+
+### Vague Answer Handling
+
+When users respond vaguely ("~is enough", "just do ~", "decide later"):
+1. **Do NOT accept as-is**
+2. **Ask specific clarifying questions**
+3. **Repeat until clear answer obtained**
+
+### User Deferral Handling (explicit defer is different from vague)
+
+When user explicitly defers ("skip", "I don't know", "your call"):
+1. Research autonomously via explore/librarian
+2. Select industry best practice or codebase-consistent approach
+3. Document: "Autonomous decision: [X] — user deferred, based on [rationale]"
+4. Continue without blocking
+
+### Persistence Rule
+
+**Continue until YOU have no questions left.** Not after 2-3 questions. The Clearance Checklist (items 1-6) is the gate — keep interviewing until all items YES + Ambiguity ≤ 0.2.
+
+### Progress Reporting (after each answer)
+
+```
+Round {n} | Ambiguity: {score}%
+
+| Dimension             | Score | Gap                 |
+|-----------------------|-------|---------------------|
+| Goal                  | {s}   | {gap or "Clear"}    |
+| Constraints           | {s}   | {gap or "Clear"}    |
+| Success Criteria      | {s}   | {gap or "Clear"}    |
+| Context (brownfield)  | {s}   | {gap or "Clear"}    |
+
+→ Next question targets: {weakest dimension}
+```
+
+The Clearance Checklist itself remains internal — only ambiguity scores are surfaced.
+
+### Subagent Use During Interview
+
+| Subagent | When to dispatch |
+|---|---|
+| **explore** | ANY codebase fact-finding (file paths, patterns, current implementation) |
+| **oracle** | Feasibility check, risk assessment, alternative evaluation, dependency mapping spanning 3+ modules, design decisions affecting performance/security/scalability |
+| **librarian** | New library introduction, major version upgrade, security-related technology choice — external authoritative documentation |
+
+Briefly announce "Consulting Oracle for [reason]" before invocation.
+
+**Spec Source Retrieval** (Scoped+ + user-facing changes): Ask user ONCE whether project specifications exist (Linear / Notion / Figma / PRD / design doc / user research). On reference provided, fetch via appropriate MCP or read tool — use as ground truth for AC and QA scenarios. Absence is NOT plan ceremony — proceed with interview-derived context.
+
+### Question Anti-Patterns
+
+| Anti-Pattern | Why |
+|---|---|
+| Multiple questions in one message | Confuses user, dilutes structured choice |
+| Bundling open questions into a list | Equivalent to compound AC — one weak answer hides issues |
+| Using AskUserQuestion for open-ended | Forces false structure; use plain text |
+| Asking codebase facts | Use explore — never burden user |
+| Stopping at 2-3 questions | Premature; clearance, not count, is the gate |
+
+> Examples (question categories, quality standard BAD/GOOD), Rich Context Pattern structure, detailed subagent prompt templates → [interview.md](interview.md). Lookup-only.
 
 ---
 
@@ -634,7 +734,7 @@ On selection: Option 1 → `Skill(skill: "sisyphus")` with plan path. Option 2 �
 
 | When | Read | Role |
 |------|------|------|
-| **Before conducting interviews (MANDATORY)** | **[interview.md](interview.md)** | Procedural + lookup |
+| **Looking up question category examples, BAD/GOOD quality patterns, or subagent prompt templates** | [interview.md](interview.md) | **Lookup-only** (contract is inline in `## Interview Mode` above) |
 | **Looking up per-tool AC Verification examples (maestro/playwright/curl/grep/CLI/unit)** | [acceptance-criteria.md](acceptance-criteria.md) | **Lookup-only** (contract is inline in `## Acceptance Criteria` above) |
 | **Looking up plan TODO/Execution/Success Criteria examples** | [plan-template.md](plan-template.md) | **Lookup-only** (contract is inline in `## Plan Structure` above) |
 | **Executing a specific reviewer invocation OR Stage A/B/C** | [review-pipeline.md](review-pipeline.md) | **Lookup-only** (contract is inline in `## Review Pipeline` above) |

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -530,7 +530,7 @@ Each TODO is a checkbox line `- [ ] N. Title` with body containing:
    - Every implementation TODO needs ≥1 Pattern or API/Type reference. Greenfield → "Greenfield — no existing pattern" explicitly.
    - **FINAL wave exemption**: F1-F4 audit tasks (Wave: FINAL) do NOT require Pattern/API/Type/Test/External references — their target IS the plan itself + the executed work. References field is optional for FINAL wave.
 5. **Parallelization** — `Blocked By: [list]`, `Blocks: [list]`, `Wave: N` (1-based, OR `Wave: FINAL` for F1-F4)
-6. **Acceptance Criteria** — Two-line format (Observable outcome + Verification). Full contract (Granularity, Consumer Boundary, Setup/Cleanup, Required Chaining Template, Anti-Patterns, Self-Check) is in `## Acceptance Criteria (Mandatory Contract)` above. Per-tool Verification examples → `acceptance-criteria.md` (lookup-only).
+6. **Acceptance Criteria** — Follow `## Acceptance Criteria (Mandatory Contract)` above.
 7. **QA Scenarios** — Minimum 2 per TODO (happy path + failure/edge case), 7-field structured block (see below)
 
 **Wave Assignment Rule**: `Wave = max(wave of each blocker) + 1`. Empty Blocked By = Wave 1. MANDATORY — no manual override. Anti-pattern: assigning Wave 2 to independent task because "it makes sense." If no dependency, Wave 1.
@@ -599,7 +599,7 @@ Wave field for F1-F4: `Wave: FINAL` (literal string). Numeric rule applies to im
 
 ## Review Pipeline (Mandatory Contract)
 
-Three-agent pipeline + Plan Presentation. All mandatory contracts (gate pattern, verdict handling, Revise definition, freshness rules, state machine, Plan Presentation mandate, **post-selection dispatch actions**) are inline below. Lookup material in `review-pipeline.md`: Metis/Oracle/Momus invocation templates, Stage A HTML rendering procedure (6 rendering + 3 translation invariants + template reference), Stage B Decision Matrix details, Stage C option *formatting* (not dispatch — dispatch is inline).
+Three-agent pipeline + Plan Presentation. All mandatory contracts inline below. Lookup material (invocation templates, Stage A rendering procedure, Stage B/C details) → `review-pipeline.md`.
 
 ### Three-Agent Pipeline
 

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -495,7 +495,7 @@ Run on every AC before proposing to user:
 
 ## Plan Structure (Mandatory Contract)
 
-This contract applies to EVERY plan regardless of intent (Trivial exempts only the Final Verification Wave). The contract lives here — not in a referenced file — so it cannot be missed via partial-read of a split reference.
+This contract applies to EVERY plan. The contract lives here — not in a referenced file — so it cannot be missed via partial-read of a split reference. (Trivial intent is exempt ONLY from the Final Verification Wave — see that section.)
 
 ### Plan Output Rules
 
@@ -527,7 +527,8 @@ Each TODO is a checkbox line `- [ ] N. Title` with body containing:
    - **API/Type**: types, interfaces, APIs + WHY
    - **Test**: existing test patterns + WHY
    - **External**: official docs, RFCs + WHY
-   - Every TODO needs ≥1 Pattern or API/Type reference. Greenfield → "Greenfield — no existing pattern" explicitly.
+   - Every implementation TODO needs ≥1 Pattern or API/Type reference. Greenfield → "Greenfield — no existing pattern" explicitly.
+   - **FINAL wave exemption**: F1-F4 audit tasks (Wave: FINAL) do NOT require Pattern/API/Type/Test/External references — their target IS the plan itself + the executed work. References field is optional for FINAL wave.
 5. **Parallelization** — `Blocked By: [list]`, `Blocks: [list]`, `Wave: N` (1-based, OR `Wave: FINAL` for F1-F4)
 6. **Acceptance Criteria** — Two-line format (Observable outcome + Verification). Detailed format in `acceptance-criteria.md`.
 7. **QA Scenarios** — Minimum 2 per TODO (happy path + failure/edge case), 7-field structured block (see below)

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -193,7 +193,7 @@ After loading context, classify the user's request. Classification determines in
 | **Greenfield** | Goal, Constraint, Success Criteria | 0.4, 0.3, 0.3 |
 | **Brownfield** | Goal, Constraint, Success Criteria, Context | 0.35, 0.25, 0.25, 0.15 |
 
-Before conducting interviews → follow `## Interview Mode (Mandatory Contract)` below (tool use vs user questions, sequential rule, vague answer handling, deferral handling, persistence, anti-patterns — all inline). [interview.md](interview.md) is lookup-only (examples + subagent prompt templates).
+Before conducting interviews → follow `## Interview Mode (Mandatory Contract)` below.
 **All YES + Ambiguity ≤ 0.2** → Proceed to Acceptance Criteria Drafting per `## Acceptance Criteria (Mandatory Contract)` below.
 After AC is confirmed → Metis consultation automatically per `## Review Pipeline (Mandatory Contract)` below.
 After Metis APPROVE/COMMENT → write plan per `## Plan Structure (Mandatory Contract)` below.

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -530,7 +530,7 @@ Each TODO is a checkbox line `- [ ] N. Title` with body containing:
    - Every implementation TODO needs ≥1 Pattern or API/Type reference. Greenfield → "Greenfield — no existing pattern" explicitly.
    - **FINAL wave exemption**: F1-F4 audit tasks (Wave: FINAL) do NOT require Pattern/API/Type/Test/External references — their target IS the plan itself + the executed work. References field is optional for FINAL wave.
 5. **Parallelization** — `Blocked By: [list]`, `Blocks: [list]`, `Wave: N` (1-based, OR `Wave: FINAL` for F1-F4)
-6. **Acceptance Criteria** — Two-line format (Observable outcome + Verification). Detailed format in `acceptance-criteria.md`.
+6. **Acceptance Criteria** — Two-line format (Observable outcome + Verification). Full contract (Granularity, Consumer Boundary, Setup/Cleanup, Required Chaining Template, Anti-Patterns, Self-Check) is in `## Acceptance Criteria (Mandatory Contract)` above. Per-tool Verification examples → `acceptance-criteria.md` (lookup-only).
 7. **QA Scenarios** — Minimum 2 per TODO (happy path + failure/edge case), 7-field structured block (see below)
 
 **Wave Assignment Rule**: `Wave = max(wave of each blocker) + 1`. Empty Blocked By = Wave 1. MANDATORY — no manual override. Anti-pattern: assigning Wave 2 to independent task because "it makes sense." If no dependency, Wave 1.
@@ -599,7 +599,7 @@ Wave field for F1-F4: `Wave: FINAL` (literal string). Numeric rule applies to im
 
 ## Review Pipeline (Mandatory Contract)
 
-Three-agent pipeline + Plan Presentation. Workflow-wide rules inline here; per-stage invocation templates + Stage A HTML rendering procedure → `review-pipeline.md` (lookup).
+Three-agent pipeline + Plan Presentation. All mandatory contracts (gate pattern, verdict handling, Revise definition, freshness rules, state machine, Plan Presentation mandate, **post-selection dispatch actions**) are inline below. Lookup material in `review-pipeline.md`: Metis/Oracle/Momus invocation templates, Stage A HTML rendering procedure (6 rendering + 3 translation invariants + template reference), Stage B Decision Matrix details, Stage C option *formatting* (not dispatch — dispatch is inline).
 
 ### Three-Agent Pipeline
 

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -496,6 +496,140 @@ Wave field for F1-F4: `Wave: FINAL` (literal string). Numeric rule applies to im
 
 ---
 
+## Review Pipeline (Mandatory Contract)
+
+Three-agent pipeline + Plan Presentation. Workflow-wide rules inline here; per-stage invocation templates + Stage A HTML rendering procedure → `review-pipeline.md` (lookup).
+
+### Three-Agent Pipeline
+
+| | Metis | Oracle | Momus |
+|---|---|---|---|
+| **Timing** | Pre-plan | Post-plan, pre-Momus | Post-Oracle |
+| **Input** | User Goal + Scope + AC | Plan + Codebase | Plan |
+| **Validates** | Requirements completeness | Codebase feasibility | Document quality |
+| **Reads code** | No | Yes (file:line) | No |
+
+### Common Gate Pattern (ALL reviewers)
+
+```
+MANDATORY: Reviewer MUST pass (APPROVE or COMMENT) before proceeding.
+- Do NOT proceed until APPROVE or COMMENT
+- On REQUEST_CHANGES: revise and re-invoke
+- On missing or ambiguous verdict: treat as REQUEST_CHANGES
+- Loop repeats indefinitely until pass
+- Skipping is NEVER permitted
+```
+
+A REQUEST_CHANGES verdict blocks ALL downstream progression — no stage advances until the blocking reviewer re-issues APPROVE or COMMENT after a proper Revise cycle.
+
+### Common Verdict Handling
+
+| Verdict | Action |
+|---------|--------|
+| **APPROVE** | Proceed to next stage |
+| **COMMENT** | Incorporate findings silently, proceed |
+| **REQUEST_CHANGES** | Revise, re-invoke. Loop until APPROVE or COMMENT |
+| **Missing / ambiguous** (no explicit verdict label, punch-list only, "verdict inferable") | Treat as REQUEST_CHANGES |
+
+> "Incorporate findings silently": absorb reviewer findings into your understanding. Reviewer names, verdict labels, advisory enumeration do NOT appear in plan body. Reviewers shape the plan; they do not annotate it.
+
+### Operational Definition of "Revise"
+
+Revise = exactly these three steps, in order:
+
+1. **Modify source material** to address every directive in the REQUEST_CHANGES verdict
+2. **Re-invoke the same reviewer type on a fresh agent instance** (Reviewer Freshness Rule)
+3. **Wait for a new APPROVE or COMMENT** on the revised material
+
+A sequence missing any step is not Revise. Self-assessment, paraphrasing the directive, partial fixes, deferring to a later TODO, executor-side fixes, asking the user to bypass — all fail step 2 or step 3.
+
+### Verdict Freshness Rule
+
+A verdict is valid only when issued by a reviewer agent on the **current version** of the artifact. Prior verdicts on earlier versions are expired.
+
+Self-assessment cannot substitute for a reviewer verdict. Even if prometheus believes the revision is correct, that belief is irrelevant — only the reviewer's re-issuance advances the pipeline.
+
+### Reviewer Freshness Rule
+
+Each reviewer invocation MUST use a **fresh agent instance**. Do not reuse an agent thread that has already issued a verdict on a prior version.
+
+**Rationale**: Reusing introduces commitment/consistency bias (Cialdini) — the agent rubber-stamps revisions because of prior commitment. Fresh instance evaluates without anchoring.
+
+**Enforcement**: Dispatch a new subagent via the platform's native subagent/dispatch primitive for every reviewer invocation. Do not pass prior verdict context into the new prompt.
+
+### Pipeline State Machine
+
+| State | Description | Transitions |
+|-------|-------------|-------------|
+| **S0: Interview Mode** | Gathering requirements | → S1 on Metis-ready clearance |
+| **S1: Metis Invocation** | 3-Section prompt to Metis | → S2 on APPROVE/COMMENT; → S0 on REQUEST_CHANGES |
+| **S2: Plan Generation** | Writing plan to `$OMT_DIR/plans/{name}.md` | → S3 on self-review pass |
+| **S3: Oracle Invocation** | Plan path to Oracle | → S4 on APPROVE/COMMENT; → S2 on REQUEST_CHANGES |
+| **S4: Momus Invocation** | Plan path to Momus | → S5 on APPROVE/COMMENT; → S2 on REQUEST_CHANGES |
+| **S5: Plan Presentation** | Stage A render + present to user | → S6 on user views plan |
+| **S6: Execution Recommendation** | Compute Stage B recommendation | → S7 on user receives |
+| **S7: Execution Bridge** | Stage C options + user selection | → S8 on selection; → S0 on "Revise plan" |
+| **S8: Execution Dispatch** | Invoke skill per selection | (terminal) |
+
+S7 → S0 edge: "Revise plan" returns to Interview Mode — full pipeline re-runs.
+
+### Loop Termination Rule
+
+Reviewer loop terminates **iff** the reviewer issues APPROVE or COMMENT on the current artifact version. REQUEST_CHANGES → Revise. Missing/ambiguous → treat as REQUEST_CHANGES.
+
+Time pressure, user override ("just proceed"), self-assessment of fix correctness, parallel dispatch on a blocked artifact — none terminate the loop.
+
+### Self-Review Checklist (after plan generation, before Oracle)
+
+| # | Item | Check |
+|---|------|-------|
+| 1 | All TODOs have acceptance criteria | Every TODO specifies verifiable completion criteria |
+| 2 | File references exist | All file paths and line references resolve |
+| 3 | Guardrails from Metis incorporated | Every Metis-flagged constraint reflected |
+| 4 | Zero human-intervention criteria | No TODO requires manual mid-execution action |
+
+Failure action: loop back and fix before submitting to Oracle.
+
+### Gap Classification (post-plan self-review)
+
+| Level | Definition | Handling |
+|---|---|---|
+| **CRITICAL** | Requires user input | Return to Interview Mode |
+| **MINOR** | Self-resolvable from context | Resolve inline during plan revision |
+| **AMBIGUOUS** | Standard convention / safe default exists | Apply documented default, note in plan |
+
+### Plan Presentation (S5/S6/S7 — MANDATORY after Momus APPROVE)
+
+This step CANNOT be skipped. After Momus APPROVE/COMMENT, prometheus MUST execute Stages A → B → C before any user-facing handoff. Skipping = treating the plan as user-ready when it is unrendered. **Past sessions have skipped Stage A entirely; do NOT.**
+
+| Stage | Mandate | Detail location |
+|---|---|---|
+| **Stage A** | Render plan → `$OMT_DIR/plans/plan.html` (single-file, browser-openable). Verbatim plan content + session-derived boxes (Stage B recommendation, Pipeline State). Graceful fallback: if conversion fails, present raw markdown and continue to Stage B. | Rendering procedure (6 invariants, 3 translation invariants, template reference) in `review-pipeline.md` |
+| **Stage B** | Compute execution recommendation using Decision Matrix (TODO count, Complex/Architecture flag, AC gap, Ambiguity Score, Oracle COMMENT signals). Output: Recommendation + Mode + Rationale + What-tips-the-balance. | Decision Matrix details in `review-pipeline.md` |
+| **Stage C** | Execution Bridge via platform's user-prompt primitive — 3 options (Full orchestration / Focused execution / Revise plan). `(Recommended)` label computed from Decision Matrix, NOT hardcoded. | Option formatting in `review-pipeline.md` |
+
+On selection: Option 1 → `Skill(skill: "sisyphus")` with plan path. Option 2 → delegate to sisyphus-junior. Option 3 → return to Interview Mode.
+
+**IMPORTANT**: On execution selection, MUST invoke via `Skill()` or delegate. Do NOT tell user to run a command manually.
+
+### Reviewer Invocation Anti-Patterns
+
+| Reviewer | Anti-Pattern | Problem |
+|---|---|---|
+| Metis | Summarized AC | Verifiability uncheckable |
+| Metis | Abstract scope | Completeness uncheckable |
+| Metis | Missing user goal | Intent unclassifiable |
+| Oracle | Restating plan content in prompt | Oracle reads file — token waste |
+| Oracle | Asking for code review | Oracle reviews feasibility, not code quality |
+| Oracle | Skipping after Metis APPROVE | Gate violation — Oracle mandatory |
+| Momus | Repeating plan content | Momus reads file — token waste |
+| Momus | Separate metis results in prompt | Already in Plan Context + anchoring risk |
+| Momus | Adding review instructions | Momus has own criteria |
+
+> Detailed invocation templates (3-Section Metis, Oracle Verification Focus, Momus path-only) + Stage A HTML rendering procedure (6 rendering invariants, 3 translation invariants, template reference, substitution semantics) + Stage B Decision Matrix details + Stage C option formatting → [review-pipeline.md](review-pipeline.md). Lookup-only — read the relevant section when executing that specific stage.
+
+---
+
 ## Reference Guides
 
 | When | Read | Role |
@@ -503,4 +637,4 @@ Wave field for F1-F4: `Wave: FINAL` (literal string). Numeric rule applies to im
 | **Before conducting interviews (MANDATORY)** | **[interview.md](interview.md)** | Procedural + lookup |
 | **Looking up per-tool AC Verification examples (maestro/playwright/curl/grep/CLI/unit)** | [acceptance-criteria.md](acceptance-criteria.md) | **Lookup-only** (contract is inline in `## Acceptance Criteria` above) |
 | **Looking up plan TODO/Execution/Success Criteria examples** | [plan-template.md](plan-template.md) | **Lookup-only** (contract is inline in `## Plan Structure` above) |
-| **Before invoking Metis/Oracle/Momus (MANDATORY — verdict handling, Stage A/B/C)** | **[review-pipeline.md](review-pipeline.md)** | Procedural + lookup |
+| **Executing a specific reviewer invocation OR Stage A/B/C** | [review-pipeline.md](review-pipeline.md) | **Lookup-only** (contract is inline in `## Review Pipeline` above) |

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -194,7 +194,7 @@ After loading context, classify the user's request. Classification determines in
 | **Brownfield** | Goal, Constraint, Success Criteria, Context | 0.35, 0.25, 0.25, 0.15 |
 
 Before conducting interviews → **MUST read [interview.md](interview.md)** — question types, vague answer handling, sequential interview rules.
-**All YES + Ambiguity ≤ 0.2** → Proceed to Acceptance Criteria Drafting (**MUST read [acceptance-criteria.md](acceptance-criteria.md)** — two-line AC format, Zero Human Intervention, verification thinking).
+**All YES + Ambiguity ≤ 0.2** → Proceed to Acceptance Criteria Drafting per `## Acceptance Criteria (Mandatory Contract)` below (two-line AC format, Zero Human Intervention, verification at consumer boundary, transparency, chaining template — all inline). [acceptance-criteria.md](acceptance-criteria.md) is lookup-only (per-tool examples).
 After AC is confirmed → Metis consultation automatically (**MUST read [review-pipeline.md](review-pipeline.md)** — three-agent pipeline, verdict handling, Stage A/B/C presentation).
 After Metis APPROVE/COMMENT → write plan per `## Plan Structure (Mandatory Contract)` below (defines structure, TODO 7-field format, AC 2-line format, QA scenarios, MECE/Atomicity, Final Verification Wave — all inline). [plan-template.md](plan-template.md) is lookup-only (worked examples).
 
@@ -270,6 +270,126 @@ The Planning-time Task Discipline is complementary (상보적) to the Pipeline S
 ### Reconciliation with Work-Principles Mandate
 
 `work-principles.md` mandates task creation before non-trivial work. This mandate applies equally during planning sessions. The platform's native task tool is the implementation vehicle, but discipline is the invariant, not the tool. Whether using the platform's native task-tracking tool, a checklist, or another tracking mechanism, the obligation — create tasks, track completion, never batch-complete — is non-negotiable.
+
+---
+
+## Acceptance Criteria (Mandatory Contract)
+
+AC contract is inline (not deferred to `acceptance-criteria.md`) because split-reference rules suffer partial-read. The reference file is now lookup-only (per-tool Verification examples + worked example).
+
+### When to Draft
+
+If user does not provide AC, you MUST draft them. Propose → user confirms → finalize. NEVER proceed to Metis without confirmed AC.
+
+### AC Format (two-line, mandatory)
+
+```
+- [ ] **[Observable outcome]**: WHAT state change is visible after completion
+      **Verification**: HOW to confirm — executable command, observable behavior, or state assertion
+```
+
+Optional `Setup` / `Cleanup` lines when Verification mutates state. The criterion is the contract between planner and executor; executor has NO interview context.
+
+### AC Granularity (1 AC = 1 observable state change)
+
+Each AC describes a single atomic outcome confirmed by a single Verification command. Compound ACs bundle independent changes — one failure hides others. Decompose: one AC per state change.
+
+### Verification at Consumer Boundary (MANDATORY)
+
+Verify at the layer the consumer observes:
+
+| Deliverable | Consumer | AC Layer |
+|---|---|---|
+| Mobile feature | End user | Maestro UI scenario |
+| Web feature | End user | Playwright UI scenario |
+| HTTP API | API client | curl + jq integration |
+| CLI command | Shell user | exec + stdout assertion |
+| Library function | Calling dev/agent | unit test (with consumer-boundary justification) |
+
+**Anti-tautology rule**: Prometheus specifies the input/output or behavioral constraint in the AC text. Do NOT delegate "what counts as passing" to executor — meta-circular verification.
+
+Implementation test files (`*.test.ts`, `*.spec.ts`) are implementation evidence, NOT default AC primitives. Citing a unit test as AC requires: (1) who's the consumer of this unit? (2) where invoked directly (file:line)? (3) why is this unit the consumer boundary?
+
+### Verification Transparency (4-question rule)
+
+Reviewer must answer 4 questions from AC text alone:
+1. What state must exist before Verification? (Setup)
+2. What command verifies the requirement? (Verification)
+3. What does success look like? (Expected outcome)
+4. How is state restored, if needed? (Cleanup)
+
+### State Mutation: Setup / Cleanup
+
+If Verification mutates state (DB rows, files, registered users, keychain entries), AC must declare Setup/Cleanup OR rely on isolation (ephemeral schema, randomized IDs, container-per-run).
+
+| Field | Purpose |
+|---|---|
+| **Setup** | Commands establishing required state (run before Verification) |
+| **Cleanup** | Commands reverting mutations (run after Verification, even on failure) |
+
+Omit when: read-only Verification, runner provides isolation. Strongly recommended when mutations cross persistent boundaries (DB, FS outside `/tmp`, simulator state).
+
+### Required Chaining Template (executable safety contract)
+
+Setup/Verification/Cleanup share a single shell session. Executor MUST chain so that (a) Cleanup runs unconditionally and (b) Verification's exit code is preserved:
+
+```bash
+setup_cmd && { verify_cmd; VERIFY_EXIT=$?; } || VERIFY_EXIT=$?
+cleanup_cmd
+exit ${VERIFY_EXIT:-1}
+```
+
+Forbidden patterns:
+
+| Pattern | Why forbidden |
+|---|---|
+| `verify_cmd && cleanup_cmd` | Skips Cleanup on verification failure → resource leak |
+| `verify_cmd; cleanup_cmd` | Cleanup exit code masks verification failure → false PASS |
+
+Defensive Cleanup guard for unset IDs: `[ -n "$id" ] && curl -X DELETE ".../$id" || true`.
+
+### Executor-Provided Variables
+
+AC may reference ambient variables exported by Argus Stage 3:
+
+| Variable | Scope | Source |
+|---|---|---|
+| `$API_BASE_URL` | HTTP API ACs | Stage 3, Step 3.2 (server boot) |
+| `$IOS_UDID` | iOS mobile ACs | Stage 3, Step 3.5 (simulator boot) |
+| `$ANDROID_SERIAL` | Android mobile ACs | Stage 3, Step 3.5 (emulator boot) |
+| `$evidence_xml` | Tool ACs emitting a report file | Stage 3, per-AC (resolved before each verification) |
+
+Adding a new variable requires (1) updating this table and (2) ensuring executor exports it. Introduce only when ≥2 AC kinds reference.
+
+### Reference Integration (when user provides references)
+
+When user specifies references ("reference X", "based on Y pattern"):
+1. Each reference MUST produce ≥1 AC item with a specific behavioral constraint derived from that reference
+2. Constraint must be verifiable without reading the reference itself — self-contained
+
+If a reference cannot produce a specific behavioral constraint, ask: "What specific aspect of [reference] should the implementation follow?"
+
+### AC Anti-Patterns (cheat-sheet)
+
+| Anti-Pattern | Why It Fails | Fix |
+|---|---|---|
+| File listing ("shared/lib/x.js created") | Implementation detail | Outcome at consumer boundary + grep verification |
+| Section adding ("Add ## Model section") | Action, not result | Behavioral outcome ("protocol contains X instruction") |
+| Vague verification ("Verify it works") | Not executable | Name command, state, or assertion |
+| Task restatement ("Auth implemented") | Restates task | Observable consumer behavior ("Unauthenticated /api/* returns 401") |
+| Universal truths ("All tests pass") | Always-true, not plan-specific | Move to Verification Strategy |
+| Absence-only ("X not in grep") | Deletion alone passes | Presence checks first, then absence |
+| Compound AC | Bundles independent changes — one failure hides others | Decompose per state change |
+| State-mutating without teardown | Re-runs fail (409 Conflict) | Setup + Cleanup or unique-input scoping |
+
+### AC Self-Check (mandatory before finalizing)
+
+Run on every AC before proposing to user:
+- [ ] If Verification passes, does the consumer actually receive value?
+- [ ] Does an implementation exist that passes Verification vacuously? If yes, layer is too deep — move outward.
+- [ ] If citing a unit test, did you justify the unit as consumer-facing (per the three questions above)?
+
+> Per-tool Verification examples (maestro, playwright, curl, grep, CLI, unit) + worked example + Handling User Response → [acceptance-criteria.md](acceptance-criteria.md). Lookup-only.
 
 ---
 
@@ -381,6 +501,6 @@ Wave field for F1-F4: `Wave: FINAL` (literal string). Numeric rule applies to im
 | When | Read | Role |
 |------|------|------|
 | **Before conducting interviews (MANDATORY)** | **[interview.md](interview.md)** | Procedural + lookup |
-| **Before AC drafting (MANDATORY — two-line format, Zero Human Intervention)** | **[acceptance-criteria.md](acceptance-criteria.md)** | Procedural + lookup |
+| **Looking up per-tool AC Verification examples (maestro/playwright/curl/grep/CLI/unit)** | [acceptance-criteria.md](acceptance-criteria.md) | **Lookup-only** (contract is inline in `## Acceptance Criteria` above) |
 | **Looking up plan TODO/Execution/Success Criteria examples** | [plan-template.md](plan-template.md) | **Lookup-only** (contract is inline in `## Plan Structure` above) |
 | **Before invoking Metis/Oracle/Momus (MANDATORY — verdict handling, Stage A/B/C)** | **[review-pipeline.md](review-pipeline.md)** | Procedural + lookup |

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -167,7 +167,7 @@ After loading context, classify the user's request. Classification determines in
 | **Complex** | Compute + anti-pattern review | Full + anti-pattern cross-check | Full + smell-action table |
 | **Architecture** | Brownfield + oracle validation | Full validation | Full check (3 conditions) |
 
-> Detailed definitions for MECE and Atomicity are in [plan-template.md](plan-template.md). Ambiguity Score is defined in the Clearance Checklist section above.
+> MECE, Atomicity, and Plan Structure Contract are defined inline below in `## Plan Structure (Mandatory Contract)`. Ambiguity Score is defined in the Clearance Checklist section above.
 
 **Clearance Checklist 6 items apply to ALL intents.** Only depth and rigor vary.
 
@@ -196,7 +196,7 @@ After loading context, classify the user's request. Classification determines in
 Before conducting interviews → **MUST read [interview.md](interview.md)** — question types, vague answer handling, sequential interview rules.
 **All YES + Ambiguity ≤ 0.2** → Proceed to Acceptance Criteria Drafting (**MUST read [acceptance-criteria.md](acceptance-criteria.md)** — two-line AC format, Zero Human Intervention, verification thinking).
 After AC is confirmed → Metis consultation automatically (**MUST read [review-pipeline.md](review-pipeline.md)** — three-agent pipeline, verdict handling, Stage A/B/C presentation).
-After Metis APPROVE/COMMENT → **MUST read [plan-template.md](plan-template.md)** before writing the plan — structure, TODO 7-field format, AC 2-line format, QA scenarios, Final Verification Wave defined ONLY there.
+After Metis APPROVE/COMMENT → write plan per `## Plan Structure (Mandatory Contract)` below (defines structure, TODO 7-field format, AC 2-line format, QA scenarios, MECE/Atomicity, Final Verification Wave — all inline). [plan-template.md](plan-template.md) is lookup-only (worked examples).
 
 This checklist is internal — do not present it to the user.
 
@@ -273,11 +273,114 @@ The Planning-time Task Discipline is complementary (상보적) to the Pipeline S
 
 ---
 
+## Plan Structure (Mandatory Contract)
+
+This contract applies to EVERY plan regardless of intent (Trivial exempts only the Final Verification Wave). The contract lives here — not in a referenced file — so it cannot be missed via partial-read of a split reference.
+
+### Plan Output Rules
+
+- **Location**: `$OMT_DIR/plans/{name}.md`
+- **Language**: English
+- **Exclude**: Vague criteria ("verify it works")
+
+### Plan Sections (all required)
+
+| Section | Contents |
+|---------|----------|
+| **TL;DR** | Quick summary, deliverables (bullet list), estimated effort (Quick/Short/Medium/Large/XL), Parallel Execution (YES/NO + wave description), Critical Path |
+| **Context** | Original Request (verbatim), Interview summary (key decisions — the WHY behind each TODO) |
+| **Work Objectives** | Core objective, Definition of Done, Must Have, Must NOT Have / Guardrails |
+| **TODOs** | Numbered checkboxed tasks per TODO 7-field format below |
+| **Execution Strategy** | Wave visualization, Dependency Matrix, Critical Path. Target 5-8 tasks/wave. Circular dependencies forbidden. **Final Verification Wave mandatory for Scoped+ intent.** |
+| **Verification Strategy** | Test decision (TDD/tests-after/none), framework, verification commands. Zero Human Intervention — agent-executed with evidence to `$OMT_DIR/evidence/{plan-name}/` |
+| **Success Criteria** | Binary pass/fail end state. Verification commands + final checklist |
+
+### TODO Task Format (7 fields, all required)
+
+Each TODO is a checkbox line `- [ ] N. Title` with body containing:
+
+1. **What to do** — Content, Scope, Approach, Inputs, Decisions from interview. Executor has NO interview context — faithfully transfer conclusions.
+2. **Must NOT do** — Explicit forbidden scope
+3. **Files** — What this TODO creates or modifies
+4. **References (CRITICAL)** — Executor has NO interview context. Provide:
+   - **Pattern**: `file:line-range` + WHY (what to adopt)
+   - **API/Type**: types, interfaces, APIs + WHY
+   - **Test**: existing test patterns + WHY
+   - **External**: official docs, RFCs + WHY
+   - Every TODO needs ≥1 Pattern or API/Type reference. Greenfield → "Greenfield — no existing pattern" explicitly.
+5. **Parallelization** — `Blocked By: [list]`, `Blocks: [list]`, `Wave: N` (1-based, OR `Wave: FINAL` for F1-F4)
+6. **Acceptance Criteria** — Two-line format (Observable outcome + Verification). Detailed format in `acceptance-criteria.md`.
+7. **QA Scenarios** — Minimum 2 per TODO (happy path + failure/edge case), 7-field structured block (see below)
+
+**Wave Assignment Rule**: `Wave = max(wave of each blocker) + 1`. Empty Blocked By = Wave 1. MANDATORY — no manual override. Anti-pattern: assigning Wave 2 to independent task because "it makes sense." If no dependency, Wave 1.
+
+### QA Scenario 7-Field Structure
+
+Each scenario:
+- **Scenario**: `{Name} — {Purpose}`
+- **Tool**: CLI command (`curl`, `bun test`, `playwright`, `maestro`, `grep` — NOT prose descriptions)
+- **Preconditions**: Scenario-level setup state
+- **Steps**: Numbered exact commands
+- **Expected**: Observable outcome on success
+- **Failure**: Specific failure symptoms (NOT "Expected does not happen")
+- **Evidence**: `$OMT_DIR/evidence/{plan-name}/{task-slug}/{scenario-slug}.{ext}`
+
+Specificity: API → exact paths/methods, HTTP codes, JSON field paths. UI → CSS selectors, DOM state assertions. All → concrete test data, wait conditions, ≥1 failure scenario per task.
+
+### MECE Decomposition
+
+Tasks must be Mutually Exclusive (no overlap) and Collectively Exhaustive (full coverage). Self-check after drafting TODOs:
+
+| Check | Action |
+|-------|--------|
+| **Overlap** | Two TODOs modify same file for same purpose? → Merge or split by layer |
+| **Coverage** | All TODOs complete → requirement fulfilled? → Add missing TODO |
+| **Hidden coupling** | Implicit state, ordering, undeclared deps? → Make explicit or merge |
+
+Anti-patterns: same-file overlap (merge or split by layer), CRUD gap (add missing op), false MECE — "frontend"/"backend" but contract owned by neither (add contract TODO).
+
+### Atomicity Heuristic
+
+Each TODO must be completable in one delegation pass:
+
+| Condition | Threshold |
+|-----------|-----------|
+| Concern scope | 1 concern per task |
+| File scope | 1-3 files per task (hard backstop) |
+| Single-delegation | Finish without mid-task coordination |
+
+Smell → action: "and" in description → split. Spans unrelated concerns → one TODO per responsibility. Requires sequential phases → each phase = own TODO with Blocked By. Touches 4+ files → decompose by responsibility.
+
+**Vertical Slice Rule**: Prefer vertical slices (one feature end-to-end) over horizontal (all models, then all services). Exception: shared foundation tasks in Wave 1.
+
+### Maximum Parallelism
+
+| Rule | Threshold |
+|------|-----------|
+| Granularity | 1 task = 1 concern = 1-3 files. 4+ files or 2+ concerns → SPLIT |
+| Parallelism Target | 5-8 tasks per wave. <3 in non-bottleneck wave = under-split |
+| Dependency Minimization | Shared deps (types, interfaces) as Wave-1 tasks |
+
+### Final Verification Wave (MANDATORY for Scoped+ intent — Trivial exempt)
+
+Every plan with Scoped or higher intent MUST include Final Verification Wave at the end. ALL F1-F4 must APPROVE. Rejection → fix task → re-enter implementation → full F1-F4 re-run.
+
+- **F1. Plan Compliance Audit** — Read plan end-to-end. For each "Must Have": verify implementation exists. For each "Must NOT Have": search for forbidden patterns. Check evidence files in `$OMT_DIR/evidence/`. Output: `Must Have [N/N] | Must NOT Have [N/N] | VERDICT`.
+- **F2. Code Quality Review** — Run build + linter + tests. Review changed files for: `as any`, empty catches, console.log, unused imports. Check AI slop: excessive comments, over-abstraction, generic names. Output: `Build [PASS/FAIL] | Tests [N/N] | VERDICT`.
+- **F3. QA Scenario Execution** — Execute EVERY QA scenario from EVERY task. Test cross-task integration. Save evidence to `$OMT_DIR/evidence/{plan-name}/final-qa/`. Output: `Scenarios [N/N pass] | Integration [N/N] | VERDICT`.
+- **F4. Scope Fidelity Check** — For each task: read spec, read actual diff. Verify 1:1 correspondence (no missing, no creep). Check "Must NOT do" compliance. Detect cross-task contamination. Output: `Tasks [N/N compliant] | VERDICT`.
+
+Wave field for F1-F4: `Wave: FINAL` (literal string). Numeric rule applies to implementation tasks only.
+
+> Worked examples (TODO body example, Wave visualization, Success Criteria template) → [plan-template.md](plan-template.md). The examples are lookup-only; the contract above is authoritative.
+
+---
+
 ## Reference Guides
 
-| When | Read |
-|------|------|
-| **Before conducting interviews (MANDATORY)** | **[interview.md](interview.md)** |
-| **Before AC drafting (MANDATORY — two-line format, Zero Human Intervention)** | **[acceptance-criteria.md](acceptance-criteria.md)** |
-| **Before writing the plan (MANDATORY — structure/TODO format/AC/QA/Final Verification Wave defined ONLY here)** | **[plan-template.md](plan-template.md)** |
-| **Before invoking Metis/Oracle/Momus (MANDATORY — verdict handling, Stage A/B/C)** | **[review-pipeline.md](review-pipeline.md)** |
+| When | Read | Role |
+|------|------|------|
+| **Before conducting interviews (MANDATORY)** | **[interview.md](interview.md)** | Procedural + lookup |
+| **Before AC drafting (MANDATORY — two-line format, Zero Human Intervention)** | **[acceptance-criteria.md](acceptance-criteria.md)** | Procedural + lookup |
+| **Looking up plan TODO/Execution/Success Criteria examples** | [plan-template.md](plan-template.md) | **Lookup-only** (contract is inline in `## Plan Structure` above) |
+| **Before invoking Metis/Oracle/Momus (MANDATORY — verdict handling, Stage A/B/C)** | **[review-pipeline.md](review-pipeline.md)** | Procedural + lookup |

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -194,9 +194,9 @@ After loading context, classify the user's request. Classification determines in
 | **Brownfield** | Goal, Constraint, Success Criteria, Context | 0.35, 0.25, 0.25, 0.15 |
 
 Before conducting interviews → follow `## Interview Mode (Mandatory Contract)` below (tool use vs user questions, sequential rule, vague answer handling, deferral handling, persistence, anti-patterns — all inline). [interview.md](interview.md) is lookup-only (examples + subagent prompt templates).
-**All YES + Ambiguity ≤ 0.2** → Proceed to Acceptance Criteria Drafting per `## Acceptance Criteria (Mandatory Contract)` below (two-line AC format, Zero Human Intervention, verification at consumer boundary, transparency, chaining template — all inline). [acceptance-criteria.md](acceptance-criteria.md) is lookup-only (per-tool examples).
-After AC is confirmed → Metis consultation automatically (**MUST read [review-pipeline.md](review-pipeline.md)** — three-agent pipeline, verdict handling, Stage A/B/C presentation).
-After Metis APPROVE/COMMENT → write plan per `## Plan Structure (Mandatory Contract)` below (defines structure, TODO 7-field format, AC 2-line format, QA scenarios, MECE/Atomicity, Final Verification Wave — all inline). [plan-template.md](plan-template.md) is lookup-only (worked examples).
+**All YES + Ambiguity ≤ 0.2** → Proceed to Acceptance Criteria Drafting per `## Acceptance Criteria (Mandatory Contract)` below.
+After AC is confirmed → Metis consultation automatically per `## Review Pipeline (Mandatory Contract)` below.
+After Metis APPROVE/COMMENT → write plan per `## Plan Structure (Mandatory Contract)` below.
 
 This checklist is internal — do not present it to the user.
 

--- a/skills/prometheus/acceptance-criteria.md
+++ b/skills/prometheus/acceptance-criteria.md
@@ -1,268 +1,26 @@
-# Acceptance Criteria Reference
+# Acceptance Criteria — Lookup
 
-**If user does not provide acceptance criteria, you MUST draft them.**
+**This file is lookup-only.** All mandatory AC rules (two-line format, Granularity, Consumer Boundary, Transparency, Setup/Cleanup, Required Chaining Template, Executor-Provided Variables, Reference Integration, Anti-Patterns, Self-Check) are defined inline in `SKILL.md > ## Acceptance Criteria (Mandatory Contract)`. The contract is authoritative; this file is per-tool examples + a worked example.
 
-## When to Draft
+Read this file when you want a concrete example for a specific tool, or want to consult a worked AC proposal.
 
-| User Provides | Your Action |
-|---------------|-------------|
-| Requirements + Acceptance Criteria | Use provided criteria, clarify if ambiguous |
-| Requirements only | Draft AC, propose to user for confirmation |
-| Vague request | Interview first, then draft based on clarified requirements |
-
-## Drafting Process
-
-1. **Analyze requirements** — Extract implicit success conditions
-2. **Draft criteria** — Write measurable, testable conditions
-3. **Propose to user** — Present draft and ask for confirmation/modification
-4. **Iterate** — Refine based on user feedback
-5. **Finalize** — Include confirmed criteria in plan
-
-## Reference Integration (MANDATORY when user provides references)
-
-When the user specifies references ("reference X", "based on Y pattern"):
-
-1. Each reference MUST produce at least one AC item with a **specific behavioral constraint derived from that reference**
-2. The constraint must be verifiable without reading the reference itself — self-contained
-
-| Pattern | WRONG | RIGHT |
-|---------|-------|-------|
-| "reference config.json" | "References config.json" | "Weighting follows priority ranking defined in config.json" |
-| "follow prompt-injection.ts pattern" | "Uses prompt-injection.ts pattern" | "Final prompt has 3-layer structure: system instructions, untrusted content with injection-safe delimiter, user prompt" |
-
-If a reference cannot produce a specific behavioral constraint, ask: "What specific aspect of [reference] should the implementation follow?"
-
-## AC Format (MANDATORY)
-
-Each criterion MUST include the following two required lines:
-
-- [ ] **[Observable outcome]**: WHAT state change is visible after completion
-      **Verification**: HOW to confirm — executable command, observable behavior, or state assertion
-
-Optional `Setup` / `Cleanup` lines may be added when state mutation requires them — see `## State Mutation: Setup / Cleanup` below.
-
-The criterion is the **contract between planner and executor**. The executor has NO interview context.
-
-## Verification Thinking Checklist
-
-When writing Verification for each criterion, run iteratively until PASS:
-
-| # | Question | On Failure |
-|---|----------|------------|
-| 1 | **What concrete state is intended?** | Rewrite vague outcomes as specific desired states |
-| 2 | **If all verifications pass, is AC fulfillment guaranteed?** | Add missing checks, return to Check 1 |
-
-**Example** — AC: "Extract duplicate validation logic into shared ValidationModule"
-
-```
---- Verification ---
-  (1) ValidationModule exports shared validation functions
-  (2) UserService and OrderService import from ValidationModule
-  (3) No inline validation logic duplicated across services
-
---- Check 1: Concrete state? ---
-  (a) Shared module exists → (1) covers
-  (b) Both services use it → (2) covers
-  (c) Duplicates removed → (3) covers
-
---- Check 2: Fulfillment guaranteed? ---
-  (1) passes → module exists  (2) passes → used  (3) passes → no duplication
-  → PASS
-```
-
-## Proposal Format
-
-Organize by **work item** (not by functional/technical category):
-
-1. State the **responsibility** — WHY this work item exists (what goes wrong if removed)
-2. List acceptance criteria using the required two-line format (plus optional Setup/Cleanup)
-3. Specify what this work item does NOT cover
-
-Overall structure:
-- Per-work-item sections with responsibility + criteria + not-scope
-- A final "Out of Scope" section for the entire plan
-- Review questions for user confirmation
-
-## AC Anti-Patterns
-
-| Anti-Pattern | Example | Why It Fails | Instead |
-|-------------|---------|--------------|---------|
-| **File listing** | "shared/lib/worker-core.js created with splitCommand" | Implementation detail, not outcome | "Common logic managed from single source. Verification: grep shows both modules import from shared" |
-| **Section adding** | "Add ## Model section to SKILL.md" | Action, not verifiable result | "Synthesis protocol contains model weighting instruction" |
-| **Vague verification** | "Verify it works", "dry-run review" | Not executable | Name the command, state, or assertion |
-| **Task restatement** | "Authentication is implemented" | Restates the task | "Unauthenticated /api/* requests return 401" |
-| **Universal truths** | "All tests pass" | Always true, not plan-specific | Move to Verification Strategy |
-| **Absence-only** | "X not found in grep" | Deletion alone passes | Write presence checks first, then add absence checks |
-| **Compound AC** | "All tests pass", "46 findings resolved", "X and Y implemented" | Bundles multiple independent state changes — one failure hides others | Decompose: one AC per state change, each with its own Verification command |
-| **State-mutating without teardown** | "Insert user / Verification: `curl -X POST /users -d @fixture.json`" | Re-runs fail with 409 Conflict; opaque global resets hide preconditions | Prefer (a) runner-native isolation, (b) API-symmetric cleanup, or (c) unique-input scoping (uuidgen) — see Verification Transparency Rule |
-
-## AC Granularity Principle
-
-**1 AC = exactly 1 observable state change.** Each AC must describe a single, atomic outcome confirmed by a single verification command.
-
-> Detail rules — verb red-flag list, batch pattern matrix, rationalization table — live in the reviewer skills (`agents/metis.md` AC Quality Detail Rules / `skills/momus/SKILL.md` AC Quality Detail Rules).
-
-## State Mutation: Setup / Cleanup
-
-If a Verification command mutates state (creates DB rows, writes files, registers users, holds keychain entries), the AC must declare how state is established before the run and torn down after, OR rely on isolation (ephemeral schema, randomized test IDs, container-per-run).
-
-Two optional fields:
-
-- **Setup**: command(s) that establish required state (run before Verification)
-- **Cleanup**: command(s) that revert mutations (run after Verification, even on failure)
-
-Either field may be omitted when:
-- The Verification is read-only (text scan, GET request, file existence check)
-- The runner provides isolation (`--db-schema=test_$RANDOM`, container-per-test, `xcrun simctl erase all`)
-
-When mutations cross persistent boundaries (DB, filesystem outside `/tmp`, simulator state), Setup and Cleanup are STRONGLY recommended.
-
-## Execution Semantics
-
-Setup, Verification, and Cleanup blocks share a single shell session by contract. Variables set in earlier blocks (Setup, Verification) are visible to later blocks (Cleanup). The executor runs them as a chained expression or within the same shell process, NOT as separate `bash -c` invocations.
-
-This contract enables the canonical pattern:
-
-- Setup creates a resource and exports its ID
-- Verification reads the resource using the exported ID
-- Cleanup deletes the resource using the same ID
-
-Even with this contract, defensive Cleanup guards against unset/empty IDs (in case Setup or Verification fails before assignment): `[ -n "$id" ] && curl -X DELETE ".../$id" || true`. The guard prevents a destructive collapse to a collection endpoint URL when the resource was never created.
-
-### Required chaining template
-
-The executor MUST chain Setup, Verification, and Cleanup so that (a) Cleanup runs unconditionally and (b) Verification's exit code is preserved as the AC outcome.
-
-```bash
-setup_cmd && { verify_cmd; VERIFY_EXIT=$?; } || VERIFY_EXIT=$?
-cleanup_cmd
-exit ${VERIFY_EXIT:-1}
-```
-
-Forbidden patterns:
-
-| Pattern | Why forbidden |
-|---------|---------------|
-| `verify_cmd && cleanup_cmd` | Skips Cleanup on verification failure → resource leak |
-| `verify_cmd; cleanup_cmd` | Cleanup's exit code masks verification failure → false PASS |
-
-## Executor-Provided Variables
-
-AC Verification commands may reference ambient variables listed below. The executor (Argus) exports these during the Stage 3 substep listed in the "Provided by" column. AC text must NOT inline the derivation of these variables — derivation lives with the executor as the single source of truth.
-
-| Variable | Scope | Provided by |
-|----------|-------|-------------|
-| `$API_BASE_URL` | HTTP API ACs | Argus Stage 3, Step 3.2 (server boot) |
-| `$IOS_UDID` | iOS mobile ACs | Argus Stage 3, Step 3.5 (simulator boot) |
-| `$ANDROID_SERIAL` | Android mobile ACs | Argus Stage 3, Step 3.5 (emulator boot) |
-| `$evidence_xml` | Tool ACs that emit a report file (`maestro --output`, `playwright --reporter=junit ... --output`) | Argus Stage 3 (per-AC, resolved via Evidence Path Priority before each verification) |
-
-Adding a new contract variable requires (1) updating this table and (2) ensuring the executor exports it in the corresponding Stage. New variables should be introduced only when at least two AC kinds reference them; otherwise inline.
-
-## Counter-Example: Fixing a Batch AC
-
-### Bad
-
-```
-- [ ] All 46 lint findings are resolved
-      Verification: grep -c "finding" report.txt → 0
-```
-
-This is a Compound AC: it bundles 46 independent state changes into one assertion.
-
-### Good
-
-Decompose by concern. Each finding type becomes its own AC with its own Verification:
-
-```
-- [ ] Report contains no forbidden-token occurrence
-      Verification: [ -f report.txt ] && ! grep -q "forbidden-token" report.txt && echo "PASS: forbidden-token absent"
-
-- [ ] Report contains no missing-verdict occurrence
-      Verification: [ -f report.txt ] && ! grep -q "missing-verdict" report.txt && echo "PASS: missing-verdict absent"
-```
-
-## AC verification layer
-
-AC measures whether the deliverable is *valuable to its consumer*. "Consumer" varies per task:
-
-| Deliverable type | Consumer | AC verification layer |
-|-------------|--------|----------------|
-| Mobile feature | End user | UI scenario (Maestro) |
-| Web feature | End user | UI scenario (Playwright) |
-| HTTP API | API client | integration (curl + jq) |
-| CLI command | shell user | command exec + stdout assertion |
-| Library function | calling developer or agent | unit test allowed (justification required) |
-
-> Terminology: this spec uses **consumer boundary** consistently — equivalent to "consumer-facing surface" or hexagonal architecture's "outer ring".
-
-Principle: **verify at the consumer boundary the consumer observes.** Internal unit verification (`*.test.ts`) is implementation evidence, not default AC — see [Implementation test files caveat](#implementation-test-files-caveat).
-
-### AC self-check (mandatory before finalizing)
-
-Run this checklist on every AC before proposing to the user:
-
-- [ ] If this verification passes, does the consumer actually receive value?
-- [ ] Does an implementation exist that passes this verification vacuously? If yes, the verification layer is too deep — move outward.
-- [ ] If citing a unit test as AC, did you justify the unit as consumer-facing (per the three questions in [Implementation test files caveat](#implementation-test-files-caveat))?
-
-**Anti-tautology rule**: Prometheus (planner) must specify the assertion's input/output or behavioral constraint in the AC itself. Do not delegate "what counts as a passing test" to Sisyphus-junior (executor) — that creates meta-circular verification.
-
-## Verification Transparency Rule
-
-A reviewer must be able to answer four questions from the AC text alone:
-
-1. What state must exist before Verification? (Setup)
-2. What command verifies the requirement? (Verification)
-3. What does success look like? (Expected outcome)
-4. How is state restored, if needed? (Cleanup)
-
-**Scenario files** (executable specifications) are valid Setup/Verification primitives — the file content IS the contract, auditable in standard tool syntax. These describe user/external-observable behavior directly. Examples: `.maestro/*.yaml`, Playwright `tests/e2e/*.spec.ts`.
-
-### Implementation test files (caveat)
-
-(Jest/Vitest `*.test.ts` or `*.spec.ts`) verify internal units. **They are NOT default AC primitives** — they are implementation evidence. A unit test can be cited as AC verification only when the unit IS the consumer boundary (CLI utility export, public library API, pure transformation function). When citing a unit test as AC, the AC must specify:
-
-1. Who is the consumer of this unit?
-2. Where is this unit invoked directly (file:line citation)?
-3. Why is this unit the consumer boundary (not internal helper)?
-
-**Always anti-pattern**:
-- Pre-seeded shared infrastructure state (rows that "just exist", magic IDs, shared dev accounts)
-- Opaque commands that hide what state they produce or assert
-
-**AC ≠ test spec.** AC names precondition, action, and asserted outcome. Click-by-click choreography belongs in the tool-native scenario file, not duplicated in the AC text.
-
-## Choosing the verification tool
-
-Before writing the AC, work through this sequence:
-
-1. **Choose the tool that observes the target state at the consumer boundary.** UI flow → maestro/playwright. HTTP API behavior → curl + jq. CLI behavior → command exec + stdout assertion. File content → grep. Internal function logic → implementation test runner (NOT AC by default — see [Implementation test files caveat](#implementation-test-files-caveat)). Don't default to the first tool you know; default to the consumer boundary.
-
-2. **If the Command API doesn't echo final state, chain a Query API.** POST → 202 → GET /resource/$id → assert. Verification observes the state, not just the action's side effect.
-
-3. **If insufficient state exists for the test, seed it explicitly.** Setup may legitimately create the precondition. Prefer seeding via the same API the test exercises — loud failure if API breaks.
-
-4. **If Setup mutates persistent state, choose the lightest cleanup that works.** Order of preference:
-   - Runner-native isolation (in-memory DB, rolled-back transaction, ephemeral container) — no manual cleanup needed
-   - API-symmetric cleanup (POST then DELETE via same API)
-   - Unique-input scoping (uuidgen-prefixed data, no cleanup needed)
+---
 
 ## Verification Examples by Tool
 
-When the Verification can be expressed as a runnable command, prefer one that is self-contained — do not invent ad-hoc shell. For outcome-based or descriptive ACs where a literal command does not fit, plain prose is acceptable.
+When the Verification can be expressed as a runnable command, prefer one that is self-contained. For outcome-based or descriptive ACs where a literal command does not fit, plain prose is acceptable.
 
 ### Mobile app E2E (maestro)
 
 - [ ] **Login flow on iOS Simulator reaches Home**
       **Verification**: `maestro --device "$IOS_UDID" test .maestro/auth/login_happy.yaml --format junit --output "$evidence_xml"`
-      (Setup/Cleanup omitted — this flow's first step is `clearState` + `launchApp`, so the flow self-resets per the exemption above. If your flow does not, add explicit Cleanup. If the flow mutates backend persistence beyond app state, chain Query API verification or add API-symmetric cleanup.)
+      (Setup/Cleanup omitted — this flow's first step is `clearState` + `launchApp`, so the flow self-resets. If your flow does not, add explicit Cleanup. If the flow mutates backend persistence beyond app state, chain Query API verification or add API-symmetric cleanup.)
 
 - [ ] **Login flow on Android Emulator reaches Home**
       **Verification**: `maestro --device "$ANDROID_SERIAL" test .maestro/auth/login_happy.yaml --format junit --output "$evidence_xml"`
-      (Setup/Cleanup omitted — this flow's first step is `clearState` + `launchApp`, so the flow self-resets per the exemption above. If your flow does not, add explicit Cleanup. If the flow mutates backend persistence beyond app state, chain Query API verification or add API-symmetric cleanup.)
+      (Same Setup/Cleanup notes as iOS above.)
 
-> Mobile ACs assume `$IOS_UDID` / `$ANDROID_SERIAL` are exported by Argus Stage 3.5 — see § Executor-Provided Variables above.
+> Mobile ACs assume `$IOS_UDID` / `$ANDROID_SERIAL` are exported by Argus Stage 3.5 — see Executor-Provided Variables in SKILL.md.
 
 ### Web UI E2E (playwright)
 
@@ -289,7 +47,7 @@ When the Verification can be expressed as a runnable command, prefer one that is
 
 ### Implementation test runner (caveat — NOT default AC)
 
-Unit/integration test runners (`bun test ...`, `vitest ...`) are **implementation evidence**, not default AC primitives. They can be cited as AC verification ONLY when the tested unit IS the consumer boundary — see [Implementation test files caveat](#implementation-test-files-caveat).
+Unit/integration test runners (`bun test ...`, `vitest ...`) are **implementation evidence**, not default AC primitives. They can be cited as AC verification ONLY when the tested unit IS the consumer boundary.
 
 Legitimate use (unit IS the consumer surface):
 
@@ -304,7 +62,34 @@ Illegitimate use (unit is internal helper):
 
 → instead, verify at the HTTP boundary that `POST /api/users` with duplicate email returns 409. The internal method behavior is implementation evidence.
 
-## Example
+---
+
+## Counter-Example: Fixing a Batch AC
+
+### Bad
+
+```
+- [ ] All 46 lint findings are resolved
+      Verification: grep -c "finding" report.txt → 0
+```
+
+This is a Compound AC: it bundles 46 independent state changes into one assertion.
+
+### Good
+
+Decompose by concern. Each finding type becomes its own AC with its own Verification:
+
+```
+- [ ] Report contains no forbidden-token occurrence
+      Verification: [ -f report.txt ] && ! grep -q "forbidden-token" report.txt && echo "PASS: forbidden-token absent"
+
+- [ ] Report contains no missing-verdict occurrence
+      Verification: [ -f report.txt ] && ! grep -q "missing-verdict" report.txt && echo "PASS: missing-verdict absent"
+```
+
+---
+
+## Worked Example — AC Proposal
 
 **User request:** "council과 spec-review에서 공통 로직을 추출하고, oh-my-claude-sisyphus의 프롬프트 조립 패턴을 참고해서 구조화된 프롬프트 파이프라인을 만들어줘"
 
@@ -345,11 +130,13 @@ Illegitimate use (unit is internal helper):
 2. Any criteria to add, modify, or remove?
 3. Any priorities among these criteria?
 
+---
+
 ## Handling User Response
 
 | User Response | Your Action |
 |---------------|-------------|
-| "Looks good" / "Approved" | Proceed to Metis consultation with these criteria (see review-pipeline.md) |
+| "Looks good" / "Approved" | Proceed to Metis consultation with these criteria (see `review-pipeline.md`) |
 | Modifications requested | Update criteria, re-propose if significant changes |
 | "Just do it" / Skips review | Use your draft as-is, note in plan that criteria were AI-generated |
 

--- a/skills/prometheus/interview.md
+++ b/skills/prometheus/interview.md
@@ -1,8 +1,12 @@
-# Interview Mode Reference
+# Interview Mode — Lookup
 
-**Use AskUserQuestion tool to interview in-depth until nothing is ambiguous.**
+**This file is lookup-only.** All mandatory interview rules (Tool Use vs User Questions, Sequential Interview Rule, Vague Answer Handling, User Deferral Handling, Persistence, Progress Reporting, Subagent Use, Anti-Patterns) are defined inline in `SKILL.md > ## Interview Mode (Mandatory Contract)`. The contract is authoritative.
 
-## Question Categories
+Read this file when you want a concrete example of question categories, a quality standard reference, the Rich Context pattern for complex design decisions, or a subagent dispatch prompt template.
+
+---
+
+## Question Categories (examples)
 
 | Category | Examples |
 |----------|----------|
@@ -11,77 +15,7 @@
 | Concerns & Risks | Failure modes, security, performance, scalability |
 | Tradeoffs | Speed vs quality, scope boundaries, priorities |
 
-## Rules
-
-| Ask User About | Use Tools Instead (explore/librarian) |
-|----------------|--------------------------------------|
-| Preferences, priorities, tradeoffs | Codebase facts, current architecture |
-| Risk tolerance, success criteria | Existing patterns, implementations |
-
-## Context Brokering Protocol (CRITICAL)
-
-**NEVER burden the user with questions the codebase can answer.**
-
-| Question Type | Ask User? | Action |
-|---------------|-----------|--------|
-| "Which project contains X?" | NO | Use explore first |
-| "What patterns exist in the codebase?" | NO | Use explore first |
-| "Where is X implemented?" | NO | Use explore first |
-| "What's the current architecture?" | NO | Use oracle |
-| "What's the tech stack?" | NO | Use explore first |
-| "What's your timeline?" | YES | Ask user (via AskUserQuestion) |
-| "Should we prioritize speed or quality?" | YES | Ask user (via AskUserQuestion) |
-| "What's the scope boundary?" | YES | Ask user (via AskUserQuestion) |
-
-**The ONLY questions for users are about PREFERENCES, not FACTS.**
-
-When user has no preference, select best practice autonomously.
-
-## Question Type Selection
-
-| Situation | Method | Why |
-|-----------|--------|-----|
-| Decision with 2-4 clear options | AskUserQuestion | Provides structured choices |
-| Open-ended/subjective question | Plain text question | Requires free-form answer |
-| Yes/No confirmation | Plain text question | AskUserQuestion is overkill |
-| Complex trade-off decision | Markdown analysis + AskUserQuestion | Deep context + structured choice |
-
-**Do NOT force AskUserQuestion for open-ended questions.**
-
-## Vague Answer Clarification
-
-When users respond vaguely ("~is enough", "just do ~", "decide later"):
-1. **Do NOT accept as-is**
-2. **Ask specific clarifying questions**
-3. **Repeat until clear answer obtained**
-
-> Note: For explicit deferral ("skip", "your call"), see User Deferral Handling.
-
-## User Deferral Handling
-
-When user explicitly defers ("skip", "I don't know", "your call"):
-1. Research autonomously via explore/librarian
-2. Select industry best practice or codebase-consistent approach
-3. Document: "Autonomous decision: [X] - user deferred, based on [rationale]"
-4. Continue without blocking
-
-## Rich Context Pattern (For Design Decisions)
-
-For complex technical decisions, provide rich context via markdown BEFORE asking AskUserQuestion.
-
-**Structure:**
-1. **Current State** — What exists now
-2. **Tension/Problem** — Why this decision matters, conflicting concerns
-3. **Existing Project Patterns** — Relevant code, prior decisions
-4. **Option Analysis** — For each option: behavior, tradeoffs, code impact
-5. **Recommendation** — Suggested option with rationale
-6. **AskUserQuestion** — Single question with 2-3 options
-
-**Rules:**
-- One question at a time (sequential interview)
-- Markdown provides depth, AskUserQuestion provides choice
-- Question must be independently understandable
-- Options need descriptions explaining consequences
+---
 
 ## Question Quality Standard
 
@@ -104,51 +38,47 @@ GOOD:
       description: "Generic on login, specific on registration only."
 ```
 
-## Persistence
+---
 
-**Continue until YOU have no questions left.** Not after 2-3 questions.
+## Rich Context Pattern (for complex design decisions)
 
-## Progress Reporting
+For complex technical decisions, provide rich context via markdown BEFORE asking AskUserQuestion.
 
-After each interview answer, display the ambiguity progress table:
+**Structure:**
+1. **Current State** — What exists now
+2. **Tension/Problem** — Why this decision matters, conflicting concerns
+3. **Existing Project Patterns** — Relevant code, prior decisions
+4. **Option Analysis** — For each option: behavior, tradeoffs, code impact
+5. **Recommendation** — Suggested option with rationale
+6. **AskUserQuestion** — Single question with 2-3 options
+
+**Rules:**
+- One question at a time (sequential interview)
+- Markdown provides depth, AskUserQuestion provides choice
+- Question must be independently understandable
+- Options need descriptions explaining consequences
+
+---
+
+## Subagent Dispatch Prompt Templates
+
+**Prompt structure**: `[CONTEXT] + [GOAL] + [DOWNSTREAM] + [REQUEST]`
+
+### Pre-interview codebase research (explore)
 
 ```
-Round {n} | Ambiguity: {score}%
-
-| Dimension             | Score | Gap                 |
-|-----------------------|-------|---------------------|
-| Goal                  | {s}   | {gap or "Clear"}    |
-| Constraints           | {s}   | {gap or "Clear"}    |
-| Success Criteria      | {s}   | {gap or "Clear"}    |
-| Context (brownfield)  | {s}   | {gap or "Clear"}    |
-
-→ Next question targets: {weakest dimension}
+Agent(subagent_type="explore", prompt="I'm planning auth feature and need existing patterns before interview. Find: auth implementations, middleware, session handling. Focus on src/ — skip tests. Return file paths with descriptions.")
 ```
 
-The Clearance Checklist (items 1-6) remains internal. Only ambiguity scores are surfaced.
+### Pre-interview external research (librarian)
 
-## Question Anti-Patterns
+```
+Agent(subagent_type="librarian", prompt="I'm planning OAuth 2.0 implementation and need authoritative guidance. Find: setup, flow types (PKCE), security considerations. Skip tutorials — production patterns only.")
+```
 
-**NEVER:**
-- Ask multiple questions in one message (one question per message, always)
-- Bundle open questions into a document or list
-- Use AskUserQuestion for open-ended/subjective questions
+### Oracle dispatch — feasibility / risk / alternative / dependency
 
-**ALWAYS:**
-- Ask exactly ONE question per message, wait for answer, then ask next
-- Use plain text for open-ended questions, AskUserQuestion only for structured choices
-
-## Subagent Usage During Interview
-
-### Explore — Codebase Fact-Finding
-
-Always dispatch explore for any codebase question. NEVER ask the user.
-
-### Oracle — Architecture Analysis (Ad-hoc)
-
-Dispatch when interview alone cannot determine technical feasibility.
-
-| Type | Question |
+| Type | Question to Oracle |
 |------|----------|
 | Feasibility | "Is this achievable in the current architecture?" |
 | Risk assessment | "What are the technical risks?" |
@@ -156,34 +86,14 @@ Dispatch when interview alone cannot determine technical feasibility.
 | Dependency mapping | "What systems does this depend on?" |
 
 **Oracle trigger conditions:**
-- User requirements may conflict with existing architecture → (feasibility)
-- Large-scale migration or schema change involved → (risk assessment)
-- 2+ technical approaches competing → (alternative evaluation)
-- Change scope spans 3+ modules/services → (dependency mapping)
-- Design decision directly affects performance/security/scalability → (risk assessment, feasibility)
+- User requirements may conflict with existing architecture → feasibility
+- Large-scale migration or schema change involved → risk assessment
+- 2+ technical approaches competing → alternative evaluation
+- Change scope spans 3+ modules/services → dependency mapping
+- Design decision directly affects performance/security/scalability → risk assessment, feasibility
 
-**When NOT to dispatch:** Simple codebase facts (use explore), user preference questions, standard low-risk implementations, codebase not yet explored.
-
-Briefly announce "Consulting Oracle for [reason]" before invocation.
-
-### Librarian — External Documentation
-
-Dispatch when the plan requires external documentation the codebase cannot provide.
-
-**Trigger conditions:** New library introduction, major version upgrade, security-related technology choices.
+**When NOT to dispatch Oracle:** Simple codebase facts (use explore), user preference questions, standard low-risk implementations, codebase not yet explored.
 
 ### Spec Source Retrieval — User-Facing Plans
 
-For Scoped+ intent involving user-facing changes, ask the user once whether project specifications exist (Linear / Notion / Figma / PRD / design doc / user research / etc). When the user provides a reference, fetch it via the appropriate MCP or read tool, and use it as ground truth for AC and QA scenario authoring. When no source exists, proceed with interview-derived context — do not record the absence as plan ceremony.
-
-### Explore/Librarian Prompt Guide
-
-**Prompt structure**: [CONTEXT] + [GOAL] + [DOWNSTREAM] + [REQUEST]
-
-```
-// Pre-interview research (internal)
-Agent(subagent_type="explore", prompt="I'm planning auth feature and need existing patterns before interview. Find: auth implementations, middleware, session handling. Focus on src/ — skip tests. Return file paths with descriptions.")
-
-// Pre-interview research (external)
-Agent(subagent_type="librarian", prompt="I'm planning OAuth 2.0 implementation and need authoritative guidance. Find: setup, flow types (PKCE), security considerations. Skip tutorials — production patterns only.")
-```
+For Scoped+ intent involving user-facing changes, ask the user ONCE whether project specifications exist (Linear / Notion / Figma / PRD / design doc / user research). When the user provides a reference, fetch it via the appropriate MCP or read tool, and use it as ground truth for AC and QA scenarios. When no source exists, proceed with interview-derived context — do not record the absence as plan ceremony.

--- a/skills/prometheus/plan-template.md
+++ b/skills/prometheus/plan-template.md
@@ -1,115 +1,12 @@
-# Plan Template Reference
+# Plan Template Examples
 
-## Plan Output
+**This file is lookup-only.** All mandatory plan-structure rules (sections, TODO 7-field format, MECE, Atomicity, Maximum Parallelism, Wave Assignment, Final Verification Wave) are defined inline in `SKILL.md > ## Plan Structure (Mandatory Contract)`. The contract is authoritative; the examples below are for reference when drafting concrete TODO bodies, Wave visualizations, or Success Criteria.
 
-**Location:** `$OMT_DIR/plans/{name}.md`
+Read this file when you want to consult a worked example. You do NOT need to read it to know what the plan structure requires — that knowledge is already in SKILL.md.
 
-**Language:** Plans MUST be written in English.
+---
 
-**What to EXCLUDE:** No vague criteria ("verify it works").
-
-## Plan Template Structure
-
-| Section | Contents |
-|---------|----------|
-| **TL;DR** | Quick summary, deliverables (bullet list), estimated effort (Quick/Short/Medium/Large/XL), Parallel Execution (YES/NO — wave description), Critical Path |
-| **Context** | Original Request (verbatim), Interview summary (key decisions — the WHY behind each TODO) |
-| **Work Objectives** | Core objective, Definition of Done, Must Have, Must NOT Have / Guardrails |
-| **TODOs** | Numbered tasks in checkbox format — each with: what to do, must NOT do, files, References, acceptance criteria, parallelization fields, QA scenarios |
-| **Execution Strategy** | Wave visualization, Dependency Matrix, Critical Path. Target 5-8 tasks per wave. Circular dependencies forbidden. Final Verification Wave mandatory for Scoped+ intent |
-| **Verification Strategy** | Test decision (TDD/tests-after/none), framework, verification commands. **Zero Human Intervention** — all verification agent-executed with evidence to `$OMT_DIR/evidence/{plan-name}/` |
-| **Success Criteria** | Binary pass/fail end state. Verification commands + final checklist |
-
-## TODO Task Format
-
-Each TODO is a checkbox line: `- [ ] N. Title` with body content indented.
-
-- Each task = implementation + test combined (never separate)
-- **What to do** — faithfully transfer interview conclusions. The executor has NO interview context. Capture:
-  - Content — what the result contains or how it behaves
-  - Scope — which areas, entities, or modules are covered
-  - Approach — what direction or pattern to follow
-  - Inputs — what specs, requirements, or prior decisions inform this
-  - Decisions — choices confirmed during interview
-- **Files**: What this TODO creates or modifies — the deliverables
-- **References (CRITICAL)** — executor has NO interview context. Provide:
-  - **Pattern References**: `file:line-range` — existing code patterns. WHY explains what to adopt.
-  - **API/Type References**: types, interfaces, APIs. WHY explains why this matters.
-  - **Test References**: existing test patterns. WHY explains what style to follow.
-  - **External References**: official docs, RFCs. WHY explains what decision this informs.
-  - Every TODO must include at least one Pattern or API/Type reference. For greenfield: state "Greenfield — no existing pattern" explicitly.
-- **Parallelization** — every TODO must include:
-  - `Blocked By`: list of TODO numbers (empty if none)
-  - `Blocks`: list of TODO numbers (empty if none)
-  - `Wave`: execution wave number (1-based)
-- **Wave Assignment Rule**: `Wave = max(wave of each blocker) + 1`. Empty Blocked By = Wave 1. MANDATORY — no manual override.
-- **Anti-pattern**: Assigning Wave 2 to independent task because "it makes sense." If no dependency, Wave 1.
-
-## MECE Decomposition
-
-Tasks must be Mutually Exclusive (no overlap) and Collectively Exhaustive (full coverage).
-
-Self-check after drafting TODOs:
-1. **Overlap**: Do any two TODOs modify the same file for the same purpose? → Merge or redraw
-2. **Coverage**: If every TODO is completed, is the requirement fulfilled? → Add missing TODO
-3. **Hidden coupling**: Implicit state, ordering, undeclared dependencies? → Make explicit or merge
-
-| Anti-Pattern | Example | Fix |
-|-------------|---------|-----|
-| **Overlap** | Both TODO 1 and 2 validate user input | Merge or split by layer with boundary |
-| **Gap** | CRUD TODOs cover create/read/update but not delete | Add delete TODO |
-| **False MECE** | "frontend" and "backend" but API contract owned by neither | Add contract TODO or assign ownership |
-
-## Maximum Parallelism
-
-| Rule | Threshold |
-|------|-----------|
-| **Granularity** | 1 task = 1 concern = 1-3 files. 4+ files or 2+ concerns → SPLIT |
-| **Parallelism Target** | 5-8 tasks per wave. <3 in non-bottleneck wave = under-split |
-| **Dependency Minimization** | Shared deps (types, interfaces) as Wave-1 tasks |
-
-## Atomicity Heuristic
-
-Each TODO must be atomic — completable in one delegation pass.
-
-| # | Condition | Threshold |
-|---|-----------|-----------|
-| 1 | Concern scope | 1 concern per task |
-| 2 | File scope | 1-3 files per task (hard backstop) |
-| 3 | Single-delegation | Finish without mid-task coordination |
-
-Any condition fails → decompose further.
-
-| Smell | Action |
-|-------|--------|
-| "and" in description | Split into separate TODOs |
-| Spans unrelated concerns | One TODO per responsibility |
-| Requires sequential phases | Each phase = own TODO with Blocked By |
-| Task touches 4+ files | Decompose by responsibility |
-
-**Vertical Slice Rule**: Prefer vertical slices (one feature end-to-end) over horizontal (all models, then all services). Exception: shared foundation tasks in Wave 1.
-
-## QA Scenarios (MANDATORY per TODO)
-
-A code change is verified at the layer the user observes. Internal tests prove the code runs; scenarios prove the product works for the user. Verification at the consumer boundary yields the highest accuracy — that is why QA Scenarios are mandatory per TODO regardless of modality.
-
-Each scenario uses a structured block with 7 fields:
-- **Scenario**: `{Name} — {Purpose}`
-- **Tool**: CLI command (`curl`, `bun test`, `playwright`, `maestro`, `grep` — NOT descriptions like "Header validation")
-- **Preconditions**: Setup state required (scenario-level; for per-AC state mutation that needs teardown, use the [Setup/Cleanup](./acceptance-criteria.md#state-mutation-setup--cleanup) fields instead)
-- **Steps**: Numbered list of exact commands
-- **Expected**: Observable outcome on success
-- **Failure**: Specific failure symptoms (NOT "Expected does not happen")
-- **Evidence**: `$OMT_DIR/evidence/{plan-name}/{task-slug}/{scenario-slug}.{ext}`
-
-**Minimum 2 scenarios per TODO**: happy path + failure/edge case.
-
-**Specificity requirements:**
-- API: Specific paths/methods, exact HTTP codes, JSON field paths
-- UI: CSS selectors, exact DOM state assertions
-- All: Concrete test data, wait conditions, at least ONE failure scenario per task
-
-## TODO Example
+## TODO Example (worked example)
 
 ```
 - [ ] 3. Implement UserService
@@ -160,7 +57,9 @@ Each scenario uses a structured block with 7 fields:
       Evidence: $OMT_DIR/evidence/{plan-name}/implement-user-service/validation-failure.json
 ```
 
-## Execution Strategy Example
+---
+
+## Execution Strategy Example (worked example)
 
 ```
 Wave Visualization:
@@ -187,45 +86,9 @@ Wave Visualization:
 Critical Path: Task 1 -> Task 2 -> Task 4 -> Task 7 -> F1-F4
 ```
 
-## Final Verification Wave
+---
 
-Every plan with Scoped or higher intent MUST include Final Verification Wave. Trivial exempt.
-
-> ALL F1-F4 must APPROVE. Rejection → fix task → re-enter implementation → full F1-F4 re-run.
-
-- [ ] F1. Plan Compliance Audit
-  What to verify:
-    - Read plan end-to-end
-    - For each "Must Have": verify implementation exists
-    - For each "Must NOT Have": search for forbidden patterns
-    - Check evidence files exist in $OMT_DIR/evidence/
-  Expected Output: Must Have [N/N] | Must NOT Have [N/N] | VERDICT
-
-- [ ] F2. Code Quality Review
-  What to verify:
-    - Run build + linter + tests
-    - Review changed files for: as any, empty catches, console.log, unused imports
-    - Check AI slop: excessive comments, over-abstraction, generic names
-  Expected Output: Build [PASS/FAIL] | Tests [N/N] | VERDICT
-
-- [ ] F3. QA Scenario Execution
-  What to verify:
-    - Execute EVERY QA scenario from EVERY task
-    - Test cross-task integration
-    - Save evidence to $OMT_DIR/evidence/{plan-name}/final-qa/
-  Expected Output: Scenarios [N/N pass] | Integration [N/N] | VERDICT
-
-- [ ] F4. Scope Fidelity Check
-  What to verify:
-    - For each task: read spec, read actual diff
-    - Verify 1:1 correspondence (no missing, no creep)
-    - Check "Must NOT do" compliance
-    - Detect cross-task contamination
-  Expected Output: Tasks [N/N compliant] | VERDICT
-
-Wave field: `Wave: FINAL` (literal string). Numeric rule applies to implementation tasks only.
-
-## Success Criteria Template
+## Success Criteria Template (worked example)
 
 ```
 ## Success Criteria

--- a/skills/prometheus/review-pipeline.md
+++ b/skills/prometheus/review-pipeline.md
@@ -184,6 +184,8 @@ Before asking the user to choose execution mode, compute a recommendation:
 
 ## Stage C: Execution Bridge — Option Formatting
 
+> This section is **option-formatting only**. Post-selection dispatch actions (which skill to invoke when the user selects Option 1/2/3) are defined inline in `SKILL.md > ## Review Pipeline > Plan Presentation` — do NOT look here for that.
+
 After the user reads Stage B's recommendation, present execution options via the platform's user-prompt primitive (structured choice):
 
 **(1) Full orchestration**

--- a/skills/prometheus/review-pipeline.md
+++ b/skills/prometheus/review-pipeline.md
@@ -184,8 +184,6 @@ Before asking the user to choose execution mode, compute a recommendation:
 
 ## Stage C: Execution Bridge — Option Formatting
 
-> This section is **option-formatting only**. Post-selection dispatch actions (which skill to invoke when the user selects Option 1/2/3) are defined inline in `SKILL.md > ## Review Pipeline > Plan Presentation` — do NOT look here for that.
-
 After the user reads Stage B's recommendation, present execution options via the platform's user-prompt primitive (structured choice):
 
 **(1) Full orchestration**

--- a/skills/prometheus/review-pipeline.md
+++ b/skills/prometheus/review-pipeline.md
@@ -1,117 +1,14 @@
-# Review Pipeline Reference
+# Review Pipeline — Lookup
 
-Plan generation trigger, three-agent review pipeline, and execution bridge.
+**This file is lookup-only.** All workflow-wide rules (Common Gate Pattern, Verdict Handling, Revise definition, Verdict/Reviewer Freshness Rules, Pipeline State Machine, Loop Termination, Self-Review Checklist, Gap Classification, Plan Presentation mandate, Anti-Patterns) are defined inline in `SKILL.md > ## Review Pipeline (Mandatory Contract)`. The contract is authoritative.
 
-## Plan Generation Trigger
-
-**Trigger**: Metis consultation passes (APPROVE or COMMENT). Proceed directly — do NOT ask user for confirmation at this stage. User reviews after Momus approval.
-
-## Three-Agent Pipeline
-
-| | Metis | Oracle | Momus |
-|---|---|---|---|
-| **Timing** | Pre-plan | Post-plan, pre-Momus | Post-Oracle |
-| **Input** | User Goal + Scope + AC | Plan + Codebase | Plan |
-| **Validates** | Requirements completeness | Codebase feasibility | Document quality |
-| **Reads code** | No | Yes (file:line) | No |
-
-## Common Gate Pattern
-
-All three agents follow the same mandatory gate:
-
-```
-MANDATORY: Agent MUST pass (APPROVE or COMMENT) before proceeding.
-- Do NOT proceed until APPROVE or COMMENT
-- On REQUEST_CHANGES: revise and re-invoke
-- On missing or ambiguous verdict: treat as REQUEST_CHANGES
-- Loop repeats indefinitely until pass
-- Skipping is NEVER permitted
-```
-
-**A REQUEST_CHANGES verdict blocks ALL downstream progression** — no stage may advance until the blocking reviewer re-issues APPROVE or COMMENT after a proper Revise cycle.
-
-**Common Verdict Handling:**
-
-| Verdict | Action |
-|---------|--------|
-| **APPROVE** | Proceed to next stage |
-| **COMMENT** | Incorporate findings silently, proceed |
-| **REQUEST_CHANGES** | Revise, re-invoke. Must loop until APPROVE or COMMENT |
-| **Missing / ambiguous** (no explicit verdict label, punch-list only, "verdict inferable") | Treat as REQUEST_CHANGES |
-
-> **Incorporate findings silently**: absorb reviewer findings (Metis/Oracle/Momus) into your understanding of the work. Reviewer names, verdict labels, and advisory enumeration do NOT appear in plan body. Reviewers shape the plan; they do not annotate it.
+Read this file when you are about to execute a SPECIFIC reviewer invocation, Stage A HTML render, Stage B Decision Matrix computation, or Stage C option presentation. Read the corresponding section in full at that moment.
 
 ---
 
-## Operational Definition of "Revise"
-
-**Revise** = exactly these three steps, in order:
-
-1. **Modify source material** to address every directive in the REQUEST_CHANGES verdict.
-2. **Re-invoke the same reviewer type on a fresh agent instance** (Reviewer Freshness Rule).
-3. **Wait for a new APPROVE or COMMENT** on the revised material.
-
-A sequence missing any of the three steps is not Revise. Self-assessment, paraphrasing the directive, partial fixes, deferring to a later TODO, executor-side fixes, and asking the user to bypass — all fail step 2 or step 3.
-
----
-
-## Verdict Freshness Rule
-
-A verdict is valid only when issued by a reviewer agent on the **current version** of the artifact. Prior verdicts on earlier versions are expired and carry no authority.
-
-**Self-assessment cannot substitute for a reviewer verdict.** If prometheus believes the revision is correct, that belief is irrelevant — only the reviewer's re-issuance of APPROVE or COMMENT advances the pipeline.
-
-Consequence: even if the planner is certain the directive has been addressed, it MUST re-invoke the reviewer and wait.
-
----
-
-## Reviewer Freshness Rule
-
-Each reviewer invocation MUST use a **fresh agent instance**. Do not reuse an agent thread that has already issued a verdict on a prior version of the artifact.
-
-**Rationale**: Reusing the same agent thread introduces **commitment/consistency bias** (Cialdini) — the agent is more likely to rubber-stamp a revision because it already issued a prior approval or rejection. A fresh instance evaluates the current artifact without anchoring to its own prior verdict.
-
-**Enforcement**: Dispatch a new subagent via the platform's native subagent/dispatch primitive for every reviewer invocation. Do not pass prior verdict context into the new invocation prompt.
-
----
-
-## Pipeline State Machine
-
-The pipeline progresses through discrete states. Transitions are triggered by reviewer verdicts or user selections.
-
-| State | Description | Transitions |
-|-------|-------------|-------------|
-| **S0: Interview Mode** | Gathering requirements from user | → S1 on Metis-ready clearance |
-| **S1: Metis Invocation** | Sending 3-Section prompt to Metis | → S2 on APPROVE/COMMENT; → S0 on REQUEST_CHANGES |
-| **S2: Plan Generation** | Writing plan to `$OMT_DIR/plans/{name}.md` | → S3 on self-review pass |
-| **S3: Oracle Invocation** | Sending plan path to Oracle for feasibility review | → S4 on APPROVE/COMMENT; → S2 on REQUEST_CHANGES |
-| **S4: Momus Invocation** | Sending plan path to Momus for document quality review | → S5 on APPROVE/COMMENT; → S2 on REQUEST_CHANGES |
-| **S5: Plan Presentation** | Rendering plan (Stage A) and presenting to user | → S6 on user views plan |
-| **S6: Execution Recommendation** | Computing and presenting Stage B recommendation | → S7 on user receives recommendation |
-| **S7: Execution Bridge** | Presenting Stage C options, awaiting user selection | → S8 on selection; → S0 on "Revise plan" |
-| **S8: Execution Dispatch** | Invoking skill per user selection | (terminal — execution handed off to dispatched skill; "Revise plan" is routed from S7, not S8) |
-
-**S7 → S0 edge**: When the user selects "Revise plan" at Stage C (S7), the pipeline returns to S0 (Interview Mode) — Metis → Plan → Oracle → Momus pipeline re-runs from the beginning after requirements are updated.
-
----
-
-## Loop Termination Rule
-
-The reviewer loop terminates **iff** the reviewer issues APPROVE or COMMENT on the current artifact version.
-
-- REQUEST_CHANGES → Revise (per Operational Definition above).
-- Missing or ambiguous verdict → treat as REQUEST_CHANGES. Re-invoke.
-- Time pressure, user override ("just proceed"), self-assessment of fix correctness, and parallel dispatch on a blocked artifact do **not** terminate the loop.
-
-Only a fresh reviewer-issued APPROVE or COMMENT on the current artifact moves pipeline state forward.
-
----
-
-## Metis Feedback Loop
+## Metis Invocation Template (3-Section)
 
 **When**: Clearance all YES + AC confirmed by user. Auto-invoke — do NOT wait for user to say "generate plan."
-
-**Invocation Template (3-Section):**
 
 ```markdown
 ## 1. USER GOAL
@@ -126,48 +23,13 @@ Only a fresh reviewer-issued APPROVE or COMMENT on the current artifact moves pi
 [Confirmed AC in full — paste verbatim. No summarizing.]
 ```
 
-**On Metis REQUEST_CHANGES: Return to Interview Mode.** Metis rejection means requirements are incomplete — do NOT guess or hallucinate missing requirements to pass the gate. Ask the user to clarify the gaps Metis identified. After resolving gaps via interview, re-invoke Metis with the same 3-Section structure containing updated content.
-
-**Anti-Patterns:**
-
-| Anti-Pattern | Problem |
-|-------------|---------|
-| Summarized AC | Metis cannot evaluate verifiability |
-| Abstract scope | Completeness uncheckable |
-| Missing user goal | Intent unclassifiable |
-
-### Gap Classification
-
-Post-plan self-review classifies each identified gap as CRITICAL (requires user input), MINOR (self-resolve), or AMBIGUOUS (apply default) — each type handled per its protocol.
-
-| Level | Definition | Handling Protocol | Example |
-|-------|-----------|-------------------|---------|
-| **CRITICAL** | Requires user input — cannot proceed without clarification | Return to Interview Mode, ask user to resolve before continuing | Acceptance criteria missing for a core TODO |
-| **MINOR** | Self-resolvable — planner can infer correct resolution from existing context | Resolve inline during plan revision, document rationale in plan | Naming convention for a new file consistent with codebase pattern |
-| **AMBIGUOUS** | Apply default — standard convention or safe default exists | Apply the documented default, note in plan | Unclear whether to use existing utility or inline logic — apply DRY default |
-
-### Self-Review Checklist
-
-After plan generation, self-review checklist is performed: all TODOs have acceptance criteria, file references exist, guardrails from Metis incorporated, zero human-intervention criteria.
-
-This checklist is planner-side (prometheus), distinct from F1-F4 executor-side verification (sisyphus/argus). Execute after plan generation and before Oracle submission.
-
-| # | Item | Check |
-|---|------|-------|
-| 1 | All TODOs have acceptance criteria | Every TODO in the plan specifies verifiable completion criteria |
-| 2 | File references exist | All file paths and line references cited in the plan resolve to actual files |
-| 3 | Guardrails from Metis incorporated | Every constraint or guardrail flagged by Metis is reflected in the plan's TODOs or notes |
-| 4 | Zero human-intervention criteria | No TODO requires manual human action mid-execution to proceed |
-
-**Failure action**: If any item fails, loop back and fix before submitting to Oracle. Do NOT submit a plan that fails this checklist.
+**On Metis REQUEST_CHANGES**: Return to Interview Mode. Metis rejection means requirements are incomplete — do NOT guess or hallucinate missing requirements to pass the gate. Ask the user to clarify the gaps Metis identified. After resolving gaps via interview, re-invoke Metis with the same 3-Section structure containing updated content.
 
 ---
 
-## Oracle Feedback Loop
+## Oracle Invocation Template
 
 **When**: After plan generated to `$OMT_DIR/plans/{name}.md`. MANDATORY before Momus.
-
-**Invocation Template:**
 
 ```
 ## Plan File
@@ -187,21 +49,13 @@ $OMT_DIR/plans/{name}.md
 
 On REQUEST_CHANGES: update plan file first, then re-invoke with same template.
 
-**Anti-Patterns:**
-
-| Anti-Pattern | Problem |
-|-------------|---------|
-| Restating plan content in prompt | Oracle reads file directly — token waste |
-| Asking for code review | Oracle reviews feasibility, not code quality |
-| Skipping after Metis APPROVE | Gate violation — Oracle mandatory regardless |
-
 ---
 
-## Momus Feedback Loop
+## Momus Invocation Template
 
 **When**: After Oracle APPROVE/COMMENT. MANDATORY before user presentation.
 
-**Invocation**: Send the plan file path only.
+Send the plan file path only:
 
 ```
 $OMT_DIR/plans/{name}.md
@@ -209,33 +63,19 @@ $OMT_DIR/plans/{name}.md
 
 All context (interview summary) is already in the plan's Context section. No supplementary prompt needed.
 
-**Anti-Patterns:**
-
-| Anti-Pattern | Problem |
-|-------------|---------|
-| Repeating plan content | Momus reads file — token waste |
-| Separate metis results | Already in Plan Context + anchoring risk |
-| Adding review instructions | Momus has its own criteria |
-
 ---
 
-## Plan Presentation (After Momus Approval)
+## Stage A: HTML Render — Procedure
 
-Plan Presentation runs in three sequential stages. This is the ONLY point where the user sees the plan. All internal gates run automatically.
-
-### Stage A: HTML Render
-
-Convert `$OMT_DIR/plans/{name}.md` to a single-file HTML document and open it in the browser so the user can read the plan in a rendered view.
+Convert `$OMT_DIR/plans/{name}.md` to a single-file HTML document and open it in the browser so the user can read the plan rendered.
 
 **Requirements:**
 - **Output artifact**: `$OMT_DIR/plans/plan.html` (single-file, self-contained, browser-openable)
-- **Content**: verbatim — no summarization, no paraphrasing, no omission (요약·각색 금지; summarization forbidden)
-- **Tool choice**: The conversion tool is an execution-time choice — use whatever tool is available at runtime (Pandoc, a script, inline generation). The tool is an implementation detail (수단은 실행 시점 선택); the output must meet the single-file + browser requirement regardless of method.
-- **Graceful fallback**: If HTML conversion fails, present the raw Markdown content directly to the user and continue to Stage B.
+- **Content**: verbatim — no summarization, no paraphrasing, no omission (요약·각색 금지)
+- **Tool choice**: execution-time choice — use whatever is available at runtime (Pandoc, a script, inline generation). Tool is an implementation detail; output must meet the single-file + browser requirement regardless.
+- **Graceful fallback**: If HTML conversion fails, present raw Markdown directly and continue to Stage B.
 
-> Stage A is intentionally tool-agnostic to allow future sub-sections to be appended here without disturbing the conversion contract above.
-
-#### HTML Components
+### HTML Components
 
 The Stage A HTML output is composed of 4 distinct components:
 
@@ -244,9 +84,7 @@ The Stage A HTML output is composed of 4 distinct components:
 - **Pipeline State** — pipeline state journal box injected from session state (S0 → S_current transitions)
 - **plan-content** — the full plan markdown rendered into `article#plan-content`; sourced verbatim from plan.md
 
-#### Source Classification
-
-Each component's data origin determines how it is populated at render time:
+### Source Classification
 
 | Component | Source |
 |---|---|
@@ -255,67 +93,57 @@ Each component's data origin determines how it is populated at render time:
 | Pipeline State | session-derived |
 | article#plan-content | plan-derived |
 
-`plan-derived` components are populated from `$OMT_DIR/plans/{name}.md` (the plan file). `session-derived` components are composed from session state (reviewer verdicts, pipeline state transitions) and injected at render time via the `<!-- SESSION-DERIVED-BOXES-HERE -->` marker.
+`plan-derived` components populated from `$OMT_DIR/plans/{name}.md`. `session-derived` composed from session state (reviewer verdicts, pipeline state transitions) and injected via `<!-- SESSION-DERIVED-BOXES-HERE -->` marker.
 
-#### Template Reference
+### Template Reference
 
-The canonical HTML shell is defined at:
+Canonical HTML shell at: `skills/prometheus/templates/plan-presentation.html`
 
-`skills/prometheus/templates/plan-presentation.html`
+Contains the static HTML structure with `{{placeholder}}` substitution variables, the `<!-- SESSION-DERIVED-BOXES-HERE -->` injection marker, and an embedded top-comment documenting all placeholders.
 
-This file contains the static HTML structure with `{{placeholder}}` substitution variables, the `<!-- SESSION-DERIVED-BOXES-HERE -->` injection marker, and an embedded top-comment documenting all placeholders and the component-to-source classification contract.
+### Translation Rule
 
-#### Translation Rule
+Three invariants govern language translation applied during Stage A rendering.
 
-Three invariants govern all language translation applied during Stage A rendering.
+**Invariant 1 — Session auto-detect of conversational language**: The session detects the conversational language in use (the language the user is writing in during the current session). All prose content in HTML output is rendered in that detected language. No language is hard-coded; detection is render-time.
 
-##### Invariant 1 — Session auto-detect of conversational language
-
-The rendering session detects the conversational language in use (the language the user is writing in during the current session). All prose content in the HTML output is rendered in that detected language. No language is hard-coded; detection is a render-time operation.
-
-##### Invariant 2 — Prose-only scope with preservation list
-
-Translation applies to **prose-only** content. The following elements are **never** translated, regardless of detected language:
+**Invariant 2 — Prose-only scope with preservation list**: Translation applies to prose-only content. The following are **never** translated:
 
 - `code block` — all fenced and inline code
-- `file path` — absolute and relative paths (e.g. `skills/prometheus/review-pipeline.md`)
+- `file path` — absolute and relative paths
 - `CLI` — command-line tool names and commands
 - `WI-N` — work-item identifiers (e.g. `WI-1`, `WI-2`)
 - `AC#M` — acceptance criteria labels (e.g. `AC#1`)
 - `S0-S8` — pipeline state identifiers
 - `grep` — tool names used as identifiers in verification commands
 
-Translating any item from this preservation list is a rule violation.
+Translating any item is a rule violation.
 
-##### Invariant 3 — plan.md as single source-of-truth, render-time-only translation
+**Invariant 3 — plan.md as single source-of-truth, render-time-only translation**: `plan.md` is the single SoT for plan content. No translated copy (`plan.{lang}.md`) is written to disk; translation is render-time only. HTML is ephemeral — re-rendering always draws from unmodified `plan.md`.
 
-`plan.md` is the single source-of-truth for plan content. No translated copy (`plan.{lang}.md`) is written to disk; translation is a render-time operation only. The HTML output is ephemeral — re-rendering always draws from the unmodified `plan.md`.
+**Fallback**: If language detection fails or yields an ambiguous result, render in original language. Do not block Stage A on detection failure.
 
-##### Fallback
+### Rendering Methodology
 
-If language detection fails or yields an ambiguous result, render in original language (the language as written in `plan.md`). Do not block Stage A on a detection failure.
-
-#### Rendering Methodology
-
-Six invariants govern substitution and injection applied during Stage A rendering.
+Six invariants govern substitution and injection during Stage A rendering.
 
 **Rule 1 — Active-element-only substitution**: `{{…}}` placeholders are substituted only at their active template elements. For `{{PLAN_MARKDOWN_JSON}}`, the active container is the `script type="application/json" id="plan-md"` element; substitution occurs only at that active element line. Literal occurrences inside the top-comment documentation block are NOT substituted. Replacement patterns must be anchored to the specific enclosing element by its opening-tag signature, not to the raw placeholder token alone.
 
-**Rule 2 — Multi-occurrence guard**: When a placeholder token appears in both documentation and an active element, the substitution engine MUST skip the documentation occurrence. Preferred implementation: element-line regex anchored on active element. **Alternatives:** first-match-only with active-element anchor; pre-pass element extraction.
+**Rule 2 — Multi-occurrence guard**: When a placeholder token appears in both documentation and an active element, the substitution engine MUST skip the documentation occurrence. Preferred: element-line regex anchored on active element. **Alternatives**: first-match-only with active-element anchor; pre-pass element extraction.
 
-**Multi-active-occurrence semantics**: If a placeholder legitimately appears across multiple active elements (e.g., `{{TOC_TITLE}}` in both navigation header and footer), substitution applies to ALL active occurrences — only documentation / top-comment literals are excluded. This prevents a future-analogous bug where first-match-only logic silently drops a second occurrence of a legitimate active placeholder.
+**Multi-active-occurrence semantics**: If a placeholder legitimately appears across multiple active elements (e.g., `{{TOC_TITLE}}` in both navigation header and footer), substitution applies to ALL active occurrences — only documentation/top-comment literals are excluded. This prevents a future-analogous bug where first-match-only logic silently drops a second occurrence of a legitimate active placeholder.
 
-**Rule 3 — Session-derived box injection sequence**: The `<!-- SESSION-DERIVED-BOXES-HERE … -->` comment block is replaced with exactly two `.section-box` elements in this exact order: (a) Stage B · Execution Recommendation, (b) Pipeline State. The entire comment block (from `<!-- SESSION-DERIVED-BOXES-HERE` to the terminating `-->`) is removed; the 2 boxes replace it verbatim in order.
+**Rule 3 — Session-derived box injection sequence**: The `<!-- SESSION-DERIVED-BOXES-HERE … -->` comment block is replaced with exactly two `.section-box` elements in this exact order: (a) Stage B · Execution Recommendation, (b) Pipeline State. The entire comment block (from `<!-- SESSION-DERIVED-BOXES-HERE` to terminating `-->`) is removed; the 2 boxes replace it verbatim in order.
 
-**Rule 4 — Error recovery / fallback**: If any placeholder is not found in the template, the rendering engine retains the original element untouched — no silent HTML destruction. If translation detection fails per the Translation Rule, fallback to original language as declared in the Translation Rule.
+**Rule 4 — Error recovery / fallback**: If any placeholder is not found in the template, the rendering engine retains the original element untouched — no silent HTML destruction. If translation detection fails per the Translation Rule, fallback to original language.
 
-**Rule 5 — Tool-agnostic**: The substitution engine is the implementer's choice (awk, sed, Node, Python, Bun script, etc.). Rendering Methodology declares invariants, not implementation. Any tool that satisfies the six rules is acceptable.
+**Rule 5 — Tool-agnostic**: Substitution engine is the implementer's choice (awk, sed, Node, Python, Bun script, etc.). Rendering Methodology declares invariants, not implementation. Any tool satisfying the six rules is acceptable.
 
-**Rule 6 — Parser-resilient container embedding**: The HTML element holding the plan markdown content (`{{PLAN_MARKDOWN_JSON}}` container) MUST satisfy two sub-requirements:
+**Rule 6 — Parser-resilient container embedding**: The HTML element holding plan markdown content (`{{PLAN_MARKDOWN_JSON}}` container) MUST satisfy:
 
 - **(6a) Inert container**: Element whose content the HTML parser treats as text — non-executable, inert. Canonical: `script type="application/json"` (HTML5 non-executable-type). Alternative inert container: `textarea hidden`.
 
-- **(6b) Content-side close-tag escape**: The injection pipeline MUST escape the container's close-tag sequence so plan prose cannot terminate the container prematurely at parse time. Canonical pattern:
+- **(6b) Content-side close-tag escape**: The injection pipeline MUST escape the container's close-tag sequence so plan prose cannot terminate the container prematurely. Canonical pattern:
   ```js
   const payload = JSON.stringify(planMarkdown).replace(/<\/script>/g, '<\\/script>');
   // consumer: JSON.parse(container.textContent)
@@ -325,11 +153,11 @@ Six invariants govern substitution and injection applied during Stage A renderin
 
 Both (6a) and (6b) MUST be present regardless of container choice; alternative inert containers MUST supply their own paired close-tag escape.
 
-### Stage B: Execution Recommendation
+---
 
-Before asking the user to choose an execution mode, compute a recommendation using the Decision Matrix below.
+## Stage B: Decision Matrix
 
-**Decision Matrix:**
+Before asking the user to choose execution mode, compute a recommendation:
 
 | Signal | Weight toward Complex/Architecture | Weight toward Trivial/Scoped |
 |--------|------------------------------------|------------------------------|
@@ -339,13 +167,11 @@ Before asking the user to choose an execution mode, compute a recommendation usi
 | AC gap (unverified acceptance criteria) | Moderate | — |
 | Ambiguity Score > 2 | Moderate | — |
 | Oracle COMMENT with codebase concern | Moderate | — |
-| scope question unresolved | Moderate | — |
+| Scope question unresolved | Moderate | — |
 
 **Conflict resolution**: When signals split evenly, "Plan more wins" — default to Full Orchestration.
 
-**Recommendation Output Template:**
-
-Present the recommendation to the user before Stage C:
+**Recommendation Output Template** (present before Stage C):
 
 ```
 **Recommendation**: [Full orchestration | Focused execution]
@@ -354,9 +180,11 @@ Present the recommendation to the user before Stage C:
 **What tips the balance**: [The single strongest signal that drove the recommendation]
 ```
 
-### Stage C: Execution Bridge
+---
 
-After the user reads Stage B's recommendation, present the execution options via the platform's user-prompt primitive (structured choice):
+## Stage C: Execution Bridge — Option Formatting
+
+After the user reads Stage B's recommendation, present execution options via the platform's user-prompt primitive (structured choice):
 
 **(1) Full orchestration**
 Multi-agent task orchestration with QA verification. 3+ TODOs or cross-module changes.
@@ -369,13 +197,6 @@ Return to Interview Mode for modifications.
 
 The `(Recommended)` label is **computed from the Decision Matrix, NOT hardcoded** — attach it to whichever option Stage B selected.
 
-**On selection:**
-- Option 1: invoke `Skill(skill: "sisyphus")` with plan file path
-- Option 2: delegate directly to sisyphus-junior
-- Option 3: return to Interview Mode → re-run Metis → Plan → Oracle → Momus pipeline
-
 | User Response | Action |
 |---------------|--------|
 | Requests changes before selecting | Return to Interview Mode, re-run pipeline |
-
-**IMPORTANT:** On execution selection, MUST invoke via Skill() or delegate. Do NOT tell user to run a command manually.


### PR DESCRIPTION
## 📌 Summary

prometheus skill의 split reference 4개 (interview.md / acceptance-criteria.md / plan-template.md / review-pipeline.md)에 묻혀 있던 mandatory procedural contracts를 SKILL.md로 일괄 통합. writing-skills의 RED-GREEN-REFACTOR 사이클로 4 iteration 진행하여 partial-read 실패 모드 (Final Verification Wave 누락, Stage A HTML 비실행 등)를 구조적으로 제거.

---

## 🔧 Changes

### SKILL.md — 4개 mandatory contract inline 통합

- `## Interview Mode (Mandatory Contract)` 추가 — Tool Use vs User Questions, Sequential Rule, Vague/Deferral Handling, Persistence, Anti-Patterns
- `## Acceptance Criteria (Mandatory Contract)` 추가 — Two-line format, Granularity, Consumer Boundary, Setup/Cleanup, Required Chaining Template, Anti-Patterns, Self-Check
- `## Plan Structure (Mandatory Contract)` 추가 — 7 sections, TODO 7-field format, MECE/Atomicity, Wave Assignment Rule, Final Verification Wave F1-F4
- `## Review Pipeline (Mandatory Contract)` 추가 — Common Gate, Verdict/Reviewer Freshness, Pipeline State Machine, Loop Termination, Plan Presentation S5/S6/S7 mandate
- Plan Presentation 섹션에 `"Past sessions have skipped Stage A entirely; do NOT"` explicit counter 포함
- TODO References 필드 사양에 FINAL wave (F1-F4) exemption bullet 명시
- Reference Guides 테이블의 4개 파일 role을 "Lookup-only"로 갱신

기존 split reference에 분산되어 있던 mandatory 규칙을 한 곳에 모아 partial-read에도 contract 누락이 발생하지 않도록 구조적 보호 추가.

**영향 범위**
- 파일 사이즈: SKILL.md 283 → 741줄 (+458)
- Skill 동작: planner가 reference 파일을 끝까지 읽지 않아도 모든 mandatory contract 적용 가능
- 외부 인터페이스: `Skill(skill: "prometheus")` invocation 동일, 하위 호환 유지

### 4개 reference 파일 — lookup-only로 재구성

- `plan-template.md` (253 → 116줄): TODO Example, Execution Strategy Example, Success Criteria Template만 유지
- `acceptance-criteria.md` (356 → 143줄): per-tool Verification examples (maestro/playwright/curl/grep/CLI/unit) + Counter-Example + 워크드 example + Handling User Response만 유지
- `interview.md` (189 → 99줄): Question Categories examples + Quality Standard BAD/GOOD + Rich Context Pattern + Subagent dispatch prompt templates만 유지
- `review-pipeline.md` (381 → 202줄): Metis/Oracle/Momus invocation templates + Stage A HTML rendering procedure (6 invariants, 3 translation invariants, template reference) + Stage B Decision Matrix + Stage C option formatting만 유지

각 파일 상단에 `"This file is lookup-only. All mandatory rules are defined inline in SKILL.md > ##..."` prologue 추가.

**영향 범위**
- 총 사이즈: 1462 → 1301줄 (−161, 중복 제거 효과)
- 컨텐츠 분류: split 파일에서 procedural mandatory 컨텐츠 완전 제거, lookup material만 보유
- 외부 의존성: 변경 없음

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. Split reference의 mandatory contract를 SKILL.md inline으로 전환

**배경 및 문제 상황:**

prior 세션에서 prometheus가 생성한 plan에 Final Verification Wave (F1-F4)가 누락되는 사례 발생. plan-template.md (253줄)의 끝 25% 구간 (line 190-226)에 FVW 사양이 위치하는데, agent가 partial-read로 앞쪽만 읽고 종료한 결과. 추가로 사용자가 "Stage A HTML 렌더링이 한번도 실제 실행되는 꼴을 못 봤다"고 관찰 — review-pipeline.md (381줄)의 끝 41% 구간 (line 222-381)에 Stage A 사양이 있어 같은 partial-read 사각지대.

baseline test에서 subagent가 verbatim으로 자기 합리화 노출:
> "SKILL.md flags these as MANDATORY only conditional on the corresponding workflow stage being active; the test instructions deactivated those stages."

→ LLM이 "MUST read"를 *stage activation에 conditional한 명령*으로 해석. 이게 deferred stage (Stage A 같은)가 영구히 비실행되는 근본 원인.

**해결 방안:**

writing-skills의 *"split = lookup material, inline = procedural contract"* 원칙 적용. 4개 split reference 파일에서 모든 mandatory procedural contract를 SKILL.md로 이동. reference 파일은 lookup material (예시, 카탈로그, 템플릿)만 보유하도록 재구성.

**구현 세부사항:**

4 iteration TDD cycle:
- Iteration 1: Plan Structure (commit `aa40385`)
- Iteration 2: Acceptance Criteria (commit `069f209`)
- Iteration 3: Review Pipeline + Stage A mandate (commit `87226e4`)
- Iteration 4: Interview Mode (commit `c48af22`)

각 iteration은 RED (baseline 측정 또는 prior 관찰) → GREEN (contract inline 이동) → REFACTOR (구조 검증). 최종 end-to-end dispatch (commit `4ef85db`)에서 subagent가 **reference 파일 0개 read**로 contract-compliant plan 생성 확인. agent reflection verbatim:
> "With contracts split, my prior pattern was partial-read: I'd glance at one referenced file (often plan-template.md), miss the AC two-line+Setup/Cleanup chaining rule, and produce a plan with vague ACs or compound ACs. The inline placement forced me to encounter the chaining template, the consumer-boundary table, and the Wave Assignment Rule in a single read."

**선택과 트레이드오프:**

선택한 방향:
- 모든 mandatory contract를 SKILL.md 한 곳에 모음
- Reference 파일은 사이즈 제한 없이 lookup material 보관소

검토했으나 채택하지 않은 대안:
- (A) split reference 안에 *"MANDATORY: read in full"* prologue + 끝쪽 self-check 추가 — "MUST read는 stage-conditional" rationalization을 못 막음
- (B) reference 파일 사이즈를 150줄 이하로 강제 — writing-skills 공식 예시(pptxgenjs.md 600줄, ooxml.md 500줄)와 모순. 사이즈가 아니라 컨텐츠 종류가 분리 기준

수용한 트레이드오프:
- SKILL.md 사이즈 증가 (283 → 741줄). writing-skills "Other skills <500 words" 가이드 위반. orchestration skill 특성상 절충점
- skill을 처음 사용하는 LLM은 더 긴 SKILL.md를 읽지만, reference 4개를 다 읽을 필요 없으므로 net으로는 read 부담 감소

### 2. Stage A HTML 렌더링 explicit counter 추가 — 과거 실패 직접 호명

**배경 및 문제 상황:**

flowchart에는 Stage A가 그려져 있지만 실제 세션에서 systemically 비실행. 원인은 Review Point 1과 동일 (review-pipeline.md 후반부의 partial-read 사각지대).

**해결 방안:**

SKILL.md Plan Presentation 섹션에 explicit "MANDATORY after Momus APPROVE" 명시 + 과거 실패 사실을 그대로 문구화:

> "This step CANNOT be skipped. After Momus APPROVE/COMMENT, prometheus MUST execute Stages A → B → C before any user-facing handoff. Past sessions have skipped Stage A entirely; do NOT."

**구현 세부사항:**

writing-skills의 *"Close every loophole explicitly"* 원칙 적용. 일반 명령형 가이드보다 *과거 실패 패턴을 명시적으로 호명*하는 게 더 강력하다는 가이드 (Cialdini commitment principle의 역활용 — 알려진 실패 모드를 명시하면 LLM이 reproducing하지 않음).

**선택과 트레이드오프:**

skill 문서에 *"Past sessions have failed..."* 같은 직설적 문구는 흔치 않음. tone이 다소 강하지만 *구체적 실패 모드 호명* > *일반 가이드*가 writing-skills 가이드라인.

대안 검토:
- 같은 의미를 좀 더 중립적 톤으로 ("Stage A is mandatory; do not skip even when other stages have been deferred") — 구체성 약화로 효과 감소 우려
- 별도 "Common Failure Modes" 섹션 분리 — 같은 partial-read 함정 재현 가능

### 3. FINAL wave 태스크의 References 필드 exemption

**배경 및 문제 상황:**

End-to-end REFACTOR 단계 subagent 검증에서 발견된 ambiguity. TODO 7-field 사양 중 *"Every TODO needs ≥1 Pattern or API/Type reference"*가 FINAL wave 태스크 (F1 Plan Compliance Audit, F2 Code Quality Review, F3 QA Scenario Execution, F4 Scope Fidelity Check)에도 적용되는지 모호.

F1-F4는 audit 태스크로 본질적으로 *plan 자체*와 *실행된 work*가 audit target. 별도의 Pattern/API/Type 참조가 부자연스러움. subagent가 *"a more explicit carve-out for FINAL-wave tasks would help"* 명시.

**해결 방안:**

TODO References 필드 사양을 두 카테고리로 명시 분리:
- *"Every **implementation** TODO needs ≥1 Pattern or API/Type reference"* (implementation 명시)
- 별도 bullet로 *"FINAL wave exemption: F1-F4 audit tasks do NOT require Pattern/API/Type/Test/External references — their target IS the plan itself + the executed work"*

**선택과 트레이드오프:**

선택: implementation TODO와 audit TODO를 다른 카테고리로 명시 분리. 깔끔하고 ambiguity 제거.

대안: F1-F4도 Pattern 참조를 강제 — *"plan 자체를 reference로"* 같은 boilerplate 유도. 의미 없는 ceremony 발생.

### 4. Reference 파일 적정 사이즈 원칙 (검토 요청)

**배경 및 문제 상황:**

초기 분석에서 reference 파일을 "150줄 이하로 유지" 권고했으나 사용자 이의 제기. writing-skills 본문 재확인 결과 공식 가이드는 *split을 정당화하는 하한선 100+ lines*만 명시. 상한선 없음. 오히려 공식 예시는 600줄 (pptxgenjs.md), 500줄 (ooxml.md).

**해결 방안:**

이번 PR에서 reference 파일들은 lookup material로 정리되었지만 사이즈는 의도적으로 제한하지 않음 (99-202줄 사이, 자연스러운 컨텐츠 사이즈). *컨텐츠 종류 (procedural vs lookup)가 분리 기준*.

**선택과 트레이드오프:**

reviewer 검토 요청: 이 원칙 (사이즈가 아니라 컨텐츠 종류로 split 결정)이 향후 다른 skill (sisyphus, momus, oracle 등) 작성/리팩토링 시에도 일관되게 적용되어야 할까? 만약 yes라면 별도 skill-writing convention 문서화가 필요할 수 있음.

이번 PR에서는 prometheus만 변경. 같은 patterns가 다른 skill에도 있을 가능성 → 후속 PR scope.

---

## ✅ Checklist

### Mandatory Contracts in SKILL.md
- [ ] SKILL.md에 `## Interview Mode (Mandatory Contract)` 섹션 존재 (Tool Use, Sequential, Vague/Deferral, Persistence, Anti-Patterns 포함)
  - `skills/prometheus/SKILL.md`
- [ ] SKILL.md에 `## Acceptance Criteria (Mandatory Contract)` 섹션 존재 (Two-line format, Granularity, Consumer Boundary, Setup/Cleanup, Required Chaining Template 포함)
  - `skills/prometheus/SKILL.md`
- [ ] SKILL.md에 `## Plan Structure (Mandatory Contract)` 섹션 존재 (7 sections, TODO 7-field, MECE/Atomicity, Wave Assignment, Final Verification Wave F1-F4 포함)
  - `skills/prometheus/SKILL.md`
- [ ] SKILL.md에 `## Review Pipeline (Mandatory Contract)` 섹션 존재 (Common Gate, Verdict/Reviewer Freshness, Pipeline State Machine, Plan Presentation mandate 포함)
  - `skills/prometheus/SKILL.md`
- [ ] SKILL.md Plan Presentation 섹션이 "Past sessions have skipped Stage A entirely; do NOT" 문구 포함
  - `skills/prometheus/SKILL.md`
- [ ] TODO References 필드 사양에 FINAL wave (F1-F4) exemption bullet 명시
  - `skills/prometheus/SKILL.md`

### Reference Files Lookup-Only Conversion
- [ ] plan-template.md 상단 prologue가 "lookup-only" 명시 + 컨텐츠가 TODO Example / Execution Strategy Example / Success Criteria Template로 제한됨
  - `skills/prometheus/plan-template.md`
- [ ] acceptance-criteria.md 상단 prologue가 "lookup-only" 명시 + 컨텐츠가 per-tool examples + Counter-Example + 워크드 example + Handling User Response로 제한됨
  - `skills/prometheus/acceptance-criteria.md`
- [ ] interview.md 상단 prologue가 "lookup-only" 명시 + 컨텐츠가 Question Categories examples + Quality Standard + Rich Context Pattern + Subagent dispatch templates로 제한됨
  - `skills/prometheus/interview.md`
- [ ] review-pipeline.md 상단 prologue가 "lookup-only" 명시 + 컨텐츠가 invocation templates + Stage A rendering procedure + Stage B Matrix + Stage C formatting로 제한됨
  - `skills/prometheus/review-pipeline.md`

### Reference Guides Table
- [ ] SKILL.md Reference Guides 테이블에서 4개 reference 파일이 모두 "Lookup-only" role로 표기됨
  - `skills/prometheus/SKILL.md`

---

## 📎 References

- prior PR #60, #61 — prometheus skill 직전 변경 이력 (이번 변경의 baseline)
- writing-skills (superpowers plugin) — split criteria / RED-GREEN-REFACTOR 방법론 참조