### PR TITLE
feat(prometheus): restore-only 상태 영속화 + 섹션 검증 게이트

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -125,13 +125,28 @@ if [ -f "$OMT_DIR/prometheus-state-${SESSION_ID}.json" ]; then
     if [ "$PROM_ACTIVE" = "true" ]; then
       PROM_PHASE=$(echo "$PROMETHEUS_STATE" | jq -r '.phase // ""' 2>/dev/null)
       PROM_PLAN_PATH=$(echo "$PROMETHEUS_STATE" | jq -r '.plan_path // ""' 2>/dev/null)
+      PROM_RESUME=$(echo "$PROMETHEUS_STATE" | jq -r '.resume_summary // ""' 2>/dev/null)
 
-      PROM_PLAN_NOTE=""
-      if [ -n "$PROM_PLAN_PATH" ] && [ "$PROM_PLAN_PATH" != "null" ] && [ ! -f "$PROM_PLAN_PATH" ]; then
-        PROM_PLAN_NOTE="\nPlan file not found on disk: restart from resume_summary.\n"
+      # Determine whether the plan file is available on disk.
+      # Unavailable means: plan_path empty/null, OR plan_path set but file missing.
+      PROM_PLAN_AVAILABLE=false
+      if [ -n "$PROM_PLAN_PATH" ] && [ "$PROM_PLAN_PATH" != "null" ] && [ -f "$PROM_PLAN_PATH" ]; then
+        PROM_PLAN_AVAILABLE=true
       fi
 
-      MESSAGES="$MESSAGES<session-restore>\n\n[PROMETHEUS RESTORED]\n\nYou have an active prometheus session.\nPhase: $PROM_PHASE\nPlan path: $PROM_PLAN_PATH\n$PROM_PLAN_NOTE\nRe-read the current plan from disk and distrust stored verdicts -- re-run all gates on the current artifact.\n\n</session-restore>\n\n---\n\n"
+      PROM_PLAN_NOTE=""
+      PROM_INSTRUCTION=""
+      if [ "$PROM_PLAN_AVAILABLE" = "true" ]; then
+        PROM_INSTRUCTION="\nRe-read the current plan from disk and distrust stored verdicts -- re-run all gates on the current artifact.\n"
+      else
+        if [ -n "$PROM_RESUME" ] && [ "$PROM_RESUME" != "null" ]; then
+          PROM_PLAN_NOTE="\nPlan file not available on disk. Resume from this bookmark: ${PROM_RESUME}\n"
+        else
+          PROM_PLAN_NOTE="\nPlan file not available on disk yet.\n"
+        fi
+      fi
+
+      MESSAGES="$MESSAGES<session-restore>\n\n[PROMETHEUS RESTORED]\n\nYou have an active prometheus session.\nPhase: $PROM_PHASE\nPlan path: $PROM_PLAN_PATH\n$PROM_PLAN_NOTE$PROM_INSTRUCTION\n</session-restore>\n\n---\n\n"
     fi
   fi
 fi

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -63,6 +63,11 @@ if [ -n "$CLAUDE_ENV_FILE" ]; then
   echo "export OMT_DIR=\"$OMT_DIR\"" >> "$CLAUDE_ENV_FILE"
 fi
 
+# Export OMT_SESSION_ID via Claude env file
+if [ -n "$CLAUDE_ENV_FILE" ]; then
+  echo "export OMT_SESSION_ID=\"$SESSION_ID\"" >> "$CLAUDE_ENV_FILE"
+fi
+
 MESSAGES=""
 
 # Cleanup stale ralph-state files (older than 3 hours)
@@ -70,7 +75,7 @@ if command -v jq &> /dev/null; then
   STALE_THRESHOLD=10800  # 3 hours in seconds
   CURRENT_TIME=$(date +%s)
 
-  for state_file in "$OMT_DIR"/ralph-state-*.json; do
+  for state_file in "$OMT_DIR"/ralph-state-*.json "$OMT_DIR"/prometheus-state-*.json; do
     if [ -f "$state_file" ]; then
       STARTED_AT=$(jq -r '.started_at // ""' "$state_file" 2>/dev/null)
       if [ -n "$STARTED_AT" ] && [ "$STARTED_AT" != "null" ]; then
@@ -111,6 +116,25 @@ if [ -f "$OMT_DIR/ralph-state-${SESSION_ID}.json" ]; then
   fi
 fi
 
+# Check for active prometheus state (session-specific)
+if [ -f "$OMT_DIR/prometheus-state-${SESSION_ID}.json" ]; then
+  PROMETHEUS_STATE=$(cat "$OMT_DIR/prometheus-state-${SESSION_ID}.json" 2>/dev/null)
+
+  if command -v jq &> /dev/null; then
+    PROM_ACTIVE=$(echo "$PROMETHEUS_STATE" | jq -r '.active // false' 2>/dev/null)
+    if [ "$PROM_ACTIVE" = "true" ]; then
+      PROM_PHASE=$(echo "$PROMETHEUS_STATE" | jq -r '.phase // ""' 2>/dev/null)
+      PROM_PLAN_PATH=$(echo "$PROMETHEUS_STATE" | jq -r '.plan_path // ""' 2>/dev/null)
+
+      PROM_PLAN_NOTE=""
+      if [ -n "$PROM_PLAN_PATH" ] && [ "$PROM_PLAN_PATH" != "null" ] && [ ! -f "$PROM_PLAN_PATH" ]; then
+        PROM_PLAN_NOTE="\nPlan file not found on disk: restart from resume_summary.\n"
+      fi
+
+      MESSAGES="$MESSAGES<session-restore>\n\n[PROMETHEUS RESTORED]\n\nYou have an active prometheus session.\nPhase: $PROM_PHASE\nPlan path: $PROM_PLAN_PATH\n$PROM_PLAN_NOTE\nRe-read the current plan from disk and distrust stored verdicts -- re-run all gates on the current artifact.\n\n</session-restore>\n\n---\n\n"
+    fi
+  fi
+fi
 
 # Check for incomplete todos in global directory
 INCOMPLETE_COUNT=0

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -126,6 +126,10 @@ if [ -f "$OMT_DIR/prometheus-state-${SESSION_ID}.json" ]; then
       PROM_PHASE=$(echo "$PROMETHEUS_STATE" | jq -r '.phase // ""' 2>/dev/null)
       PROM_PLAN_PATH=$(echo "$PROMETHEUS_STATE" | jq -r '.plan_path // ""' 2>/dev/null)
       PROM_RESUME=$(echo "$PROMETHEUS_STATE" | jq -r '.resume_summary // ""' 2>/dev/null)
+      # Escape backslashes so the value is safe to embed in a hand-built JSON string.
+      # Must happen here (data field only) — not at the final sed — to avoid doubling
+      # the intentional \n newline markers already present in the MESSAGES template.
+      PROM_RESUME=$(printf '%s' "$PROM_RESUME" | sed 's/\\/\\\\/g')
 
       # Determine whether the plan file is available on disk.
       # Unavailable means: plan_path empty/null, OR plan_path set but file missing.

--- a/hooks/session-start_test.sh
+++ b/hooks/session-start_test.sh
@@ -335,6 +335,38 @@ test_session_start_uses_project_root_variable() {
 }
 
 # =============================================================================
+# Tests: Prometheus restore — resume_summary surfaced when plan file unavailable
+# =============================================================================
+
+test_session_start_prometheus_surfaces_resume_summary_when_plan_unavailable() {
+    local sid="test-prometheus-resume"
+
+    # Active prometheus state: resume_summary set, plan_path empty (never written)
+    cat > "$TEST_OMT_DIR/prometheus-state-${sid}.json" << 'EOF'
+{
+  "active": true,
+  "phase": "STAGE_B",
+  "plan_path": "",
+  "resume_summary": "Working on feature X. Next: implement the validation logic in validator.ts."
+}
+EOF
+
+    local output
+    output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid"'"}' | "$SCRIPT_DIR/session-start.sh" 2>&1) || true
+
+    # Stdout must be valid JSON
+    if ! echo "$output" | jq . > /dev/null 2>&1; then
+        echo "ASSERTION FAILED: hook stdout is not valid JSON"
+        echo "  Output: ${output:0:500}"
+        return 1
+    fi
+
+    # additionalContext must contain the bookmark text
+    assert_output_contains "$output" "Working on feature X" "additionalContext should contain resume_summary text" || return 1
+    assert_output_contains "$output" "Resume from this bookmark" "additionalContext should contain bookmark label" || return 1
+}
+
+# =============================================================================
 # Main Test Runner
 # =============================================================================
 
@@ -363,6 +395,9 @@ main() {
     # Project root detection - session-start (from hooks/test/project_root_test.sh)
     run_test test_get_project_root_function_exists_in_session_start
     run_test test_session_start_uses_project_root_variable
+
+    # Prometheus restore: resume_summary surfaced when plan file unavailable
+    run_test test_session_start_prometheus_surfaces_resume_summary_when_plan_unavailable
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/session-start_test.sh
+++ b/hooks/session-start_test.sh
@@ -366,6 +366,50 @@ EOF
     assert_output_contains "$output" "Resume from this bookmark" "additionalContext should contain bookmark label" || return 1
 }
 
+test_session_start_prometheus_resume_summary_backslash_produces_valid_json() {
+    local sid="test-prometheus-backslash"
+
+    # Active prometheus state: resume_summary with literal backslashes (Windows path + regex)
+    cat > "$TEST_OMT_DIR/prometheus-state-${sid}.json" << 'EOF'
+{
+  "active": true,
+  "phase": "STAGE_B",
+  "plan_path": "",
+  "resume_summary": "editing C:\\tmp\\plan with regex \\d+"
+}
+EOF
+
+    local output
+    output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid"'"}' | "$SCRIPT_DIR/session-start.sh" 2>&1) || true
+
+    # (a) stdout must be valid JSON
+    if ! echo "$output" | jq . > /dev/null 2>&1; then
+        echo "ASSERTION FAILED: hook stdout is not valid JSON when resume_summary contains backslashes"
+        echo "  Output: ${output:0:500}"
+        return 1
+    fi
+
+    # (b) the parsed additionalContext must contain backslashes intact
+    local ctx
+    ctx=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
+
+    if echo "$ctx" | grep -qF 'C:\tmp\plan'; then
+        : # good
+    else
+        echo "ASSERTION FAILED: additionalContext should preserve backslash path C:\\tmp\\plan"
+        echo "  additionalContext: ${ctx:0:500}"
+        return 1
+    fi
+
+    if echo "$ctx" | grep -qF '\d+'; then
+        : # good
+    else
+        echo "ASSERTION FAILED: additionalContext should preserve backslash regex \\d+"
+        echo "  additionalContext: ${ctx:0:500}"
+        return 1
+    fi
+}
+
 # =============================================================================
 # Main Test Runner
 # =============================================================================
@@ -398,6 +442,9 @@ main() {
 
     # Prometheus restore: resume_summary surfaced when plan file unavailable
     run_test test_session_start_prometheus_surfaces_resume_summary_when_plan_unavailable
+
+    # Prometheus restore: backslashes in resume_summary produce valid JSON and are preserved
+    run_test test_session_start_prometheus_resume_summary_backslash_produces_valid_json
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -913,7 +913,7 @@ S7 → S0 edge: "Revise plan" returns to Interview Mode — full pipeline re-run
 These directives govern how prometheus records its own pipeline state via the state CLI.
 
 - **S0 entry**: run `bun skills/prometheus/scripts/prometheus-state.ts set --phase S0`.
-- **Per each S-transition**: run `bun skills/prometheus/scripts/prometheus-state.ts set --phase <S> [--plan-path <p>] [--resume-summary "<one line>"]` immediately after entering the new state. `--plan-path` is required from S2 onward (when the plan file exists); `--resume-summary` is a single-line description of current progress, helpful for restore.
+- **Per each S-transition**: run `bun skills/prometheus/scripts/prometheus-state.ts set --phase <S>` immediately after entering the new state. Pass `--plan-path <p>` once at S2 (when the plan file is first written); later transitions may omit it and the stored value is preserved automatically — omitting does NOT clear it. Pass `--resume-summary "<one line>"` whenever you want to refresh the pause bookmark; omitting it likewise preserves the previous bookmark.
 - **Teardown**: AFTER S8 dispatch is invoked, and on abort, run `bun skills/prometheus/scripts/prometheus-state.ts clear`.
 - **Session key**: state is keyed by the exported `$OMT_SESSION_ID` environment variable (the CLI falls back to `default` when `OMT_SESSION_ID` is unset).
 - **Restore**: on restore, re-read the current plan file, restart from `resume_summary` if `plan_path` is missing, distrust any stored verdict, and re-run gates on the current artifact. A stored verdict is not a pass — re-verification is mandatory.

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -650,6 +650,19 @@ This contract applies to EVERY plan. The contract lives here — not in a refere
 | **Success Criteria** | Binary pass/fail end state. Verification commands + final checklist |
 | **ADR** | Architecture Decision Record — MADR 7-field (Context / Decision Drivers / Considered Options / Decision / Rationale / Consequences / Follow-ups). Scoped+ default; Trivial exempt. |
 
+Canonical required section headings (validator single source):
+```
+## TL;DR
+## Context
+## Work Objectives
+## TODOs
+## Execution Strategy
+## Verification Strategy
+## Success Criteria
+```
+
+Each plan section is emitted as exactly its canonical heading above (plus `## ADR` when Scoped+).
+
 ### ADR
 
 Architecture Decision Record (Nygard 2011 / MADR) — one entry per significant design choice in the plan. **Required for Scoped+ intent. Trivial intent is exempt from ADR output.** Inline in the plan; no separate file needed.
@@ -895,6 +908,16 @@ Each reviewer invocation MUST use a **fresh agent instance**. Do not reuse an ag
 
 S7 → S0 edge: "Revise plan" returns to Interview Mode — full pipeline re-runs.
 
+### State Lifecycle Directives
+
+These directives govern how prometheus records its own pipeline state via the state CLI.
+
+- **S0 entry**: run `bun skills/prometheus/scripts/prometheus-state.ts set --phase S0`.
+- **Per each S-transition**: run `bun skills/prometheus/scripts/prometheus-state.ts set --phase <S> [--plan-path <p>] [--resume-summary "<one line>"]` immediately after entering the new state. `--plan-path` is required from S2 onward (when the plan file exists); `--resume-summary` is a single-line description of current progress, helpful for restore.
+- **Teardown**: AFTER S8 dispatch is invoked, and on abort, run `bun skills/prometheus/scripts/prometheus-state.ts clear`.
+- **Session key**: state is keyed by the exported `$OMT_SESSION_ID` environment variable (the CLI falls back to `default` when `OMT_SESSION_ID` is unset).
+- **Restore**: on restore, re-read the current plan file, restart from `resume_summary` if `plan_path` is missing, distrust any stored verdict, and re-run gates on the current artifact. A stored verdict is not a pass — re-verification is mandatory.
+
 ### Loop Termination Rule
 
 Reviewer loop terminates **iff** the reviewer issues APPROVE or COMMENT on the current artifact version. REQUEST_CHANGES → Revise. Missing/ambiguous → treat as REQUEST_CHANGES.
@@ -909,6 +932,7 @@ Time pressure, user override ("just proceed"), self-assessment of fix correctnes
 | 2 | File references exist | All file paths and line references resolve |
 | 3 | Guardrails from Metis incorporated | Every Metis-flagged constraint reflected |
 | 4 | Zero human-intervention criteria | No TODO requires manual mid-execution action |
+| 5 | Section validator passes | Run `bun skills/prometheus/scripts/validate-plan.ts <plan_path>` (invoked ONLY here, post-S4, full plan). If it reports missing or empty sections, fix the plan and re-run before submitting to Daedalus. |
 
 Item 2 ("File references exist") is a lightweight pre-Momus self-filter — it catches obviously stale paths before the plan reaches the feasibility gate. It is complementary to, not a substitute for, Momus's authoritative codebase-feasibility verification: this self-check is a cheap first pass; Momus is the gate.
 

--- a/skills/prometheus/scripts/prometheus-state.test.ts
+++ b/skills/prometheus/scripts/prometheus-state.test.ts
@@ -112,4 +112,28 @@ describe('prometheus state', () => {
     const path = resolveStatePath(sessionId);
     expect(path).toBe(`${tmpDir}/prometheus-state-default.json`);
   });
+
+  test('prometheus phase-only update preserves prior plan_path and resume_summary', () => {
+    process.env.OMT_SESSION_ID = 'test-session';
+
+    // First write: full fields
+    setPrometheusState('test-session', {
+      phase: 'S2',
+      plan_path: `${tmpDir}/plans/my-plan.md`,
+      resume_summary: 'paused at interview',
+    });
+    const first = readPrometheusState('test-session');
+    expect(first).not.toBeNull();
+    const firstStartedAt = first!.started_at;
+
+    // Second write: phase only, omitting plan_path and resume_summary
+    setPrometheusState('test-session', { phase: 'S4' });
+
+    const second = readPrometheusState('test-session');
+    expect(second).not.toBeNull();
+    expect(second!.phase).toBe('S4');
+    expect(second!.plan_path).toBe(`${tmpDir}/plans/my-plan.md`);
+    expect(second!.resume_summary).toBe('paused at interview');
+    expect(second!.started_at).toBe(firstStartedAt);
+  });
 });

--- a/skills/prometheus/scripts/prometheus-state.test.ts
+++ b/skills/prometheus/scripts/prometheus-state.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  readPrometheusState,
+  setPrometheusState,
+  clearPrometheusState,
+  resolveStatePath,
+} from './prometheus-state.ts';
+
+let tmpDir: string;
+const originalOmtDir = process.env.OMT_DIR;
+const originalSessionId = process.env.OMT_SESSION_ID;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'prometheus-state-test-'));
+  process.env.OMT_DIR = tmpDir;
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  if (originalOmtDir !== undefined) {
+    process.env.OMT_DIR = originalOmtDir;
+  } else {
+    delete process.env.OMT_DIR;
+  }
+  if (originalSessionId !== undefined) {
+    process.env.OMT_SESSION_ID = originalSessionId;
+  } else {
+    delete process.env.OMT_SESSION_ID;
+  }
+});
+
+describe('prometheus state', () => {
+  test('prometheus roundtrip', () => {
+    process.env.OMT_SESSION_ID = 'test-session';
+    setPrometheusState('test-session', {
+      phase: 'S3',
+      plan_path: `${tmpDir}/plans/my-plan.md`,
+      resume_summary: 'paused after interview',
+    });
+    const state = readPrometheusState('test-session');
+    expect(state).not.toBeNull();
+    expect(state!.active).toBe(true);
+    expect(state!.phase).toBe('S3');
+    expect(state!.plan_path).toBe(`${tmpDir}/plans/my-plan.md`);
+    expect(state!.resume_summary).toBe('paused after interview');
+  });
+
+  test('prometheus inactive returns null', () => {
+    process.env.OMT_SESSION_ID = 'test-session';
+    // absent file
+    expect(readPrometheusState('test-session')).toBeNull();
+
+    // file with active:false
+    const { writeFileSync } = require('fs');
+    const path = resolveStatePath('test-session');
+    writeFileSync(path, JSON.stringify({ active: false, phase: 'S1', plan_path: '', resume_summary: '', started_at: '2024-01-01T00:00:00' }), 'utf8');
+    expect(readPrometheusState('test-session')).toBeNull();
+  });
+
+  test('prometheus clear removes file', () => {
+    process.env.OMT_SESSION_ID = 'test-session';
+    setPrometheusState('test-session', { phase: 'S1', plan_path: '', resume_summary: '' });
+    const path = resolveStatePath('test-session');
+    expect(existsSync(path)).toBe(true);
+    clearPrometheusState('test-session');
+    expect(existsSync(path)).toBe(false);
+  });
+
+  test('prometheus state path literal', () => {
+    process.env.OMT_SESSION_ID = 'my-session';
+    const path = resolveStatePath('my-session');
+    expect(path).toBe(`${tmpDir}/prometheus-state-my-session.json`);
+  });
+
+  test('prometheus resume_summary control-char normalized', () => {
+    process.env.OMT_SESSION_ID = 'test-session';
+    const dirty = 'line1\nline2\ttabbed\x01control';
+    setPrometheusState('test-session', {
+      phase: 'S2',
+      plan_path: '',
+      resume_summary: dirty,
+    });
+    const state = readPrometheusState('test-session');
+    expect(state).not.toBeNull();
+    // No characters in U+0000-U+001F should remain
+    const hasBadChars = /[\x00-\x1F]/.test(state!.resume_summary);
+    expect(hasBadChars).toBe(false);
+  });
+
+  test('prometheus started_at seeded and preserved', () => {
+    process.env.OMT_SESSION_ID = 'test-session';
+    setPrometheusState('test-session', { phase: 'S1', plan_path: '', resume_summary: '' });
+    const first = readPrometheusState('test-session');
+    expect(first).not.toBeNull();
+    const firstStartedAt = first!.started_at;
+
+    // Second set call
+    setPrometheusState('test-session', { phase: 'S2', plan_path: '', resume_summary: '' });
+    const second = readPrometheusState('test-session');
+    expect(second!.started_at).toBe(firstStartedAt);
+
+    // Format: no milliseconds, matches local ISO-8601 date+time
+    expect(firstStartedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  test('prometheus session id fallback', () => {
+    delete process.env.OMT_SESSION_ID;
+    const sessionId = process.env.OMT_SESSION_ID || 'default';
+    const path = resolveStatePath(sessionId);
+    expect(path).toBe(`${tmpDir}/prometheus-state-default.json`);
+  });
+});

--- a/skills/prometheus/scripts/prometheus-state.ts
+++ b/skills/prometheus/scripts/prometheus-state.ts
@@ -115,7 +115,7 @@ export function readPrometheusState(sessionId: string): PrometheusState | null {
 
 export function setPrometheusState(
   sessionId: string,
-  opts: { phase: string; plan_path: string; resume_summary: string }
+  opts: { phase: string; plan_path?: string; resume_summary?: string }
 ): void {
   const path = resolveStatePath(sessionId);
   const existing = readFileOrNull(path);
@@ -175,8 +175,8 @@ function main(): void {
 
   if (subcommand === 'set') {
     const phase = String(args['phase'] ?? '');
-    const planPath = String(args['plan-path'] ?? '');
-    const resumeSummary = String(args['resume-summary'] ?? '');
+    const planPath = args['plan-path'] !== undefined ? String(args['plan-path']) : undefined;
+    const resumeSummary = args['resume-summary'] !== undefined ? String(args['resume-summary']) : undefined;
     setPrometheusState(sessionId, { phase, plan_path: planPath, resume_summary: resumeSummary });
   } else if (subcommand === 'clear') {
     clearPrometheusState(sessionId);

--- a/skills/prometheus/scripts/prometheus-state.ts
+++ b/skills/prometheus/scripts/prometheus-state.ts
@@ -1,0 +1,192 @@
+/**
+ * Prometheus skill state CLI.
+ *
+ * State file path: ${OMT_DIR}/prometheus-state-${sessionId}.json
+ * Session ID: process.env.OMT_SESSION_ID || "default"
+ *
+ * Subcommands:
+ *   set --phase <S> [--plan-path <p>] [--resume-summary <s>]
+ *   clear
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
+import { dirname } from 'path';
+import { execSync } from 'child_process';
+
+export interface PrometheusState {
+  active: boolean;
+  /** Pipeline token: S0-S8 */
+  phase: string;
+  /** Absolute path under $OMT_DIR/plans/, empty string until plan written */
+  plan_path: string;
+  /** Single-line pause bookmark, control chars normalized to spaces */
+  resume_summary: string;
+  /** Local ISO-8601 without milliseconds, seeded once via `date -Iseconds` */
+  started_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// IO helpers (safe write semantics, no import from hooks/)
+// ---------------------------------------------------------------------------
+
+function ensureDir(path: string): void {
+  if (!existsSync(path)) {
+    mkdirSync(path, { recursive: true });
+  }
+}
+
+function readFileOrNull(path: string): string | null {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function writeFileSafe(path: string, content: string): void {
+  ensureDir(dirname(path));
+  writeFileSync(path, content, 'utf8');
+}
+
+function deleteFile(path: string): void {
+  try {
+    unlinkSync(path);
+  } catch {
+    // ignore missing file
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Path resolution
+// ---------------------------------------------------------------------------
+
+function getOmtDir(): string {
+  const dir = process.env.OMT_DIR;
+  if (!dir) throw new Error('OMT_DIR environment variable is not set');
+  return dir;
+}
+
+export function resolveStatePath(sessionId: string): string {
+  return `${getOmtDir()}/prometheus-state-${sessionId}.json`;
+}
+
+// ---------------------------------------------------------------------------
+// started_at seeding — spawns shell date to match ralph's BSD-parseable format
+// ---------------------------------------------------------------------------
+
+function seedStartedAt(): string {
+  try {
+    const result = execSync(
+      'date -Iseconds 2>/dev/null || date +"%Y-%m-%dT%H:%M:%S"',
+      { encoding: 'utf8', shell: '/bin/sh' }
+    );
+    return result.trim();
+  } catch {
+    // Final fallback: manual ISO-8601 without milliseconds
+    const d = new Date();
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Normalize resume_summary: replace U+0000-U+001F with space
+// ---------------------------------------------------------------------------
+
+function normalizeResumeSummary(s: string): string {
+  return s.replace(/[\x00-\x1F]/g, ' ');
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function readPrometheusState(sessionId: string): PrometheusState | null {
+  const path = resolveStatePath(sessionId);
+  const content = readFileOrNull(path);
+  if (!content) return null;
+  try {
+    const state = JSON.parse(content) as PrometheusState;
+    return state.active ? state : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setPrometheusState(
+  sessionId: string,
+  opts: { phase: string; plan_path: string; resume_summary: string }
+): void {
+  const path = resolveStatePath(sessionId);
+  const existing = readFileOrNull(path);
+  let prior: Partial<PrometheusState> = {};
+  if (existing) {
+    try {
+      prior = JSON.parse(existing) as Partial<PrometheusState>;
+    } catch {
+      // corrupt file; start fresh
+    }
+  }
+
+  const state: PrometheusState = {
+    active: true,
+    phase: opts.phase,
+    plan_path: opts.plan_path ?? prior.plan_path ?? '',
+    resume_summary: normalizeResumeSummary(opts.resume_summary ?? prior.resume_summary ?? ''),
+    // Preserve existing started_at on subsequent writes; seed on first write
+    started_at: prior.started_at ?? seedStartedAt(),
+  };
+
+  writeFileSafe(path, JSON.stringify(state, null, 2));
+}
+
+export function clearPrometheusState(sessionId: string): void {
+  deleteFile(resolveStatePath(sessionId));
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+function parseArgs(args: string[]): Record<string, string | boolean> {
+  const result: Record<string, string | boolean> = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const next = args[i + 1];
+      if (next !== undefined && !next.startsWith('--')) {
+        result[key] = next;
+        i++;
+      } else {
+        result[key] = true;
+      }
+    } else if (!result['_subcommand']) {
+      result['_subcommand'] = arg;
+    }
+  }
+  return result;
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  const subcommand = args['_subcommand'];
+  const sessionId = process.env.OMT_SESSION_ID || 'default';
+
+  if (subcommand === 'set') {
+    const phase = String(args['phase'] ?? '');
+    const planPath = String(args['plan-path'] ?? '');
+    const resumeSummary = String(args['resume-summary'] ?? '');
+    setPrometheusState(sessionId, { phase, plan_path: planPath, resume_summary: resumeSummary });
+  } else if (subcommand === 'clear') {
+    clearPrometheusState(sessionId);
+  } else {
+    process.stderr.write('Usage: prometheus-state.ts <set|clear> [options]\n');
+    process.exit(1);
+  }
+}
+
+// Only run CLI when executed directly (not when imported as a module)
+if (import.meta.main) {
+  main();
+}

--- a/skills/prometheus/scripts/validate-plan.test.ts
+++ b/skills/prometheus/scripts/validate-plan.test.ts
@@ -1,4 +1,6 @@
 import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { REQUIRED_HEADINGS, validatePlan } from './validate-plan.ts';
 
 // ---------------------------------------------------------------------------
@@ -133,4 +135,41 @@ describe('validator policy', () => {
     const missing = validatePlan(plan);
     expect(missing).not.toContain('TODOs');
   });
+});
+
+// ---------------------------------------------------------------------------
+// Drift-lock: canonical headings in SKILL.md must match REQUIRED_HEADINGS
+// ---------------------------------------------------------------------------
+
+test('validator headings match SKILL contract', () => {
+  // Resolve SKILL.md relative to this test file's directory
+  const skillPath = join(import.meta.dir, '..', 'SKILL.md');
+  const skillContent = readFileSync(skillPath, 'utf8');
+
+  // Find the anchor line, then extract the immediately following fenced block
+  const anchorLine = 'Canonical required section headings (validator single source):';
+  const anchorIdx = skillContent.indexOf(anchorLine);
+  if (anchorIdx === -1) throw new Error(`Anchor not found in SKILL.md: "${anchorLine}"`);
+
+  const afterAnchor = skillContent.slice(anchorIdx + anchorLine.length);
+
+  // Find the opening fence (```)
+  const fenceOpenMatch = afterAnchor.match(/^[ \t]*```[^\n]*\n/m);
+  if (!fenceOpenMatch) throw new Error('Opening fence not found after anchor in SKILL.md');
+  const fenceOpenEnd = fenceOpenMatch.index! + fenceOpenMatch[0].length;
+
+  // Find the closing fence
+  const afterFenceOpen = afterAnchor.slice(fenceOpenEnd);
+  const fenceCloseMatch = afterFenceOpen.match(/^[ \t]*```[ \t]*$/m);
+  if (!fenceCloseMatch) throw new Error('Closing fence not found after anchor in SKILL.md');
+
+  const fenceBody = afterFenceOpen.slice(0, fenceCloseMatch.index!);
+
+  // Extract lines that start with "## " — these are the canonical headings
+  const extracted = fenceBody
+    .split('\n')
+    .filter((line) => line.startsWith('## '))
+    .map((line) => line.slice('## '.length).trim());
+
+  expect(extracted).toEqual(REQUIRED_HEADINGS);
 });

--- a/skills/prometheus/scripts/validate-plan.test.ts
+++ b/skills/prometheus/scripts/validate-plan.test.ts
@@ -1,0 +1,136 @@
+import { describe, test, expect } from 'bun:test';
+import { REQUIRED_HEADINGS, validatePlan } from './validate-plan.ts';
+
+// ---------------------------------------------------------------------------
+// Self-test: canonical heading list
+// ---------------------------------------------------------------------------
+
+test('validator required headings are the 7 canonical literals', () => {
+  expect(REQUIRED_HEADINGS).toEqual([
+    'TL;DR',
+    'Context',
+    'Work Objectives',
+    'TODOs',
+    'Execution Strategy',
+    'Verification Strategy',
+    'Success Criteria',
+  ]);
+});
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function buildPlan(overrides: Partial<Record<string, string>> = {}): string {
+  const defaults: Record<string, string> = {
+    'TL;DR': 'Short summary of the work.',
+    'Context': 'Background and motivation for the work.',
+    'Work Objectives': 'The concrete goals we want to achieve.',
+    'TODOs': '- [ ] Step 1\n- [ ] Step 2',
+    'Execution Strategy': 'How we will execute the plan.',
+    'Verification Strategy': 'How we verify correctness.',
+    'Success Criteria': 'Definition of done.',
+  };
+  const sections = { ...defaults, ...overrides };
+  return REQUIRED_HEADINGS.map((h) => {
+    const body = sections[h] ?? `Body for ${h}.`;
+    return `## ${h}\n\n${body}\n`;
+  }).join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Happy-path
+// ---------------------------------------------------------------------------
+
+describe('real-plan fixture passes', () => {
+  test('real-plan fixture passes', () => {
+    const plan = buildPlan();
+    const missing = validatePlan(plan);
+    expect(missing).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty section tests — one per required heading
+// ---------------------------------------------------------------------------
+
+describe('empty sections', () => {
+  test('empty section: TL;DR', () => {
+    const plan = buildPlan({ 'TL;DR': '' });
+    const missing = validatePlan(plan);
+    expect(missing).toContain('TL;DR');
+  });
+
+  test('empty section: Context', () => {
+    const plan = buildPlan({ 'Context': '' });
+    const missing = validatePlan(plan);
+    expect(missing).toContain('Context');
+  });
+
+  test('empty section: Work Objectives', () => {
+    const plan = buildPlan({ 'Work Objectives': '' });
+    const missing = validatePlan(plan);
+    expect(missing).toContain('Work Objectives');
+  });
+
+  test('empty section: TODOs', () => {
+    const plan = buildPlan({ 'TODOs': '' });
+    const missing = validatePlan(plan);
+    expect(missing).toContain('TODOs');
+  });
+
+  test('empty section: Execution Strategy', () => {
+    const plan = buildPlan({ 'Execution Strategy': '' });
+    const missing = validatePlan(plan);
+    expect(missing).toContain('Execution Strategy');
+  });
+
+  test('empty section: Verification Strategy', () => {
+    const plan = buildPlan({ 'Verification Strategy': '' });
+    const missing = validatePlan(plan);
+    expect(missing).toContain('Verification Strategy');
+  });
+
+  test('empty section: Success Criteria', () => {
+    const plan = buildPlan({ 'Success Criteria': '' });
+    const missing = validatePlan(plan);
+    expect(missing).toContain('Success Criteria');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Policy tests
+// ---------------------------------------------------------------------------
+
+describe('validator policy', () => {
+  test('validator policy: fenced heading not counted', () => {
+    // ## Success Criteria appears ONLY inside a code fence — must NOT count
+    const plan =
+      buildPlan({ 'Success Criteria': '' })
+        .replace(
+          '## Success Criteria\n\n\n',
+          // Remove the real (empty) heading and replace entire section with
+          // a fenced block that contains the heading literal
+          '```\n## Success Criteria\nThis is inside a fence.\n```\n',
+        );
+    const missing = validatePlan(plan);
+    expect(missing).toContain('Success Criteria');
+  });
+
+  test('validator policy: whitespace-only body empty', () => {
+    // Body is only spaces/newlines — counts as empty
+    const plan = buildPlan({ 'TODOs': '   \n   \n   ' });
+    const missing = validatePlan(plan);
+    expect(missing).toContain('TODOs');
+  });
+
+  test('validator policy: duplicate heading first occurrence', () => {
+    // First occurrence of TODOs has content; second is empty.
+    // Validator must use FIRST occurrence → result should NOT list TODOs as missing.
+    const plan =
+      buildPlan() +
+      '\n## TODOs\n\n\n';
+    const missing = validatePlan(plan);
+    expect(missing).not.toContain('TODOs');
+  });
+});

--- a/skills/prometheus/scripts/validate-plan.ts
+++ b/skills/prometheus/scripts/validate-plan.ts
@@ -1,0 +1,115 @@
+/**
+ * validate-plan.ts
+ *
+ * Deterministic section-presence validator for prometheus plans.
+ * Checks that the 7 always-required plan sections exist as level-2 headings
+ * with non-empty bodies. This is a cheap PRESENCE pre-filter, not a quality gate.
+ *
+ * Usage: bun skills/prometheus/scripts/validate-plan.ts <plan_path>
+ * Exit 0 = all sections present and non-empty.
+ * Exit 1 = one or more sections missing or empty (offending literals printed to stdout).
+ */
+
+export const REQUIRED_HEADINGS: string[] = [
+  'TL;DR',
+  'Context',
+  'Work Objectives',
+  'TODOs',
+  'Execution Strategy',
+  'Verification Strategy',
+  'Success Criteria',
+];
+
+/**
+ * Strip fenced code blocks (``` ... ```) from markdown content.
+ * This prevents headings inside fences from being counted.
+ */
+function stripFences(content: string): string {
+  return content.replace(/^```[\s\S]*?^```/gm, '');
+}
+
+/**
+ * Validate a plan's text for section presence and non-emptiness.
+ *
+ * Rules:
+ * (a) Fenced code blocks are stripped before scanning.
+ * (b) A heading matches exactly `## <literal>` (level-2, case-sensitive, no extra text).
+ * (c) Duplicate headings: first occurrence wins.
+ * (d) Non-empty = body between this heading and the next ## heading has trimmed length > 0.
+ *
+ * @returns Array of heading literals that are missing or empty.
+ */
+export function validatePlan(content: string): string[] {
+  const stripped = stripFences(content);
+
+  // Parse the heading line regex: exactly ## <literal> (optional trailing whitespace)
+  const headingRegex = /^##[ \t]+(.+?)[ \t]*$/gm;
+
+  // Collect first-occurrence positions of level-2 headings
+  const headingPositions: Array<{ literal: string; bodyStart: number }> = [];
+  const seen = new Set<string>();
+
+  let match: RegExpExecArray | null;
+  while ((match = headingRegex.exec(stripped)) !== null) {
+    const literal = match[1];
+    if (!seen.has(literal)) {
+      seen.add(literal);
+      headingPositions.push({
+        literal,
+        bodyStart: match.index + match[0].length,
+      });
+    }
+  }
+
+  const missing: string[] = [];
+
+  for (const required of REQUIRED_HEADINGS) {
+    const entry = headingPositions.find((h) => h.literal === required);
+
+    if (entry === undefined) {
+      // Heading not found at all
+      missing.push(required);
+      continue;
+    }
+
+    // Find the start of the next ## heading after this one
+    const nextHeadingMatch = /^##[ \t]+/m.exec(stripped.slice(entry.bodyStart));
+    const bodyEnd =
+      nextHeadingMatch !== null
+        ? entry.bodyStart + nextHeadingMatch.index
+        : stripped.length;
+
+    const body = stripped.slice(entry.bodyStart, bodyEnd).trim();
+
+    if (body.length === 0) {
+      missing.push(required);
+    }
+  }
+
+  return missing;
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+if (import.meta.main) {
+  const planPath = process.argv[2];
+  if (!planPath) {
+    console.error('Usage: bun validate-plan.ts <plan_path>');
+    process.exit(2);
+  }
+
+  const { readFileSync } = await import('fs');
+  const content = readFileSync(planPath, 'utf8');
+  const missing = validatePlan(content);
+
+  if (missing.length > 0) {
+    for (const h of missing) {
+      console.log(h);
+    }
+    process.exit(1);
+  }
+
+  process.exit(0);
+}


### PR DESCRIPTION
## 📌 Summary

prometheus 플래닝 스킬을 stateless에서 restore-only stateful로 전환하고, Self-Review 경계에 결정론적 섹션 존재 검증 게이트를 추가합니다. 중단된 플래닝 세션이 다음 세션 시작 시 복원되고, 골격만 있는 plan이 리뷰 단계에 진입하기 전에 걸러집니다.

---

## 🔧 Changes

### 상태 영속화 — state CLI + session-start 브리지

- `prometheus-state.ts`: `set` / `clear` 서브커맨드 CLI. `$OMT_DIR/prometheus-state-${sessionId}.json`에 `phase` / `plan_path` / `resume_summary` / `started_at` 기록. `started_at`은 첫 write에서 `date -Iseconds`로 seed 후 보존, `resume_summary`는 write 시점에 제어문자(U+0000–U+001F)를 공백으로 정규화.
- `session-start.sh`: `OMT_SESSION_ID` export, 활성 상태 시 `[PROMETHEUS RESTORED]` 복원 블록 주입, stale-sweep glob을 확장해 prometheus 상태도 동일 3h 임계로 reap. plan 파일 부재 시 `resume_summary` 북마크 내용을 복원 블록에 노출.
- ralph 상태 shape(sessionId 키잉 경로, SessionStart 복원, 3h sweep)를 그대로 미러링하되 Stop hook은 추가하지 않습니다.

**영향 범위**: prometheus 스킬 전용. 기존 ralph / ultrawork 복원·sweep 로직은 불변. 상태 파일은 `$OMT_DIR` 내 모드 자체의 휘발성 북마크(사용자 데이터 아님). 세션 격리용 신규 env var `OMT_SESSION_ID` 추가.

### 섹션 존재 검증 게이트 — validator + SKILL 계약

- `validate-plan.ts`: plan의 7개 필수 `##` 섹션 존재 + 비어있지 않음 검사. fenced 코드블록 제거 후 스캔, 중복 heading은 첫 발생, 공백-only 본문은 빈 것으로 판정. 누락/빈 섹션 발견 시 해당 섹션명을 출력하고 non-zero exit.
- `SKILL.md`: 7개 canonical `##` heading을 delimited block에 고정(validator 단일 소스), Self-Review 체크리스트 5번째 항목이 validator를 실행하고 실패 시 plan 수정 후 재실행. `validate-plan.test.ts`의 drift-lock 테스트가 SKILL 블록과 `REQUIRED_HEADINGS`의 동등성을 기계 검증.

**영향 범위**: plan 작성 후 Self-Review(S2→S3) 경계에서만 동작. 품질 판정이 아닌 존재 pre-filter. `plan-template.md`는 스캔 대상이 아님.

### 리뷰 반영 수정 — 상태 흐름 정합 (fix 커밋 3개)

- 후속 `set`이 `--plan-path` / `--resume-summary`를 생략하면 이전 값을 보존(기존엔 caller가 `''`로 강제해 wipe되던 버그).
- 복원 블록이 `resume_summary` 실제 내용을 출력(기존엔 저장만 하고 hook이 읽지 않음).
- lifecycle directive를 "S2에서 한 번 기록, 이후 생략해도 보존" 의미론으로 정합(표기-산문 모순 제거).

**영향 범위**: 위 상태 영속화 동작의 정확성 수정. 외부 계약 변화 없음. `make validate` + `make test` 그린(1920+ 테스트).

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. restore-only 영속화 — Stop hook을 도입하지 않은 이유

**배경 및 문제 상황:**
prometheus는 의도적으로 stateless였고, stateful 전환 요구가 들어왔습니다. 참조 모델인 ralph는 Stop hook으로 "미완료 작업"을 강제 재개시키지만, prometheus는 인터뷰 매 턴마다 정당하게 pause합니다. ralph식 Stop hook을 그대로 미러링하면 모든 인터뷰 턴이 "작업 남긴 채 중단"으로 오탐지돼 인터뷰 루프 자체가 깨집니다.

**해결 방안:**
SessionStart에 북마크를 주입하는 restore-only 방식만 채택하고 Stop hook은 건드리지 않았습니다.

**구현 세부사항:**
`session-start.sh`가 활성 상태를 읽어 `[PROMETHEUS RESTORED]` 블록을 주입할 뿐, `persistent-mode/decision.ts`나 Stop hook 경로는 일절 변경하지 않습니다. 복원 블록은 stored verdict를 불신하고 현재 plan을 다시 읽어 게이트를 재실행하라는 지시를 포함합니다.

**선택과 트레이드오프:**
restore-only는 다음 SessionStart에만 복원되므로 빈도가 낮습니다(기대값 modest, 인정). 다만 plan 파일 자체가 이미 `$OMT_DIR/plans/`에 영속하므로, 북마크의 한계 가치는 "어느 S-phase였나"를 알려주는 보조 수준입니다. 사용자 요구("stateless 유지하고 싶지 않다")를 인터뷰 루프를 깨지 않고 충족하는 최소-상태 형태입니다.

### 2. 상태 코드를 스킬에 co-locate (persistent-mode/ 미배치)

**배경 및 문제 상황:**
ralph 상태 코드가 `hooks/persistent-mode/state.ts`에 있는 이유는 Stop hook(`decision.ts`)이 TS로 import해 소비하기 때문입니다. prometheus는 Stop hook 소비자가 없고, 유일한 writer는 스킬(CLI), 유일한 reader는 `session-start.sh`(bash/jq, 파일 경로로만 접근)입니다.

**해결 방안:**
상태 타입·로직·CLI·테스트를 `skills/prometheus/scripts/prometheus-state.ts`에 자체 포함시켰습니다.

**구현 세부사항:**
`skills/` → `hooks/persistent-mode/` 역방향 import를 만들지 않기 위해, safe-write / 정규화 등 소형 IO helper를 재구현했습니다. 사용자 가시 산출물(ralph식 경로의 상태 JSON 파일)은 동일하게 유지하고 writer 코드 위치만 다릅니다.

**선택과 트레이드오프:**
helper 소량 중복을 수용하는 대가로 hook 내부에 대한 역방향 의존을 제거했습니다. 코드는 소비자 곁에 두는 것이 원칙이고, prometheus 상태에는 hook측 TS 소비자가 없으므로 ralph가 `persistent-mode/`에 있던 근거가 적용되지 않습니다.

### 3. producer/consumer heading 단일 소스 + scoped drift-lock

**배경 및 문제 상황:**
게이트가 섹션을 검사하려면 스킬이 실제로 emit하는 heading과 validator가 검사하는 heading이 일치해야 합니다. 기존 Plan Structure 계약은 섹션을 bold label로 나열해 `##` 리터럴 철자를 보장하지 못했고, 이대로면 게이트가 vacuous해질 수 있습니다.

**해결 방안:**
7개 always-required 섹션을 SKILL의 delimited block에 canonical `##` heading으로 고정하고, validator가 같은 리스트를 `REQUIRED_HEADINGS`로 참조하도록 했습니다. drift-lock 테스트가 두 소스의 집합 동등성을 검증하되, SKILL측 추출을 그 delimited block으로 한정해 무관한 `##` heading이 락을 깨지 않게 했습니다.

**선택과 트레이드오프:**
섹션 rename이 3점 동시 변경(계약 블록 + validator + drift-lock)이 되는 ossification을 감수했습니다. 대신 게이트가 vacuous해지거나 spurious하게 실패하는 경로를 원천 차단합니다. validator는 존재 pre-filter일 뿐 분해 품질·AC 강도를 판정하지 않으며, 품질 게이트는 Momus/Daedalus가 담당합니다 — validator-green이 "plan이 좋다"를 의미하지 않도록 범위를 정직하게 명명했습니다.

### 4. 상태 갱신 once-and-preserve 의미론 + 두 소비자 모델 (리뷰 반영)

**배경 및 문제 상황:**
초기 구현은 매 S-transition마다 모든 필드를 다시 넘기게 했고, caller가 생략된 인자를 `''`로 강제해 이전 `plan_path` / `resume_summary`를 묵시적으로 wipe했습니다(보존 로직이 caller에 의해 무력화). 또 `resume_summary`는 저장·정규화까지 하면서 hook이 한 번도 읽지 않아, "restart from resume_summary" 안내가 가리킬 내용이 없었습니다.

**해결 방안:**
생략된 인자를 `undefined`로 넘겨 기존 `?? prior` 보존 체인을 살렸고(S2에서 한 번 기록하면 이후 전이는 자동 보존), hook이 plan 부재 시 `resume_summary` 실제 내용을 노출하도록 했습니다.

**구현 세부사항:**
상태 파일의 소비자는 둘입니다 — `session-start.sh`(결정론적 bash: `jq` 추출 + `[ -f ]` 파일 존재 검사 + `date` 파싱)와 복원된 AI(산문 읽기). 그래서 `plan_path` / `started_at` / `active`는 bash가 요구하는 구조화 필드, `resume_summary`는 AI용 산문 북마크로 나뉩니다. 구조와 산문의 혼합 설계입니다.

**선택과 트레이드오프:**
LLM이 매 전이마다 정확한 플래그를 재전달하도록 강제하는 것은 취약하며(실제로 wipe 버그의 근본 원인), "한 번 기록·이후 보존"으로 LLM 부담을 최소화했습니다. `resume_summary`의 다중 라인 입력은 write-time에 공백으로 평탄화(단일 라인 북마크 불변식의 자가 강제). 다만 restore-only의 기대 가치가 낮다는 점은 인정되며(복원 빈도 미측정), 운영 후 가치가 낮다고 판명되면 `resume_summary` 구조를 단순화할 여지를 남겨둡니다.

---

## ✅ Checklist

### 상태 영속화
- [ ] 활성 prometheus 세션이 SessionStart에서 phase + plan_path와 함께 `[PROMETHEUS RESTORED]`로 복원된다
  - `hooks/session-start.sh`
- [ ] `active=false` 또는 상태 파일 부재 시 복원 블록이 주입되지 않는다
  - `hooks/session-start.sh`
- [ ] 4시간 경과 prometheus 상태 파일이 기존 stale-sweep으로 reap된다
  - `hooks/session-start.sh`
- [ ] 후속 `set`이 `--plan-path` / `--resume-summary` 생략 시 이전 값을 보존하고 phase만 갱신한다
  - `skills/prometheus/scripts/prometheus-state.ts`
- [ ] plan 파일 부재 시 복원 블록이 `resume_summary` 북마크 텍스트를 출력하고 stdout이 유효 JSON이다
  - `hooks/session-start.sh`

### 섹션 검증 게이트
- [ ] validator가 7개 필수 섹션 각각의 누락/빈 상태를 섹션명과 함께 non-zero exit으로 검출한다
  - `skills/prometheus/scripts/validate-plan.ts`
- [ ] SKILL canonical block과 validator `REQUIRED_HEADINGS`가 drift-lock 테스트로 일치한다
  - `skills/prometheus/scripts/validate-plan.test.ts`
- [ ] Self-Review 5번째 항목이 validator를 실행하고 실패 시 루프백한다
  - `skills/prometheus/SKILL.md`

### 전체
- [ ] `make validate` + `make test` 통과 (스키마 + 컴포넌트 + typecheck + Shell/TS 테스트)

---

## 📎 References
- 없음 (외부 reviewer-accessible 문서 없음 — 설계 근거 ADR은 Review Points에 인라인 정리)
