### PR TITLE
fix(skills): diagnose collect 폴링 조기 종료 방지

### DIFF
--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -7,7 +7,7 @@ description: Use when asked to analyze architecture, debug issues, identify root
 
 ## Overview
 
-Delegates architecture analysis and debugging to the Hephaestus opencode agent via a background job. If the agent is unavailable (CLI not installed, timeout, error, or canceled), falls back to in-session analysis using the Hephaestus framework.
+Delegates architecture analysis and debugging to the Hephaestus opencode agent, which runs as a detached worker you observe by polling. This skill is finished only once you have pulled a definitive answer out of the job — nothing notifies you when the worker is done. If the agent is unavailable (CLI not installed, timeout, error, or canceled), falls back to in-session analysis using the Hephaestus framework.
 
 ---
 
@@ -38,7 +38,7 @@ The command prints the `jobDir` path on stdout, captured into `$JOB_DIR` above.
 bun .claude/skills/diagnose/scripts/job.ts collect $JOB_DIR
 ```
 
-`collect` polls until the job reaches a terminal state and returns a JSON manifest. Repeat if the overall state is `running` or `queued`.
+`collect` polls internally, but it returns after a fixed internal timeout that is deliberately shorter than the worker's full run budget. A non-`done` return (`running`, `queued`, or `awaiting_resume`) is therefore expected — it does NOT mean the job will finish on its own, and nothing will notify you when it does. Re-run `collect` in the foreground until it returns `done`, or go to Step 4 when the state is `awaiting_resume`. Do not end the turn while the overall state is non-terminal.
 
 ### Step 4: Fallback branch
 
@@ -71,6 +71,23 @@ bun .claude/skills/diagnose/scripts/job.ts clean $JOB_DIR
 ```
 
 Run cleanup only after all resumable states are closed (member is `done`, in-session fallback is complete, or resume cap is exhausted).
+
+---
+
+## Completion Contract
+
+The skill produces an answer only by reading it out of the job, and the job is poll-only: a detached worker writes to the jobDir, and nothing notifies you when it finishes. "Let it run and come back" has no mechanism behind it. Get a definitive answer out of the job, then finish — not before.
+
+You are done only when BOTH hold:
+1. The member reached a terminal, answered state — `done` with substantive analysis, in-session fallback completed, or the resume cap (3) exhausted.
+2. You hold that content and have forwarded it to the caller.
+
+| Red flag (about to fail) | Reality |
+|--------------------------|---------|
+| "`collect` returned `running`, it's working in the background" | Non-`done` means poll again now. There is no background monitor. |
+| "I'll report once it finishes" | Nothing will wake you. Loop `collect` to terminal in this turn. |
+| "It's `awaiting_resume`, close enough to done" | Recoverable — `resume-member` it (Step 4). Do not stop. |
+| "I forwarded the plan it produced" | A plan or framing is not analysis. Drive it to a real answer or fall back in-session. |
 
 ---
 


### PR DESCRIPTION
## 📌 Summary

diagnose 스킬을 따르는 에이전트가 poll-only job에서 결과를 끝까지 받아오지 않고 중간에 종료하던 문제를 고칩니다. `collect`가 비종료 상태로 반환되는 걸 "백그라운드에서 알아서 끝나겠지"로 오해한 게 원인이었습니다.

---

## 🔧 Changes

### diagnose 스킬 (`skills/diagnose/SKILL.md`)

- Overview에서 "via a background job" 표현을 걷어내고, worker는 polling으로만 관측되는 detached 프로세스이며 job에서 확실한 답을 받아낸 뒤에야 스킬이 끝난다고 명시
- Step 3의 사실 오류 수정 — 기존엔 `collect`가 "terminal 상태까지 폴링한다"고 적혀 있었으나, 실제로는 worker 실행 예산보다 짧은 내부 타임아웃(150s)에서 비종료 상태로 반환됨. 비종료 반환이 정상이라는 점, foreground에서 `done`까지 재폴링해야 한다는 점, non-terminal 상태로 턴을 끝내면 안 된다는 규칙을 추가
- "Completion Contract" 섹션 신설 — job은 poll-only라 완료 알림이 없으니 확실한 답을 받아낸 뒤 종료하라는 계약과 red-flags 표

oracle 에이전트가 이 스킬을 따르는데, 한 번 폴링하고 비종료 결과를 받자 "백그라운드 진행 중"으로 오해해 verdict 없이 턴을 끝낸 사례가 있었습니다. 문서가 `collect`를 잘못 설명한 게 직접 원인이었습니다.

**영향 범위**
- 문서(SKILL.md)만 변경 — 실행 코드·동작 변경 없음
- diagnose 스킬을 따르는 주체(특히 oracle 에이전트)의 행동 가이드에 영향
- 소스 repo 기준 반영이며, 런타임 적용은 별도 sync 필요

---

## 💬 Review Points

### 1. Completion Contract를 에이전트 정체성이 아니라 job 상태에 앵커

**배경 및 문제 상황:**
조기 종료 방지 규칙을 "너는 서브에이전트라 다시 깨어나지 못한다" 식으로 쓸 수도 있었습니다. 그러나 이건 에이전트가 자기 실행 컨텍스트를 인지·신경 써야 성립하는 취약한 전제이고, 메인 세션에서 같은 스킬을 직접 호출해도 "완료 알림이 없다"는 함정은 똑같이 존재합니다.

**해결 방안:**
계약을 "job에서 확실한 답을 받아내기 전엔 끝내지 마라"로 잡았습니다. 누가 실행하든 관측 가능한 job 상태(terminal + 답 확보)에만 의존합니다.

**선택과 트레이드오프:**
- 채택: job 메커니즘 앵커 — poll-only라 완료 알림이 없다는 사실 자체를 못 박아 "백그라운드가 끝내주겠지"라는 변명의 전제를 제거
- 기각: 서브에이전트 정체성 앵커 — 호출 맥락에 따라 무너지고 메인 세션 호출엔 적용되지 않음
- 스코프 아웃: 같은 contract를 여러 job 기반 스킬이 각자 산문으로 재기술해 drift 위험이 있습니다. 공유 레이어(`collect` 출력)로 끌어올리는 안을 검토했으나 이번 PR에서는 제외했고, 별도 논의 대상입니다

---

## ✅ Checklist

### diagnose 스킬 문서
- [ ] Step 3가 `collect`의 150s 내부 타임아웃과 "비종료 반환은 정상"임을 명시한다
  - `skills/diagnose/SKILL.md`
- [ ] "Completion Contract" 섹션이 존재하며 확실한 답을 받기 전 종료를 금지한다
  - `skills/diagnose/SKILL.md`
- [ ] `make validate-components` 통과
  - `skills/diagnose/SKILL.md`

---

## 📎 References
- 별도 트래킹 이슈 없음 (self-contained 스킬 수정)