### PR TITLE
refactor: deep-interview 미배선 dead 선언 제거

### DIFF
--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deep-interview
 description: Socratic deep interview with mathematical ambiguity gating before autonomous execution
-argument-hint: "[--quick|--standard|--deep] <idea or vague description>"
+argument-hint: "<idea or vague description>"
 next-skill: prometheus
 next-skill-args: --consensus --direct
 handoff: $OMT_DIR/deep-interview/{slug}.md
@@ -515,13 +515,7 @@ Optional settings in `.claude/settings.json`:
 {
   "omt": {
     "deepInterview": {
-      "ambiguityThreshold": <resolvedThreshold>,
-      "maxRounds": 20,
-      "softWarningRounds": 10,
-      "minRoundsBeforeExit": 3,
-      "enableChallengeAgents": true,
-      "autoExecuteOnComplete": false,
-      "defaultExecutionMode": "prometheus"
+      "ambiguityThreshold": <resolvedThreshold>
     }
   }
 }

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -2,8 +2,6 @@
 name: deep-interview
 description: Socratic deep interview with mathematical ambiguity gating before autonomous execution
 argument-hint: "<idea or vague description>"
-next-skill: prometheus
-next-skill-args: --consensus --direct
 handoff: $OMT_DIR/deep-interview/{slug}.md
 level: 3
 ---


### PR DESCRIPTION
## 📌 Summary

`deep-interview` 스킬의 SKILL.md에서, 어떤 harness 코드도 읽지 않아 실행 AI를 오도하던 미배선(dead) 선언들을 제거합니다 — `argument-hint`의 모드 플래그, 미사용 config 키 6개, `next-skill` 핸드오프 쌍. 실제 동작 명세는 그대로 보존하므로 **동작 변화는 없습니다**.

---

## 🔧 Changes

### deep-interview SKILL.md

- `argument-hint`에서 `[--quick|--standard|--deep]` 모드 플래그 제거 → `"<idea or vague description>"`
- `Advanced > Configuration`에서 코드가 읽지 않는 키 6개(`maxRounds`, `softWarningRounds`, `minRoundsBeforeExit`, `enableChallengeAgents`, `autoExecuteOnComplete`, `defaultExecutionMode`) 제거, 실제 참조되는 `ambiguityThreshold`만 유지
- frontmatter의 `next-skill: prometheus` / `next-skill-args: --consensus --direct` 쌍 제거

이 선언들은 `deep-interview`가 oh-my-claudecode에서 포팅될 때 따라온 잔재입니다. 원본에는 frontmatter·config를 읽어 소비하는 코드 레이어가 있었지만, 본 레포에는 그 파이프라인이 없어 전부 "선언만 있고 읽히지 않는" 상태였습니다. SKILL.md는 실행 AI가 그대로 읽는 instruction이므로, 동작하지 않는 선언은 낡은 문서가 아니라 AI를 오도하는 함정으로 작동합니다.

**영향 범위**
- `skills/deep-interview/SKILL.md` 단일 파일 (+2 −10)
- 동작 변화 없음: 제거된 키/플래그를 읽는 코드가 레포 전체에 0건임을 grep으로 확인, `make validate-schema` 통과
- 보존된 실제 동작: Phase 2f 라운드 캡(Round 10/20/3+), challenge agent 라운드 4/6/8 발동, Phase 5 `prometheus` 핸드오프 prose, `ambiguityThreshold` 해석(Phase 1.5)

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.

### 1. 미배선 선언: "배선 복원"이 아니라 "삭제"를 택한 이유

**배경 및 문제 상황:**
`deep-interview`는 oh-my-claudecode에서 포팅됐습니다. 원본은 `skill-pipeline.ts`가 frontmatter(`next-skill-args` 등)를 읽어 다음 스킬에 인자를 주입하고, 일부 설정도 코드가 소비합니다. 본 레포에는 그 인프라가 없어 동일 선언이 전부 죽어 있었고, 레포 전체 grep에서 `--quick/--standard/--deep`·6개 config 키·`next-skill` 쌍 모두 **reader 0건**이었습니다.

**해결 방안:**
원본 인프라를 이식해 배선을 복원하는 대신, 선언을 삭제했습니다. 복원 대상 자체가 본 레포에 없기 때문입니다 — `--consensus --direct`는 우리 `prometheus`가 받지 않는 플래그이고, 핸드오프 타깃도 포팅 시 `omc-plan` → `prometheus`로 이미 바뀌어 있었습니다.

**구현 세부사항:**
"동작 명세"와 "거짓 configurability"를 구분해 전자만 남겼습니다. `ambiguityThreshold`는 Phase 1.5 prose가 실제로 settings.json에서 해석하므로 유지했고, Phase 2f의 라운드 캡 숫자(10/20/3)는 "설정 가능한 값"이 아니라 이 스킬의 고정 동작이므로 prose에 남겼습니다. 반면 `maxRounds: 20` 같은 config 키는 그 숫자를 바꿔도 동작이 안 바뀌는 거짓 토글이라 제거했습니다.

**선택과 트레이드오프:**
삭제는 upstream(oh-my-claudecode)과의 divergence를 만듭니다 — 원본도 이 선언들을 (배선 여부와 무관하게) 보유 중이기 때문입니다. 다만 두 레포는 정기 머지하는 live fork가 아니라 일회성 port 관계라 정합 유지의 실익이 낮다고 판단했습니다. "지금 필요 없는 기능을 위해 인프라를 도입"하는 대안은 simplicity 원칙에 반해 기각했습니다.

---

## ✅ Checklist

### deep-interview SKILL.md
- [ ] `make validate-schema` 통과 — frontmatter에서 `next-skill` 등 키 제거 후에도 스키마 유효(= 해당 키들이 required가 아님)
  - `skills/deep-interview/SKILL.md`
- [ ] `argument-hint`에 `--quick`/`--standard`/`--deep` 토큰이 존재하지 않음
  - `skills/deep-interview/SKILL.md`
- [ ] Configuration 블록에 미배선 6개 키가 없고 `ambiguityThreshold`만 존재
  - `skills/deep-interview/SKILL.md`
- [ ] frontmatter에 `next-skill` / `next-skill-args` 키가 존재하지 않음
  - `skills/deep-interview/SKILL.md`
- [ ] Phase 2f 라운드 캡(Round 10/20/3+)과 Phase 5 `prometheus` 핸드오프 prose가 보존됨
  - `skills/deep-interview/SKILL.md`