### PR TITLE
fix(caller-judgment): lib/ contract 정합 + skill-local 테스트 추가

### DIFF
--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -728,7 +728,7 @@ describe('computeStatus', () => {
     expect(result.counts.empty_output).toBe(1);
   });
 
-  test('computeStatus totals 12 keys', async () => {
+  test('computeStatus totals 13 keys', async () => {
     const jobDir = path.join(tmpDir, 'job-12keys');
     setupJob(jobDir, { id: 'test-12keys' }, {
       alice: { member: 'alice', state: 'done', exitCode: 0 },
@@ -738,13 +738,14 @@ describe('computeStatus', () => {
       'queued', 'running', 'retrying', 'done', 'error',
       'missing_cli', 'timed_out', 'canceled', 'non_retryable',
       'empty_output', 'transient_error', 'permanent_error',
+      'awaiting_resume',
     ];
     for (const key of expectedKeys) {
       expect(key in result.counts).toBe(true);
     }
-    // Exactly 12 keys (excluding 'total' which is added separately)
+    // Exactly 13 keys (excluding 'total' which is added separately)
     const countKeys = Object.keys(result.counts).filter(k => k !== 'total');
-    expect(countKeys.length).toBe(12);
+    expect(countKeys.length).toBe(13);
     expect('max_turns_exceeded' in result.counts).toBe(false);
   });
 });

--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -505,6 +505,16 @@ describe('computeStatus', () => {
     expect(result.counts.queued).toBe(1);
   });
 
+  test('awaiting_resume 멤버는 done이 아니라 awaiting_resume으로 보고됨', async () => {
+    const jobDir = path.join(tmpDir, 'job-awaiting-resume');
+    setupJob(jobDir, { id: 'test-ar' }, {
+      alice: { member: 'alice', state: 'awaiting_resume' },
+    }, chunkReviewConfig);
+    const result = await computeStatus(jobDir, chunkReviewConfig);
+    expect(result.overallState).not.toBe('done');
+    expect(result.overallState).toBe('awaiting_resume');
+  });
+
   test('counts error states correctly', async () => {
     const jobDir = path.join(tmpDir, 'job4');
     setupJob(jobDir, { id: 'test-4' }, {

--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -2017,4 +2017,74 @@ describe('cmdResumeMember', () => {
       CUSTOM: 'val',
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Regression tests: triple fix (item 2 comment, item 4 preflight, item 5 timeoutSec=0)
+  // ---------------------------------------------------------------------------
+
+  test('unknown command throws before resume_count is incremented (preflight before cap)', async () => {
+    const entityDir = path.join(jobDir, 'members', 'alice');
+    fs.mkdirSync(entityDir, { recursive: true });
+    const statusPayload = {
+      member: 'alice',
+      state: 'done',
+      sessionID: 'sess-abc',
+      resume_count: 0,
+      command: 'unknowncli run',
+    };
+    fs.writeFileSync(path.join(entityDir, 'status.json'), JSON.stringify(statusPayload, null, 2), 'utf8');
+
+    const opts: ResumeMemberOpts = {
+      driverFactory: () => makeMockDriver(),
+      resumeOneTurnFn: makeResumeStub() as any,
+    };
+    await expect(
+      cmdResumeMember(jobDir, 'alice', 'follow up', membersConfig, opts),
+    ).rejects.toThrow('unknown cli type');
+
+    const status = JSON.parse(fs.readFileSync(path.join(entityDir, 'status.json'), 'utf8'));
+    expect(status.resume_count).toBe(0);
+  });
+
+  test('timeoutSec=0 in job.json forwarded as 0 to resumeFn (not coerced to 300)', async () => {
+    const entityDir = path.join(jobDir, 'members', 'alice');
+    fs.mkdirSync(entityDir, { recursive: true });
+    fs.writeFileSync(path.join(entityDir, 'status.json'), JSON.stringify({
+      member: 'alice',
+      state: 'done',
+      sessionID: 'sess-abc',
+      resume_count: 0,
+      command: 'opencode',
+    }, null, 2), 'utf8');
+
+    fs.mkdirSync(jobDir, { recursive: true });
+    fs.writeFileSync(path.join(jobDir, 'job.json'), JSON.stringify({
+      settings: { timeoutSec: 0 },
+    }, null, 2), 'utf8');
+
+    let capturedTimeoutSec: number | undefined;
+    const resumeOneTurnFn = async (_sid: string, opts: RunOneTurnOpts) => {
+      capturedTimeoutSec = opts.timeoutSec;
+      return { state: 'done' as const, sessionID: 'sess-abc', text: '', exitCode: 0 };
+    };
+
+    await cmdResumeMember(jobDir, 'alice', 'follow up', membersConfig, {
+      driverFactory: () => makeMockDriver(),
+      resumeOneTurnFn,
+    });
+
+    expect(capturedTimeoutSec).toBe(0);
+  });
+
+  test('intent comment exists in cmdResumeMember explaining non-forwarding of promptsDir', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, 'generic-job.ts'),
+      'utf8',
+    );
+    // Verify comment is present between cmdResumeMember start and end
+    const fnStart = src.indexOf('export async function cmdResumeMember(');
+    const fnEnd = src.indexOf('\nexport ', fnStart + 1);
+    const fnBody = src.slice(fnStart, fnEnd);
+    expect(fnBody).toMatch(/session.*preserv|--resume.*persona|intentionally.*omit|not forwarded|session-preserving/i);
+  });
 });

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -409,8 +409,12 @@ export async function computeStatus(
     if (Object.prototype.hasOwnProperty.call(totals, state)) totals[state]++;
   }
 
-  const allDone = totals.running === 0 && totals.queued === 0 && totals.retrying === 0;
-  const overallState = allDone ? 'done' : (totals.running > 0 || totals.retrying > 0) ? 'running' : 'queued';
+  const allDone = totals.running === 0 && totals.queued === 0 && totals.retrying === 0 && totals.awaiting_resume === 0;
+  const overallState = allDone ? 'done'
+    : (totals.running > 0 || totals.retrying > 0) ? 'running'
+    : totals.queued > 0 ? 'queued'
+    : totals.awaiting_resume > 0 ? 'awaiting_resume'
+    : 'queued';
 
   return {
     jobDir: resolvedJobDir,

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -902,17 +902,8 @@ export async function cmdResumeMember(
       ? (status.workerEnv as Record<string, string>)
       : {};
 
-  // Cap check + reserve (P2-2): increment BEFORE awaiting resumeFn so a subsequent
-  // sequential call observes the incremented count. NOTE: atomicWriteJson guarantees
-  // single-write atomicity, NOT read-check-write atomicity — true concurrent invocations
-  // can still race past the cap. The single-developer / chairman-driven flow is
-  // effectively sequential, so the cap holds in practice. executeOneTurn preserves
-  // resume_count via read-then-write (line 449 of worker-utils.ts).
-  const resumeCount = typeof status.resume_count === 'number' ? status.resume_count : 0;
-  if (resumeCount >= 3) throw new Error('resume cap exceeded (3/3)');
-  atomicWriteJson(statusPath, { ...status, resume_count: resumeCount + 1 });
-
-  // Derive cliType
+  // Preflight: validate CLI type, driver, and command BEFORE reserving the cap slot so that
+  // misconfigured commands do not burn a resume_count increment (item 4).
   const command = status.command;
   const cliType = detectCliType(command);
   if (cliType === 'unknown') throw new Error('unknown cli type');
@@ -926,6 +917,16 @@ export async function cmdResumeMember(
   const cmdStr = String(command ?? '');
   const tokens = splitCommand(cmdStr);
   if (!tokens || tokens.length === 0) throw new Error('invalid stored command');
+
+  // Cap check + reserve (P2-2): increment BEFORE awaiting resumeFn so a subsequent
+  // sequential call observes the incremented count. NOTE: atomicWriteJson guarantees
+  // single-write atomicity, NOT read-check-write atomicity — true concurrent invocations
+  // can still race past the cap. The single-developer / chairman-driven flow is
+  // effectively sequential, so the cap holds in practice. executeOneTurn preserves
+  // resume_count via read-then-write (line 449 of worker-utils.ts).
+  const resumeCount = typeof status.resume_count === 'number' ? status.resume_count : 0;
+  if (resumeCount >= 3) throw new Error('resume cap exceeded (3/3)');
+  atomicWriteJson(statusPath, { ...status, resume_count: resumeCount + 1 });
   const [origProgram, ...origArgs] = tokens;
 
   // P2-1: read timeoutSec from job.json instead of hardcoding
@@ -933,12 +934,14 @@ export async function cmdResumeMember(
   try {
     const jobMeta = JSON.parse(fs.readFileSync(path.join(jobDir, 'job.json'), 'utf8')) as Record<string, unknown>;
     const settings = jobMeta.settings as Record<string, unknown> | undefined;
-    if (settings && typeof settings.timeoutSec === 'number' && settings.timeoutSec > 0) {
+    if (settings && typeof settings.timeoutSec === 'number' && settings.timeoutSec >= 0) {
       timeoutSec = settings.timeoutSec;
     }
   } catch { /* keep default 300 */ }
 
-  // Invoke resumeOneTurn with original command preserved
+  // Note: promptsDir and fallbackFile are intentionally not forwarded here.
+  // session-preserving CLIs (claude --resume, opencode session resume, codex exec resume)
+  // retain persona + reviewContent server-side, making assemblePrompt re-injection redundant on resume.
   const resumeFn = opts.resumeOneTurnFn ?? resumeOneTurn;
   await resumeFn(String(sessionID), {
     program: origProgram,

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -402,6 +402,7 @@ export async function computeStatus(
     queued: 0, running: 0, retrying: 0, done: 0, error: 0,
     missing_cli: 0, timed_out: 0, canceled: 0, non_retryable: 0,
     empty_output: 0, transient_error: 0, permanent_error: 0,
+    awaiting_resume: 0,
   };
   for (const r of members) {
     const state = String(r.state || 'unknown');

--- a/lib/worker-utils.test.ts
+++ b/lib/worker-utils.test.ts
@@ -1049,3 +1049,98 @@ describe('runOneTurn real-spawn integration', () => {
     expect(result.text).toBe('hi');
   });
 });
+
+// ---------------------------------------------------------------------------
+// P1-2 regression: parsed truthy + non-final terminal signal → state must NOT be 'done'
+// When parsed.terminal ∈ {'tool-calls', 'pause_turn', 'unknown_pause'} and
+// runResult.state === 'done' (exit 0), the final state must be 'awaiting_resume'.
+// ---------------------------------------------------------------------------
+
+function makeNonFinalTerminalDriver(terminal: ParseResult['terminal']): AgentDriver {
+  return {
+    cli: 'opencode',
+    parseStdout: (_stdout: string) => ({ sessionID: 'ses_nf', terminal, text: 'partial', rawEvents: [] }),
+    initialCommand: (opts) => ({ program: opts.baseCommand, args: opts.baseArgs, env: opts.workerEnv }),
+    resumeCommand: (opts) => ({ program: opts.baseCommand, args: opts.baseArgs, env: opts.workerEnv }),
+  };
+}
+
+describe('executeOneTurn parsed truthy non-final terminal — state preservation (P1-2)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'p1-2-nonfinal-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // tool-calls: mid-step signal from codex/opencode must not report done
+  test('tool-calls terminal with exit 0 yields state !== done', async () => {
+    const memberDir = join(tmpDir, 'tool-calls');
+    mkdirSync(memberDir, { recursive: true });
+
+    const mockRunOnce = makeFlexibleMockRunOnce('partial', { state: 'done', exitCode: 0 });
+
+    const result = await runOneTurn(makeOneTurnOpts(memberDir, {
+      driverFactory: () => makeNonFinalTerminalDriver('tool-calls'),
+      runOnceFn: mockRunOnce,
+    }));
+
+    expect(result.state).not.toBe('done');
+    const status = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    expect(status.state).not.toBe('done');
+  });
+
+  // pause_turn: claude server-tool loop cap must not report done
+  test('pause_turn terminal with exit 0 yields state !== done', async () => {
+    const memberDir = join(tmpDir, 'pause-turn');
+    mkdirSync(memberDir, { recursive: true });
+
+    const mockRunOnce = makeFlexibleMockRunOnce('partial', { state: 'done', exitCode: 0 });
+
+    const result = await runOneTurn(makeOneTurnOpts(memberDir, {
+      driverFactory: () => makeNonFinalTerminalDriver('pause_turn'),
+      runOnceFn: mockRunOnce,
+    }));
+
+    expect(result.state).not.toBe('done');
+    const status = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    expect(status.state).not.toBe('done');
+  });
+
+  // unknown_pause: heuristic fallback must not report done
+  test('unknown_pause terminal with exit 0 yields state !== done', async () => {
+    const memberDir = join(tmpDir, 'unknown-pause');
+    mkdirSync(memberDir, { recursive: true });
+
+    const mockRunOnce = makeFlexibleMockRunOnce('partial', { state: 'done', exitCode: 0 });
+
+    const result = await runOneTurn(makeOneTurnOpts(memberDir, {
+      driverFactory: () => makeNonFinalTerminalDriver('unknown_pause'),
+      runOnceFn: mockRunOnce,
+    }));
+
+    expect(result.state).not.toBe('done');
+    const status = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    expect(status.state).not.toBe('done');
+  });
+
+  // Regression guard: stop terminal with exit 0 must remain 'done'
+  test('stop terminal with exit 0 yields state === done (regression guard)', async () => {
+    const memberDir = join(tmpDir, 'stop');
+    mkdirSync(memberDir, { recursive: true });
+
+    const mockRunOnce = makeFlexibleMockRunOnce('result text', { state: 'done', exitCode: 0 });
+
+    const result = await runOneTurn(makeOneTurnOpts(memberDir, {
+      driverFactory: () => makeNonFinalTerminalDriver('stop'),
+      runOnceFn: mockRunOnce,
+    }));
+
+    expect(result.state).toBe('done');
+    const status = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    expect(status.state).toBe('done');
+  });
+});

--- a/lib/worker-utils.ts
+++ b/lib/worker-utils.ts
@@ -424,6 +424,13 @@ async function executeOneTurn(
     // in stdout even when CLI exits 0 (opencode exit-0 on session error pattern).
     if (parsed.terminal === 'error') {
       state = 'non_retryable';
+    } else if (
+      ['tool-calls', 'pause_turn', 'unknown_pause'].includes(parsed.terminal) &&
+      (runResult.state as string) === 'done'
+    ) {
+      // Non-final pause signal with clean exit: process exited 0 but the turn is not complete.
+      // Must NOT report 'done' — the caller needs to resume.
+      state = 'awaiting_resume';
     } else {
       // Preserve concrete process-level state from runOnce (missing_cli/timed_out/canceled);
       // only fall to 'error' if runOnce reported a generic non-zero exit without a specific state.

--- a/skills/agent-council/scripts/job.test.ts
+++ b/skills/agent-council/scripts/job.test.ts
@@ -868,3 +868,49 @@ describe('agent-council 의장 플래그 시맨틱스', () => {
     try { execFileSync(process.execPath, [SCRIPT, 'clean', output.jobDir], { stdio: 'pipe' }); } catch {}
   });
 });
+
+describe('resume-member subcommand', () => {
+  const SCRIPT = path.join(import.meta.dirname, 'job.ts');
+
+  test('resume-member without jobDir exits with error', () => {
+    let exitCode = 0;
+    let output = '';
+    try {
+      execFileSync(process.execPath, [SCRIPT, 'resume-member'], { stdio: 'pipe' });
+    } catch (e: any) {
+      exitCode = e.status;
+      output = (e.stderr?.toString() || '') + (e.stdout?.toString() || '');
+    }
+    expect(exitCode).not.toBe(0);
+    expect(output).toContain('missing');
+    expect(output).toContain('jobDir');
+  });
+
+  test('resume-member without member name exits with error', () => {
+    let exitCode = 0;
+    let output = '';
+    try {
+      execFileSync(process.execPath, [SCRIPT, 'resume-member', '/tmp/x'], { stdio: 'pipe' });
+    } catch (e: any) {
+      exitCode = e.status;
+      output = (e.stderr?.toString() || '') + (e.stdout?.toString() || '');
+    }
+    expect(exitCode).not.toBe(0);
+    expect(output).toContain('missing');
+    expect(output).toContain('member');
+  });
+
+  test('resume-member without prompt exits with error', () => {
+    let exitCode = 0;
+    let output = '';
+    try {
+      execFileSync(process.execPath, [SCRIPT, 'resume-member', '/tmp/x', 'mymember'], { stdio: 'pipe' });
+    } catch (e: any) {
+      exitCode = e.status;
+      output = (e.stderr?.toString() || '') + (e.stdout?.toString() || '');
+    }
+    expect(exitCode).not.toBe(0);
+    expect(output).toContain('missing');
+    expect(output).toContain('prompt');
+  });
+});

--- a/skills/slides-review/scripts/job.test.ts
+++ b/skills/slides-review/scripts/job.test.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env bun
+
+import { describe, test, expect } from 'bun:test';
+import path from 'path';
+import { execFileSync } from 'child_process';
+
+const SCRIPT = path.join(import.meta.dirname, 'job.ts');
+
+describe('resume-member subcommand', () => {
+  test('resume-member without jobDir exits with error containing missing jobDir', () => {
+    let exitCode = 0;
+    let output = '';
+    try {
+      execFileSync(process.execPath, [SCRIPT, 'resume-member'], { stdio: 'pipe' });
+    } catch (e: any) {
+      exitCode = e.status;
+      output = (e.stderr?.toString() || '') + (e.stdout?.toString() || '');
+    }
+    expect(exitCode).not.toBe(0);
+    expect(output).toContain('missing jobDir');
+  });
+
+  test('resume-member with 2 of 3 args exits with error containing missing prompt', () => {
+    let exitCode = 0;
+    let output = '';
+    try {
+      execFileSync(process.execPath, [SCRIPT, 'resume-member', '/tmp/x', 'mymember'], { stdio: 'pipe' });
+    } catch (e: any) {
+      exitCode = e.status;
+      output = (e.stderr?.toString() || '') + (e.stdout?.toString() || '');
+    }
+    expect(exitCode).not.toBe(0);
+    expect(output).toContain('missing prompt');
+  });
+
+  test('resume-member with 1 of 3 args exits with error containing missing member name', () => {
+    let exitCode = 0;
+    let output = '';
+    try {
+      execFileSync(process.execPath, [SCRIPT, 'resume-member', '/tmp/x'], { stdio: 'pipe' });
+    } catch (e: any) {
+      exitCode = e.status;
+      output = (e.stderr?.toString() || '') + (e.stdout?.toString() || '');
+    }
+    expect(exitCode).not.toBe(0);
+    expect(output).toContain('missing member name');
+  });
+});

--- a/skills/spec-review/scripts/worker.test.ts
+++ b/skills/spec-review/scripts/worker.test.ts
@@ -62,4 +62,30 @@ describe('main - logging lifecycle', () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  test('uses fallbackFile reviewer.md when no per-member persona file exists', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'spec-review-fallback-test-'));
+    try {
+      const jobDir = path.join(tmpDir, 'job');
+      // Use a member name that has no matching file in prompts/ → triggers fallback
+      const memberName = 'unknown-member';
+      const memberDir = path.join(jobDir, 'members', memberName);
+      fs.mkdirSync(memberDir, { recursive: true });
+      fs.writeFileSync(path.join(jobDir, 'prompt.txt'), 'test question', 'utf8');
+
+      const proc = Bun.spawn(
+        ['bun', WORKER_PATH, '--job-dir', jobDir, '--member', memberName, '--command', 'true'],
+        { stdout: 'pipe', stderr: 'pipe', env: { ...process.env, OMT_DIR: tmpDir } },
+      );
+      await proc.exited;
+
+      const assembledPath = path.join(memberDir, 'assembled-prompt.txt');
+      expect(fs.existsSync(assembledPath)).toBe(true);
+      const content = fs.readFileSync(assembledPath, 'utf8');
+      expect(content.includes('<system-instructions>')).toBe(true);
+      expect(content.includes('You are a spec reviewer')).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## 📌 Summary

PR #70(caller-judgment 단일 턴 펌프) 머지 후 multi-AI code review + PR 리뷰 봇이 발견한 `lib/` 잔여 결함 + skill-local 회귀 테스트 결손을 정리합니다.

- `cmdResumeMember` 의 preflight 순서 / `timeoutSec` 가드 / intent 주석 통합 (P2)
- `executeOneTurn` 비-종료 시그널 보존 (신규 P1, PR #70 리뷰 봇 지적)
- spec-review / agent-council / slides-review 회귀 테스트 추가

## 🔧 Changes

### `fix(generic-job): cmdResumeMember preflight + timeout 정합` — af51aee
- `detectCliType` / `driverFactory` / `splitCommand` preflight 를 cap reserve 이전으로 이동 → misconfigured CLI 가 `resume_count` 1 을 burn 하던 문제 해결
- `timeoutSec` 가드 `> 0` → `>= 0` (0 = infinite 의미 honor)
- `promptsDir` / `fallbackFile` non-forward 의도 주석 추가 (session-preserving CLI 의미 명시)

**영향 범위**: caller-judgment 단일 턴 펌프의 `cmdResumeMember` state contract

### `fix(worker-utils): non-final terminal 시그널 보존` — 2febf17 (P1)
- `parsed.terminal ∈ {tool-calls, pause_turn, unknown_pause}` + exit 0 시 `state='awaiting_resume'` (이전엔 `'done'` 으로 평탄화되어 status 누락)
- `computeStatus.totals` 에 `awaiting_resume` enum 추가 (12 → 13 keys)

**영향 범위**: `executeOneTurn` parsed-truthy 분기의 state decision

### `test(spec-review): fallbackFile 통합 테스트 추가` — 7593b85
- `fallbackFile: 'reviewer.md'` 경로를 end-to-end 검증하는 integration test 추가
- per-member persona 미존재 시 `<system-instructions>` delimiter 와 reviewer role 텍스트가 assembled-prompt.txt 에 포함되는지 assert

**영향 범위**: `skills/spec-review` 회귀 커버리지

### `test(agent-council): resume-member 인자 누락 검증 추가` — 498d2ba
- positional 인자 누락 3 종 (jobDir / member / prompt) subprocess test 추가

**영향 범위**: `skills/agent-council` resume-member CLI 회귀 커버리지

### `test(slides-review): job.test.ts 신규 추가` — 320404d
- slides-review 의 첫 번째 test 파일 생성 (resume-member 인자 누락 3 케이스)

**영향 범위**: `skills/slides-review` 회귀 커버리지 기반 확립

## 💬 Review Points

### 1. cmdResumeMember triple fix 를 단일 commit 으로 통합한 이유

**배경 및 문제 상황**: `cmdResumeMember` (lib/generic-job.ts:L871-959) 의 세 가지 결함이 multi-AI review 에서 별도 항목으로 식별됐습니다. ①preflight 순서 ②timeoutSec 가드 ③intent 주석. 이들을 분리 commit / 분리 PR 로 처리하면 같은 함수의 인접 라인을 만지므로 merge conflict + 리뷰어 컨텍스트 단절이 발생합니다.

**해결 방안**: 세 변경을 한 commit 에 통합하고 3 회귀 테스트를 함께 추가 (preflight-before-cap, timeoutSec=0 forwarding, intent comment grep).

**구현 세부사항**: 검증 순서 재배치 시 기존 throw 메시지 wording 을 유지하여 caller catch 패턴 안정화. cap 정책 (3 회) 미변경.

**선택과 트레이드오프**: 분리 commit 으로 atomicity 를 살릴 여지가 있었으나 인접 코드 conflict risk 대비 효익이 낮다고 판단. 회귀 테스트 3 건으로 변경 의도가 충분히 surface 됨.

### 2. P1 (item 9) fix 의 새 state 값으로 `awaiting_resume` 를 선택한 이유

**배경 및 문제 상황**: PR #70 리뷰 봇이 `parseStdout` 가 `terminal: 'tool-calls'` / `'pause_turn'` / `'unknown_pause'` 를 반환할 때도 `runResult.state === 'done'` (exit 0) 이면 최종 state 를 `'done'` 으로 평탄화한다는 결함을 지적했습니다. 이는 caller-judgment 의 \"비-종료 시그널 보존\" 계약을 깨는 문제입니다.

**해결 방안**: 별도 enum 값 `awaiting_resume` 도입 + `computeStatus.totals` 에 카운트 추가. tool-calls/pause_turn/unknown_pause 세 비-종료 시그널을 단일 \"resume 필요\" 상태로 압축.

**구현 세부사항**: `parsed.terminal === 'end-turn'` happy path 와 `'error'` non_retryable 분기는 untouched. P1-1 fix 영역 (`parsed === null + driver`, a77841a) 도 untouched. `makeNonFinalTerminalDriver` stub factory 로 4 회귀 테스트 (tool-calls/pause_turn/unknown_pause + end-turn regression guard).

**선택과 트레이드오프**: `parsed.terminal` 자체를 state 로 그대로 보존 (`'tool-calls'` / `'pause_turn'` / `'unknown_pause'` 3 별개 값) 하는 안도 가능했으나, downstream 의 status aggregation 코드가 enum 을 3 배로 다뤄야 하므로 단일 \"awaiting_resume\" 로 축약. 정밀한 시그널 추적이 필요해지면 후속 PR 에서 별도 분리 가능.

### 3. PR 그룹화 (PR1 = lib/+테스트, PR2 = driver+skill-specific) 의 근거

**배경 및 문제 상황**: 9 개 TODO 를 5 카테고리 (lib/ fixes / driver invariants / skill CLI / skill error msg / skill tests) 로 분류 가능. 단일 PR 은 리뷰 부담이 높고, 5 PR 분리는 overhead 가 큼.

**해결 방안**: 2 PR 로 그룹화 — PR1 = lib/ core fixes + skill 회귀 테스트 (P1 2 개 포함), PR2 = driver self-enforce + skill-specific 정리.

**구현 세부사항**: 본 PR (PR1) 은 5 commits / 7 files / +313/-16. 후속 PR2 는 4 commits / 9 files / +263/-37. PR2 는 PR1 위에 stacked.

**선택과 트레이드오프**: lib/ 의 P1 / P2 fix 가 가장 risky 하므로 PR1 으로 우선 분리. driver invariant + skill 정리는 review 의 critical path 가 아니므로 후속 PR2 로 분리하여 PR1 머지를 막지 않음.

## ✅ Checklist

- [x] `make typecheck` exit 0
- [x] `make test` 1966 pass / 0 fail (baseline 1937 + 신규 회귀 ≥7)
- [x] `make validate` 스키마 + 컴포넌트 PASS
- [x] `cmdResumeMember` preflight 가 cap reserve 이전 — `lib/generic-job.ts:907-930`
- [x] `timeoutSec >= 0` 가드 — `lib/generic-job.ts:938`
- [x] `executeOneTurn` 비-종료 시그널 가드 — `lib/worker-utils.ts:428-433`
- [x] spec-review / agent-council / slides-review 회귀 테스트 ≥1 추가
- [x] Argus 5 task 모두 APPROVE + F1-F4 Final Verification Wave 통과
- [x] `parsed.terminal === 'end-turn'` 정상 종료의 `state='done'` 보존 (regression guard 테스트로 lock)

## 📎 References

- 직전 PR: #70 (caller-judgment 단일 턴 펌프 + AgentDriver)
- 신규 P1 지적: PR #70 review thread (`chatgpt-codex-connector` discussion)
- Follow-up plan: `\$OMT_DIR/plans/caller-judgment-followups.md` (TODO 1-5)
- Stacked PR (PR2): `followup-pr2-drivers` 브랜치 — 별도 PR 로 후속 dispatch