### PR TITLE
refactor(caller-judgment): driver invariant + skill 정리

### DIFF
--- a/lib/agent-drivers/codex.test.ts
+++ b/lib/agent-drivers/codex.test.ts
@@ -148,6 +148,52 @@ describe('codex AgentDriver', () => {
     expect(result.args).toContain('--skip-git-repo-check');
   });
 
+  // -------------------------------------------------------------------------
+  // --json self-enforcement (idempotent guard)
+  // -------------------------------------------------------------------------
+
+  test('`initialCommand` - --json 없으면 주입', () => {
+    const result = codexDriver.initialCommand({
+      prompt: 'prompt-content',
+      baseCommand: 'codex',
+      baseArgs: ['exec', 'prompt-content'],
+      workerEnv: {},
+    });
+    expect(result.args).toContain('--json');
+  });
+
+  test('`initialCommand` - --json 이미 있으면 중복 없음', () => {
+    const result = codexDriver.initialCommand({
+      prompt: 'prompt-content',
+      baseCommand: 'codex',
+      baseArgs: ['exec', '--json', 'prompt-content'],
+      workerEnv: {},
+    });
+    expect(result.args.filter((a) => a === '--json').length).toBe(1);
+  });
+
+  test('`resumeCommand` - --json 없으면 주입', () => {
+    const result = codexDriver.resumeCommand({
+      sessionID: '019e3152-c43b-7e03-8ada-4620be171fa7',
+      prompt: 'continue',
+      baseCommand: 'codex',
+      baseArgs: ['exec', 'prompt-content'],
+      workerEnv: {},
+    });
+    expect(result.args).toContain('--json');
+  });
+
+  test('`resumeCommand` - --json 이미 있으면 중복 없음', () => {
+    const result = codexDriver.resumeCommand({
+      sessionID: '019e3152-c43b-7e03-8ada-4620be171fa7',
+      prompt: 'continue',
+      baseCommand: 'codex',
+      baseArgs: ['exec', '--json', 'prompt-content'],
+      workerEnv: {},
+    });
+    expect(result.args.filter((a) => a === '--json').length).toBe(1);
+  });
+
   test('`resumeCommand` - baseArgs의 -c 오버라이드 보존', () => {
     const result = codexDriver.resumeCommand({
       sessionID: '019e3152-c43b-7e03-8ada-4620be171fa7',

--- a/lib/agent-drivers/codex.ts
+++ b/lib/agent-drivers/codex.ts
@@ -90,6 +90,9 @@ export const codexDriver: AgentDriver = {
     if (!args.includes('--skip-git-repo-check')) {
       args.push('--skip-git-repo-check');
     }
+    if (!args.includes('--json')) {
+      args.push('--json');
+    }
     return {
       program: opts.baseCommand,
       args,
@@ -112,6 +115,9 @@ export const codexDriver: AgentDriver = {
 
     if (!args.includes('--skip-git-repo-check')) {
       args.push('--skip-git-repo-check');
+    }
+    if (!args.includes('--json')) {
+      args.push('--json');
     }
 
     return {

--- a/lib/agent-drivers/opencode.test.ts
+++ b/lib/agent-drivers/opencode.test.ts
@@ -126,6 +126,53 @@ describe('opencode AgentDriver', () => {
   });
 
   // -------------------------------------------------------------------------
+  // resumeCommand — --format value check (regression)
+  // -------------------------------------------------------------------------
+
+  test('`resumeCommand` - baseArgs에 --format text가 있으면 --format json으로 교체', () => {
+    const result = opencodeDriver.resumeCommand({
+      sessionID: 'ses_abc',
+      prompt: 'continue',
+      baseCommand: 'opencode',
+      baseArgs: ['run', '--format', 'text'],
+      workerEnv: {},
+    });
+    // exactly one --format
+    expect(result.args.filter((a) => a === '--format').length).toBe(1);
+    // value is json, not text
+    const fmtIdx = result.args.indexOf('--format');
+    expect(result.args[fmtIdx + 1]).toBe('json');
+    expect(result.args).not.toContain('text');
+  });
+
+  test('`resumeCommand` - baseArgs에 --format json이 이미 있으면 중복 없이 1개만 유지', () => {
+    const result = opencodeDriver.resumeCommand({
+      sessionID: 'ses_abc',
+      prompt: 'continue',
+      baseCommand: 'opencode',
+      baseArgs: ['run', '--format', 'json'],
+      workerEnv: {},
+    });
+    // idempotent: exactly one --format json, no duplicates
+    expect(result.args.filter((a) => a === '--format').length).toBe(1);
+    const fmtIdx = result.args.indexOf('--format');
+    expect(result.args[fmtIdx + 1]).toBe('json');
+  });
+
+  test('`resumeCommand` - baseArgs에 --format 없으면 --format json 추가', () => {
+    const result = opencodeDriver.resumeCommand({
+      sessionID: 'ses_abc',
+      prompt: 'continue',
+      baseCommand: 'opencode',
+      baseArgs: ['run', '--prompt', 'hi'],
+      workerEnv: {},
+    });
+    expect(result.args).toContain('--format');
+    const fmtIdx = result.args.indexOf('--format');
+    expect(result.args[fmtIdx + 1]).toBe('json');
+  });
+
+  // -------------------------------------------------------------------------
   // initialCommand
   // -------------------------------------------------------------------------
 

--- a/lib/agent-drivers/opencode.test.ts
+++ b/lib/agent-drivers/opencode.test.ts
@@ -176,7 +176,7 @@ describe('opencode AgentDriver', () => {
   // initialCommand
   // -------------------------------------------------------------------------
 
-  test('`initialCommand` - baseCommand/baseArgs/workerEnv를 그대로 전달', () => {
+  test('`initialCommand` - baseCommand/baseArgs/workerEnv 기본 전달 + --format json 강제', () => {
     const result = opencodeDriver.initialCommand({
       prompt: 'hello',
       baseCommand: 'opencode',
@@ -184,7 +184,67 @@ describe('opencode AgentDriver', () => {
       workerEnv: { OPENCODE_TOKEN: 'tok' },
     });
     expect(result.program).toBe('opencode');
-    expect(result.args).toEqual(['run', '--format', 'json', '--prompt', 'hello']);
+    // --format json stripped and re-appended → idempotent, still present once at end
+    expect(result.args.filter((a) => a === '--format').length).toBe(1);
+    const fmtIdx = result.args.indexOf('--format');
+    expect(result.args[fmtIdx + 1]).toBe('json');
+    expect(result.args).toContain('run');
+    expect(result.args).toContain('--prompt');
+    expect(result.args).toContain('hello');
+    expect(result.env).toMatchObject({ OPENCODE_TOKEN: 'tok' });
+  });
+
+  test('`initialCommand` - --format 없는 baseArgs에 --format json 추가', () => {
+    const result = opencodeDriver.initialCommand({
+      prompt: 'hello',
+      baseCommand: 'opencode',
+      baseArgs: ['exec'],
+      workerEnv: {},
+    });
+    expect(result.args).toContain('--format');
+    const fmtIdx = result.args.indexOf('--format');
+    expect(result.args[fmtIdx + 1]).toBe('json');
+  });
+
+  test('`initialCommand` - baseArgs에 --format text가 있으면 --format json으로 교체', () => {
+    const result = opencodeDriver.initialCommand({
+      prompt: 'hello',
+      baseCommand: 'opencode',
+      baseArgs: ['exec', '--format', 'text'],
+      workerEnv: {},
+    });
+    expect(result.args.filter((a) => a === '--format').length).toBe(1);
+    const fmtIdx = result.args.indexOf('--format');
+    expect(result.args[fmtIdx + 1]).toBe('json');
+    expect(result.args).not.toContain('text');
+  });
+
+  test('`initialCommand` - baseArgs에 --format json이 이미 있으면 중복 없이 1개만 유지 (멱등)', () => {
+    const result = opencodeDriver.initialCommand({
+      prompt: 'hello',
+      baseCommand: 'opencode',
+      baseArgs: ['exec', '--format', 'json'],
+      workerEnv: {},
+    });
+    expect(result.args.filter((a) => a === '--format').length).toBe(1);
+    const fmtIdx = result.args.indexOf('--format');
+    expect(result.args[fmtIdx + 1]).toBe('json');
+  });
+
+  test('`initialCommand` - 다른 인자 보존 + --format json 추가', () => {
+    const result = opencodeDriver.initialCommand({
+      prompt: 'hello',
+      baseCommand: 'opencode',
+      baseArgs: ['exec', '--model', 'opus-4'],
+      workerEnv: { OPENCODE_TOKEN: 'tok' },
+    });
+    expect(result.program).toBe('opencode');
+    expect(result.args).toContain('exec');
+    expect(result.args).toContain('--model');
+    expect(result.args).toContain('opus-4');
+    expect(result.args).toContain('--format');
+    const fmtIdx = result.args.indexOf('--format');
+    expect(result.args[fmtIdx + 1]).toBe('json');
     expect(result.env).toMatchObject({ OPENCODE_TOKEN: 'tok' });
   });
 });

--- a/lib/agent-drivers/opencode.ts
+++ b/lib/agent-drivers/opencode.ts
@@ -139,9 +139,10 @@ function parseStdout(stdout: string): ParseResult | null {
 // ---------------------------------------------------------------------------
 
 function initialCommand(opts: InitialCommandOpts): BuiltCommand {
+  const stripped = stripFormatPair(opts.baseArgs, '--format');
   return {
     program: opts.baseCommand,
-    args: [...opts.baseArgs],
+    args: [...stripped, '--format', 'json'],
     env: opts.workerEnv,
   };
 }

--- a/lib/agent-drivers/opencode.ts
+++ b/lib/agent-drivers/opencode.ts
@@ -139,7 +139,7 @@ function parseStdout(stdout: string): ParseResult | null {
 // ---------------------------------------------------------------------------
 
 function initialCommand(opts: InitialCommandOpts): BuiltCommand {
-  const stripped = stripFormatPair(opts.baseArgs, '--format');
+  const stripped = stripFlagPair(opts.baseArgs, '--format');
   return {
     program: opts.baseCommand,
     args: [...stripped, '--format', 'json'],
@@ -152,7 +152,7 @@ function initialCommand(opts: InitialCommandOpts): BuiltCommand {
 // ---------------------------------------------------------------------------
 
 /** Strip any existing --flagName <value> pair from args (returns new array). */
-function stripFormatPair(args: string[], flagName: string): string[] {
+function stripFlagPair(args: string[], flagName: string): string[] {
   const out: string[] = [];
   let i = 0;
   while (i < args.length) {
@@ -167,20 +167,9 @@ function stripFormatPair(args: string[], flagName: string): string[] {
 }
 
 function resumeCommand(opts: ResumeCommandOpts): BuiltCommand {
-  // Strip existing --session pair from baseArgs (replace, not duplicate).
-  let stripped: string[] = [];
-  const baseArgs = opts.baseArgs;
-  for (let i = 0; i < baseArgs.length; i++) {
-    if (baseArgs[i] === '--session') {
-      i++; // skip the value too
-      continue;
-    }
-    stripped.push(baseArgs[i]);
-  }
-
-  // Ensure --format json is present with exactly the right value.
-  // Strip any existing --format <value> pair, then unconditionally append --format json.
-  stripped = stripFormatPair(stripped, '--format');
+  // Strip existing --session and --format pairs (replace, not duplicate), then append the
+  // canonical values. parseStdout requires --format json, so its value is enforced unconditionally.
+  const stripped = stripFlagPair(stripFlagPair(opts.baseArgs, '--session'), '--format');
   const args = [...stripped, '--session', opts.sessionID, '--format', 'json'];
 
   return {

--- a/lib/agent-drivers/opencode.ts
+++ b/lib/agent-drivers/opencode.ts
@@ -150,9 +150,24 @@ function initialCommand(opts: InitialCommandOpts): BuiltCommand {
 // resumeCommand
 // ---------------------------------------------------------------------------
 
+/** Strip any existing --flagName <value> pair from args (returns new array). */
+function stripFormatPair(args: string[], flagName: string): string[] {
+  const out: string[] = [];
+  let i = 0;
+  while (i < args.length) {
+    if (args[i] === flagName) {
+      i += 2; // skip flag + value
+    } else {
+      out.push(args[i]);
+      i++;
+    }
+  }
+  return out;
+}
+
 function resumeCommand(opts: ResumeCommandOpts): BuiltCommand {
   // Strip existing --session pair from baseArgs (replace, not duplicate).
-  const stripped: string[] = [];
+  let stripped: string[] = [];
   const baseArgs = opts.baseArgs;
   for (let i = 0; i < baseArgs.length; i++) {
     if (baseArgs[i] === '--session') {
@@ -162,13 +177,10 @@ function resumeCommand(opts: ResumeCommandOpts): BuiltCommand {
     stripped.push(baseArgs[i]);
   }
 
-  // Inject --session and ensure --format json is present.
-  // --format json may already be in stripped (from yaml buildAugmentedCommand); keep it.
-  // Only add --format json if not already present.
-  const args = [...stripped, '--session', opts.sessionID];
-  if (!args.includes('--format')) {
-    args.push('--format', 'json');
-  }
+  // Ensure --format json is present with exactly the right value.
+  // Strip any existing --format <value> pair, then unconditionally append --format json.
+  stripped = stripFormatPair(stripped, '--format');
+  const args = [...stripped, '--session', opts.sessionID, '--format', 'json'];
 
   return {
     program: opts.baseCommand,

--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -2330,4 +2330,86 @@ describe('cmdResumeMember', () => {
       cmdResumeMember(jobDir, 'alice', 'follow up', membersConfig, opts),
     ).rejects.toThrow('orchestrate-review: resume cap exceeded (3/3)');
   });
+
+  test('cap exceeded writes non_retryable state to status.json before throwing', async () => {
+    const entityDir = path.join(jobDir, 'members', 'alice');
+    writeMemberStatus(entityDir, {
+      member: 'alice',
+      state: 'empty_output',
+      sessionID: 'sess-abc',
+      resume_count: 3,
+      command: 'opencode',
+    });
+
+    const opts: ResumeMemberOpts = {
+      driverFactory: () => makeMockDriver(),
+      resumeOneTurnFn: makeResumeStub() as any,
+    };
+    await expect(
+      cmdResumeMember(jobDir, 'alice', 'follow up', membersConfig, opts),
+    ).rejects.toThrow('resume cap exceeded (3/3)');
+
+    const status = readMemberStatus(entityDir);
+    expect(status.state).toBe('non_retryable');
+    expect(status.resume_count).toBe(3);
+  });
+
+  test('cap exceeded member does not block computeStatus overallState done when other member is done', async () => {
+    // Set up job with two members: alice (capped) and bob (done)
+    const aliceDir = path.join(jobDir, 'members', 'alice');
+    const bobDir = path.join(jobDir, 'members', 'bob');
+    writeMemberStatus(aliceDir, {
+      member: 'alice',
+      state: 'empty_output',
+      sessionID: 'sess-abc',
+      resume_count: 3,
+      command: 'opencode',
+    });
+    writeMemberStatus(bobDir, {
+      member: 'bob',
+      state: 'done',
+      sessionID: 'sess-bob',
+      resume_count: 0,
+      command: 'opencode',
+    });
+    fs.mkdirSync(jobDir, { recursive: true });
+    fs.writeFileSync(path.join(jobDir, 'job.json'), JSON.stringify({ id: 'test-cap-job' }));
+
+    const opts: ResumeMemberOpts = {
+      driverFactory: () => makeMockDriver(),
+      resumeOneTurnFn: makeResumeStub() as any,
+    };
+    await expect(
+      cmdResumeMember(jobDir, 'alice', 'follow up', membersConfig, opts),
+    ).rejects.toThrow('resume cap exceeded (3/3)');
+
+    const result = await computeStatus(jobDir, membersConfig);
+    expect(result.overallState).toBe('done');
+  });
+
+  test('cap exceeded member appears in buildManifest with outputFilePath null', async () => {
+    const aliceDir = path.join(jobDir, 'members', 'alice');
+    writeMemberStatus(aliceDir, {
+      member: 'alice',
+      state: 'empty_output',
+      sessionID: 'sess-abc',
+      resume_count: 3,
+      command: 'opencode',
+    });
+    fs.mkdirSync(jobDir, { recursive: true });
+    fs.writeFileSync(path.join(jobDir, 'job.json'), JSON.stringify({ id: 'test-cap-manifest' }));
+
+    const opts: ResumeMemberOpts = {
+      driverFactory: () => makeMockDriver(),
+      resumeOneTurnFn: makeResumeStub() as any,
+    };
+    await expect(
+      cmdResumeMember(jobDir, 'alice', 'follow up', membersConfig, opts),
+    ).rejects.toThrow('resume cap exceeded (3/3)');
+
+    const manifest = buildManifest(jobDir, membersConfig);
+    const aliceEntry = manifest.members.find((m: any) => m.member === 'alice');
+    expect(aliceEntry).toBeDefined();
+    expect(aliceEntry.outputFilePath).toBe(null);
+  });
 });

--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -781,6 +781,49 @@ describe('computeStatus', () => {
     expect(result.overallState).toBe('running');
   });
 
+  // empty_output overallState integration tests
+  test('모든 멤버 empty_output이면 overallState는 done이 아님', async () => {
+    const jobDir = path.join(tmpDir, 'job-all-empty-output');
+    setupJob(jobDir, { id: 'test-all-eo' }, {
+      alice: { member: 'alice', state: 'empty_output' },
+      bob: { member: 'bob', state: 'empty_output' },
+    }, chunkReviewConfig);
+    const result = await computeStatus(jobDir, chunkReviewConfig);
+    expect(result.overallState).not.toBe('done');
+    expect(result.overallState).toBe('empty_output');
+  });
+
+  test('일부 done, 일부 empty_output이면 overallState는 done이 아님', async () => {
+    const jobDir = path.join(tmpDir, 'job-partial-empty-output');
+    setupJob(jobDir, { id: 'test-partial-eo' }, {
+      alice: { member: 'alice', state: 'done', exitCode: 0 },
+      bob: { member: 'bob', state: 'empty_output' },
+    }, chunkReviewConfig);
+    const result = await computeStatus(jobDir, chunkReviewConfig);
+    expect(result.overallState).not.toBe('done');
+    expect(result.overallState).toBe('empty_output');
+  });
+
+  test('일부 running, 일부 empty_output이면 overallState는 running (running 우선)', async () => {
+    const jobDir = path.join(tmpDir, 'job-running-empty-output');
+    setupJob(jobDir, { id: 'test-run-eo' }, {
+      alice: { member: 'alice', state: 'running' },
+      bob: { member: 'bob', state: 'empty_output' },
+    }, chunkReviewConfig);
+    const result = await computeStatus(jobDir, chunkReviewConfig);
+    expect(result.overallState).toBe('running');
+  });
+
+  test('awaiting_resume과 empty_output 동시 존재 시 awaiting_resume 우선', async () => {
+    const jobDir = path.join(tmpDir, 'job-ar-and-eo');
+    setupJob(jobDir, { id: 'test-ar-eo' }, {
+      alice: { member: 'alice', state: 'awaiting_resume' },
+      bob: { member: 'bob', state: 'empty_output' },
+    }, chunkReviewConfig);
+    const result = await computeStatus(jobDir, chunkReviewConfig);
+    expect(result.overallState).toBe('awaiting_resume');
+  });
+
   test('모든 멤버 done이면 overallState는 done (regression)', async () => {
     const jobDir = path.join(tmpDir, 'job-all-done-regression');
     setupJob(jobDir, { id: 'test-all-done' }, {

--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -748,6 +748,48 @@ describe('computeStatus', () => {
     expect(countKeys.length).toBe(13);
     expect('max_turns_exceeded' in result.counts).toBe(false);
   });
+
+  // awaiting_resume overallState integration tests
+  test('모든 멤버가 awaiting_resume이면 overallState는 done이 아님', async () => {
+    const jobDir = path.join(tmpDir, 'job-all-awaiting-resume');
+    setupJob(jobDir, { id: 'test-all-ar' }, {
+      alice: { member: 'alice', state: 'awaiting_resume' },
+      bob: { member: 'bob', state: 'awaiting_resume' },
+    }, chunkReviewConfig);
+    const result = await computeStatus(jobDir, chunkReviewConfig);
+    expect(result.overallState).not.toBe('done');
+    expect(result.overallState).toBe('awaiting_resume');
+  });
+
+  test('일부 done, 일부 awaiting_resume이면 overallState는 done이 아님', async () => {
+    const jobDir = path.join(tmpDir, 'job-partial-awaiting-resume');
+    setupJob(jobDir, { id: 'test-partial-ar' }, {
+      alice: { member: 'alice', state: 'done', exitCode: 0 },
+      bob: { member: 'bob', state: 'awaiting_resume' },
+    }, chunkReviewConfig);
+    const result = await computeStatus(jobDir, chunkReviewConfig);
+    expect(result.overallState).not.toBe('done');
+  });
+
+  test('일부 running, 일부 awaiting_resume이면 overallState는 running (running 우선)', async () => {
+    const jobDir = path.join(tmpDir, 'job-running-awaiting-resume');
+    setupJob(jobDir, { id: 'test-run-ar' }, {
+      alice: { member: 'alice', state: 'running' },
+      bob: { member: 'bob', state: 'awaiting_resume' },
+    }, chunkReviewConfig);
+    const result = await computeStatus(jobDir, chunkReviewConfig);
+    expect(result.overallState).toBe('running');
+  });
+
+  test('모든 멤버 done이면 overallState는 done (regression)', async () => {
+    const jobDir = path.join(tmpDir, 'job-all-done-regression');
+    setupJob(jobDir, { id: 'test-all-done' }, {
+      alice: { member: 'alice', state: 'done', exitCode: 0 },
+      bob: { member: 'bob', state: 'done', exitCode: 0 },
+    }, chunkReviewConfig);
+    const result = await computeStatus(jobDir, chunkReviewConfig);
+    expect(result.overallState).toBe('done');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -960,6 +1002,21 @@ describe('buildUiPayload', () => {
     };
     const result = buildUiPayload(payload, chunkReviewConfig);
     expect(result.progress.overallState).toBe('running');
+  });
+
+  test('awaiting_resume 멤버는 completed가 아닌 in_progress로 분류됨 (non-terminal)', () => {
+    const payload = {
+      overallState: 'awaiting_resume',
+      counts: { total: 1, done: 0, queued: 0, running: 0, awaiting_resume: 1 },
+      members: [{ member: 'alice', state: 'awaiting_resume' }],
+    };
+    const result = buildUiPayload(payload, chunkReviewConfig);
+    // The reviewer step (index 1) must NOT be 'completed' — awaiting_resume is non-terminal
+    const reviewerStep = result.codex.update_plan.plan[1];
+    expect(reviewerStep.status).not.toBe('completed');
+    // Synthesize step must NOT be in_progress yet (job not done)
+    const synthStep = result.codex.update_plan.plan[result.codex.update_plan.plan.length - 1];
+    expect(synthStep.status).not.toBe('completed');
   });
 });
 
@@ -1574,6 +1631,35 @@ describe('cmdCollect', () => {
     expect(output.length).toBeGreaterThan(0);
     const result = JSON.parse(output[0]);
     expect(result.overallState).toBe('done');
+  }, 15000);
+
+  test('awaiting_resume 상태에서는 done manifest를 반환하지 않고 timeout fallback', async () => {
+    const jobDir = path.join(tmpDir, 'job-collect-awaiting-resume');
+    setupCollectJob(jobDir, {
+      alice: { member: 'alice', state: 'awaiting_resume' },
+    });
+
+    const output: string[] = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (chunk: string | Uint8Array, ..._args: unknown[]) => {
+      if (typeof chunk === 'string') output.push(chunk);
+      return origWrite(chunk as any);
+    };
+
+    try {
+      // timeout-ms must exceed COLLECT_POLL_INTERVAL_MS (5000ms) to allow one poll cycle.
+      // The loop sleeps 5s then re-checks timeout, so total wall time is ~10s; set to 11s.
+      await cmdCollect({ 'timeout-ms': 5100 }, jobDir, chunkReviewConfig);
+    } finally {
+      process.stdout.write = origWrite;
+    }
+
+    expect(output.length).toBeGreaterThan(0);
+    const result = JSON.parse(output[0]);
+    // Must NOT return done manifest when awaiting_resume
+    expect(result.overallState).not.toBe('done');
+    // Must not contain manifest 'members' array (done manifest only)
+    expect(result.members).toBeUndefined();
   }, 15000);
 });
 

--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -804,6 +804,28 @@ describe('computeStatus', () => {
     expect(result.overallState).toBe('empty_output');
   });
 
+  // queued precedence over intervention states: a member still awaiting dispatch must keep
+  // overallState at 'queued' so cmdCollect does not early-return on a sibling's intervention state.
+  test('일부 queued, 일부 awaiting_resume이면 overallState는 queued (queued 우선)', async () => {
+    const jobDir = path.join(tmpDir, 'job-queued-awaiting-resume');
+    setupJob(jobDir, { id: 'test-queued-ar' }, {
+      alice: { member: 'alice', state: 'queued' },
+      bob: { member: 'bob', state: 'awaiting_resume' },
+    }, chunkReviewConfig);
+    const result = await computeStatus(jobDir, chunkReviewConfig);
+    expect(result.overallState).toBe('queued');
+  });
+
+  test('일부 queued, 일부 empty_output이면 overallState는 queued (queued 우선)', async () => {
+    const jobDir = path.join(tmpDir, 'job-queued-empty-output');
+    setupJob(jobDir, { id: 'test-queued-eo' }, {
+      alice: { member: 'alice', state: 'queued' },
+      bob: { member: 'bob', state: 'empty_output' },
+    }, chunkReviewConfig);
+    const result = await computeStatus(jobDir, chunkReviewConfig);
+    expect(result.overallState).toBe('queued');
+  });
+
   test('일부 running, 일부 empty_output이면 overallState는 running (running 우선)', async () => {
     const jobDir = path.join(tmpDir, 'job-running-empty-output');
     setupJob(jobDir, { id: 'test-run-eo' }, {

--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -1676,7 +1676,7 @@ describe('cmdCollect', () => {
     expect(result.overallState).toBe('done');
   }, 15000);
 
-  test('awaiting_resume 상태에서는 done manifest를 반환하지 않고 timeout fallback', async () => {
+  test('awaiting_resume 상태에서는 done manifest를 반환하지 않고 즉시 members 포함 반환', async () => {
     const jobDir = path.join(tmpDir, 'job-collect-awaiting-resume');
     setupCollectJob(jobDir, {
       alice: { member: 'alice', state: 'awaiting_resume' },
@@ -1690,9 +1690,7 @@ describe('cmdCollect', () => {
     };
 
     try {
-      // timeout-ms must exceed COLLECT_POLL_INTERVAL_MS (5000ms) to allow one poll cycle.
-      // The loop sleeps 5s then re-checks timeout, so total wall time is ~10s; set to 11s.
-      await cmdCollect({ 'timeout-ms': 5100 }, jobDir, chunkReviewConfig);
+      await cmdCollect({ 'timeout-ms': 5000 }, jobDir, chunkReviewConfig);
     } finally {
       process.stdout.write = origWrite;
     }
@@ -1700,9 +1698,10 @@ describe('cmdCollect', () => {
     expect(output.length).toBeGreaterThan(0);
     const result = JSON.parse(output[0]);
     // Must NOT return done manifest when awaiting_resume
-    expect(result.overallState).not.toBe('done');
-    // Must not contain manifest 'members' array (done manifest only)
-    expect(result.members).toBeUndefined();
+    expect(result.overallState).toBe('awaiting_resume');
+    // Must contain members array for chairman to identify which member needs resume-member
+    expect(Array.isArray(result.members)).toBe(true);
+    expect(result.members[0].state).toBe('awaiting_resume');
   }, 15000);
 });
 

--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -1061,6 +1061,21 @@ describe('buildUiPayload', () => {
     const synthStep = result.codex.update_plan.plan[result.codex.update_plan.plan.length - 1];
     expect(synthStep.status).not.toBe('completed');
   });
+
+  test('empty_output 멤버는 completed가 아닌 pending으로 분류됨 (non-terminal)', () => {
+    const payload = {
+      overallState: 'empty_output',
+      counts: { total: 1, done: 0, queued: 0, running: 0, empty_output: 1 },
+      members: [{ member: 'alice', state: 'empty_output' }],
+    };
+    const result = buildUiPayload(payload, chunkReviewConfig);
+    // The reviewer step (index 1) must NOT be 'completed' — empty_output is non-terminal
+    const reviewerStep = result.codex.update_plan.plan[1];
+    expect(reviewerStep.status).not.toBe('completed');
+    // Synthesize step must NOT be completed yet (job not done)
+    const synthStep = result.codex.update_plan.plan[result.codex.update_plan.plan.length - 1];
+    expect(synthStep.status).not.toBe('completed');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -2174,4 +2174,103 @@ describe('cmdResumeMember', () => {
     const fnBody = src.slice(fnStart, fnEnd);
     expect(fnBody).toMatch(/session.*preserv|--resume.*persona|intentionally.*omit|not forwarded|session-preserving/i);
   });
+
+  // ---------------------------------------------------------------------------
+  // skillName-aware error messages
+  // ---------------------------------------------------------------------------
+
+  test('skillName absent + no driver emits generic message', async () => {
+    const entityDir = path.join(jobDir, 'members', 'alice');
+    writeMemberStatus(entityDir, {
+      member: 'alice',
+      state: 'done',
+      sessionID: 'sess-abc',
+      resume_count: 0,
+      command: 'opencode',
+    });
+
+    const opts: ResumeMemberOpts = {
+      driverFactory: () => null as any,
+      resumeOneTurnFn: makeResumeStub() as any,
+    };
+    await expect(
+      cmdResumeMember(jobDir, 'alice', 'follow up', membersConfig, opts),
+    ).rejects.toThrow('no driver for opencode');
+    // Must NOT include skill prefix
+    await expect(
+      cmdResumeMember(jobDir, 'alice', 'follow up', membersConfig, opts),
+    ).rejects.toThrow(/^no driver for/);
+  });
+
+  test('skillName + no driver emits prefixed message with guidance', async () => {
+    const entityDir = path.join(jobDir, 'members', 'alice');
+    writeMemberStatus(entityDir, {
+      member: 'alice',
+      state: 'done',
+      sessionID: 'sess-abc',
+      resume_count: 0,
+      command: 'opencode',
+    });
+
+    const opts: ResumeMemberOpts = {
+      driverFactory: () => null as any,
+      resumeOneTurnFn: makeResumeStub() as any,
+      skillName: 'slides-review',
+    };
+    await expect(
+      cmdResumeMember(jobDir, 'alice', 'follow up', membersConfig, opts),
+    ).rejects.toThrow('slides-review: no driver for opencode, implement driver or change default member');
+  });
+
+  test('skillName + unknown cli type emits prefixed message', async () => {
+    const entityDir = path.join(jobDir, 'members', 'alice');
+    writeMemberStatus(entityDir, {
+      member: 'alice',
+      state: 'done',
+      sessionID: 'sess-abc',
+      resume_count: 0,
+      command: 'unknowncli run',
+    });
+
+    const opts: ResumeMemberOpts = {
+      driverFactory: () => makeMockDriver(),
+      resumeOneTurnFn: makeResumeStub() as any,
+      skillName: 'orchestrate-review',
+    };
+    await expect(
+      cmdResumeMember(jobDir, 'alice', 'follow up', membersConfig, opts),
+    ).rejects.toThrow('orchestrate-review: unknown cli type');
+  });
+
+  test('skillName + no resumable session emits prefixed message', async () => {
+    // No status.json written → 'no resumable session'
+    const opts: ResumeMemberOpts = {
+      driverFactory: () => makeMockDriver(),
+      resumeOneTurnFn: makeResumeStub() as any,
+      skillName: 'slides-review',
+    };
+    await expect(
+      cmdResumeMember(jobDir, 'ghost', 'follow up', membersConfig, opts),
+    ).rejects.toThrow('slides-review: no resumable session');
+  });
+
+  test('skillName + resume cap exceeded emits prefixed message', async () => {
+    const entityDir = path.join(jobDir, 'members', 'alice');
+    writeMemberStatus(entityDir, {
+      member: 'alice',
+      state: 'done',
+      sessionID: 'sess-abc',
+      resume_count: 3,
+      command: 'opencode',
+    });
+
+    const opts: ResumeMemberOpts = {
+      driverFactory: () => makeMockDriver(),
+      resumeOneTurnFn: makeResumeStub() as any,
+      skillName: 'orchestrate-review',
+    };
+    await expect(
+      cmdResumeMember(jobDir, 'alice', 'follow up', membersConfig, opts),
+    ).rejects.toThrow('orchestrate-review: resume cap exceeded (3/3)');
+  });
 });

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -939,7 +939,10 @@ export async function cmdResumeMember(
   // effectively sequential, so the cap holds in practice. executeOneTurn preserves
   // resume_count via read-then-write (line 449 of worker-utils.ts).
   const resumeCount = typeof status.resume_count === 'number' ? status.resume_count : 0;
-  if (resumeCount >= 3) throw new Error(`${prefix}resume cap exceeded (3/3)`);
+  if (resumeCount >= 3) {
+    atomicWriteJson(statusPath, { ...status, state: 'non_retryable', message: 'resume cap exceeded (3/3)' });
+    throw new Error(`${prefix}resume cap exceeded (3/3)`);
+  }
   atomicWriteJson(statusPath, { ...status, resume_count: resumeCount + 1 });
   const [origProgram, ...origArgs] = tokens;
 

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -870,6 +870,8 @@ export type ResumeMemberOpts = {
   resumeOneTurnFn?: (sessionID: string, opts: RunOneTurnOpts) => Promise<OneTurnResult>;
   /** Test-only: forwarded to resumeOneTurn for spawn-less e2e wire validation. */
   runOnceFn?: typeof runOnce;
+  /** Optional skill name for skill-aware error messages (e.g., 'slides-review', 'orchestrate-review'). */
+  skillName?: string;
 };
 
 export async function cmdResumeMember(
@@ -881,23 +883,24 @@ export async function cmdResumeMember(
 ): Promise<void> {
   const memberDir = path.join(jobDir, config.entityDirName, name);
   const statusPath = path.join(memberDir, 'status.json');
+  const prefix = opts.skillName ? `${opts.skillName}: ` : '';
 
   // Read status.json
   let status: Record<string, unknown>;
   try {
     status = JSON.parse(fs.readFileSync(statusPath, 'utf8')) as Record<string, unknown>;
   } catch {
-    throw new Error('no resumable session');
+    throw new Error(`${prefix}no resumable session`);
   }
 
   // Check sessionID
   const sessionID = status.sessionID;
-  if (!sessionID) throw new Error('no resumable session');
+  if (!sessionID) throw new Error(`${prefix}no resumable session`);
 
   // State check
   const state = String(status.state ?? '');
   if (state === 'error' || state === 'non_retryable') {
-    throw new Error(`member in non-resumable state: ${state}`);
+    throw new Error(`${prefix}member in non-resumable state: ${state}`);
   }
 
   // Restore workerEnv saved by executeOneTurn (P1-4: preserve cross-CLI env contract across resume).
@@ -910,17 +913,17 @@ export async function cmdResumeMember(
   // misconfigured commands do not burn a resume_count increment (item 4).
   const command = status.command;
   const cliType = detectCliType(command);
-  if (cliType === 'unknown') throw new Error('unknown cli type');
+  if (cliType === 'unknown') throw new Error(`${prefix}unknown cli type`);
 
   // Driver lookup
   const driverFactory = opts.driverFactory ?? pickDriver;
   const driver = driverFactory(cliType as CliType);
-  if (!driver) throw new Error(`no driver for ${cliType}`);
+  if (!driver) throw new Error(`${prefix}no driver for ${cliType}, implement driver or change default member`);
 
   // P1-3: parse status.command to restore original program+args (preserve --agent/--model/-p/run/etc.)
   const cmdStr = String(command ?? '');
   const tokens = splitCommand(cmdStr);
-  if (!tokens || tokens.length === 0) throw new Error('invalid stored command');
+  if (!tokens || tokens.length === 0) throw new Error(`${prefix}invalid stored command`);
 
   // Cap check + reserve (P2-2): increment BEFORE awaiting resumeFn so a subsequent
   // sequential call observes the incremented count. NOTE: atomicWriteJson guarantees
@@ -929,7 +932,7 @@ export async function cmdResumeMember(
   // effectively sequential, so the cap holds in practice. executeOneTurn preserves
   // resume_count via read-then-write (line 449 of worker-utils.ts).
   const resumeCount = typeof status.resume_count === 'number' ? status.resume_count : 0;
-  if (resumeCount >= 3) throw new Error('resume cap exceeded (3/3)');
+  if (resumeCount >= 3) throw new Error(`${prefix}resume cap exceeded (3/3)`);
   atomicWriteJson(statusPath, { ...status, resume_count: resumeCount + 1 });
   const [origProgram, ...origArgs] = tokens;
 

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -481,7 +481,7 @@ export function buildUiPayload(
     .filter((r) => r.entity)
     .sort((a, b) => a.entity.localeCompare(b.entity));
 
-  const terminalStates = new Set(['done', 'missing_cli', 'error', 'timed_out', 'canceled', 'non_retryable', 'empty_output', 'transient_error', 'permanent_error']);
+  const terminalStates = new Set(['done', 'missing_cli', 'error', 'timed_out', 'canceled', 'non_retryable', 'transient_error', 'permanent_error']);
   const dispatchStatus = asCodexStepStatus(isDone ? 'completed' : queued > 0 ? 'in_progress' : 'completed');
   let hasInProgress = dispatchStatus === 'in_progress';
 

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -852,6 +852,12 @@ export async function cmdCollect(
       );
       return;
     }
+    if (status.overallState === 'awaiting_resume' || status.overallState === 'empty_output') {
+      process.stdout.write(
+        `${JSON.stringify({ overallState: status.overallState, id: status.id, counts: status.counts, members: status.members }, null, 2)}\n`,
+      );
+      return;
+    }
     if (timeoutMs > 0 && Date.now() - start >= timeoutMs) {
       process.stdout.write(
         `${JSON.stringify({ overallState: status.overallState, id: status.id, counts: status.counts }, null, 2)}\n`,

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -409,8 +409,11 @@ export async function computeStatus(
     if (Object.prototype.hasOwnProperty.call(totals, state)) totals[state]++;
   }
 
-  const allDone = totals.running === 0 && totals.queued === 0 && totals.retrying === 0;
-  const overallState = allDone ? 'done' : (totals.running > 0 || totals.retrying > 0) ? 'running' : 'queued';
+  const allDone = totals.running === 0 && totals.queued === 0 && totals.retrying === 0 && totals.awaiting_resume === 0;
+  const overallState = allDone ? 'done'
+    : (totals.running > 0 || totals.retrying > 0) ? 'running'
+    : totals.awaiting_resume > 0 ? 'awaiting_resume'
+    : 'queued';
 
   return {
     jobDir: resolvedJobDir,

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -412,6 +412,9 @@ export async function computeStatus(
   const allDone = totals.running === 0 && totals.queued === 0 && totals.retrying === 0 && totals.awaiting_resume === 0 && totals.empty_output === 0;
   const overallState = allDone ? 'done'
     : (totals.running > 0 || totals.retrying > 0) ? 'running'
+    // queued outranks the intervention states: a member still awaiting dispatch must not let
+    // cmdCollect early-return on a sibling's awaiting_resume/empty_output before that member runs.
+    : totals.queued > 0 ? 'queued'
     : totals.awaiting_resume > 0 ? 'awaiting_resume'
     : totals.empty_output > 0 ? 'empty_output'
     : 'queued';

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -409,10 +409,11 @@ export async function computeStatus(
     if (Object.prototype.hasOwnProperty.call(totals, state)) totals[state]++;
   }
 
-  const allDone = totals.running === 0 && totals.queued === 0 && totals.retrying === 0 && totals.awaiting_resume === 0;
+  const allDone = totals.running === 0 && totals.queued === 0 && totals.retrying === 0 && totals.awaiting_resume === 0 && totals.empty_output === 0;
   const overallState = allDone ? 'done'
     : (totals.running > 0 || totals.retrying > 0) ? 'running'
     : totals.awaiting_resume > 0 ? 'awaiting_resume'
+    : totals.empty_output > 0 ? 'empty_output'
     : 'queued';
 
   return {

--- a/lib/worker-utils.test.ts
+++ b/lib/worker-utils.test.ts
@@ -1340,16 +1340,12 @@ describe('`executeOneTurn` empty_output 분류 및 raw NDJSON 보존', () => {
     expect(outputTxt).toBe('hi');
   });
 
-  // P1.1: telemetry 필드가 status.json에 포함됨
-  test('status.json에 terminal/eventCount/lastEventType/tokens 텔레메트리 필드가 포함됨', async () => {
+  // status.json에 driver terminal classification이 기록됨
+  test('status.json에 terminal 필드가 기록됨', async () => {
     const memberDir = join(tmpDir, 'telemetry');
     mkdirSync(memberDir, { recursive: true });
 
-    const rawEvents = [
-      { type: 'step_start', part: {} },
-      { type: 'step_finish', part: { tokens: { input: 100, output: 50, cache_read: 0, cache_write: 0 } } },
-    ];
-    const mockDriver = makeStopWithEventsDriver('some content', rawEvents);
+    const mockDriver = makeStopWithEventsDriver('some content', []);
     const mockRunOnce = makeFlexibleMockRunOnce('raw', { state: 'done', exitCode: 0 });
 
     await runOneTurn(makeOneTurnOpts(memberDir, {
@@ -1359,22 +1355,15 @@ describe('`executeOneTurn` empty_output 분류 및 raw NDJSON 보존', () => {
 
     const status = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
     expect(status.terminal).toBe('stop');
-    expect(status.eventCount).toBe(2);
-    expect(status.lastEventType).toBe('step_finish');
-    expect(status.tokens).toEqual({ input: 100, output: 50, cache_read: 0, cache_write: 0 });
   });
 
-  // P0.3 + P1.1 happy path: stop + non-empty text → state='done', size_bytes>0, telemetry 정상
-  test('stop terminal에 text가 있으면 state=done이고 size_bytes>0이며 telemetry가 포함됨', async () => {
+  // P0.3 happy path: stop + non-empty text → state='done', size_bytes>0, terminal 기록
+  test('stop terminal에 text가 있으면 state=done이고 size_bytes>0이며 terminal이 기록됨', async () => {
     const memberDir = join(tmpDir, 'happy-path');
     mkdirSync(memberDir, { recursive: true });
 
     const content = 'real content here';
-    const rawEvents = [
-      { type: 'agent_message', content },
-      { type: 'step_finish', part: { tokens: { input: 50, output: 20 } } },
-    ];
-    const mockDriver = makeStopWithEventsDriver(content, rawEvents);
+    const mockDriver = makeStopWithEventsDriver(content, []);
     const mockRunOnce = makeFlexibleMockRunOnce('raw ndjson', { state: 'done', exitCode: 0 });
 
     const result = await runOneTurn(makeOneTurnOpts(memberDir, {
@@ -1387,9 +1376,6 @@ describe('`executeOneTurn` empty_output 분류 및 raw NDJSON 보존', () => {
     expect(status.state).toBe('done');
     expect(status.size_bytes).toBe(Buffer.byteLength(content, 'utf8'));
     expect(status.terminal).toBe('stop');
-    expect(status.eventCount).toBe(2);
-    expect(status.lastEventType).toBe('step_finish');
-    expect(status.tokens).toEqual({ input: 50, output: 20 });
   });
 
   // P1 회귀: no-driver 경로에서 size_bytes가 rawStdout byte length와 일치해야 함 (0이면 안 됨)

--- a/lib/worker-utils.test.ts
+++ b/lib/worker-utils.test.ts
@@ -1391,4 +1391,22 @@ describe('`executeOneTurn` empty_output 분류 및 raw NDJSON 보존', () => {
     expect(status.lastEventType).toBe('step_finish');
     expect(status.tokens).toEqual({ input: 50, output: 20 });
   });
+
+  // P1 회귀: no-driver 경로에서 size_bytes가 rawStdout byte length와 일치해야 함 (0이면 안 됨)
+  test('driver가 null일 때 size_bytes가 rawStdout의 byte length와 일치하고 0이 아님', async () => {
+    const memberDir = join(tmpDir, 'no-driver-size-bytes');
+    mkdirSync(memberDir, { recursive: true });
+
+    const rawOutput = 'some raw output';
+    const mockRunOnce = makeFlexibleMockRunOnce(rawOutput, { state: 'done', exitCode: 0 });
+
+    await runOneTurn(makeOneTurnOpts(memberDir, {
+      driverFactory: () => null,
+      runOnceFn: mockRunOnce,
+    }));
+
+    const status = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    expect(status.size_bytes).toBe(Buffer.byteLength(rawOutput, 'utf8'));
+    expect(status.size_bytes).toBeGreaterThan(0);
+  });
 });

--- a/lib/worker-utils.test.ts
+++ b/lib/worker-utils.test.ts
@@ -1144,3 +1144,133 @@ describe('executeOneTurn parsed truthy non-final terminal — state preservation
     expect(status.state).toBe('done');
   });
 });
+
+// ---------------------------------------------------------------------------
+// P2-N: terminal==='error' → errorEvent preserved in status.json
+// ---------------------------------------------------------------------------
+
+function makeErrorTerminalDriver(rawEvents: unknown[]): AgentDriver {
+  return {
+    cli: 'opencode',
+    parseStdout: (_stdout: string) => ({
+      sessionID: 'ses_err',
+      terminal: 'error' as const,
+      text: '',
+      rawEvents,
+    }),
+    initialCommand: (opts) => ({ program: opts.baseCommand, args: opts.baseArgs, env: opts.workerEnv }),
+    resumeCommand: (opts) => ({ program: opts.baseCommand, args: opts.baseArgs, env: opts.workerEnv }),
+  };
+}
+
+describe('executeOneTurn terminal===error → errorEvent in status.json', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'p2-n-error-event-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // RED: errorEvent must be present in status.json when terminal==='error'
+  test('errorEvent preserved in status.json when driver terminal=error', async () => {
+    const memberDir = join(tmpDir, 'error-event');
+    mkdirSync(memberDir, { recursive: true });
+
+    const errorRawEvents = [
+      { type: 'error', sessionID: 'ses_err', error: { message: 'provider 400', isRetryable: false } },
+    ];
+    const mockRunOnce = makeFlexibleMockRunOnce('', { state: 'done', exitCode: 0 });
+
+    await runOneTurn(makeOneTurnOpts(memberDir, {
+      driverFactory: () => makeErrorTerminalDriver(errorRawEvents),
+      runOnceFn: mockRunOnce,
+    }));
+
+    const status = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    expect(status.state).toBe('non_retryable');
+    expect(status.errorEvent).toBeDefined();
+    expect(status.errorEvent).toEqual(errorRawEvents);
+  });
+
+  // REGRESSION GUARD: errorEvent must NOT appear in status.json for non-error terminals
+  test('errorEvent absent in status.json when driver terminal=stop (regression guard)', async () => {
+    const memberDir = join(tmpDir, 'stop-no-error');
+    mkdirSync(memberDir, { recursive: true });
+
+    const mockDriver = makeOneTurnMockDriver({
+      sessionID: 'ses_stop', terminal: 'stop', text: 'result', rawEvents: [],
+    });
+    const mockRunOnce = makeFlexibleMockRunOnce('result', { state: 'done', exitCode: 0 });
+
+    await runOneTurn(makeOneTurnOpts(memberDir, {
+      driverFactory: () => mockDriver,
+      runOnceFn: mockRunOnce,
+    }));
+
+    const status = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    expect(status.errorEvent).toBeUndefined();
+  });
+
+  test('errorEvent absent in status.json when driver terminal=tool-calls (regression guard)', async () => {
+    const memberDir = join(tmpDir, 'tool-calls-no-error');
+    mkdirSync(memberDir, { recursive: true });
+
+    const mockRunOnce = makeFlexibleMockRunOnce('partial', { state: 'done', exitCode: 0 });
+
+    await runOneTurn(makeOneTurnOpts(memberDir, {
+      driverFactory: () => makeNonFinalTerminalDriver('tool-calls'),
+      runOnceFn: mockRunOnce,
+    }));
+
+    const status = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    expect(status.errorEvent).toBeUndefined();
+  });
+
+  test('errorEvent absent in status.json when driver terminal=pause_turn (regression guard)', async () => {
+    const memberDir = join(tmpDir, 'pause-turn-no-error');
+    mkdirSync(memberDir, { recursive: true });
+
+    const mockRunOnce = makeFlexibleMockRunOnce('partial', { state: 'done', exitCode: 0 });
+
+    await runOneTurn(makeOneTurnOpts(memberDir, {
+      driverFactory: () => makeNonFinalTerminalDriver('pause_turn'),
+      runOnceFn: mockRunOnce,
+    }));
+
+    const status = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    expect(status.errorEvent).toBeUndefined();
+  });
+
+  test('errorEvent absent in status.json when driver terminal=unknown_pause (regression guard)', async () => {
+    const memberDir = join(tmpDir, 'unknown-pause-no-error');
+    mkdirSync(memberDir, { recursive: true });
+
+    const mockRunOnce = makeFlexibleMockRunOnce('partial', { state: 'done', exitCode: 0 });
+
+    await runOneTurn(makeOneTurnOpts(memberDir, {
+      driverFactory: () => makeNonFinalTerminalDriver('unknown_pause'),
+      runOnceFn: mockRunOnce,
+    }));
+
+    const status = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    expect(status.errorEvent).toBeUndefined();
+  });
+
+  test('errorEvent absent in status.json when driver is null (no driver, regression guard)', async () => {
+    const memberDir = join(tmpDir, 'no-driver-no-error');
+    mkdirSync(memberDir, { recursive: true });
+
+    const mockRunOnce = makeFlexibleMockRunOnce('raw output', { state: 'done', exitCode: 0 });
+
+    await runOneTurn(makeOneTurnOpts(memberDir, {
+      driverFactory: () => null,
+      runOnceFn: mockRunOnce,
+    }));
+
+    const status = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    expect(status.errorEvent).toBeUndefined();
+  });
+});

--- a/lib/worker-utils.test.ts
+++ b/lib/worker-utils.test.ts
@@ -366,8 +366,6 @@ describe('runOnce 환경 변수 전파', () => {
 // retry 시 output 정제
 // ---------------------------------------------------------------------------
 
-import type { ResumeCommandOpts } from './agent-drivers/types.ts';
-
 // ---------------------------------------------------------------------------
 // runOneTurn / resumeOneTurn helpers
 // ---------------------------------------------------------------------------
@@ -1272,5 +1270,125 @@ describe('executeOneTurn terminal===error → errorEvent in status.json', () => 
 
     const status = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
     expect(status.errorEvent).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P0.1/P0.2/P0.3/P1.1 회귀: empty_output 분류, raw NDJSON 보존, size_bytes, telemetry
+// ---------------------------------------------------------------------------
+
+function makeStopWithEventsDriver(text: string, rawEvents: unknown[]): AgentDriver {
+  return {
+    cli: 'opencode',
+    parseStdout: (_stdout: string) => ({ sessionID: 'ses_ev', terminal: 'stop' as const, text, rawEvents }),
+    initialCommand: (opts) => ({ program: opts.baseCommand, args: opts.baseArgs, env: opts.workerEnv }),
+    resumeCommand: (opts) => ({ program: opts.baseCommand, args: opts.baseArgs, env: opts.workerEnv }),
+  };
+}
+
+describe('`executeOneTurn` empty_output 분류 및 raw NDJSON 보존', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'p0-empty-output-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // P0.1: stop + empty text → state='empty_output', size_bytes=0
+  test('stop terminal에 text가 빈 문자열이면 state가 empty_output이고 size_bytes가 0임', async () => {
+    const memberDir = join(tmpDir, 'empty-output');
+    mkdirSync(memberDir, { recursive: true });
+
+    const mockDriver = makeStopWithEventsDriver('', [
+      { type: 'step_finish', part: { tokens: { input: 10, output: 5 } } },
+    ]);
+    const mockRunOnce = makeFlexibleMockRunOnce('raw ndjson line\n', { state: 'done', exitCode: 0 });
+
+    const result = await runOneTurn(makeOneTurnOpts(memberDir, {
+      driverFactory: () => mockDriver,
+      runOnceFn: mockRunOnce,
+    }));
+
+    expect(result.state).toBe('empty_output');
+    const status = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    expect(status.state).toBe('empty_output');
+    expect(status.size_bytes).toBe(0);
+  });
+
+  // P0.2: raw-output.ndjson에 원본 stdout이 그대로 저장됨
+  test('raw-output.ndjson 파일에 driver parseStdout 호출 이전 rawStdout이 저장됨', async () => {
+    const memberDir = join(tmpDir, 'raw-ndjson');
+    mkdirSync(memberDir, { recursive: true });
+
+    const rawContent = '{"type":"step_finish","part":{}}\n{"type":"agent_message","content":"hi"}\n';
+    const mockDriver = makeStopWithEventsDriver('hi', []);
+    const mockRunOnce = makeFlexibleMockRunOnce(rawContent, { state: 'done', exitCode: 0 });
+
+    await runOneTurn(makeOneTurnOpts(memberDir, {
+      driverFactory: () => mockDriver,
+      runOnceFn: mockRunOnce,
+    }));
+
+    const rawNdjson = readFileSync(join(memberDir, 'raw-output.ndjson'), 'utf8');
+    expect(rawNdjson).toBe(rawContent);
+
+    // output.txt는 parsed.text로 덮어씌워져야 함 (chairman 계약 유지)
+    const outputTxt = readFileSync(join(memberDir, 'output.txt'), 'utf8');
+    expect(outputTxt).toBe('hi');
+  });
+
+  // P1.1: telemetry 필드가 status.json에 포함됨
+  test('status.json에 terminal/eventCount/lastEventType/tokens 텔레메트리 필드가 포함됨', async () => {
+    const memberDir = join(tmpDir, 'telemetry');
+    mkdirSync(memberDir, { recursive: true });
+
+    const rawEvents = [
+      { type: 'step_start', part: {} },
+      { type: 'step_finish', part: { tokens: { input: 100, output: 50, cache_read: 0, cache_write: 0 } } },
+    ];
+    const mockDriver = makeStopWithEventsDriver('some content', rawEvents);
+    const mockRunOnce = makeFlexibleMockRunOnce('raw', { state: 'done', exitCode: 0 });
+
+    await runOneTurn(makeOneTurnOpts(memberDir, {
+      driverFactory: () => mockDriver,
+      runOnceFn: mockRunOnce,
+    }));
+
+    const status = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    expect(status.terminal).toBe('stop');
+    expect(status.eventCount).toBe(2);
+    expect(status.lastEventType).toBe('step_finish');
+    expect(status.tokens).toEqual({ input: 100, output: 50, cache_read: 0, cache_write: 0 });
+  });
+
+  // P0.3 + P1.1 happy path: stop + non-empty text → state='done', size_bytes>0, telemetry 정상
+  test('stop terminal에 text가 있으면 state=done이고 size_bytes>0이며 telemetry가 포함됨', async () => {
+    const memberDir = join(tmpDir, 'happy-path');
+    mkdirSync(memberDir, { recursive: true });
+
+    const content = 'real content here';
+    const rawEvents = [
+      { type: 'agent_message', content },
+      { type: 'step_finish', part: { tokens: { input: 50, output: 20 } } },
+    ];
+    const mockDriver = makeStopWithEventsDriver(content, rawEvents);
+    const mockRunOnce = makeFlexibleMockRunOnce('raw ndjson', { state: 'done', exitCode: 0 });
+
+    const result = await runOneTurn(makeOneTurnOpts(memberDir, {
+      driverFactory: () => mockDriver,
+      runOnceFn: mockRunOnce,
+    }));
+
+    expect(result.state).toBe('done');
+    const status = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    expect(status.state).toBe('done');
+    expect(status.size_bytes).toBe(Buffer.byteLength(content, 'utf8'));
+    expect(status.terminal).toBe('stop');
+    expect(status.eventCount).toBe(2);
+    expect(status.lastEventType).toBe('step_finish');
+    expect(status.tokens).toEqual({ input: 50, output: 20 });
   });
 });

--- a/lib/worker-utils.ts
+++ b/lib/worker-utils.ts
@@ -412,6 +412,9 @@ async function executeOneTurn(
   let rawStdout = '';
   try { rawStdout = fs.readFileSync(outputPath, 'utf8'); } catch { /* absent → empty */ }
 
+  // P0.2: Preserve raw NDJSON before any driver transformation
+  try { fs.writeFileSync(path.join(memberDir, 'raw-output.ndjson'), rawStdout, 'utf8'); } catch { /* ignore */ }
+
   // Parse stdout via driver
   const parsed = driverInstance ? driverInstance.parseStdout(rawStdout) : null;
 
@@ -431,6 +434,15 @@ async function executeOneTurn(
       // Non-final pause signal with clean exit: process exited 0 but the turn is not complete.
       // Must NOT report 'done' — the caller needs to resume.
       state = 'awaiting_resume';
+    } else if (
+      parsed.terminal === 'stop' &&
+      (parsed.text ?? '').trim().length === 0 &&
+      (runResult.state as string) === 'done'
+    ) {
+      // P0.1: Model returned stop but produced no text — silent empty output.
+      // Only when process exited cleanly (done); process-level failures (missing_cli/canceled/timed_out)
+      // fall through to preserve their concrete state.
+      state = 'empty_output';
     } else {
       // Preserve concrete process-level state from runOnce (missing_cli/timed_out/canceled);
       // only fall to 'error' if runOnce reported a generic non-zero exit without a specific state.
@@ -457,6 +469,15 @@ async function executeOneTurn(
   }
 
   const runResultRecord = runResult as Record<string, unknown>;
+
+  // P1.1: extract telemetry from raw events
+  const rawEvents = parsed?.rawEvents ?? [];
+  const lastEvent = rawEvents.length > 0 ? (rawEvents[rawEvents.length - 1] as Record<string, unknown>) : null;
+  const lastStepFinish = [...rawEvents].reverse().find(
+    (e) => (e as Record<string, unknown>).type === 'step_finish'
+  ) as Record<string, unknown> | undefined;
+  const tokens = lastStepFinish ? ((lastStepFinish.part as Record<string, unknown> | undefined)?.tokens ?? null) : null;
+
   atomicWriteJson(path.join(memberDir, 'status.json'), {
     member,
     state,
@@ -467,6 +488,13 @@ async function executeOneTurn(
     message: runResultRecord.message ?? null,
     finishedAt: runResultRecord.finishedAt ?? new Date().toISOString(),
     workerEnv: builtCmd.env,
+    // P0.3: byte length of parsed text for manifest size_bytes guard
+    size_bytes: parsed ? Buffer.byteLength(parsed.text, 'utf8') : 0,
+    // P1.1: telemetry fields
+    terminal: parsed?.terminal ?? null,
+    eventCount: rawEvents.length,
+    lastEventType: lastEvent ? (lastEvent.type as string | null) : null,
+    tokens,
     ...(parsed?.terminal === 'error' ? { errorEvent: parsed.rawEvents } : {}),
   });
 

--- a/lib/worker-utils.ts
+++ b/lib/worker-utils.ts
@@ -489,7 +489,7 @@ async function executeOneTurn(
     finishedAt: runResultRecord.finishedAt ?? new Date().toISOString(),
     workerEnv: builtCmd.env,
     // P0.3: byte length of parsed text for manifest size_bytes guard
-    size_bytes: parsed ? Buffer.byteLength(parsed.text, 'utf8') : 0,
+    size_bytes: Buffer.byteLength(text, 'utf8'),
     // P1.1: telemetry fields
     terminal: parsed?.terminal ?? null,
     eventCount: rawEvents.length,

--- a/lib/worker-utils.ts
+++ b/lib/worker-utils.ts
@@ -470,14 +470,6 @@ async function executeOneTurn(
 
   const runResultRecord = runResult as Record<string, unknown>;
 
-  // P1.1: extract telemetry from raw events
-  const rawEvents = parsed?.rawEvents ?? [];
-  const lastEvent = rawEvents.length > 0 ? (rawEvents[rawEvents.length - 1] as Record<string, unknown>) : null;
-  const lastStepFinish = [...rawEvents].reverse().find(
-    (e) => (e as Record<string, unknown>).type === 'step_finish'
-  ) as Record<string, unknown> | undefined;
-  const tokens = lastStepFinish ? ((lastStepFinish.part as Record<string, unknown> | undefined)?.tokens ?? null) : null;
-
   atomicWriteJson(path.join(memberDir, 'status.json'), {
     member,
     state,
@@ -490,11 +482,8 @@ async function executeOneTurn(
     workerEnv: builtCmd.env,
     // P0.3: byte length of parsed text for manifest size_bytes guard
     size_bytes: Buffer.byteLength(text, 'utf8'),
-    // P1.1: telemetry fields
+    // driver terminal classification (pairs with state for diagnosis)
     terminal: parsed?.terminal ?? null,
-    eventCount: rawEvents.length,
-    lastEventType: lastEvent ? (lastEvent.type as string | null) : null,
-    tokens,
     ...(parsed?.terminal === 'error' ? { errorEvent: parsed.rawEvents } : {}),
   });
 

--- a/lib/worker-utils.ts
+++ b/lib/worker-utils.ts
@@ -467,6 +467,7 @@ async function executeOneTurn(
     message: runResultRecord.message ?? null,
     finishedAt: runResultRecord.finishedAt ?? new Date().toISOString(),
     workerEnv: builtCmd.env,
+    ...(parsed?.terminal === 'error' ? { errorEvent: parsed.rawEvents } : {}),
   });
 
   return { state, sessionID, text, exitCode };

--- a/skills/agent-council/SKILL.md
+++ b/skills/agent-council/SKILL.md
@@ -126,7 +126,7 @@ bun .claude/skills/agent-council/scripts/job.ts collect "$JOB_DIR"
 
 - If response shows `"overallState": "done"` → proceed to Step 3.
 - If `"overallState": "awaiting_resume"` → identify members with `state: "awaiting_resume"` in `members[]` and call `bun .claude/skills/agent-council/scripts/job.ts resume-member "$JOB_DIR" <member> "<resume prompt>"` for each, then call `collect` again.
-- If `"overallState": "empty_output"` → identify members with `state: "empty_output"` in `members[]` and call `resume-member` once to retry. If `resume_count` reaches cap (3) the command throws — skip that member and proceed with the remaining members in synthesis.
+- If `"overallState": "empty_output"` → identify members with `state: "empty_output"` in `members[]` and call `resume-member` once to retry. If `resume_count` reaches cap (3) the command throws — call `collect` again; the capped member now appears as a failed member (`outputFilePath` null) in the manifest, so apply the Degradation Policy.
 - Otherwise (`"running"`, `"queued"`, etc.) → call `collect` again (same command, foreground, timeout: 180000).
 
 **3. Read raw outputs**

--- a/skills/agent-council/SKILL.md
+++ b/skills/agent-council/SKILL.md
@@ -125,6 +125,8 @@ bun .claude/skills/agent-council/scripts/job.ts collect "$JOB_DIR"
 ```
 
 - If response shows `"overallState": "done"` → proceed to Step 3.
+- If `"overallState": "awaiting_resume"` → identify members with `state: "awaiting_resume"` in `members[]` and call `bun .claude/skills/agent-council/scripts/job.ts resume-member "$JOB_DIR" <member> "<resume prompt>"` for each, then call `collect` again.
+- If `"overallState": "empty_output"` → identify members with `state: "empty_output"` in `members[]` and call `resume-member` once to retry. If `resume_count` reaches cap (3) the command throws — skip that member and proceed with the remaining members in synthesis.
 - Otherwise (`"running"`, `"queued"`, etc.) → call `collect` again (same command, foreground, timeout: 180000).
 
 **3. Read raw outputs**

--- a/skills/agent-council/scripts/job.test.ts
+++ b/skills/agent-council/scripts/job.test.ts
@@ -913,4 +913,20 @@ describe('resume-member subcommand', () => {
     expect(output).toContain('missing');
     expect(output).toContain('prompt');
   });
+
+  test('resume-member에서 --json 등 flag-like 토큰을 prompt로 전달하면 missing prompt로 거부되지 않는다', () => {
+    // 회귀 테스트: parseArgs가 --json을 소비하여 prompt가 빈 문자열이 되는 버그 방지.
+    // process.argv.slice(5)로 raw argv에서 prompt를 캡처하므로 --json이 그대로 전달된다.
+    let exitCode = 0;
+    let output = '';
+    try {
+      execFileSync(process.execPath, [SCRIPT, 'resume-member', '/tmp/no-such-dir', 'mymember', '--json'], { stdio: 'pipe' });
+    } catch (e: any) {
+      exitCode = e.status;
+      output = (e.stderr?.toString() || '') + (e.stdout?.toString() || '');
+    }
+    // Should fail (nonexistent jobDir -> no resumable session), but NOT with "missing prompt"
+    expect(exitCode).not.toBe(0);
+    expect(output).not.toContain('missing prompt');
+  });
 });

--- a/skills/agent-council/scripts/job.ts
+++ b/skills/agent-council/scripts/job.ts
@@ -426,7 +426,7 @@ async function main() {
     if (!jobDirArg) exitWithError('resume-member: missing jobDir');
     if (!nameArg) exitWithError('resume-member: missing member name');
     if (!promptArg) exitWithError('resume-member: missing prompt');
-    await cmdResumeMember(jobDirArg, nameArg, promptArg, COUNCIL_CONFIG);
+    await cmdResumeMember(jobDirArg, nameArg, promptArg, COUNCIL_CONFIG, { skillName: 'agent-council' });
     return;
   }
   if (command === 'stop') {

--- a/skills/agent-council/scripts/job.ts
+++ b/skills/agent-council/scripts/job.ts
@@ -422,7 +422,9 @@ async function main() {
   if (command === 'resume-member') {
     const jobDirArg = rest[0];
     const nameArg = rest[1];
-    const promptArg = rest.slice(2).join(' ');
+    // Capture prompt from raw argv to avoid parseArgs consuming --flag tokens inside the prompt.
+    // argv layout: [node, script, 'resume-member', jobDir, memberName, ...promptTokens]
+    const promptArg = process.argv.slice(5).join(' ');
     if (!jobDirArg) exitWithError('resume-member: missing jobDir');
     if (!nameArg) exitWithError('resume-member: missing member name');
     if (!promptArg) exitWithError('resume-member: missing prompt');

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -42,7 +42,7 @@ bun .claude/skills/diagnose/scripts/job.ts collect $JOB_DIR
 
 - If `"overallState": "done"` → proceed to Step 4.
 - If `"overallState": "awaiting_resume"` → identify members with `state: "awaiting_resume"` in `members[]` and call `bun .claude/skills/diagnose/scripts/job.ts resume-member $JOB_DIR <member> "<resume prompt>"` for each, then call `collect` again.
-- If `"overallState": "empty_output"` → identify members with `state: "empty_output"` in `members[]` and call `resume-member` once to retry. If `resume_count` reaches cap (3) the command throws — skip that member and proceed with the remaining members in synthesis.
+- If `"overallState": "empty_output"` → identify members with `state: "empty_output"` in `members[]` and call `resume-member` once to retry. If `resume_count` reaches cap (3) the command throws — call `collect` again; the capped member now appears as a failed member (`outputFilePath` null) in the manifest, so apply the Degradation Policy.
 - Otherwise (`"running"`, `"queued"`, etc.) → call `collect` again.
 
 ### Step 4: Fallback branch

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -42,7 +42,7 @@ bun .claude/skills/diagnose/scripts/job.ts collect $JOB_DIR
 
 - If `"overallState": "done"` → proceed to Step 4.
 - If `"overallState": "awaiting_resume"` → identify members with `state: "awaiting_resume"` in `members[]` and call `bun .claude/skills/diagnose/scripts/job.ts resume-member $JOB_DIR <member> "<resume prompt>"` for each, then call `collect` again.
-- If `"overallState": "empty_output"` → identify members with `state: "empty_output"` in `members[]` and call `resume-member` once to retry. If `resume_count` reaches cap (3) the command throws — call `collect` again; the capped member now appears as a failed member (`outputFilePath` null) in the manifest, so apply the Degradation Policy.
+- If `"overallState": "empty_output"` → identify members with `state: "empty_output"` in `members[]` and call `resume-member` once to retry. If `resume_count` reaches cap (3) the command throws — call `collect` again; the capped member is now `non_retryable`, so proceed to Step 4 and apply its `non_retryable` fallback (become Hephaestus in-session).
 - Otherwise (`"running"`, `"queued"`, etc.) → call `collect` again.
 
 ### Step 4: Fallback branch

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -38,7 +38,12 @@ The command prints the `jobDir` path on stdout, captured into `$JOB_DIR` above.
 bun .claude/skills/diagnose/scripts/job.ts collect $JOB_DIR
 ```
 
-`collect` polls until the job reaches a terminal state and returns a JSON manifest. Repeat if the overall state is `running` or `queued`.
+`collect` polls until the job reaches a terminal state and returns a JSON manifest. Branch on `overallState`:
+
+- If `"overallState": "done"` → proceed to Step 4.
+- If `"overallState": "awaiting_resume"` → identify members with `state: "awaiting_resume"` in `members[]` and call `bun .claude/skills/diagnose/scripts/job.ts resume-member $JOB_DIR <member> "<resume prompt>"` for each, then call `collect` again.
+- If `"overallState": "empty_output"` → identify members with `state: "empty_output"` in `members[]` and call `resume-member` once to retry. If `resume_count` reaches cap (3) the command throws — skip that member and proceed with the remaining members in synthesis.
+- Otherwise (`"running"`, `"queued"`, etc.) → call `collect` again.
 
 ### Step 4: Fallback branch
 

--- a/skills/diagnose/scripts/job.test.ts
+++ b/skills/diagnose/scripts/job.test.ts
@@ -220,4 +220,20 @@ describe('resume-member subcommand', () => {
     expect(exitCode).not.toBe(0);
     expect(output).toContain('resume-member: missing prompt');
   });
+
+  test('resume-member에서 --json 등 flag-like 토큰을 prompt로 전달하면 missing prompt로 거부되지 않는다', () => {
+    // 회귀 테스트: parseArgs가 --json을 소비하여 prompt가 빈 문자열이 되는 버그 방지.
+    // process.argv.slice(5)로 raw argv에서 prompt를 캡처하므로 --json이 그대로 전달된다.
+    let exitCode = 0;
+    let output = '';
+    try {
+      execFileSync(process.execPath, [SCRIPT, 'resume-member', '/tmp/no-such-dir', 'mymember', '--json'], { stdio: 'pipe' });
+    } catch (e: any) {
+      exitCode = e.status;
+      output = (e.stderr?.toString() || '') + (e.stdout?.toString() || '');
+    }
+    // Should fail (nonexistent jobDir -> no resumable session), but NOT with "missing prompt"
+    expect(exitCode).not.toBe(0);
+    expect(output).not.toContain('missing prompt');
+  });
 });

--- a/skills/diagnose/scripts/job.ts
+++ b/skills/diagnose/scripts/job.ts
@@ -212,7 +212,7 @@ async function main() {
     if (!jobDirArg) exitWithError('resume-member: missing jobDir');
     if (!nameArg) exitWithError('resume-member: missing member name');
     if (!promptArg) exitWithError('resume-member: missing prompt');
-    await cmdResumeMember(jobDirArg, nameArg, promptArg, DIAGNOSE_CONFIG);
+    await cmdResumeMember(jobDirArg, nameArg, promptArg, DIAGNOSE_CONFIG, { skillName: 'diagnose' });
     return;
   }
 

--- a/skills/diagnose/scripts/job.ts
+++ b/skills/diagnose/scripts/job.ts
@@ -208,7 +208,9 @@ async function main() {
   if (command === 'resume-member') {
     const jobDirArg = rest[0];
     const nameArg = rest[1];
-    const promptArg = rest.slice(2).join(' ');
+    // Capture prompt from raw argv to avoid parseArgs consuming --flag tokens inside the prompt.
+    // argv layout: [node, script, 'resume-member', jobDir, memberName, ...promptTokens]
+    const promptArg = process.argv.slice(5).join(' ');
     if (!jobDirArg) exitWithError('resume-member: missing jobDir');
     if (!nameArg) exitWithError('resume-member: missing member name');
     if (!promptArg) exitWithError('resume-member: missing prompt');

--- a/skills/orchestrate-review/SKILL.md
+++ b/skills/orchestrate-review/SKILL.md
@@ -126,7 +126,7 @@ Each reviewer CLI emits its native structured output (opencode: NDJSON via `--fo
 호출 형식:
 
 ```
-bun job.ts resume-member --job <jobDir> --member <name> --prompt "마무리되었나요? 답변 주세요"
+bun job.ts resume-member <jobDir> <name> "마무리되었나요? 답변 주세요"
 ```
 
 프롬프트는 chairman LLM이 상황에 맞게 작성한다. 위 예시는 참고용이다.

--- a/skills/orchestrate-review/SKILL.md
+++ b/skills/orchestrate-review/SKILL.md
@@ -67,6 +67,8 @@ bun .claude/skills/orchestrate-review/scripts/job.ts collect "$JOB_DIR"
 ```
 
 - If response shows `"overallState": "done"` → proceed to Step 3.
+- If `"overallState": "awaiting_resume"` → identify members with `state: "awaiting_resume"` in `members[]` and call `bun .claude/skills/orchestrate-review/scripts/job.ts resume-member "$JOB_DIR" <member> "<resume prompt>"` for each, then call `collect` again.
+- If `"overallState": "empty_output"` → identify members with `state: "empty_output"` in `members[]` and call `resume-member` once to retry. If `resume_count` reaches cap (3) the command throws — skip that member and proceed with the remaining members in synthesis.
 - Otherwise (`"running"`, `"queued"`, etc.) → call `collect` again (same command, foreground, timeout: 180000).
 
 Response JSON (done):

--- a/skills/orchestrate-review/SKILL.md
+++ b/skills/orchestrate-review/SKILL.md
@@ -30,6 +30,7 @@ Your job is to orchestrate external AI reviewers, collect their independent resu
 You may ONLY execute these commands via Bash:
 - `bun .claude/skills/orchestrate-review/scripts/job.ts start --prompt-file "$PROMPT_FILE"` — start a review job
 - `bun .claude/skills/orchestrate-review/scripts/job.ts collect "$JOB_DIR"` — collect results (polls internally every 5s, 150s default timeout). No external sleep needed.
+- `bun .claude/skills/orchestrate-review/scripts/job.ts resume-member "$JOB_DIR" <member> "<prompt>"` — recover a stalled member
 
 **CRITICAL**: Always set `timeout: 180000` on every Bash tool call.
 
@@ -68,7 +69,7 @@ bun .claude/skills/orchestrate-review/scripts/job.ts collect "$JOB_DIR"
 
 - If response shows `"overallState": "done"` → proceed to Step 3.
 - If `"overallState": "awaiting_resume"` → identify members with `state: "awaiting_resume"` in `members[]` and call `bun .claude/skills/orchestrate-review/scripts/job.ts resume-member "$JOB_DIR" <member> "<resume prompt>"` for each, then call `collect` again.
-- If `"overallState": "empty_output"` → identify members with `state: "empty_output"` in `members[]` and call `resume-member` once to retry. If `resume_count` reaches cap (3) the command throws — skip that member and proceed with the remaining members in synthesis.
+- If `"overallState": "empty_output"` → identify members with `state: "empty_output"` in `members[]` and call `resume-member` once to retry. If `resume_count` reaches cap (3) the command throws — call `collect` again; the capped reviewer now appears as a failed reviewer (`outputFilePath` null) in the manifest, so apply the Degradation Policy.
 - Otherwise (`"running"`, `"queued"`, etc.) → call `collect` again (same command, foreground, timeout: 180000).
 
 Response JSON (done):

--- a/skills/orchestrate-review/scripts/job.test.ts
+++ b/skills/orchestrate-review/scripts/job.test.ts
@@ -1788,41 +1788,44 @@ describe('resume-member', () => {
     expect(resumeIdx).toBeLessThan(unknownIdx);
   });
 
-  test('resume-member D7a rejects when --job missing', async () => {
-    // Test via CLI spawn — missing --job arg
+  test('resume-member D7a rejects when jobDir missing', () => {
+    // Test via CLI spawn — no positional args
+    let exitCode = 0;
+    let output = '';
     try {
-      execFileSync(process.execPath, [SCRIPT, 'resume-member', '--member', 'alice', '--prompt', 'hi'], {
-        stdio: 'pipe',
-      });
-      throw new Error('expected non-zero exit');
+      execFileSync(process.execPath, [SCRIPT, 'resume-member'], { stdio: 'pipe' });
     } catch (err: any) {
-      expect(err.status).toBeGreaterThan(0);
-      expect(err.stderr.toString()).toContain('--job required');
+      exitCode = err.status;
+      output = (err.stderr?.toString() || '') + (err.stdout?.toString() || '');
     }
+    expect(exitCode).not.toBe(0);
+    expect(output).toContain('resume-member: missing jobDir');
   });
 
-  test('resume-member D7b rejects when --member missing', async () => {
+  test('resume-member D7b rejects when member name missing', () => {
+    let exitCode = 0;
+    let output = '';
     try {
-      execFileSync(process.execPath, [SCRIPT, 'resume-member', '--job', jobDir, '--prompt', 'hi'], {
-        stdio: 'pipe',
-      });
-      throw new Error('expected non-zero exit');
+      execFileSync(process.execPath, [SCRIPT, 'resume-member', jobDir], { stdio: 'pipe' });
     } catch (err: any) {
-      expect(err.status).toBeGreaterThan(0);
-      expect(err.stderr.toString()).toContain('--member required');
+      exitCode = err.status;
+      output = (err.stderr?.toString() || '') + (err.stdout?.toString() || '');
     }
+    expect(exitCode).not.toBe(0);
+    expect(output).toContain('resume-member: missing member name');
   });
 
-  test('resume-member D7c rejects when --prompt missing', async () => {
+  test('resume-member D7c rejects when prompt missing', () => {
+    let exitCode = 0;
+    let output = '';
     try {
-      execFileSync(process.execPath, [SCRIPT, 'resume-member', '--job', jobDir, '--member', 'opencode'], {
-        stdio: 'pipe',
-      });
-      throw new Error('expected non-zero exit');
+      execFileSync(process.execPath, [SCRIPT, 'resume-member', jobDir, 'opencode'], { stdio: 'pipe' });
     } catch (err: any) {
-      expect(err.status).toBeGreaterThan(0);
-      expect(err.stderr.toString()).toContain('--prompt required');
+      exitCode = err.status;
+      output = (err.stderr?.toString() || '') + (err.stdout?.toString() || '');
     }
+    expect(exitCode).not.toBe(0);
+    expect(output).toContain('resume-member: missing prompt');
   });
 
   test('resume-member D8 rejects when no driver for gemini', async () => {

--- a/skills/orchestrate-review/scripts/job.test.ts
+++ b/skills/orchestrate-review/scripts/job.test.ts
@@ -1898,6 +1898,23 @@ describe('resume-member', () => {
       })
     ).rejects.toThrow('unknown cli type');
   });
+
+  test('resume-member D12 flag-like 토큰을 prompt로 전달하면 missing prompt로 거부되지 않는다', () => {
+    // 회귀 테스트: parseArgs가 --json을 소비하여 prompt가 빈 문자열이 되는 버그 방지.
+    // process.argv.slice(5)로 raw argv에서 prompt를 캡처하므로 --json이 그대로 전달된다.
+    // /tmp/no-such-dir 을 사용 — session 없는 jobDir이므로 non-zero exit을 보장한다.
+    let exitCode = 0;
+    let output = '';
+    try {
+      execFileSync(process.execPath, [SCRIPT, 'resume-member', '/tmp/no-such-dir', 'opencode', '--json'], { stdio: 'pipe' });
+    } catch (err: any) {
+      exitCode = err.status;
+      output = (err.stderr?.toString() || '') + (err.stdout?.toString() || '');
+    }
+    // Should fail (no resumable session), but NOT with "missing prompt"
+    expect(exitCode).not.toBe(0);
+    expect(output).not.toContain('missing prompt');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/skills/orchestrate-review/scripts/job.test.ts
+++ b/skills/orchestrate-review/scripts/job.test.ts
@@ -2370,6 +2370,48 @@ describe('cmdCollect', () => {
     }
   });
 
+  test('empty_output 즉시 반환: overallState와 members 포함', () => {
+    const jobDir = path.join(tmpDir, 'job-collect-empty-output');
+    setupCollectFixture(jobDir, {
+      'claude-0': { member: 'claude', state: 'empty_output', exitCode: 0, output: '' },
+      'codex-0': { member: 'codex', state: 'empty_output', exitCode: 0, output: '' },
+    });
+
+    const result = execFileSync(process.execPath, [
+      SCRIPT, 'collect', '--timeout-ms', '5000', jobDir,
+    ], { stdio: 'pipe', timeout: 10000 });
+    const parsed = JSON.parse(result.toString());
+
+    expect(parsed.overallState).toBe('empty_output');
+    expect(parsed.id).toBe('collect-test');
+    expect(parsed).toHaveProperty('counts');
+    expect(parsed).toHaveProperty('members');
+    expect(parsed.members).toHaveLength(2);
+    expect(parsed.members[0].state).toBe('empty_output');
+    expect(parsed.members[1].state).toBe('empty_output');
+  });
+
+  test('awaiting_resume 즉시 반환: overallState와 members 포함', () => {
+    const jobDir = path.join(tmpDir, 'job-collect-awaiting-resume');
+    setupCollectFixture(jobDir, {
+      'claude-0': { member: 'claude', state: 'awaiting_resume', exitCode: 0, output: '' },
+      'codex-0': { member: 'codex', state: 'awaiting_resume', exitCode: 0, output: '' },
+    });
+
+    const result = execFileSync(process.execPath, [
+      SCRIPT, 'collect', '--timeout-ms', '5000', jobDir,
+    ], { stdio: 'pipe', timeout: 10000 });
+    const parsed = JSON.parse(result.toString());
+
+    expect(parsed.overallState).toBe('awaiting_resume');
+    expect(parsed.id).toBe('collect-test');
+    expect(parsed).toHaveProperty('counts');
+    expect(parsed).toHaveProperty('members');
+    expect(parsed.members).toHaveLength(2);
+    expect(parsed.members[0].state).toBe('awaiting_resume');
+    expect(parsed.members[1].state).toBe('awaiting_resume');
+  });
+
   test('cmdCollect propagates size_bytes to chairman payload', () => {
     const jobDir = path.join(tmpDir, 'job-collect-size-bytes');
     fs.mkdirSync(jobDir, { recursive: true });

--- a/skills/orchestrate-review/scripts/job.ts
+++ b/skills/orchestrate-review/scripts/job.ts
@@ -440,12 +440,12 @@ async function main(): Promise<void> {
     return;
   }
   if (command === 'resume-member') {
-    const jobDirArg = options.job as string | undefined;
-    if (!jobDirArg) exitWithError('--job required');
-    const nameArg = options.member as string | undefined;
-    if (!nameArg) exitWithError('--member required');
-    const promptArg = options.prompt as string | undefined;
-    if (!promptArg) exitWithError('--prompt required');
+    const jobDirArg = rest[0];
+    if (!jobDirArg) exitWithError('resume-member: missing jobDir');
+    const nameArg = rest[1];
+    if (!nameArg) exitWithError('resume-member: missing member name');
+    const promptArg = rest.slice(2).join(' ');
+    if (!promptArg) exitWithError('resume-member: missing prompt');
     try {
       await _cmdResumeMember(jobDirArg, nameArg, promptArg, CHUNK_REVIEW_JOB_CONFIG);
     } catch (e: unknown) {

--- a/skills/orchestrate-review/scripts/job.ts
+++ b/skills/orchestrate-review/scripts/job.ts
@@ -444,7 +444,9 @@ async function main(): Promise<void> {
     if (!jobDirArg) exitWithError('resume-member: missing jobDir');
     const nameArg = rest[1];
     if (!nameArg) exitWithError('resume-member: missing member name');
-    const promptArg = rest.slice(2).join(' ');
+    // Capture prompt from raw argv to avoid parseArgs consuming --flag tokens inside the prompt.
+    // argv layout: [node, script, 'resume-member', jobDir, memberName, ...promptTokens]
+    const promptArg = process.argv.slice(5).join(' ');
     if (!promptArg) exitWithError('resume-member: missing prompt');
     try {
       await _cmdResumeMember(jobDirArg, nameArg, promptArg, CHUNK_REVIEW_JOB_CONFIG, { skillName: 'orchestrate-review' });

--- a/skills/orchestrate-review/scripts/job.ts
+++ b/skills/orchestrate-review/scripts/job.ts
@@ -447,7 +447,7 @@ async function main(): Promise<void> {
     const promptArg = rest.slice(2).join(' ');
     if (!promptArg) exitWithError('resume-member: missing prompt');
     try {
-      await _cmdResumeMember(jobDirArg, nameArg, promptArg, CHUNK_REVIEW_JOB_CONFIG);
+      await _cmdResumeMember(jobDirArg, nameArg, promptArg, CHUNK_REVIEW_JOB_CONFIG, { skillName: 'orchestrate-review' });
     } catch (e: unknown) {
       exitWithError(e instanceof Error ? e.message : String(e));
     }

--- a/skills/slides-review/SKILL.md
+++ b/skills/slides-review/SKILL.md
@@ -67,7 +67,7 @@ bun .claude/skills/slides-review/scripts/job.ts collect "$JOB_DIR"
 
 - `"overallState": "done"` → Step 4로 진행
 - `"overallState": "awaiting_resume"` → `members[]` 에서 `state: "awaiting_resume"` 인 member를 식별 후 `bun .claude/skills/slides-review/scripts/job.ts resume-member "$JOB_DIR" <member> "<resume prompt>"` 호출, 다시 `collect` 재호출
-- `"overallState": "empty_output"` → `members[]` 에서 `state: "empty_output"` 인 member 를 식별 후 `resume-member` 로 1회 retry. `resume_count` cap (3) 도달 시 명령이 throw → `collect` 를 다시 호출; cap 소진 member 는 실패한 member (`outputFilePath` null) 로 manifest 에 나타나므로 Degradation Policy 적용
+- `"overallState": "empty_output"` → `members[]` 에서 `state: "empty_output"` 인 member 를 식별 후 `resume-member` 로 1회 retry. `resume_count` cap (3) 도달 시 명령이 throw → `collect` 를 다시 호출; cap 소진 member 는 `non_retryable` 로 manifest 에 나타나므로 **quiet pass** (기존 HTML 유지)
 - `"running"` / `"queued"` → `collect` 재호출 (동일 명령)
 - 멤버 상태가 `missing_cli` → **quiet pass** (Step 5로 직행, 지침 적용 없음)
 - 멤버 상태가 `error` / `timed_out` → **quiet pass** (기존 HTML 유지)

--- a/skills/slides-review/SKILL.md
+++ b/skills/slides-review/SKILL.md
@@ -67,7 +67,7 @@ bun .claude/skills/slides-review/scripts/job.ts collect "$JOB_DIR"
 
 - `"overallState": "done"` → Step 4로 진행
 - `"overallState": "awaiting_resume"` → `members[]` 에서 `state: "awaiting_resume"` 인 member를 식별 후 `bun .claude/skills/slides-review/scripts/job.ts resume-member "$JOB_DIR" <member> "<resume prompt>"` 호출, 다시 `collect` 재호출
-- `"overallState": "empty_output"` → `members[]` 에서 `state: "empty_output"` 인 member 를 식별 후 `resume-member` 로 1회 retry. `resume_count` cap (3) 도달 시 명령이 throw → 해당 member 는 skip 하고 남은 member 로 synthesis 진행
+- `"overallState": "empty_output"` → `members[]` 에서 `state: "empty_output"` 인 member 를 식별 후 `resume-member` 로 1회 retry. `resume_count` cap (3) 도달 시 명령이 throw → `collect` 를 다시 호출; cap 소진 member 는 실패한 member (`outputFilePath` null) 로 manifest 에 나타나므로 Degradation Policy 적용
 - `"running"` / `"queued"` → `collect` 재호출 (동일 명령)
 - 멤버 상태가 `missing_cli` → **quiet pass** (Step 5로 직행, 지침 적용 없음)
 - 멤버 상태가 `error` / `timed_out` → **quiet pass** (기존 HTML 유지)

--- a/skills/slides-review/SKILL.md
+++ b/skills/slides-review/SKILL.md
@@ -66,6 +66,8 @@ bun .claude/skills/slides-review/scripts/job.ts collect "$JOB_DIR"
 ```
 
 - `"overallState": "done"` → Step 4로 진행
+- `"overallState": "awaiting_resume"` → `members[]` 에서 `state: "awaiting_resume"` 인 member를 식별 후 `bun .claude/skills/slides-review/scripts/job.ts resume-member "$JOB_DIR" <member> "<resume prompt>"` 호출, 다시 `collect` 재호출
+- `"overallState": "empty_output"` → `members[]` 에서 `state: "empty_output"` 인 member 를 식별 후 `resume-member` 로 1회 retry. `resume_count` cap (3) 도달 시 명령이 throw → 해당 member 는 skip 하고 남은 member 로 synthesis 진행
 - `"running"` / `"queued"` → `collect` 재호출 (동일 명령)
 - 멤버 상태가 `missing_cli` → **quiet pass** (Step 5로 직행, 지침 적용 없음)
 - 멤버 상태가 `error` / `timed_out` → **quiet pass** (기존 HTML 유지)

--- a/skills/slides-review/scripts/job-gemini-guard.test.ts
+++ b/skills/slides-review/scripts/job-gemini-guard.test.ts
@@ -43,12 +43,39 @@ function makeJobDir(command: string): string {
   return dir;
 }
 
+function makeJobDirForMember(memberName: string, command: string): string {
+  const dir = fs.mkdtempSync(path.join(tmpdir(), 'slides-review-test-'));
+  const memberDir = path.join(dir, 'reviewers', memberName);
+  fs.mkdirSync(memberDir, { recursive: true });
+
+  const status = {
+    state: 'stop',
+    sessionID: 'fake-session-id',
+    command,
+    resume_count: 0,
+    workerEnv: {},
+  };
+  fs.writeFileSync(path.join(memberDir, 'status.json'), JSON.stringify(status), 'utf8');
+
+  const jobMeta = {
+    id: 'slides-review-test',
+    createdAt: new Date().toISOString(),
+    settings: { timeoutSec: 60 },
+    members: [{ name: memberName, command }],
+  };
+  fs.writeFileSync(path.join(dir, 'job.json'), JSON.stringify(jobMeta), 'utf8');
+
+  return dir;
+}
+
 const geminiDir = makeJobDir('gemini');
 const claudeDir = makeJobDir('claude');
+const opencodeDir = makeJobDirForMember('opencode', 'opencode');
 
 afterAll(() => {
   try { fs.rmSync(geminiDir, { recursive: true, force: true }); } catch {}
   try { fs.rmSync(claudeDir, { recursive: true, force: true }); } catch {}
+  try { fs.rmSync(opencodeDir, { recursive: true, force: true }); } catch {}
 });
 
 describe('resume-member gemini pre-check', () => {
@@ -70,6 +97,24 @@ describe('resume-member gemini pre-check', () => {
     expect(stderr).toContain('gemini');
     expect(stderr).toContain('no driver');
     expect(stderr).toContain('implement driver or change default member');
+  });
+
+  test('happy path: registered cliType reaches cmdResumeMember beyond driver gate', async () => {
+    // GIVEN: job dir with opencode member status.json (opencode is a registered driver)
+    // WHEN: resume-member invoked for that member
+    // THEN: stderr does NOT contain 'no driver for' — driver gate is passed
+    //       (downstream failure e.g. spawning real opencode is acceptable)
+    let stderr = '';
+    try {
+      execFileSync(process.execPath, [SCRIPT, 'resume-member', opencodeDir, 'opencode', 'test prompt'], {
+        stdio: 'pipe',
+      });
+    } catch (e: any) {
+      stderr = e.stderr?.toString() || '';
+    }
+
+    expect(stderr).not.toContain('no driver for');
+    expect(stderr).not.toContain('slides-review: no driver');
   });
 
   test('claude fixture: does NOT trigger the gemini guard (exits with a different error)', () => {

--- a/skills/slides-review/scripts/job-gemini-guard.test.ts
+++ b/skills/slides-review/scripts/job-gemini-guard.test.ts
@@ -5,6 +5,11 @@
  * RED test: with a gemini fixture status.json, resume-member should exit non-zero
  * and print a skill-aware error containing 'slides-review', 'gemini', 'no driver'.
  *
+ * Hermetic: registered-driver fixtures (opencode/claude) would otherwise have resume-member
+ * spawn the real authenticated CLI. A fake bin dir is prepended to PATH so the downstream
+ * spawn resolves to a no-op exit-0 stub instead of the real binary — keeping `bun test`
+ * deterministic and offline.
+ *
  * Must NOT modify job.test.ts (T5 territory).
  */
 
@@ -68,28 +73,44 @@ function makeJobDirForMember(memberName: string, command: string): string {
   return dir;
 }
 
-const geminiDir = makeJobDir('gemini');
-const claudeDir = makeJobDir('claude');
-const opencodeDir = makeJobDirForMember('opencode', 'opencode');
+let geminiDir: string;
+let claudeDir: string;
+let opencodeDir: string;
+let fakeBinDir: string;
+
+beforeAll(() => {
+  // Fake CLI stubs prepended to PATH: resume-member's downstream spawn resolves these no-op
+  // exit-0 binaries instead of the real authenticated opencode/claude CLIs.
+  fakeBinDir = fs.mkdtempSync(path.join(tmpdir(), 'slides-review-fakebin-'));
+  for (const bin of ['opencode', 'claude']) {
+    fs.writeFileSync(path.join(fakeBinDir, bin), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+  }
+  geminiDir = makeJobDir('gemini');
+  claudeDir = makeJobDir('claude');
+  opencodeDir = makeJobDirForMember('opencode', 'opencode');
+});
 
 afterAll(() => {
-  try { fs.rmSync(geminiDir, { recursive: true, force: true }); } catch {}
-  try { fs.rmSync(claudeDir, { recursive: true, force: true }); } catch {}
-  try { fs.rmSync(opencodeDir, { recursive: true, force: true }); } catch {}
+  for (const d of [geminiDir, claudeDir, opencodeDir, fakeBinDir]) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
+  }
 });
+
+function runResumeMember(jobDir: string, member: string, prompt: string): { exitCode: number; stderr: string } {
+  try {
+    execFileSync(process.execPath, [SCRIPT, 'resume-member', jobDir, member, prompt], {
+      stdio: 'pipe',
+      env: { ...process.env, PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ''}` },
+    });
+    return { exitCode: 0, stderr: '' };
+  } catch (e: any) {
+    return { exitCode: e.status ?? 1, stderr: e.stderr?.toString() ?? '' };
+  }
+}
 
 describe('resume-member gemini pre-check', () => {
   test('gemini fixture: exits non-zero with skill-aware error containing all 3 keywords', () => {
-    let exitCode = 0;
-    let stderr = '';
-    try {
-      execFileSync(process.execPath, [SCRIPT, 'resume-member', geminiDir, 'gemini', 'follow-up'], {
-        stdio: 'pipe',
-      });
-    } catch (e: any) {
-      exitCode = e.status;
-      stderr = e.stderr?.toString() || '';
-    }
+    const { exitCode, stderr } = runResumeMember(geminiDir, 'gemini', 'follow-up');
 
     expect(exitCode).not.toBe(0);
     // Skill-aware error from cmdResumeMember (generic-job) with skillName='slides-review'.
@@ -99,40 +120,20 @@ describe('resume-member gemini pre-check', () => {
     expect(stderr).toContain('implement driver or change default member');
   });
 
-  test('happy path: registered cliType reaches cmdResumeMember beyond driver gate', async () => {
-    // GIVEN: job dir with opencode member status.json (opencode is a registered driver)
-    // WHEN: resume-member invoked for that member
-    // THEN: stderr does NOT contain 'no driver for' — driver gate is passed
-    //       (downstream failure e.g. spawning real opencode is acceptable)
-    let stderr = '';
-    try {
-      execFileSync(process.execPath, [SCRIPT, 'resume-member', opencodeDir, 'opencode', 'test prompt'], {
-        stdio: 'pipe',
-      });
-    } catch (e: any) {
-      stderr = e.stderr?.toString() || '';
-    }
+  test('happy path: registered cliType reaches cmdResumeMember beyond driver gate', () => {
+    // opencode is a registered driver: the driver gate is passed and the faked CLI is spawned.
+    // The assertion only checks the gate is cleared — no 'no driver' error is emitted.
+    const { stderr } = runResumeMember(opencodeDir, 'opencode', 'test prompt');
 
     expect(stderr).not.toContain('no driver for');
     expect(stderr).not.toContain('slides-review: no driver');
   });
 
-  test('claude fixture: does NOT trigger the gemini guard (exits with a different error)', () => {
-    let exitCode = 0;
-    let stderr = '';
-    try {
-      execFileSync(process.execPath, [SCRIPT, 'resume-member', claudeDir, 'gemini', 'follow-up'], {
-        stdio: 'pipe',
-      });
-    } catch (e: any) {
-      exitCode = e.status;
-      stderr = e.stderr?.toString() || '';
-    }
+  test('claude fixture: does NOT trigger the gemini guard (passes the driver gate)', () => {
+    const { stderr } = runResumeMember(claudeDir, 'gemini', 'follow-up');
 
-    // The claude path should NOT produce the gemini guard message.
-    // It will fail for a different reason (no actual claude CLI), but not with the guard.
+    // The claude path is a registered driver, so the gemini guard must not fire.
     expect(stderr).not.toContain('no driver for gemini');
-    // Must NOT contain the skill-aware guard message
     expect(stderr).not.toContain('slides-review default member is gemini');
   });
 });

--- a/skills/slides-review/scripts/job-gemini-guard.test.ts
+++ b/skills/slides-review/scripts/job-gemini-guard.test.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env bun
+/**
+ * TDD: gemini pre-check in resume-member.
+ *
+ * RED test: with a gemini fixture status.json, resume-member should exit non-zero
+ * and print a skill-aware error containing 'slides-review', 'gemini', 'no driver'.
+ *
+ * Must NOT modify job.test.ts (T5 territory).
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import path from 'path';
+import fs from 'fs';
+import { execFileSync } from 'child_process';
+import { tmpdir } from 'os';
+
+const SCRIPT = path.join(import.meta.dirname, 'job.ts');
+
+function makeJobDir(command: string): string {
+  const dir = fs.mkdtempSync(path.join(tmpdir(), 'slides-review-test-'));
+  const reviewersDir = path.join(dir, 'reviewers', 'gemini');
+  fs.mkdirSync(reviewersDir, { recursive: true });
+
+  // Minimal status.json with a fake sessionID to pass the no-session check
+  const status = {
+    state: 'stop',
+    sessionID: 'fake-session-id',
+    command,
+    resume_count: 0,
+    workerEnv: {},
+  };
+  fs.writeFileSync(path.join(reviewersDir, 'status.json'), JSON.stringify(status), 'utf8');
+
+  // Minimal job.json
+  const jobMeta = {
+    id: 'slides-review-test',
+    createdAt: new Date().toISOString(),
+    settings: { timeoutSec: 60 },
+    members: [{ name: 'gemini', command }],
+  };
+  fs.writeFileSync(path.join(dir, 'job.json'), JSON.stringify(jobMeta), 'utf8');
+
+  return dir;
+}
+
+const geminiDir = makeJobDir('gemini');
+const claudeDir = makeJobDir('claude');
+
+afterAll(() => {
+  try { fs.rmSync(geminiDir, { recursive: true, force: true }); } catch {}
+  try { fs.rmSync(claudeDir, { recursive: true, force: true }); } catch {}
+});
+
+describe('resume-member gemini pre-check', () => {
+  test('gemini fixture: exits non-zero with skill-aware error containing all 3 keywords', () => {
+    let exitCode = 0;
+    let stderr = '';
+    try {
+      execFileSync(process.execPath, [SCRIPT, 'resume-member', geminiDir, 'gemini', 'follow-up'], {
+        stdio: 'pipe',
+      });
+    } catch (e: any) {
+      exitCode = e.status;
+      stderr = e.stderr?.toString() || '';
+    }
+
+    expect(exitCode).not.toBe(0);
+    // Must be the skill-aware message from the pre-check in job.ts, not the generic
+    // 'no driver for gemini' from cmdResumeMember.
+    expect(stderr).toContain('slides-review');
+    expect(stderr).toContain('gemini');
+    expect(stderr).toContain('no driver');
+    // The skill-aware message must reference review.config.yaml so the user knows where to act.
+    expect(stderr).toContain('review.config.yaml');
+  });
+
+  test('claude fixture: does NOT trigger the gemini guard (exits with a different error)', () => {
+    let exitCode = 0;
+    let stderr = '';
+    try {
+      execFileSync(process.execPath, [SCRIPT, 'resume-member', claudeDir, 'gemini', 'follow-up'], {
+        stdio: 'pipe',
+      });
+    } catch (e: any) {
+      exitCode = e.status;
+      stderr = e.stderr?.toString() || '';
+    }
+
+    // The claude path should NOT produce the gemini guard message.
+    // It will fail for a different reason (no actual claude CLI), but not with the guard.
+    expect(stderr).not.toContain('no driver for gemini');
+    // Must NOT contain the skill-aware guard message
+    expect(stderr).not.toContain('slides-review default member is gemini');
+  });
+});

--- a/skills/slides-review/scripts/job-gemini-guard.test.ts
+++ b/skills/slides-review/scripts/job-gemini-guard.test.ts
@@ -65,13 +65,11 @@ describe('resume-member gemini pre-check', () => {
     }
 
     expect(exitCode).not.toBe(0);
-    // Must be the skill-aware message from the pre-check in job.ts, not the generic
-    // 'no driver for gemini' from cmdResumeMember.
+    // Skill-aware error from cmdResumeMember (generic-job) with skillName='slides-review'.
     expect(stderr).toContain('slides-review');
     expect(stderr).toContain('gemini');
     expect(stderr).toContain('no driver');
-    // The skill-aware message must reference review.config.yaml so the user knows where to act.
-    expect(stderr).toContain('review.config.yaml');
+    expect(stderr).toContain('implement driver or change default member');
   });
 
   test('claude fixture: does NOT trigger the gemini guard (exits with a different error)', () => {

--- a/skills/slides-review/scripts/job.test.ts
+++ b/skills/slides-review/scripts/job.test.ts
@@ -45,4 +45,20 @@ describe('resume-member subcommand', () => {
     expect(exitCode).not.toBe(0);
     expect(output).toContain('missing member name');
   });
+
+  test('resume-member에서 --json 등 flag-like 토큰을 prompt로 전달하면 missing prompt로 거부되지 않는다', () => {
+    // 회귀 테스트: parseArgs가 --json을 소비하여 prompt가 빈 문자열이 되는 버그 방지.
+    // process.argv.slice(5)로 raw argv에서 prompt를 캡처하므로 --json이 그대로 전달된다.
+    let exitCode = 0;
+    let output = '';
+    try {
+      execFileSync(process.execPath, [SCRIPT, 'resume-member', '/tmp/no-such-dir', 'mymember', '--json'], { stdio: 'pipe' });
+    } catch (e: any) {
+      exitCode = e.status;
+      output = (e.stderr?.toString() || '') + (e.stdout?.toString() || '');
+    }
+    // Should fail (nonexistent jobDir -> no resumable session), but NOT with "missing prompt"
+    expect(exitCode).not.toBe(0);
+    expect(output).not.toContain('missing prompt');
+  });
 });

--- a/skills/slides-review/scripts/job.ts
+++ b/skills/slides-review/scripts/job.ts
@@ -23,10 +23,7 @@ import {
   cmdResumeMember,
   gcStaleJobs,
   parseYamlSimple as frameworkParseYamlSimple,
-  detectCliType,
 } from '@lib/generic-job';
-
-import { pickDriver, type CliType } from '@lib/agent-drivers/types';
 
 import { getOmtDir } from '@lib/omt-dir';
 
@@ -197,21 +194,7 @@ async function main() {
     if (!jobDirArg) exitWithError('resume-member: missing jobDir');
     if (!nameArg) exitWithError('resume-member: missing member name');
     if (!promptArg) exitWithError('resume-member: missing prompt');
-    // Pre-check: detect CLI type from status.json and fail fast with a skill-aware error
-    // before cmdResumeMember can burn the resume cap.
-    const memberDir = path.join(jobDirArg, REVIEW_CONFIG.entityDirName, nameArg);
-    const statusRaw = (() => { try { return fs.readFileSync(path.join(memberDir, 'status.json'), 'utf8'); } catch { return null; } })();
-    if (statusRaw) {
-      const status = JSON.parse(statusRaw) as Record<string, unknown>;
-      const cliType = detectCliType(status.command);
-      if (!pickDriver(cliType as CliType)) {
-        exitWithError(
-          `slides-review default member is ${cliType}, which has no driver registered. ` +
-          `Implement ${cliType} driver or change default member in review.config.yaml`
-        );
-      }
-    }
-    await cmdResumeMember(jobDirArg, nameArg, promptArg, REVIEW_CONFIG);
+    await cmdResumeMember(jobDirArg, nameArg, promptArg, REVIEW_CONFIG, { skillName: 'slides-review' });
     return;
   }
   if (command === 'stop') {

--- a/skills/slides-review/scripts/job.ts
+++ b/skills/slides-review/scripts/job.ts
@@ -23,7 +23,10 @@ import {
   cmdResumeMember,
   gcStaleJobs,
   parseYamlSimple as frameworkParseYamlSimple,
+  detectCliType,
 } from '@lib/generic-job';
+
+import { pickDriver, type CliType } from '@lib/agent-drivers/types';
 
 import { getOmtDir } from '@lib/omt-dir';
 
@@ -194,6 +197,20 @@ async function main() {
     if (!jobDirArg) exitWithError('resume-member: missing jobDir');
     if (!nameArg) exitWithError('resume-member: missing member name');
     if (!promptArg) exitWithError('resume-member: missing prompt');
+    // Pre-check: detect CLI type from status.json and fail fast with a skill-aware error
+    // before cmdResumeMember can burn the resume cap.
+    const memberDir = path.join(jobDirArg, REVIEW_CONFIG.entityDirName, nameArg);
+    const statusRaw = (() => { try { return fs.readFileSync(path.join(memberDir, 'status.json'), 'utf8'); } catch { return null; } })();
+    if (statusRaw) {
+      const status = JSON.parse(statusRaw) as Record<string, unknown>;
+      const cliType = detectCliType(status.command);
+      if (!pickDriver(cliType as CliType)) {
+        exitWithError(
+          `slides-review default member is ${cliType}, which has no driver registered. ` +
+          `Implement ${cliType} driver or change default member in review.config.yaml`
+        );
+      }
+    }
     await cmdResumeMember(jobDirArg, nameArg, promptArg, REVIEW_CONFIG);
     return;
   }

--- a/skills/slides-review/scripts/job.ts
+++ b/skills/slides-review/scripts/job.ts
@@ -190,7 +190,9 @@ async function main() {
   if (command === 'resume-member') {
     const jobDirArg = rest[0];
     const nameArg = rest[1];
-    const promptArg = rest.slice(2).join(' ');
+    // Capture prompt from raw argv to avoid parseArgs consuming --flag tokens inside the prompt.
+    // argv layout: [node, script, 'resume-member', jobDir, memberName, ...promptTokens]
+    const promptArg = process.argv.slice(5).join(' ');
     if (!jobDirArg) exitWithError('resume-member: missing jobDir');
     if (!nameArg) exitWithError('resume-member: missing member name');
     if (!promptArg) exitWithError('resume-member: missing prompt');

--- a/skills/spec-review/SKILL.md
+++ b/skills/spec-review/SKILL.md
@@ -73,6 +73,7 @@ Proceed with implementation.
 You may ONLY execute these commands via Bash:
 - `bun .claude/skills/spec-review/scripts/job.ts start --prompt-file "$PROMPT_FILE" [--spec <spec-name>]` — start a review job
 - `bun .claude/skills/spec-review/scripts/job.ts collect "$JOB_DIR"` — collect results (polls internally every 5s, 150s default timeout). No external sleep needed.
+- `bun .claude/skills/spec-review/scripts/job.ts resume-member "$JOB_DIR" <member> "<prompt>"` — recover a stalled member
 
 **CRITICAL**: Always set `timeout: 180000` on every Bash tool call.
 
@@ -164,7 +165,7 @@ bun .claude/skills/spec-review/scripts/job.ts collect "$JOB_DIR"
 
 - If response shows `"overallState": "done"` → proceed to Phase 3.
 - If `"overallState": "awaiting_resume"` → identify members with `state: "awaiting_resume"` in `members[]` and call `bun .claude/skills/spec-review/scripts/job.ts resume-member "$JOB_DIR" <member> "<resume prompt>"` for each, then call `collect` again.
-- If `"overallState": "empty_output"` → identify members with `state: "empty_output"` in `members[]` and call `resume-member` once to retry. If `resume_count` reaches cap (3) the command throws — skip that member and proceed with the remaining members in synthesis.
+- If `"overallState": "empty_output"` → identify members with `state: "empty_output"` in `members[]` and call `resume-member` once to retry. If `resume_count` reaches cap (3) the command throws — call `collect` again; the capped reviewer now appears as a failed reviewer (`outputFilePath` null) in the manifest, so apply the Degradation Policy.
 - Otherwise (`"running"`, `"queued"`, etc.) → call `collect` again (same command, foreground, timeout: 180000).
 
 Response JSON (done):

--- a/skills/spec-review/SKILL.md
+++ b/skills/spec-review/SKILL.md
@@ -163,6 +163,8 @@ bun .claude/skills/spec-review/scripts/job.ts collect "$JOB_DIR"
 ```
 
 - If response shows `"overallState": "done"` → proceed to Phase 3.
+- If `"overallState": "awaiting_resume"` → identify members with `state: "awaiting_resume"` in `members[]` and call `bun .claude/skills/spec-review/scripts/job.ts resume-member "$JOB_DIR" <member> "<resume prompt>"` for each, then call `collect` again.
+- If `"overallState": "empty_output"` → identify members with `state: "empty_output"` in `members[]` and call `resume-member` once to retry. If `resume_count` reaches cap (3) the command throws — skip that member and proceed with the remaining members in synthesis.
 - Otherwise (`"running"`, `"queued"`, etc.) → call `collect` again (same command, foreground, timeout: 180000).
 
 Response JSON (done):

--- a/skills/spec-review/scripts/job.test.ts
+++ b/skills/spec-review/scripts/job.test.ts
@@ -1013,3 +1013,66 @@ describe('cmdResults', () => {
     expect(parsed.members[0].output).toBe('clean output');
   });
 });
+
+// ---------------------------------------------------------------------------
+// resume-member subcommand
+// ---------------------------------------------------------------------------
+
+describe('resume-member subcommand', () => {
+  const SCRIPT = path.join(import.meta.dirname, 'job.ts');
+
+  test('resume-member without jobDir exits with error', () => {
+    let exitCode = 0;
+    let output = '';
+    try {
+      execFileSync(process.execPath, [SCRIPT, 'resume-member'], { stdio: 'pipe' });
+    } catch (e: any) {
+      exitCode = e.status;
+      output = (e.stderr?.toString() || '') + (e.stdout?.toString() || '');
+    }
+    expect(exitCode).not.toBe(0);
+    expect(output).toContain('missing jobDir');
+  });
+
+  test('resume-member without member name exits with error', () => {
+    let exitCode = 0;
+    let output = '';
+    try {
+      execFileSync(process.execPath, [SCRIPT, 'resume-member', '/tmp/x'], { stdio: 'pipe' });
+    } catch (e: any) {
+      exitCode = e.status;
+      output = (e.stderr?.toString() || '') + (e.stdout?.toString() || '');
+    }
+    expect(exitCode).not.toBe(0);
+    expect(output).toContain('missing member name');
+  });
+
+  test('resume-member without prompt exits with error', () => {
+    let exitCode = 0;
+    let output = '';
+    try {
+      execFileSync(process.execPath, [SCRIPT, 'resume-member', '/tmp/x', 'mymember'], { stdio: 'pipe' });
+    } catch (e: any) {
+      exitCode = e.status;
+      output = (e.stderr?.toString() || '') + (e.stdout?.toString() || '');
+    }
+    expect(exitCode).not.toBe(0);
+    expect(output).toContain('missing prompt');
+  });
+
+  test('resume-member에서 --json 등 flag-like 토큰을 prompt로 전달하면 missing prompt로 거부되지 않는다', () => {
+    // 회귀 테스트: parseArgs가 --json을 소비하여 prompt가 빈 문자열이 되는 버그 방지.
+    // process.argv.slice(5)로 raw argv에서 prompt를 캡처하므로 --json이 그대로 전달된다.
+    let exitCode = 0;
+    let output = '';
+    try {
+      execFileSync(process.execPath, [SCRIPT, 'resume-member', '/tmp/no-such-dir', 'mymember', '--json'], { stdio: 'pipe' });
+    } catch (e: any) {
+      exitCode = e.status;
+      output = (e.stderr?.toString() || '') + (e.stdout?.toString() || '');
+    }
+    // Should fail (nonexistent jobDir -> no resumable session), but NOT with "missing prompt"
+    expect(exitCode).not.toBe(0);
+    expect(output).not.toContain('missing prompt');
+  });
+});

--- a/skills/spec-review/scripts/job.ts
+++ b/skills/spec-review/scripts/job.ts
@@ -514,7 +514,9 @@ async function main(): Promise<void> {
   if (command === 'resume-member') {
     const jobDirArg = rest[0] as string;
     const nameArg = rest[1] as string;
-    const promptArg = (rest as string[]).slice(2).join(' ');
+    // Capture prompt from raw argv to avoid parseArgs consuming --flag tokens inside the prompt.
+    // argv layout: [node, script, 'resume-member', jobDir, memberName, ...promptTokens]
+    const promptArg = process.argv.slice(5).join(' ');
     if (!jobDirArg) exitWithError('resume-member: missing jobDir');
     if (!nameArg) exitWithError('resume-member: missing member name');
     if (!promptArg) exitWithError('resume-member: missing prompt');

--- a/skills/spec-review/scripts/job.ts
+++ b/skills/spec-review/scripts/job.ts
@@ -518,7 +518,7 @@ async function main(): Promise<void> {
     if (!jobDirArg) exitWithError('resume-member: missing jobDir');
     if (!nameArg) exitWithError('resume-member: missing member name');
     if (!promptArg) exitWithError('resume-member: missing prompt');
-    await cmdResumeMember(jobDirArg, nameArg, promptArg, JOB_CONFIG);
+    await cmdResumeMember(jobDirArg, nameArg, promptArg, JOB_CONFIG, { skillName: 'spec-review' });
     return;
   }
   if (command === 'stop') {


### PR DESCRIPTION
## 📌 Summary

후속 PR2 (PR #71 `followup-pr1-lib` 위에 stacked). 당초 PR #70 리뷰의 잔여 P2/P3 (driver invariant + skill 정리)로 시작했으나, caller-judgment 펌프의 **state contract 전반**을 마저 정리하는 범위로 확장되었습니다. #71의 `cmdResumeMember` preflight-before-cap + `executeOneTurn` 비-종료 시그널 보존을 기반으로 합니다.

- **Driver parser invariant 자체 강제** — codex `--json`, opencode `--format json` (`initialCommand` + `resumeCommand` 양쪽)
- **비-종료 / 빈-출력 state 분류** — `awaiting_resume` / `empty_output`을 종료 상태로 평탄화하지 않고 노출
- **resume / collect 생명주기** — resume cap 소진 시 `non_retryable` 종결, `cmdCollect` 조기 반환
- **skill CLI 표면 정합** — 5개 skill resume-member positional + `skillName` 전달 + raw argv 캡처
- **multi-AI 코드 리뷰 후속 수정 5건**

> ℹ️ #71 (`followup-pr1-lib`) 위에 stacked. #71 머지 시 base가 main으로 자동 재정렬됩니다.

## 🔧 Changes

### A. Driver parser invariant 자체 강제
- **codex `--json` 멱등 가드** (`bbaa1e5`) — `initialCommand` + `resumeCommand` 양쪽. `parseStdout`의 NDJSON invariant를 driver가 self-enforce
- **opencode `resumeCommand --format json` 값 검증** (`0a19f0d`) — 키-only 가드를 값 검증으로 교체, file-local `stripFlagPair` 헬퍼 도입
- **opencode `initialCommand`도 `--format json` 강제** (`a0c7e42`) — resumeCommand와 대칭. ⚠️ 당초 plan은 initialCommand를 별도 P3로 분리했으나 invariant gap을 닫기 위해 본 PR에 포함 (Review Point 1)

### B. 비-종료 / 빈-출력 state 분류
- **`awaiting_resume`를 overallState `done`에서 제외** (`f0aeea9`)
- **`empty_output` 분류 + raw NDJSON 보존** (`1393f8a`) — `stop` + 빈 텍스트 + clean exit을 `empty_output`로, driver 변환 전 stdout을 `raw-output.ndjson`로 보존
- **`empty_output` non-terminal 처리** (`7133504`) + **terminalStates에서 제외** (`ae4ac0e`)
- **terminal error 시 `errorEvent` 보존** (`6bd6020`) — 진단용 failure evidence
- **no-driver 경로 `size_bytes` 0 회귀 수정** (`e44178f`) — `buildManifest`의 readability gate와 정합

### C. resume / collect 생명주기
- **resume cap 소진 시 `non_retryable` 종결** (`cce28aa`, `35dec66`) — cap(3) 도달 시 `non_retryable` 기록 후 throw, collect 재호출 시 실패 멤버로 surface + allowlist 정합
- **`cmdCollect` early-return** (`9d58e98`, `e88efef`) — `awaiting_resume` / `empty_output`에서 members 배열 반환, chairman 처리 명시

### D. skill CLI 표면 정합
- **orchestrate-review resume-member positional** (`a8cdfb3`) — flag form → positional, 4 sibling과 일치, `SKILL.md` 예시 동시 갱신 (doc-code drift 방지)
- **slides-review gemini skill-aware error** (`d8f82d4`) — gemini(driver 미등록) 호출 시 actionable 메시지
- **`cmdResumeMember` `skillName` 파라미터 + 5개 skill 전달** (`44feed3`, `09acf4b`) — skill-aware 에러를 `cmdResumeMember`가 직접 생성 (Review Point 2)
- **resume-member prompt raw argv 캡처** (`a406b17`, 5개 skill) — `process.argv.slice(5)`로 `--json` 등 flag 토큰이 `parseArgs`에 소비되지 않게

### E. multi-AI 코드 리뷰 후속 수정
- **computeStatus `queued` 우선순위 보정** (`d17bed7`) — `queued`를 `awaiting_resume`/`empty_output`보다 우선시켜, 미dispatch 멤버가 있을 때 `cmdCollect`가 조기 반환하지 않도록 + 회귀 테스트
- **미사용 telemetry 필드 제거** (`3fde0ff`) — 소비처 없는 `eventCount`/`lastEventType`/`tokens` 제거 (`terminal`/`errorEvent`/`raw-output.ndjson`은 유지)
- **opencode flag strip 통일** (`f7e6d33`) — `--session` 수동 루프를 `stripFlagPair`로 일원화 (`stripFormatPair` → `stripFlagPair` rename)
- **gemini guard 테스트 hermetic화** (`bd388a1`) — fake CLI를 PATH에 prepend해 실제 인증 opencode/claude spawn 차단 (결정적·offline)
- **미정의 Degradation Policy 참조 해소** (`8b99049`) — diagnose(`non_retryable` fallback) / slides-review(quiet pass) 각자의 실제 메커니즘으로 교체

## 💬 Review Points

### 1. opencode `initialCommand --format json`을 본 PR에 포함한 이유

당초 plan(T7)은 opencode `initialCommand`를 별도 P3 follow-up으로 분리했습니다. 그러나 `parseStdout`는 `--format json`(NDJSON)을 요구하는데 `initialCommand`가 이를 강제하지 않으면 caller가 빠뜨릴 때 silent parse 실패가 발생합니다. codex는 plan(T6)에서 `initialCommand` + `resumeCommand` 양쪽을 강제했으므로, 대칭을 위해 opencode `initialCommand`도 포함했습니다. speculative flexibility가 아니라 실재 invariant gap을 닫는 변경입니다.

### 2. skill-aware 에러를 `cmdResumeMember`의 `skillName` 파라미터로 구현한 이유

`cmdResumeMember`가 generic `no driver for X`로 throw하면 사용자가 어느 skill의 설정 문제인지 알기 어렵습니다. (a) skill 측 pre-check를 두는 방안과 (b) `cmdResumeMember`에 `skillName`을 넘기는 방안을 검토해 **(b)를 채택**했습니다 — `skillName`은 caller가 넘기는 라벨일 뿐 `lib/`가 skill 이름을 import/하드코딩하지 않으므로 의존성 역전이 아니며, 5개 skill의 pre-check 중복을 제거합니다. driver 조회가 cap reserve 이전이라 misconfigured 호출이 `resume_count`를 burn하지 않는 불변식도 유지됩니다.

### 3. `empty_output`을 마스킹이 아닌 노출로 처리한 이유

모델이 `stop`으로 종료하되 텍스트가 비고 process가 정상(clean exit) 종료하면, 기존엔 `done`으로 평탄화되어 chairman이 빈 출력을 완료로 합성할 위험이 있었습니다. 이를 `empty_output`(non-terminal)로 분류해 resume을 유발하고, 반복 시 cap(3) 도달 → `non_retryable`로 surface합니다. 결함을 숨기지 않고 노출하는 방향입니다.

## ✅ Checklist

- [x] `make typecheck` exit 0
- [x] `make test` 2007 pass / 0 fail
- [x] `make validate` schema + components PASS
- [x] codex/opencode driver invariant 양쪽 강제
- [x] empty_output/awaiting_resume 종료 평탄화 방지 + cap 소진 `non_retryable` 종결
- [x] 5개 skill resume-member positional + `skillName` + raw argv 캡처 정합
- [x] 코드 리뷰 후속 5건 반영 (computeStatus 우선순위 / telemetry 제거 / guard 테스트 hermetic화 / flag strip 통일 / dangling policy 해소)

## 📎 References

- Stacked on: #71 (`followup-pr1-lib`)
- 직전 PR: #70 + #71
