### PR TITLE
chore: autocompact PCT override를 window 400k로 교체

### DIFF
--- a/claude.yaml
+++ b/claude.yaml
@@ -3,7 +3,7 @@ config:
   outputStyle: "Explanatory"
   includeCoAuthoredBy: false
   env:
-    CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: "40"
+    CLAUDE_CODE_AUTO_COMPACT_WINDOW: "400000"
   attribution:
     commit: ""
     pr: ""


### PR DESCRIPTION
## 📌 Summary
1M 컨텍스트 모델에서 `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`가 적용되지 않는 업스트림 버그로 auto-compact가 의도한 지점에서 발동하지 않았다. 퍼센트 override 경로(버그 경로)에 의존하는 대신 auto-compact window 자체를 400k로 지정해, 임계가 무엇이든 ~400k 부근에서 압축되도록 전환한다. 본 PR은 SSOT(`claude.yaml`)만 변경하며 실제 배포는 별도다.

## 🔧 Changes
### auto-compact 트리거를 window 기반으로 전환
- `claude.yaml`의 `config.env`에서 `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: "40"` 제거, `CLAUDE_CODE_AUTO_COMPACT_WINDOW: "400000"` 추가
- **영향 범위**: 이 SSOT가 sync되는 `~/.claude/settings.json`의 auto-compact 발동 시점. 코드 로직·다른 컴포넌트 무영향.

## 💬 Review Points
### 1. PCT override 대신 window 축소를 택한 이유
- **배경 및 문제 상황**: 200k 세션에선 PCT override(40%)가 정상 작동하나, 1M 모델에선 무시돼 `기본 임계 × 1M`이라 사실상 압축이 안 걸렸다.
- **해결 방안**: 퍼센트를 덮어쓰는 버그 경로 대신, window(분모) 자체를 400k로 축소.
- **구현 세부사항**: PCT를 빼면 기본 임계(90%대)가 400k window에 적용 → 정확히 400k가 아니라 그 직전(~360–400k)에서 압축.
- **선택과 트레이드오프**: window 방식은 망가진 레버에 의존하지 않아 1M 버그에 견고. 단 트리거가 정확히 400k는 아님(기본 임계%만큼 앞당겨짐). native `autoCompactWindow`를 중복 적용하지 않은 건, 한 번에 한 변수만 바꿔 새 세션 `/context`로 효과를 깨끗이 진단하기 위함.

### 2. 배포 시 sync additive 머지 주의
- **배경 및 문제 상황**: OMT sync의 config 머지는 additive — `claude.yaml`에서 키를 지워도 이미 배포된 `settings.json`의 해당 키는 prune되지 않는다.
- **해결 방안**: 머지 후 배포 시 `make sync` → `settings.json`에서 잔존 `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` 수동 제거.
- **구현 세부사항**: 두 키 공존 시 `40% × 400k = 160k`에서 압축돼 의도와 정반대. 글로벌 env라 라이브 세션 없는 타이밍에 배포.
- **선택과 트레이드오프**: 본 PR 범위는 SSOT 변경까지로 한정. 배포 절차를 PR에 묶지 않아 적용 타이밍을 통제 가능.

## ✅ Checklist
- [ ] `claude.yaml`의 `config.env`에 `CLAUDE_CODE_AUTO_COMPACT_WINDOW: "400000"`만 존재하고 PCT override는 없음
  - `claude.yaml`
- [ ] `make validate` 통과 (schema + components + typecheck)

## 📎 References
- 없음