### PR TITLE
refactor(prometheus): 현실성 검증 momus 이관·daedalus 설계 자문화

### DIFF
--- a/agents/daedalus.md
+++ b/agents/daedalus.md
@@ -7,7 +7,7 @@ skills: design-review
 
 You are the Daedalus agent. Follow the design-review skill exactly.
 
-**Identity**: READ-ONLY plan/design reviewer. You evaluate plans and provide steelman antithesis with tradeoff tension. You do NOT implement.
+**Identity**: READ-ONLY plan/design reviewer. You evaluate plans and provide steelman antithesis with tradeoff tension. You do NOT implement. You are advisory — you provide design counsel and do NOT gate; you emit no verdict.
 
 **Input**: Plan review requests, design alternative analysis, architectural soundness checks.
 

--- a/skills/design-review/SKILL.md
+++ b/skills/design-review/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: design-review
-description: Use when delegating plan/design review with steelman antithesis and tradeoff tension analysis. Triggers include "design review", "plan review", "review the plan", "architectural soundness", "설계 검토", "플랜 리뷰", "아키텍처 건전성", "트레이드오프 분석".
+description: Use for advisory design review — steelman antithesis and tradeoff tension analysis. Triggers include "design review", "plan review", "review the plan", "architectural soundness", "설계 검토", "플랜 리뷰", "아키텍처 건전성", "트레이드오프 분석".
 ---
 
 # Design-Review
 
 ## Overview
 
-Delegates plan and design review to the Daedalus opencode agent, which runs as a detached worker you observe by polling. This skill is finished only once you have pulled a definitive answer out of the job — nothing notifies you when the worker is done. If the agent is unavailable (CLI not installed, timeout, error, or canceled), falls back to in-session analysis using the in-session fallback framework.
+Provides advisory design counsel — surfaces tradeoff tensions, steelman antitheses, and architectural considerations (analysis, not a verdict gate). Dispatches the review to a detached worker (configured members) and observes it by polling. This skill is finished only once you have pulled a definitive answer out of the job — nothing notifies you when the worker is done. If no worker is available (members empty, CLI not installed, timeout, error, or canceled), falls back to in-session analysis using the in-session fallback framework.
 
 ---
 

--- a/skills/design-review/prompts/default.md
+++ b/skills/design-review/prompts/default.md
@@ -142,27 +142,13 @@ Watch out for: Code that treats undefined from getUser() as "user not found" wil
 
 ### Consensus Addendum
 
-**Mandatory.** Append to every evaluative response (APPROVE / COMMENT / REQUEST_CHANGES). Omit only for pure diagnosis-only requests (e.g., "explain this design", "trace this dependency").
+**Mandatory.** Always append to every response. Omit only for pure diagnosis-only requests (e.g., "explain this design", "trace this dependency").
 
-**steelman antithesis**: State the strongest reasonable case *against* your verdict or primary recommendation. One to two sentences. Do not strawman — argue as if you hold the opposing view.
+**steelman antithesis**: State the strongest reasonable case *against* your primary recommendation. One to two sentences. Do not strawman — argue as if you hold the opposing view.
 
 **tradeoff tension**: Name the core tension the plan is navigating (e.g., consistency vs. availability, simplicity vs. extensibility, speed vs. correctness). One sentence. Cite the specific plan element that embodies it.
 
 **synthesis (optional)**: If the steelman reveals a genuine gap or a condition under which the opposing view would be correct, state it concisely. Skip if the steelman is fully answered by the existing recommendation.
-
-## Verdict Option
-
-This advisor does not emit verdicts by default. When the caller's request is evaluative in
-nature (e.g., "review this", "assess feasibility", "approve or reject"), append a single
-verdict line at the end of the diagnosis:
-
-`Verdict: APPROVE | COMMENT | REQUEST_CHANGES`
-
-- **APPROVE**: no blocking issues found.
-- **COMMENT**: issues exist but do not block; advisory only.
-- **REQUEST_CHANGES**: issues block the caller's intent; must be addressed.
-
-Diagnosis-only requests (e.g., "explain this design", "trace this dependency") remain verdict-free.
 
 ---
 
@@ -244,7 +230,7 @@ Before delivering any analysis:
 - [ ] Did I apply the circuit breaker if 3+ attempts failed?
 - [ ] For design review: did I confirm the design context aligns with codebase facts before evaluating?
 - [ ] For build errors: did I recommend fixes for ALL errors, not just some?
-- [ ] For evaluative requests: did I include the Consensus Addendum?
+- [ ] Did I include the Consensus Addendum (always append; omit only for diagnosis-only requests)?
 
 ## Scope Discipline
 

--- a/skills/momus/SKILL.md
+++ b/skills/momus/SKILL.md
@@ -112,11 +112,13 @@ Unresolved ambiguities → list as blocking gaps in verdict.
 
 ### Reference Verification Strategy
 
+**MANDATORY**: Read every file the plan references. Verify (a) it exists, (b) it contains what the plan claims, (c) the plan's stated assumptions hold against the actual code. A reference that does not exist or points to wrong content is a [CERTAIN] finding → REQUEST_CHANGES.
+
 **When you CAN access the codebase:**
 - READ every referenced file to verify it exists and contains what the plan claims
 - If references don't exist or are wrong: REQUEST_CHANGES with specific findings
 
-**When you CANNOT access the codebase** (reviewing plan in isolation):
+**When you CANNOT access the codebase** (degraded fallback — use only when codebase is inaccessible):
 - Evaluate whether references are SPECIFIC enough (file path, line numbers, function names)
 - Vague references like "follow existing patterns" → REQUEST_CHANGES (which patterns? where?)
 - Specific references like `src/services/AuthService.ts:45-60` → acceptable IF plausible

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -78,8 +78,7 @@ digraph prometheus_flow {
     "Metis consultation" [shape=box];
     "Metis verdict?" [shape=diamond];
     "Write plan to $OMT_DIR/plans/*.md" [shape=box];
-    "Daedalus review" [shape=box];
-    "Daedalus verdict?" [shape=diamond];
+    "Daedalus review (advisory)" [shape=box];
     "Momus review" [shape=box];
     "Momus verdict?" [shape=diamond];
     "Stage A: HTML Render" [shape=box];
@@ -101,10 +100,8 @@ digraph prometheus_flow {
     "Metis consultation" -> "Metis verdict?";
     "Metis verdict?" -> "Interview Mode" [label="REQUEST_CHANGES\n(resolve gaps, re-review)"];
     "Metis verdict?" -> "Write plan to $OMT_DIR/plans/*.md" [label="APPROVE/COMMENT"];
-    "Write plan to $OMT_DIR/plans/*.md" -> "Daedalus review";
-    "Daedalus review" -> "Daedalus verdict?";
-    "Daedalus verdict?" -> "Write plan to $OMT_DIR/plans/*.md" [label="REQUEST_CHANGES\n(revise plan, re-review)"];
-    "Daedalus verdict?" -> "Momus review" [label="APPROVE/COMMENT"];
+    "Write plan to $OMT_DIR/plans/*.md" -> "Daedalus review (advisory)";
+    "Daedalus review (advisory)" -> "Momus review" [label="advisory input folded into plan\n(no gate — see Design Consensus)"];
     "Momus review" -> "Momus verdict?";
     "Momus verdict?" -> "Write plan to $OMT_DIR/plans/*.md" [label="REQUEST_CHANGES\n(revise plan, re-review)"];
     "Momus verdict?" -> "Stage A: HTML Render" [label="APPROVE/COMMENT"];
@@ -117,7 +114,11 @@ digraph prometheus_flow {
 }
 ```
 
-**Flowchart Enforcement Rule**: The review loops (Metis → Daedalus → Momus REQUEST_CHANGES back to plan writing) are MANDATORY loops, not advisory paths. Skipping any review stage or proceeding past REQUEST_CHANGES without resolution violates the planning contract.
+**Flowchart Enforcement Rule**: The verdict review loops (Metis and Momus bounce back to plan writing on REQUEST_CHANGES) are MANDATORY loops, not advisory paths.
+Proceeding past a Metis/Momus REQUEST_CHANGES without resolution violates the planning contract.
+Skipping any review stage — including the mandatory Daedalus advisory pass — is likewise a violation.
+
+The Daedalus stage is on the mandatory path but is purely advisory: it emits no gating signal and never bounces the plan back. Its design input is folded into the plan per `## Design Consensus` before Momus runs.
 
 ## Subagent Selection Guide
 
@@ -125,11 +126,11 @@ digraph prometheus_flow {
 |------|-------|------|
 | Codebase exploration | explore | Find current implementation, similar features, existing patterns |
 | Architecture/design analysis | oracle | Architecture decisions, risk assessment, feasibility validation |
-| Codebase verification (pipeline) | daedalus | **MANDATORY** — auto-invoked after plan generation |
-| Plan review with antithesis | daedalus | Steelman + tradeoff tension on design decisions |
+| Codebase verification (pipeline) | momus | **MANDATORY** — auto-invoked after the advisory design pass; verifies codebase feasibility + document quality |
+| Design review with antithesis | daedalus | **MANDATORY (advisory)** — steelman + tradeoff tension on design soundness; advisory only, never gates |
 | External documentation research | librarian | Official docs, library specs, API references, best practices |
 | Gap analysis | metis | **MANDATORY** — auto-invoked when Clearance + AC complete |
-| Plan review | momus | **MANDATORY** — after Daedalus approval |
+| Plan review | momus | **MANDATORY** — after Daedalus advisory input |
 
 ### Do vs Delegate Decision Matrix
 
@@ -143,7 +144,8 @@ digraph prometheus_flow {
 | Architecture feasibility check | NEVER | oracle |
 | External tech research | NEVER | librarian |
 | Pre-plan gap analysis | NEVER | metis |
-| Post-plan codebase verification | NEVER | daedalus (MANDATORY) |
+| Post-plan design review (advisory) | NEVER | daedalus (MANDATORY — advisory only, never gates) |
+| Post-plan codebase verification | NEVER | momus (MANDATORY) |
 | Plan quality review | NEVER | momus (MANDATORY) |
 
 **RULE**: Planning, interviewing, checklist evaluation = Do directly. Research, analysis, gap detection = DELEGATE.
@@ -361,17 +363,19 @@ Decomposition Formalism (line 161-170) requires MECE + Atomicity + Anti-pattern 
 
 ### Per-Phase Completion Triggers
 
-A phase task is complete only when its reviewer verdict is received:
+A phase task is complete only when its reviewer signal is received:
 
 | Reviewer | Completion Condition |
 |----------|---------------------|
 | Metis | Verdict = APPROVE or COMMENT (proceed to plan write) |
-| Daedalus | Verdict = APPROVE or COMMENT (proceed to Momus) |
+| Daedalus | Advisory design input received and folded into the plan per `## Design Consensus` (advisory only — proceed to Momus) |
 | Momus | Verdict = APPROVE or COMMENT (proceed to user presentation) |
 
-REQUEST_CHANGES from any reviewer means the current phase task remains in incomplete state. The downstream phase task is prohibited from starting until the REQUEST_CHANGES is resolved and a new APPROVE/COMMENT verdict is received.
+REQUEST_CHANGES from a verdict-emitting reviewer (Metis or Momus) means the current phase task remains in incomplete state. The downstream phase task is prohibited from starting until the REQUEST_CHANGES is resolved and a new APPROVE/COMMENT verdict is received.
 
-Starting a downstream phase task while a prior phase remains in REQUEST_CHANGES state is a planning contract violation.
+Starting a downstream phase task while a prior verdict phase remains in REQUEST_CHANGES state is a planning contract violation.
+
+The Daedalus phase is advisory rather than gated: it completes once its design input is received and reconciled into the plan (genuine conflicts escalate per `## Design Consensus`), then Momus proceeds.
 
 ### Relationship to Pipeline State Machine
 
@@ -816,11 +820,16 @@ Three-agent pipeline + Plan Presentation. All mandatory contracts inline below. 
 | | Metis | Daedalus | Momus |
 |---|---|---|---|
 | **Timing** | Pre-plan | Post-plan, pre-Momus | Post-Daedalus |
-| **Input** | User Goal + Scope + AC | Plan + Codebase (Daedalus reads plan file) | Plan |
-| **Validates** | Requirements completeness | Codebase feasibility (Daedalus checks against codebase) | Document quality |
-| **Reads code** | No | Yes — Daedalus reads file:line | No |
+| **Input** | User Goal + Scope + AC | Plan file + design context | Plan + Codebase |
+| **Validates** | Requirements completeness | Design soundness | Document quality + Codebase feasibility |
+| **Reads code** | No | Yes (design context) | Yes |
+| **Role** | Gap gate (verdict) | Design advisor (advisory — no verdict, no gate) | Feasibility + quality gate (verdict) |
 
-### Common Gate Pattern (ALL reviewers)
+### Common Gate Pattern (verdict-emitting reviewers: Metis + Momus)
+
+Only Metis and Momus emit verdicts and gate the pipeline.
+
+Daedalus is an advisory design reviewer that does NOT gate — it surfaces design tradeoffs only (see `## Design Consensus` for how its advisory input is folded in).
 
 ```
 MANDATORY: Reviewer MUST pass (APPROVE or COMMENT) before proceeding.
@@ -833,7 +842,9 @@ MANDATORY: Reviewer MUST pass (APPROVE or COMMENT) before proceeding.
 
 A REQUEST_CHANGES verdict blocks ALL downstream progression — no stage advances until the blocking reviewer re-issues APPROVE or COMMENT after a proper Revise cycle.
 
-### Common Verdict Handling
+### Common Verdict Handling (Metis + Momus only)
+
+Daedalus does NOT appear in this table — it is advisory and emits no gating signal. Its design output is handled per `## Design Consensus`.
 
 | Verdict | Action |
 |---------|--------|
@@ -875,7 +886,7 @@ Each reviewer invocation MUST use a **fresh agent instance**. Do not reuse an ag
 | **S0: Interview Mode** | Gathering requirements | → S1 on Metis-ready clearance |
 | **S1: Metis Invocation** | 3-Section prompt to Metis | → S2 on APPROVE/COMMENT; → S0 on REQUEST_CHANGES |
 | **S2: Plan Generation** | Writing plan to `$OMT_DIR/plans/{name}.md` | → S3 on self-review pass |
-| **S3: Daedalus Invocation** | Plan path to Daedalus | → S4 on APPROVE/COMMENT; → S2 on REQUEST_CHANGES |
+| **S3: Daedalus Invocation** | Plan path to Daedalus (advisory design review) | → S4 always (advisory only — no gating signal; design input folded in per `## Design Consensus` before S4) |
 | **S4: Momus Invocation** | Plan path to Momus | → S5 on APPROVE/COMMENT; → S2 on REQUEST_CHANGES |
 | **S5: Plan Presentation** | Stage A render + present to user | → S6 on user views plan |
 | **S6: Execution Recommendation** | Compute Stage B recommendation | → S7 on user receives |
@@ -899,6 +910,8 @@ Time pressure, user override ("just proceed"), self-assessment of fix correctnes
 | 3 | Guardrails from Metis incorporated | Every Metis-flagged constraint reflected |
 | 4 | Zero human-intervention criteria | No TODO requires manual mid-execution action |
 
+Item 2 ("File references exist") is a lightweight pre-Momus self-filter — it catches obviously stale paths before the plan reaches the feasibility gate. It is complementary to, not a substitute for, Momus's authoritative codebase-feasibility verification: this self-check is a cheap first pass; Momus is the gate.
+
 Failure action: loop back and fix before submitting to Daedalus.
 
 ### Gap Classification (post-plan self-review)
@@ -909,6 +922,21 @@ Failure action: loop back and fix before submitting to Daedalus.
 | **MINOR** | Self-resolvable from context | Resolve inline during plan revision |
 | **AMBIGUOUS** | Standard convention / safe default exists | Apply documented default, note in plan |
 
+### Design Consensus (reconciling Daedalus advisory input)
+
+Daedalus is advisory: it emits no gating signal and never bounces the plan back. Instead it returns design opinions (steelman antithesis, tradeoff tensions, alternative options). Prometheus reconciles each opinion into the plan through this procedure, between the S3 Daedalus pass and the S4 Momus invocation. The Daedalus advisory pass is MANDATORY across ALL intents (Trivial / Scoped / Complex / Architecture) — no intent class skips it.
+
+Per design opinion:
+
+1. **Collect + dedup** — gather every Daedalus opinion, deduplicate against opinions already reflected in the plan.
+2. **Decide accept or reject** — prometheus judges each opinion on its merits (it is advice, not a directive).
+   - **Accepted** → fold the opinion into the plan body (revise the affected TODOs / approach), AND record it in the relevant ADR entry's **Considered Options** (as an evaluated option), **Decision** (if it changed the chosen path), and **Consequences** (the tradeoff now accepted). No new ADR sub-field — the existing MADR 7-field ADR (`## Plan Structure > ADR`) is where consensus outcomes land.
+   - **Rejected** → record the rejected opinion and the reason it was not adopted in that ADR entry's **Rationale** field (the Rationale already explains the chosen option over alternatives — a rejected Daedalus opinion is one such alternative).
+3. **Escalate genuine conflicts to the USER** — when an opinion exposes a genuine conflict or a material tradeoff that prometheus cannot resolve on the plan's own evidence (e.g. it pits two user-stated goals against each other, or it would change scope the user fixed), surface it to the user as a preference question. This is prometheus's own judgment of what counts as a genuine conflict — there is NO severity taxonomy; do not label opinions Critical/High/Medium. Routine advice prometheus can absorb is folded silently per step 2; only genuine conflicts / material tradeoffs reach the user.
+4. **1-revision-round backstop** — reconcile in a single revision round. If, after that one round, a genuine conflict still remains unresolved, escalate the remaining conflict to the user rather than looping further. The backstop bounds reconciliation to one round; it is not a gate, since this advisory pass never blocks the pipeline.
+
+After reconciliation, proceed to S4 (Momus). Momus then verifies the reconciled plan for codebase feasibility + document quality and emits the gating verdict.
+
 ### Plan Presentation (S5/S6/S7 — MANDATORY after Momus APPROVE)
 
 This step CANNOT be skipped. After Momus APPROVE/COMMENT, prometheus MUST execute Stages A → B → C before any user-facing handoff. Skipping = treating the plan as user-ready when it is unrendered. **Past sessions have skipped Stage A entirely; do NOT.**
@@ -916,7 +944,7 @@ This step CANNOT be skipped. After Momus APPROVE/COMMENT, prometheus MUST execut
 | Stage | Mandate | Detail location |
 |---|---|---|
 | **Stage A** | Render plan to a single-file, browser-openable HTML — one file per plan, so plans never overwrite each other. Faithful content (no omission/contradiction/invented facts) + readability rewrite in the communication language + context callouts + session-derived boxes (Stage B recommendation, Pipeline State). Always produced via template substitution (no converter needed); when the plan is approved, the HTML gets made. | Exact output path, rendering invariants (6), translation invariants (3), readability enrichment, template reference in `review-pipeline.md` |
-| **Stage B** | Compute execution recommendation using Decision Matrix (TODO count, Complex/Architecture flag, AC gap, Ambiguity Score, Daedalus COMMENT signals). Output: Recommendation + Mode + Rationale + What-tips-the-balance. | Decision Matrix details in `review-pipeline.md` |
+| **Stage B** | Compute execution recommendation using Decision Matrix (TODO count, Complex/Architecture flag, AC gap, Ambiguity Score, Momus feasibility signal). Output: Recommendation + Mode + Rationale + What-tips-the-balance. | Decision Matrix details in `review-pipeline.md` |
 | **Stage C** | Execution Bridge via platform's user-prompt primitive — 3 options (Full orchestration / Focused execution / Revise plan). `(Recommended)` label computed from Decision Matrix, NOT hardcoded. | Option formatting in `review-pipeline.md` |
 
 On selection: Option 1 → `Skill(skill: "sisyphus")` with plan path. Option 2 → delegate to sisyphus-junior. Option 3 → return to Interview Mode.
@@ -931,8 +959,8 @@ On selection: Option 1 → `Skill(skill: "sisyphus")` with plan path. Option 2 �
 | Metis | Abstract scope | Completeness uncheckable |
 | Metis | Missing user goal | Intent unclassifiable |
 | Daedalus | Restating plan content in prompt | Daedalus reads file — token waste |
-| Daedalus | Asking for code review | Daedalus reviews feasibility, not code quality |
-| Daedalus | Skipping after Metis APPROVE | Gate violation — Daedalus mandatory |
+| Daedalus | Asking it to approve, gate, or block | Daedalus is advisory — it surfaces design tradeoffs only, it does not approve or block |
+| Daedalus | Skipping after Metis APPROVE | Daedalus advisory pass is mandatory across all intents — its design input must be sought and folded in before Momus |
 | Momus | Repeating plan content | Momus reads file — token waste |
 | Momus | Separate metis results in prompt | Already in Plan Context + anchoring risk |
 | Momus | Adding review instructions | Momus has own criteria |

--- a/skills/prometheus/review-pipeline.md
+++ b/skills/prometheus/review-pipeline.md
@@ -35,34 +35,20 @@ Read this file when you are about to execute a SPECIFIC reviewer invocation, Sta
 ## Plan File
 $OMT_DIR/plans/{name}.md
 
-## Verification Focus
-- Do referenced files/modules exist?
-- Are pattern references (file:line-range) current?
-- Do dependency assumptions hold architecturally?
-- Any codebase constraints conflicting with the plan?
-
-## Output Format
-- **Verdict**: APPROVE / REQUEST_CHANGES / COMMENT
-- **Evidence**: file:line citations
-- **Rationale**: Brief justification
-```
-
-### Decision Quality Focus
-
-This plan review phase must also evaluate decision quality, not just factual correctness. In addition to the Verification Focus above, assess:
-
-- **steelman antithesis**: What is the strongest case against this plan? Surface it explicitly, even if you ultimately endorse the approach.
+## Design Opinion Focus
+- **Steelman antithesis**: What is the strongest case against this plan? Surface it explicitly, even if you ultimately endorse the approach.
 - **Tradeoff tension**: Identify the key tradeoff tensions present (e.g., speed vs. safety, complexity vs. flexibility). Are they acknowledged and resolved in the plan?
 - **Synthesis**: Where competing forces exist, does the plan synthesize a defensible resolution, or does it silently pick one side?
 - **Evaluative trigger**: If the plan contains a major architectural or strategic decision, an explicit evaluative statement of the chosen approach's merits and risks is required — not just a description of what was chosen.
+```
 
-On REQUEST_CHANGES: update plan file first, then re-invoke with same template.
+Design-advisory opinion only — no verdict, no file-existence checks. Feasibility verification is Momus's responsibility.
 
 ---
 
 ## Momus Invocation Template
 
-**When**: After Daedalus APPROVE/COMMENT. MANDATORY before user presentation.
+**When**: After Daedalus advisory review. MANDATORY before user presentation.
 
 Send the plan file path only:
 
@@ -71,6 +57,8 @@ $OMT_DIR/plans/{name}.md
 ```
 
 All context (interview summary) is already in the plan's Context section. No supplementary prompt needed.
+
+Momus verifies both document quality and codebase feasibility: it reads the referenced files cited in the plan to confirm existence, current file:line accuracy, and that dependency assumptions hold.
 
 ---
 
@@ -144,7 +132,7 @@ Translating any item is a rule violation.
 - Omitting, weakening, or contradicting any plan content.
 - Writing enrichment back to disk. Per Invariant 3 the callouts live only in the ephemeral HTML; `plan.md` stays the single source of truth and every re-render redraws from it.
 
-Rationale: `plan.md` is the artifact Oracle and Momus reviewed and the artifact the executor runs from. Net-new content in the HTML would be unreviewed and would split the presentation from the execution source of truth. Re-surfacing context that already lives in the plan carries no such risk.
+Rationale: `plan.md` is the artifact Daedalus and Momus reviewed and the artifact the executor runs from. Net-new content in the HTML would be unreviewed and would split the presentation from the execution source of truth. Re-surfacing context that already lives in the plan carries no such risk.
 
 ### Rendering Methodology
 
@@ -189,7 +177,8 @@ Before asking the user to choose execution mode, compute a recommendation:
 | Trivial/Scoped flag in plan | — | Strong |
 | AC gap (unverified acceptance criteria) | Moderate | — |
 | Ambiguity Score > 2 | Moderate | — |
-| Daedalus COMMENT with codebase concern | Moderate | — |
+| Daedalus COMMENT with design-complexity concern | Moderate | — |
+| Momus COMMENT with codebase/feasibility concern | Moderate | — |
 | Scope question unresolved | Moderate | — |
 
 **Conflict resolution**: When signals split evenly, "Plan more wins" — default to Full Orchestration.

--- a/skills/prometheus/review-pipeline.md
+++ b/skills/prometheus/review-pipeline.md
@@ -177,7 +177,7 @@ Before asking the user to choose execution mode, compute a recommendation:
 | Trivial/Scoped flag in plan | — | Strong |
 | AC gap (unverified acceptance criteria) | Moderate | — |
 | Ambiguity Score > 2 | Moderate | — |
-| Daedalus COMMENT with design-complexity concern | Moderate | — |
+| Daedalus surfaces a design-complexity concern (advisory) | Moderate | — |
 | Momus COMMENT with codebase/feasibility concern | Moderate | — |
 | Scope question unresolved | Moderate | — |
 


### PR DESCRIPTION
## 📌 Summary

prometheus 플랜 리뷰 파이프라인의 리뷰어 역할을 재정의합니다. 현실성(codebase feasibility) 검증을 **momus**의 책임(게이트)으로 되돌리고, **daedalus**를 설계 자문(advisory — verdict 없음, 게이트 아님)으로 전환하며, prometheus가 daedalus의 설계 의견을 ADR로 병합하는 합의 절차를 추가합니다.

관통 원칙은 **"반증 가능한 주장에만 게이트를 건다"**입니다. 현실성("파일 X가 존재하는가 / 플랜 가정이 실제 코드에 대해 성립하는가")은 반증 가능 → 게이트(momus). 설계 건전성("이게 최선의 아키텍처인가")은 평가적 → 자문(daedalus). oh-my-claudecode의 architect(자문)/critic(게이트) 분리와 동형입니다.

## 🔧 Changes

### momus — 현실성 검증 reclaim (게이트)
`skills/momus/SKILL.md`의 Reference Verification Strategy 최상단에 필수 read-and-verify 문장을 추가했습니다(모든 참조 파일을 읽어 ⓐ존재 ⓑ플랜이 주장하는 내용 일치 ⓒ플랜 가정의 코드 대비 성립을 검증). codebase 접근 불가 분기는 "degraded fallback"으로 명시. 3-tier verdict와 문서품질 4기준은 그대로 유지하며 현실성은 additive로 얹었습니다. 설계 의견(approach optimality/architecture ideality 등)은 여전히 momus scope 밖입니다.
- **영향 범위**: momus 리뷰 동작 — 이제 항상 참조 파일 현실성을 검증. prometheus 파이프라인의 유일한 현실성 게이트.

### daedalus — 설계 자문화 (verdict/게이트 제거)
`agents/daedalus.md`에 advisory·non-gate·no-verdict 식별 문장을 추가했습니다. `skills/design-review/prompts/default.md`에서 verdict apparatus(`## Verdict Option` 섹션·토큰)를 제거하고 Consensus Addendum 트리거를 verdict 비종속 무조건 append로 바꾸되 steelman/tradeoff tension/synthesis 구조는 보존했습니다. `skills/design-review/SKILL.md`는 범용 advisory 설계-리뷰 capability로 재서술하며 "Daedalus" 이름을 제거했습니다(Review Point 2 참조).
- **영향 범위**: daedalus는 더 이상 verdict를 내지 않음(게이트 아님). design-review 스킬은 특정 에이전트에 비종속.

### prometheus — 역할 분리 전파 + 설계 합의 절차
`skills/prometheus/SKILL.md`의 3-agent 표·상태머신(S3 daedalus 비게이트)·flowchart·anti-pattern·do-vs-delegate 전반에 역할 분리를 반영하고, **Design Consensus** 절차를 신설했습니다(채택 의견→plan+ADR, 기각 사유→ADR Rationale, genuine conflict/material tradeoff만 사용자 escalate, 1-revision-round backstop). `skills/prometheus/review-pipeline.md`는 Daedalus 템플릿을 설계 의견 출력으로, Momus 템플릿에 현실성을 더하고 Decision Matrix 신호를 재배선했습니다.
- **영향 범위**: prometheus 플랜 리뷰 시퀀스. 게이트 수 net 불변(Metis+Momus 게이트, Daedalus 자문). interview-phase oracle 참조는 불변(carve-out).

## 💬 Review Points

### 1. 반증가능/평가적 기준에 따른 게이트-자문 분리
- **배경 및 문제 상황**: 직전까지 daedalus가 현실성 검증 + 설계 비평을 동시에 verdict로 게이트했습니다. git 이력상 현실성 검증은 원래 momus 소유였고(2026-01-19 이전, 이후 oracle→daedalus로 이전), 평가적 판단(설계 건전성)에 pass/fail 토큰을 붙이면 commitment-bias rubber-stamping 위험이 있습니다.
- **해결 방안**: 반증가능한 것(현실성)은 게이트(momus), 평가적인 것(설계)은 자문(daedalus, verdict 없음)으로 분리.
- **구현 세부사항**: momus가 참조 파일 read+검증을 필수 1차 단계로 수행; daedalus는 steelman/tradeoff/synthesis 분석만 산출.
- **선택과 트레이드오프**: oh-my-claudecode의 5-iteration TS 상태머신 대신 markdown 파이프라인 + 기존 MADR ADR을 합의 표면으로 재사용했습니다(단순성 우선). 부수적으로 `skills/prometheus/tests/*` 픽스처는 아직 구(舊) "Oracle" 게이트 의미를 담고 있어 별도 work unit으로 **deferred**했습니다 — 이 PR 범위 밖입니다.

### 2. design-review 스킬의 에이전트 비종속화 (레이어링 수정)
- **배경 및 문제 상황**: `design-review/SKILL.md`가 자신을 "Daedalus를 engage한다"고 서술했지만, `agents/daedalus.md`는 `skills: design-review`로 design-review를 *보유*합니다. 즉 Daedalus(에이전트)가 design-review(스킬)를 감싸는데 스킬이 자신의 래퍼를 명명하는 역전된 순환 참조였습니다(`members: []`라 dispatch 경로는 이미 dead).
- **해결 방안**: design-review를 범용 capability로 환원하고 "Daedalus"를 제거. 이름은 caller→callee 방향으로만 흐릅니다(에이전트가 스킬을, prometheus가 에이전트를 명명).
- **선택과 트레이드오프**: 원 계획은 "advisory 재서술"뿐이었으나 리뷰 중 이 레이어링 위반을 발견해 de-naming까지 확장했습니다. design-review를 다른 페르소나로 재사용 가능하게 유지하는 것이 목적입니다.

### 3. 설계 합의의 ADR 병합 + 판단 기반 escalation
- **배경 및 문제 상황**: daedalus가 자문이 되면 그 의견을 prometheus가 어떻게 수렴·기록하는가가 새 과제입니다.
- **해결 방안**: 채택 의견은 plan + ADR(Considered Options/Decision/Consequences)로 fold, 기각 의견은 ADR Rationale에 사유 기록.
- **구현 세부사항**: prometheus가 genuine conflict / material tradeoff라고 *판단*한 것만 사용자에게 escalate하며 severity 라벨 taxonomy는 두지 않습니다. 1-revision-round backstop으로 종료를 보장합니다.
- **선택과 트레이드오프**: severity 분류 대신 prometheus 판단에 위임 → 인간 개입을 진짜 분기점에만 집중. 판단 책임이 prometheus에 집중되는 비용은 backstop과 ADR Rationale audit trail로 bound합니다.

## ✅ Checklist

- [ ] momus가 참조 파일 현실성 검증을 필수 단계로 수행(조건 분기 위에 위치), CANNOT-access는 degraded fallback으로 표기
  - `skills/momus/SKILL.md`
- [ ] daedalus가 verdict 토큰을 내지 않음 (`APPROVE|REQUEST_CHANGES|COMMENT|Verdict:` 0건) + advisory 식별 존재
  - `agents/daedalus.md`
- [ ] design-review 영역에 "Daedalus" 문자열 0건 (agent-agnostic)
  - `skills/design-review/SKILL.md`, `skills/design-review/prompts/default.md`
- [ ] design-review prompt에서 `## Verdict Option` 제거 + steelman/tradeoff tension/synthesis 구조 보존
  - `skills/design-review/prompts/default.md`
- [ ] prometheus에서 daedalus와 verdict/feasibility/codebase/REQUEST_CHANGES의 동일 줄 공존 0건, momus가 현실성 게이트로 명시
  - `skills/prometheus/SKILL.md`
- [ ] Design Consensus 절차 4요소(채택→ADR fold / 기각→Rationale / genuine conflict escalate / 1-round backstop) 존재
  - `skills/prometheus/SKILL.md`
- [ ] interview-phase oracle 참조·agent-anonymity 예시 불변 (carve-out)
  - `skills/prometheus/SKILL.md`, `skills/prometheus/review-pipeline.md`
- [ ] `make validate-components` 통과

## 📎 References

관련 이슈/PR 없음.
