### PR TITLE
refactor(pins): emit 트리거 MUST 명시 + 영문화

### DIFF
--- a/hooks/pin-session-start/formatter.ts
+++ b/hooks/pin-session-start/formatter.ts
@@ -4,9 +4,9 @@
  * Output format (within <pins>...</pins> XML wrapper):
  *   <pins>
  *   pins:N
- *   컨텍스트 필요 시: 우선 select-pin 스킬 invoke
- *   발견·갱신 시: write-pin 스킬 invoke로 <pin> XML 형식 학습 후 emit
- *   잘못된 indexing: write-pin supersedes 갱신
+ *   Need context: invoke select-pin first
+ *   Acquired info worth finding again later? You MUST emit a <pin> immediately via write-pin
+ *   Stale entry: write-pin with supersedes
  *   </pins>
  *
  * All counts (0, 1..N) produce the same block. Total output ≤80 tokens (AC-2).
@@ -15,9 +15,9 @@
 import type { ScanResult } from './types.ts';
 
 const MODEL2_LINES = [
-  '컨텍스트 필요 시: 우선 select-pin 스킬 invoke',
-  '발견·갱신 시: write-pin 스킬 invoke로 <pin> XML 형식 학습 후 emit',
-  '잘못된 indexing: write-pin supersedes 갱신',
+  'Need context: invoke select-pin first',
+  'Acquired info worth finding again later? You MUST emit a <pin> immediately via write-pin',
+  'Stale entry: write-pin with supersedes',
 ];
 
 /**

--- a/skills/write-pin/SKILL.md
+++ b/skills/write-pin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-pin
-description: "Use when emitting a new pin, updating a stale pin, or superseding existing indexing — triggers include 박기, 발견, write pin, supersedes, pin 갱신, 새 pin, 잘못된 indexing 수정. Also use when learning the pin XML emission format before emitting. Do NOT trigger on pin retrieval tasks (use select-pin instead)."
+description: "Use when you've acquired info worth finding again later — external SSOT cited (URL/Notion/Linear/GitHub/Slack), ground truth located in code, person named as authority, or stale indexing needs supersedes. Also use when learning the <pin> XML emission format. Korean trigger keywords: 박기, 발견, write pin, supersedes, pin 갱신, 새 pin, 잘못된 indexing 수정. Do NOT trigger on pin retrieval tasks (use select-pin instead)."
 ---
 
 # write-pin


### PR DESCRIPTION
## 📌 Summary

SessionStart에 inject되는 pin emit reminder와 write-pin skill description 모두 "발견 시" 모호 표현으로 인해 agent가 후보 제시·permission asking으로 emit을 회피하던 문제를 수정. SessionStart reminder는 `You MUST emit a <pin> immediately` positive imperative + 영문 통일로, write-pin description은 `acquired info worth finding again later` retrieval-test framing + 외부 SSOT symptom enumeration으로 재작성. Pressure test에서 baseline 회피 패턴(2개 SSOT 동시 발견 시 후보 나열)이 사라지고 즉시 emit 행동으로 역전됨을 확인.

## 🔧 Changes

### SessionStart pin reminder MUST 격상 + 영문화

`hooks/pin-session-start/formatter.ts`의 MODEL2_LINES를 한국어 정중 안내문에서 영문 MUST imperative로 교체. `You MUST emit a <pin> immediately via write-pin` 한 줄로 deferral / permission asking / candidate listing을 일괄 차단.

**영향 범위**: 모든 Claude Code 세션의 SessionStart hook 출력 (AC-2 ≤80 token 예산 내, 현재 27 words)

### write-pin description retrieval-test framing 전환

`skills/write-pin/SKILL.md`의 description을 self-referential trigger(`Use when emitting...`)에서 input-symptom trigger(`Use when you've acquired info worth finding again later`)로 재작성. 외부 SSOT symptom 4종(URL/Notion/Linear/GitHub/Slack 인용, 코드 내 ground truth 발견, person 지목, stale supersedes 필요)을 positive anchor로 enumeration. Korean trigger keyword(`박기, 발견, 갱신` 등)는 명시적 prefix와 함께 보존.

**영향 범위**: write-pin skill discovery 시점의 trigger 매칭 정확도

## 💬 Review Points

### MUST positive imperative vs negative cut-off enumeration

**배경 및 문제 상황**: 초기 draft에서는 회피 패턴을 명시 차단하기 위해 `never list as candidate, never ask "shall I pin?"` 같은 negative enumeration cut-off 절을 추가했음. 그러나 이는 "ban list 밖이면 OK"라는 closed-list trap을 재도입하는 부작용이 있음.

**해결 방안**: Negative enumeration을 모두 제거하고 `You MUST emit ... immediately` 단일 positive imperative로 교체.

**구현 세부사항**: `formatter.ts:18`의 두 번째 line이 단일 modal verb를 보유. 묻기 / 제안 / 유보 등 모든 회피 변종이 obligation 위반으로 자동 분류됨.

**선택과 트레이드오프**: 짧음과 강도가 상충하지 않고, 오히려 짧을수록 강함이 유지됨. Trade-off로 *어떤* 회피가 위반인지 명시되지 않지만, MUST가 모든 변종을 일괄 차단하므로 enumeration 누락 위험이 더 큼.

### Description vs SessionStart reminder의 layer 분리

**배경 및 문제 상황**: write-pin description에도 동일 MUST imperative를 박을지 검토. 그러나 description에 행동 verb를 넣으면 description이 workflow summary를 제공해 skill body 읽기 자체를 short-circuit하는 함정이 있음 (description = "when to use" only 원칙 위반).

**해결 방안**: SessionStart reminder는 *행동 강제* (`You MUST emit ... immediately`), description은 *trigger 매칭* (`Use when you've acquired info worth finding again later`)으로 layer 책임 분리. 같은 retrieval-test framing을 두 layer가 공유하되 modal verb 위치를 분리.

**구현 세부사항**: 3-layer reinforcement 구조 — SessionStart reminder (turn 시작 시 행동 강제) ↔ skill description (discovery 시 trigger 매칭) ↔ skill body rationalization table (invoke 후 회피 차단). 같은 framing 공유로 trigger 누락 확률이 곱셈으로 떨어짐.

**선택과 트레이드오프**: Description에서 positive symptom enumeration은 trigger 정확도를 *높임* (search surface). 반대로 SessionStart reminder에서 negative cut-off enumeration은 closed-list trap. Layer마다 enumeration 효과가 정반대 — audience-driven 정책 분리.

### Validator-coupled token 보존 + Korean trigger keyword 보존

**배경 및 문제 상황**: 영문화 작업 시 모든 한국어 일괄 변경 검토. 그러나 `hooks/pin-up/validator.ts:27-30`의 4개 token (`한 줄 요지` / `SSOT 위치` / `전후 컨텍스트` / `관련 cross-link`)은 validator가 literal grep하는 schema magic string. 영문 변경 시 시스템 break.

**해결 방안**: Audience-driven 분리 정책. AI prose는 영문 default, schema magic string과 한국어 화자 가독성용 텍스트(test displayName, code comment)는 한국어 유지.

**구현 세부사항**: write-pin description의 trigger keyword(`박기, 발견, 갱신` 등)도 Korean input-trigger 보존 원칙에 따라 `Korean trigger keywords:` prefix와 함께 유지.

**선택과 트레이드오프**: 일관 영문화의 단순함을 포기하는 대신 시스템 정합성과 한국어 화자 search surface를 둘 다 확보.

## ✅ Checklist

- [ ] SessionStart reminder MODEL2_LINES가 영문 + MUST imperative 형태인가
  - `hooks/pin-session-start/formatter.ts`
- [ ] write-pin description이 input-symptom trigger 형태이며 Korean trigger keyword가 보존되어 있는가
  - `skills/write-pin/SKILL.md`
- [ ] formatPinsContext keyword contract (select-pin / write-pin / supersedes 모두 포함)이 유지되는가
  - `hooks/pin-session-start/formatter.test.ts`
- [ ] AC-2 token budget (≤80 words)을 초과하지 않는가
  - `hooks/pin-session-start/formatter.test.ts`
- [ ] write-pin description이 1024 char 한도 내인가
  - `skills/write-pin/SKILL.md`
- [ ] pin-up + pin-session-start 전체 테스트가 통과하는가
  - `hooks/pin-session-start/`, `hooks/pin-up/`
- [ ] validator-coupled Korean token 4종이 보존되어 있는가
  - `hooks/pin-up/validator.ts`

## 📎 References

- 직전 commit `b1e35b0 refactor(prometheus): reference 트리거 MANDATORY 명시` — 같은 trigger reinforcement 패턴
- `skills/pins/SKILL.md` — 4 axiom (`indexing-not-wiki`, `ssot-no-copy`, `5-elements-only`, `long-body-wrong-ssot`) source
- `hooks/pin-up/validator.ts` — validator-coupled Korean token 원본