### PR TITLE
feat(prometheus): 발표본 HTML 표현·경로 지침 정비

### DIFF
--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -630,6 +630,7 @@ This contract applies to EVERY plan. The contract lives here — not in a refere
 - **Location**: `$OMT_DIR/plans/{name}.md`
 - **Language**: English
 - **Exclude**: Vague criteria ("verify it works")
+- **Agent anonymity**: The plan file records established facts, not the agents or tool-passes that produced them. Do not name explore / librarian / oracle / Metis / Momus — or write phrases like "3 oracle passes confirmed", "per the reviewer", "explore found" — anywhere in the plan body. State the conclusion as fact and let the WHY stand on its own evidence; the agents' results are fully applied to the planning and the plan, but the agents themselves do not appear in it. (Scope: the durable plan file only. The ephemeral Stage A HTML presentation MAY surface pipeline/reviewer state as an intentional process-transparency overlay — see `## Review Pipeline`.)
 
 ### Plan Sections (all required)
 
@@ -913,7 +914,7 @@ This step CANNOT be skipped. After Momus APPROVE/COMMENT, prometheus MUST execut
 
 | Stage | Mandate | Detail location |
 |---|---|---|
-| **Stage A** | Render plan → `$OMT_DIR/plans/plan.html` (single-file, browser-openable). Verbatim plan content + session-derived boxes (Stage B recommendation, Pipeline State). Graceful fallback: if conversion fails, present raw markdown and continue to Stage B. | Rendering procedure (6 invariants, 3 translation invariants, template reference) in `review-pipeline.md` |
+| **Stage A** | Render plan to a single-file, browser-openable HTML — one file per plan, so plans never overwrite each other. Faithful content (no omission/contradiction/invented facts) + readability rewrite in the communication language + context callouts + session-derived boxes (Stage B recommendation, Pipeline State). Graceful fallback: if conversion fails, present raw markdown and continue to Stage B. | Exact output path, rendering invariants (6), translation invariants (3), readability enrichment, template reference in `review-pipeline.md` |
 | **Stage B** | Compute execution recommendation using Decision Matrix (TODO count, Complex/Architecture flag, AC gap, Ambiguity Score, Oracle COMMENT signals). Output: Recommendation + Mode + Rationale + What-tips-the-balance. | Decision Matrix details in `review-pipeline.md` |
 | **Stage C** | Execution Bridge via platform's user-prompt primitive — 3 options (Full orchestration / Focused execution / Revise plan). `(Recommended)` label computed from Decision Matrix, NOT hardcoded. | Option formatting in `review-pipeline.md` |
 
@@ -935,7 +936,7 @@ On selection: Option 1 → `Skill(skill: "sisyphus")` with plan path. Option 2 �
 | Momus | Separate metis results in prompt | Already in Plan Context + anchoring risk |
 | Momus | Adding review instructions | Momus has own criteria |
 
-> Detailed invocation templates (3-Section Metis, Oracle Verification Focus, Momus path-only) + Stage A HTML rendering procedure (6 rendering invariants, 3 translation invariants, template reference, substitution semantics) + Stage B Decision Matrix details + Stage C option formatting → [review-pipeline.md](review-pipeline.md). Lookup-only — read the relevant section when executing that specific stage.
+> Detailed invocation templates (3-Section Metis, Oracle Verification Focus, Momus path-only) + Stage A HTML rendering procedure (6 rendering invariants, 3 translation invariants, readability enrichment, template reference, substitution semantics) + Stage B Decision Matrix details + Stage C option formatting → [review-pipeline.md](review-pipeline.md). Lookup-only — read the relevant section when executing that specific stage.
 
 ---
 

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -630,7 +630,7 @@ This contract applies to EVERY plan. The contract lives here — not in a refere
 - **Location**: `$OMT_DIR/plans/{name}.md`
 - **Language**: English
 - **Exclude**: Vague criteria ("verify it works")
-- **Agent anonymity**: The plan file records established facts, not the agents or tool-passes that produced them. Do not name explore / librarian / oracle / Metis / Momus — or write phrases like "3 oracle passes confirmed", "per the reviewer", "explore found" — anywhere in the plan body. State the conclusion as fact and let the WHY stand on its own evidence; the agents' results are fully applied to the planning and the plan, but the agents themselves do not appear in it. (Scope: the durable plan file only. The ephemeral Stage A HTML presentation MAY surface pipeline/reviewer state as an intentional process-transparency overlay — see `## Review Pipeline`.)
+- **Agent anonymity**: The plan file records established facts, not the agents or passes that produced them. The ban is on agent-as-source attribution, not token presence: do not write "oracle confirmed", "explore found", "per the reviewer", "3 oracle passes established", or any phrasing that credits explore / librarian / oracle / Metis / Momus as the source of a fact. Bare domain use of those words is fine (e.g. "migrate to Oracle DB", "explore the cache policy"). State the conclusion as fact and let the WHY stand on its own evidence; the agents' results are fully applied to the planning and the plan, but the agents do not appear as the plan's source. (Scope: the durable plan file only. The ephemeral Stage A HTML presentation MAY surface pipeline/reviewer state as an intentional process-transparency overlay — see `## Review Pipeline`.)
 
 ### Plan Sections (all required)
 

--- a/skills/prometheus/review-pipeline.md
+++ b/skills/prometheus/review-pipeline.md
@@ -70,8 +70,8 @@ All context (interview summary) is already in the plan's Context section. No sup
 Convert `$OMT_DIR/plans/{name}.md` to a single-file HTML document and open it in the browser so the user can read the plan rendered.
 
 **Requirements:**
-- **Output artifact**: `$OMT_DIR/plans/plan.html` (single-file, self-contained, browser-openable)
-- **Content**: verbatim — no summarization, no paraphrasing, no omission (요약·각색 금지)
+- **Output artifact**: `$OMT_DIR/plans/presentation/{name}.html` — `{name}` is the same stem as the plan markdown (`{name}.md`), so each plan owns its own HTML file and concurrent or successive plans never overwrite a shared file. Create the `presentation/` directory if it does not yet exist. Single-file, self-contained, browser-openable.
+- **Content fidelity (faithful, not verbatim)**: Render the plan faithfully — no plan content may be omitted, weakened, or contradicted. Within that bound, prose MAY be rewritten for readability (see Translation Rule) and MAY carry readability callouts (see Readability Enrichment). The rendered HTML is a presentation for the human reader, not a second source of truth.
 - **Tool choice**: execution-time choice — use whatever is available at runtime (Pandoc, a script, inline generation). Tool is an implementation detail; output must meet the single-file + browser requirement regardless.
 - **Graceful fallback**: If HTML conversion fails, present raw Markdown directly and continue to Stage B.
 
@@ -82,7 +82,7 @@ The Stage A HTML output is composed of 4 distinct components:
 - **hero header** — plan title, meta pills (TODO count, AC count, wave label, plan file path), and stage kicker
 - **Stage B** — execution recommendation box injected from session state (reviewer verdicts, recommendation output)
 - **Pipeline State** — pipeline state journal box injected from session state (S0 → S_current transitions)
-- **plan-content** — the full plan markdown rendered into `article#plan-content`; sourced verbatim from plan.md
+- **plan-content** — the full plan markdown rendered into `article#plan-content`; sourced faithfully from plan.md (readability rewrite + enrichment callouts allowed per Readability Enrichment — no omission, no contradiction, no invented facts)
 
 ### Source Classification
 
@@ -105,7 +105,7 @@ Contains the static HTML structure with `{{placeholder}}` substitution variables
 
 Three invariants govern language translation applied during Stage A rendering.
 
-**Invariant 1 — Session auto-detect of conversational language**: The session detects the conversational language in use (the language the user is writing in during the current session). All prose content in HTML output is rendered in that detected language. No language is hard-coded; detection is render-time.
+**Invariant 1 — Session auto-detect of conversational language**: The session detects the conversational language in use (the language the user is writing in during the current session). All prose content in HTML output is **rewritten in that detected communication language** so the reader can follow it naturally — a readability-oriented rewrite, not a word-for-word translation of the plan's source prose. No language is hard-coded; detection is render-time.
 
 **Invariant 2 — Prose-only scope with preservation list**: Translation applies to prose-only content. The following are **never** translated:
 
@@ -122,6 +122,21 @@ Translating any item is a rule violation.
 **Invariant 3 — plan.md as single source-of-truth, render-time-only translation**: `plan.md` is the single SoT for plan content. No translated copy (`plan.{lang}.md`) is written to disk; translation is render-time only. HTML is ephemeral — re-rendering always draws from unmodified `plan.md`.
 
 **Fallback**: If language detection fails or yields an ambiguous result, render in original language. Do not block Stage A on detection failure.
+
+### Readability Enrichment
+
+`plan.md` is written in terse, executor-facing spec language. The HTML presentation MAY add readability aids so the human reader can follow it — but only within the content-fidelity bound declared in Requirements.
+
+**Allowed:**
+- Rephrasing plan prose for natural reading flow in the communication language (per Translation Rule).
+- Markdown blockquote callouts (`>`) that surface context the reader needs — drawn from the plan's own Context / interview-rationale / ADR sections. Use them to make an already-stated WHY easy to find, not to assert anything new.
+
+**Forbidden:**
+- Introducing any fact, decision, scope, or rationale not already present in `plan.md`. Enrichment re-surfaces existing context; it does not author new context. If the plan genuinely lacks context the reader needs, that is a plan defect — fix the plan and re-run the pipeline, do not paper over it at render time.
+- Omitting, weakening, or contradicting any plan content.
+- Writing enrichment back to disk. Per Invariant 3 the callouts live only in the ephemeral HTML; `plan.md` stays the single source of truth and every re-render redraws from it.
+
+Rationale: `plan.md` is the artifact Oracle and Momus reviewed and the artifact the executor runs from. Net-new content in the HTML would be unreviewed and would split the presentation from the execution source of truth. Re-surfacing context that already lives in the plan carries no such risk.
 
 ### Rendering Methodology
 

--- a/skills/prometheus/tests/application-scenarios.md
+++ b/skills/prometheus/tests/application-scenarios.md
@@ -290,7 +290,7 @@ Interview is completed (all clarifying questions answered, acceptance criteria c
 | V4 | Context section with Interview Summary | Plan includes Context section containing Interview Summary (key decisions from extended interview) |
 | V5 | Verification Strategy section present | Plan includes Verification Strategy with Test Decision, and Agent-Executed QA Scenarios for each TODO |
 | V6 | TODOs have populated References | Every TODO includes at least one Pattern or API/Type reference with WHY explanation; OR for greenfield tasks where no existing code patterns or types exist, states "Greenfield — no existing pattern" explicitly |
-| V7 | Agent anonymity in plan body | The plan body (Context / Interview Summary / WHY / any TODO field) records established facts without naming the agents or tool-passes that produced them — no "explore / librarian / oracle / Metis / Momus", "N oracle passes", "per the reviewer". The WHY stands on its own evidence; agent results are applied, agent identities are absent |
+| V7 | Agent anonymity in plan body | The plan body (Context / Interview Summary / WHY / any TODO field) records established facts without attributing them to a producing agent — no "oracle confirmed" / "explore found" / "per the reviewer" / "N oracle passes" style source-attribution to explore / librarian / oracle / Metis / Momus. Bare domain use of such words (e.g. "Oracle DB") is allowed; what is absent is agent-as-source attribution, not the tokens themselves |
 
 ---
 

--- a/skills/prometheus/tests/application-scenarios.md
+++ b/skills/prometheus/tests/application-scenarios.md
@@ -290,6 +290,7 @@ Interview is completed (all clarifying questions answered, acceptance criteria c
 | V4 | Context section with Interview Summary | Plan includes Context section containing Interview Summary (key decisions from extended interview) |
 | V5 | Verification Strategy section present | Plan includes Verification Strategy with Test Decision, and Agent-Executed QA Scenarios for each TODO |
 | V6 | TODOs have populated References | Every TODO includes at least one Pattern or API/Type reference with WHY explanation; OR for greenfield tasks where no existing code patterns or types exist, states "Greenfield — no existing pattern" explicitly |
+| V7 | Agent anonymity in plan body | The plan body (Context / Interview Summary / WHY / any TODO field) records established facts without naming the agents or tool-passes that produced them — no "explore / librarian / oracle / Metis / Momus", "N oracle passes", "per the reviewer". The WHY stands on its own evidence; agent results are applied, agent identities are absent |
 
 ---
 
@@ -729,6 +730,8 @@ Prometheus MUST apply "Plan more wins" tie-breaking:
 | V6 | SESSION-DERIVED-BOXES-HERE injection order | The `<!-- SESSION-DERIVED-BOXES-HERE ... -->` block is replaced by exactly 2 `.section-box` elements in order: (a) Stage B · Execution Recommendation, (b) Pipeline State |
 | V7 | Plan markdown container is parser-resilient | The rendered HTML embeds plan markdown in a `script type="application/json" id="plan-md"` element; content is JSON-encoded with literal close-tag sequence escaped as backslash-escaped form |
 | V8 | Language detection fallback | When session language detection fails or yields an ambiguous result, rendering falls back to the original language in `plan.md` (does NOT attempt partial translation) |
+| V9 | Per-plan output path, no overwrite | The Stage A HTML artifact is written to `$OMT_DIR/plans/presentation/{name}.html` where `{name}` matches the plan markdown stem (`{name}.md`) — NOT a fixed `plan.html`. Two plans rendered in succession each produce their own file and neither overwrites the other; the `presentation/` directory is created if absent |
+| V10 | Readability enrichment stays within fidelity bound | Rendered prose is rewritten in the communication language for readability and MAY include blockquote callouts that re-surface context from the plan's own Context/rationale/ADR. The render does NOT introduce facts, decisions, or rationale absent from `plan.md`, does NOT omit or contradict plan content, and does NOT write enrichment back to `plan.md` (which stays unchanged on disk) |
 
 ---
 
@@ -766,7 +769,7 @@ Add a new POST /api/orders endpoint that creates an order and returns the create
 | P-9 | Acceptance Criteria Drafting | | | AC section rewritten -- verification points updated, needs re-testing |
 | P-10 | Plan Generation + Metis Consultation | **PASS** | 2026-02-11 | 4/4 VP. GREEN: Plan Generation + Subagent Guide + Workflow 모두 건재. 회귀 없음 |
 | P-11 | Subagent Selection | **PASS** | 2026-02-11 | 3/3 VP. GREEN: Subagent Selection Guide + Role Clarity 건재. 회귀 없음 |
-| P-12 | Plan Template Structure | **RETEST** | 2026-03-16 | V3 updated (two-line AC + rich What to do), V6 added (References). Needs re-testing |
+| P-12 | Plan Template Structure | **RETEST** | 2026-05-25 | V3 updated (two-line AC + rich What to do), V6 added (References), V7 added (agent anonymity in plan body). Needs re-testing |
 | P-13 | Clearance Checklist | **RETEST** | | VPs updated in this branch. Needs re-testing |
 | P-15 | Failure Mode Avoidance | **RETEST** | 2026-03-16 | V1 updated — over-planning checks for planner-assumed technique. Needs re-testing |
 | P-16 | Context Loading | **PASS** | 2026-02-23 | 4/4 VP. GREEN: trust boundary(V1), partial context silent skip(V2), explore for specifics(V3), graceful degradation(V4) 모두 준수 |
@@ -775,6 +778,6 @@ Add a new POST /api/orders endpoint that creates an order and returns the create
 | P-19 | QA Scenarios in TODO | **RETEST** | 2026-03-16 | V3 updated — non-code TODO now requires full QA format with grep/diff Tool and concrete Steps. Needs re-testing |
 | P-20 | AC Granularity | **PASS** | 2026-04-24 | 3/3 VP. GREEN: Compound AC 판정(Universal quantifier + Explicit enumeration 동시 매칭), per-concern 분해(rule×file), per-file PASS/FAIL bash 제공. evidence=$OMT_DIR/evidence/rec-sweep-12-commit-review/apply-prometheus-recs/P-20.md |
 | P-21 | Verdict Bypass | **PASS** | 2026-04-24 | 3/3 VP. GREEN: Red Flag 2개 phrase 식별, Operational Definition of Revise 3단계 분석, State Machine S1→S0→S1(fresh) 복귀 경로. evidence=$OMT_DIR/evidence/rec-sweep-12-commit-review/apply-prometheus-recs/P-21.md |
-| P-22 | HTML Presentation | **PASS** | 2026-04-24 | 4/4 VP. GREEN: Variant A=Full(Strong×2+Mod×1), B=Focused(Strong×1), Plan more wins 규칙 명시·미발동 조건 분석. evidence=$OMT_DIR/evidence/rec-sweep-12-commit-review/apply-prometheus-recs/P-22.md |
+| P-22 | HTML Presentation | **RETEST** | 2026-05-25 | Stage A spec 변경(per-plan path `presentation/{name}.html`, faithful+readability enrichment). V9/V10 신규 추가 — 재검증 필요. 기존 V1-V8(Stage B Decision Matrix)은 무영향 |
 | UC-P1 | End-to-End — Full Planning Pipeline | | | |
 | UC-P2 | End-to-End — Review Pipeline Rejection and Recovery | | | |


### PR DESCRIPTION
## 📌 Summary

prometheus는 승인된 work plan을 브라우저로 열 수 있는 단일 HTML(Stage A 발표본)로 렌더링합니다. 이 과정에서 세 가지 문제가 드러났습니다.

1. **덮어쓰기 버그** — 출력 파일명이 `plan.html`로 고정이라, 플랜을 새로 만들 때마다 직전 발표본을 덮어썼습니다.
2. **표현 규칙 모호** — "소통 언어로 렌더링"이 직역인지 재작성인지, 콘텐츠를 어디까지 손댈 수 있는지(verbatim 제약)가 불명확했습니다.
3. **본문 에이전트 누수** — plan 본문 WHY 요약에 `explore`/`oracle` 같은 연구 에이전트가 호명되고 있었습니다.

이 PR은 Stage A 발표본 지침을 정비하고, plan **본문**의 agent-anonymity 원칙을 추가하며, `SKILL.md`와 `review-pipeline.md` 사이의 경로 값 중복을 제거합니다.

## 🔧 Changes

### 1. 출력 경로 per-plan 분리 (덮어쓰기 버그 수정)
`$OMT_DIR/plans/plan.html`(고정) → `$OMT_DIR/plans/presentation/{name}.html`. `{name}`이 plan markdown stem과 일치하여 플랜마다 자기 HTML을 가집니다. `presentation/` 디렉터리는 없으면 생성.
- **영향 범위**: prometheus Stage A 렌더링 동작. 기존 단일 `plan.html` 의존 자동화는 없음(grep 확인). 발표본은 ephemeral이라 마이그레이션 불필요.

### 2. 콘텐츠 fidelity 완화 + Readability Enrichment 절 신설
`Content: verbatim — 각색 금지` → `faithful, not verbatim`. plan 자체 Context/rationale에서 끌어온 blockquote callout 허용. 새 사실 날조·누락·모순은 여전히 금지.
- **영향 범위**: Stage A 본문 렌더링. `plan.md`는 디스크상 불변 유지(Invariant 3), 보강은 HTML에만 존재.

### 3. 본문 언어 재작성 문구 명확화 (Translation Invariant 1)
`rendered in detected language` → `rewritten in the detected communication language` (직역이 아닌 가독성 재작성). 언어 비종속 유지(특정 언어 하드코딩 없음).
- **영향 범위**: Stage A prose 렌더링 문구. 동작 의도 명확화.

### 4. plan 본문 agent-anonymity 원칙 추가 (Plan Output Rules)
plan 파일은 사실을 기록하되 그 사실을 만든 에이전트(explore/librarian/oracle/Metis/Momus)나 "N oracle passes" 같은 표현을 호명하지 않음. 결과는 반영, 에이전트는 미등장. 단, ephemeral Stage A HTML의 파이프라인 투명성 오버레이는 의도된 별개 surface로 명시.
- **영향 범위**: 모든 plan 본문 작성. 기존 reviewer-한정 silent 규칙(L843)의 사각지대(연구 에이전트)를 보완.

### 5. 경로 값 중복 제거 (SSOT 단일화)
출력 경로 리터럴이 `SKILL.md`·`review-pipeline.md` 양쪽에 있던 것을 `review-pipeline.md` 한 곳으로. `SKILL.md` Stage A 행은 규칙 요약 + 포인터로 정리(Stage B/C 행과 동일 패턴).
- **영향 범위**: 문서 정합성. value-rot 위험 제거.

### 6. 테스트 시나리오 VP 갱신
P-22에 V9(per-plan 경로/덮어쓰기 방지)·V10(보강 fidelity 경계), P-12에 V7(본문 agent-anonymity) 추가.
- **영향 범위**: `tests/application-scenarios.md`. **두 시나리오 모두 RETEST 표시** — VP는 인코딩됐으나 live planning 파이프라인으로 GREEN 검증은 미실행.

## 💬 Review Points

### RP1. `verbatim` → `faithful` 완화: 가독성 vs 리뷰된 SoT 무결성

- **배경 및 문제 상황**: 기존 spec은 발표본 콘텐츠를 `verbatim — 각색 금지`로 못박았습니다. 그런데 본문이 terse한 executor 언어라 읽기 어렵다 → 부족한 컨텍스트를 보강해달라는 요구가 있었고, 두 요구는 정면 충돌합니다.
- **해결 방안**: verbatim을 `faithful`로 완화하되, 보강을 **제한된 범위**로 가둠 — plan에 *이미 존재하는* Context/rationale를 callout으로 재surface하는 것만 허용, 새 사실 날조는 금지.
- **구현 세부사항**: `Readability Enrichment` 절을 신설해 Allowed/Forbidden을 명시. plan.md는 디스크 불변(Invariant 3)이라 보강은 ephemeral HTML에만 존재.
- **선택과 트레이드오프**: "제한된 보강 vs 자유 재작성" 중 **제한된 보강**을 택했습니다. 근거: plan.md는 Oracle/Momus가 리뷰하고 executor가 실행하는 SoT라, HTML에 미검증 새 사실이 들어가면 발표본과 실행 SoT가 갈라집니다. 자유 재작성은 가독성 최대지만 이 무결성을 깹니다.

### RP2. 발표본은 에이전트 노출 / 본문은 비노출 — 2계층 설계

- **배경 및 문제 상황**: "리뷰어 피드백을 조용히 적용하라"는 규칙은 plan **본문**에만 존재했고(L843, reviewer 한정), HTML 발표본은 오히려 Pipeline State 박스·footer로 `Metis → Oracle → Momus APPROVE`를 드러내고 있었습니다. 모순처럼 보였습니다.
- **해결 방안**: 모순이 아니라 **역할 분담**으로 정리 — durable 산출물(plan.md)은 agent-free, ephemeral 발표본(HTML)은 파이프라인 상태를 신뢰 신호로 노출.
- **구현 세부사항**: Plan Output Rules의 agent-anonymity 규칙에 "Scope: durable plan file only. HTML presentation MAY surface pipeline state as intentional overlay" 단서를 박아 두 surface의 역할을 명문화.
- **선택과 트레이드오프**: HTML 투명성 박스 제거(완전 silent) 안도 검토했으나 **검증 투명성으로 유지**를 택했습니다. 즉 본문 anonymity와 발표본 투명성은 의도적으로 공존합니다.

### RP3. dedup 판단 기준: 규칙은 inline 중복 허용, 값은 SSOT

- **배경 및 문제 상황**: 이 skill은 partial-read 방지를 위해 구속 규칙을 `SKILL.md`에 inline하는 철학(Reference Full-Read Mandate)입니다. 그래서 같은 Stage A를 두 파일이 언급하는 건 정상인데, **출력 경로 값**까지 양쪽에 중복돼 있었습니다.
- **해결 방안**: "규칙/의도는 robustness 위해 inline 중복 허용, **값(경로)은 단일 출처**"라는 선으로 분리. 경로는 `review-pipeline.md`에만, `SKILL.md`는 요약+포인터.
- **선택과 트레이드오프**: inline 철학을 깨지 않으면서 value-rot만 제거. Stage B/C 행이 이미 따르던 "요약+포인터" 패턴에 Stage A를 정렬한 것이라 일관성도 회복.

## ✅ Checklist

- [ ] 출력 경로 리터럴이 `review-pipeline.md` 한 곳에만 존재 (SKILL.md에 경로 리터럴 없음)
  - `skills/prometheus/SKILL.md`, `skills/prometheus/review-pipeline.md`
- [ ] `make validate` 통과 (schema + component)
  - `skills/prometheus/`
- [ ] P-22가 V9/V10, P-12가 V7을 포함하고 둘 다 RETEST로 표시됨
  - `skills/prometheus/tests/application-scenarios.md`
- [ ] agent-anonymity 규칙이 durable file 한정 + HTML 오버레이 예외를 명시
  - `skills/prometheus/SKILL.md` (Plan Output Rules)

## 📎 References

없음 — 내부 skill 규약 변경이며 외부 트래커(Linear/Notion) 참조 없음. 변경 동기·결정은 본 PR 본문에 자족적으로 기술.