### PR TITLE
feat(mock-interview): 꼬리질문을 소크라테스식 추궁으로 재설계

### DIFF
--- a/skills/mock-interview/SKILL.md
+++ b/skills/mock-interview/SKILL.md
@@ -7,9 +7,11 @@ description: Use when generating interviewer-side mock-interview questions from 
 
 ## Overview
 
-Generate **interviewer-side** mock-interview question sets from a candidate's resume, with drill-down chains that probe each main question to 2–3 deeper levels.
+Generate **interviewer-side** mock-interview question sets from a candidate's resume, with drill-down chains that probe each main question level by level down the same thread.
 
-**Core principle**: Each follow-up question must be a natural next question to the candidate's *previous answer*. Same thread, one level deeper — not a different branch.
+**This is the Socratic method applied to interviewing.** Each follow-up digs one level deeper into the candidate's *previous answer* — same thread, never a sibling branch — and the chain keeps going until the candidate either reaches solid ground (genuine first-hand depth) or their reasoning collapses and they hit the edge of what they actually understand. **That terminus — solid ground vs. collapse, and how deep it took to reach — is the signal the interview exists to produce.**
+
+**Core principle**: Each follow-up question must be a natural next question to the candidate's *previous answer*. Same thread, one level deeper — not a different branch. Stop only when the thread itself terminates (see Chain Depth Decision).
 
 **This is a collaborative co-design process with the interviewer, NOT a one-shot generator.** The two rules below are mandatory and define how this skill works.
 
@@ -23,7 +25,7 @@ Do not dump a finished set. Build it *with* the interviewer, question by questio
 
 - **Direction**: "이 질문 이런 방향(키워드 X)으로 가려는데 어때?"
 - **Follow-up candidates**: "이 답변 다음 꼬리질문 후보가 (A) …, (B) … 인데 뭐가 더 좋아?"
-- **Happy-case keywords + evidence**: "이 질문엔 이런 키워드로 답이 나와야 할 것 같고, 이력서 근거가 X라서 ✅(또는 ⚠️)로 봤는데 동의해?"
+- **Happy-case keywords + evidence**: "이 질문엔 이런 키워드로 답이 나와야 할 것 같고, 이력서 근거는 X야(또는 이력서엔 없고 후보 이해도를 떠보는 질문이야) — 동의해?"
 
 Incorporate the interviewer's answer, then move on. You may batch the stages of ONE chain (one area) into a single checkpoint message, but **never batch multiple areas or the full set, and never ask for a blanket rubber-stamp** — each stage's direction / keywords / evidence must be individually visible and individually confirmable, and you wait for per-stage feedback before the next area. **The process and its granularity ARE the product** — the interviewer's domain judgment is what makes the keywords and evidence correct.
 
@@ -88,7 +90,7 @@ Triggers that map to THIS skill:
 2. Extract project-by-project facts.
 3. Identify 5–10 candidate high-signal areas (trade-off decision, design rationale, or operational depth).
    → PING-PONG: present the area list, ask "이 영역들 어때? 더 팔 곳 / 뺄 곳?" Incorporate before continuing.
-4. For each agreed area, present the chain as ONE checkpoint (Rule 1a batching): show the Main question and each stage — direction / happy-case keywords / evidence / ✅⚠️ marker individually visible — and wait for the interviewer's per-stage feedback before moving to the next area. Apply the Chain Depth Decision flowchart per stage; stop the chain when it says stop (depth 2 with ⚠️ is normal). Never rubber-stamp a whole chain; never batch multiple areas into one checkpoint.
+4. For each agreed area, present the chain as ONE checkpoint (Rule 1a batching): show the Main question and each stage — direction / happy-case keywords / resume evidence individually visible — and wait for the interviewer's per-stage feedback before moving to the next area. Apply the Chain Depth Decision per stage; keep drilling the same thread until it terminates (the candidate reaches solid ground, or a natural next question no longer follows). Never rubber-stamp a whole chain; never batch multiple areas into one checkpoint.
 5. Assemble the agreed draft per Required Deliverable Structure (incl. [Interviewer Guide] blocks, 1-page summary).
 6. COUNCIL VALIDATION (default): load references/council-iteration.md via Read tool, run council on the 10 review axes, iterate to unanimous APPROVE, bring each round's conflicts back to the interviewer. (If the interviewer opted out: run exactly one silent council round — auto-apply verified factual-error fixes and consensus fixes, no user arbitration — then ship.)
 7. Ship after unanimous APPROVE (or the interviewer explicitly stops).
@@ -98,7 +100,7 @@ Triggers that map to THIS skill:
 
 ## Chain Depth Decision
 
-The most common per-chain failure is grinding to stage 3 when the resume cannot support it. Use this flowchart at each potential next stage.
+Drill the same thread until it terminates. There is exactly ONE reason to stop: no natural next question follows from the prior answer. Use this at each potential next stage.
 
 ```dot
 digraph chain_depth {
@@ -106,24 +108,25 @@ digraph chain_depth {
     node [shape=box, style=rounded];
 
     "Does a natural next question\nfollow from the prior answer?" [shape=diamond];
-    "Does the resume back an answer\nat this depth?" [shape=diamond];
 
     "Just heard the prior stage's answer" -> "Does a natural next question\nfollow from the prior answer?";
-    "Does a natural next question\nfollow from the prior answer?" -> "STOP — anything you add now\nis a sibling branch, not depth" [label="no"];
-    "Does a natural next question\nfollow from the prior answer?" -> "Does the resume back an answer\nat this depth?" [label="yes"];
-    "Does the resume back an answer\nat this depth?" -> "Mark ✅ — write the next stage.\nFailure to answer = scoring signal" [label="yes"];
-    "Does the resume back an answer\nat this depth?" -> "Mark ⚠️ — write it but tell the interviewer\nnot to force depth here" [label="no"];
+    "Does a natural next question\nfollow from the prior answer?" -> "STOP — the thread terminated:\nsolid ground reached, or the candidate\nhit the edge of their knowledge.\nThat terminus IS the signal." [label="no"];
+    "Does a natural next question\nfollow from the prior answer?" -> "Write the next stage and keep drilling —\neven past what the resume explicitly states." [label="yes"];
 }
 ```
 
-**Rule**: Going deeper than the resume supports is not "thoroughness" — it forces the candidate to invent answers under pressure, inflating false negatives.
+If the only way to "continue" is to jump to a different aspect, that is a sibling branch, not depth — stop this chain and open a new Main question (Rule 2).
+
+**Do NOT stop because the resume text "ran out."** The resume records what the candidate *claimed*, not the limit of what is worth probing — and real understanding usually lies *past* the literal resume text. A natural next question on the same thread is fair game no matter how deep it goes.
+
+**Fairness guard:** keep "I don't know" (모르겠습니다) cost-free. Deep drilling is fair *only* if admitting the edge of one's knowledge is cheap — then a collapse is honest signal, not a manufactured one. A candidate who invents an answer under pressure does so because the *interviewer punishes "I don't know,"* not because the question is deep — so fix the reaction, not the depth. The Interviewer Guide should say "if they reach their limit and say so, that is a clean terminus — note the depth and move on," never "they should have known this."
 
 ## Anatomy of a Good Stage
 
 Use numeric main-question IDs (`Q1`, `Q2`, …). Never use letter suffixes (`Q-A`, `Q-B`, `Q-C`) — those signal sibling branching, which Rule 2 forbids.
 
 ```markdown
-### Q{n} → stage-{N} drill-down (✅ or ⚠️)
+### Q{n} → stage-{N} drill-down
 
 > [Natural next question from the prior stage's expected answer]
 
@@ -134,21 +137,8 @@ Use numeric main-question IDs (`Q1`, `Q2`, …). Never use letter suffixes (`Q-A
 - [Operational signals — not buzzwords]
 - *(Bonus, if mentioned spontaneously)* [Vendor / framework nuance — extra credit only; absence is not a scoring penalty]
 
-**Resume evidence**: [Direct quote from resume OR explicit "depends on candidate's operational judgment" if ⚠️]
+**Resume evidence**: [Direct quote from resume that anchors this stage — OR, when the stage probes past the literal resume, say so plainly (e.g. "beyond the resume: does the GET_LOCK claim rest on real understanding of its lack of TTL?"). This line tells the interviewer how to read a failure here: a contradicted claim, or just the edge of the candidate's knowledge.]
 ```
-
-## Marker Convention (Mandatory)
-
-Every drill-down stage MUST carry exactly one marker:
-
-| Marker | Meaning | Interviewer Implication |
-|--------|---------|-------------------------|
-| **✅** | Directly stated in resume — candidate has evidence to answer | Failure to answer is a scoring signal |
-| **⚠️** | No direct resume backing — general operational knowledge area | Failure to answer is normal; do not force chain deeper |
-
-**Why this matters**: Without markers, the interviewer applies the same expectation to backed and unbacked stages — producing false negatives in ⚠️ areas.
-
-**Mixed-backing stage** (happy-case keywords mix resume-direct facts with operational-judgment items): set the marker to the **weakest backing level** (conservative), OR move operational items into a `*(Bonus, if mentioned spontaneously)*` sub-bullet so the stage body stays ✅. Both are legitimate. **Leaving the stage marked ✅ while mixing in unbacked keywords is unsafe** — the interviewer will hold the candidate to ✅-grade expectation on items the resume does not actually back.
 
 ## Happy-case Keyword Rules
 
@@ -237,7 +227,7 @@ Bad mapping is worse than no mapping. Example: mapping medical-reservation concu
 ## Required Deliverable Structure
 
 1. **Part 1 — Resume body extracted as markdown**: For PDF/image resumes, render the resume content at the top (personal info, experience, projects, activities). Interviewers cross-check facts without reopening the PDF.
-2. **Part 2 — Areas (5–10)**: Main → stage-1 → stage-2 → (stage-3 if backed). Every stage carries a marker.
+2. **Part 2 — Areas (5–10)**: Main → drill-down stages, each a natural next question down the same thread, continuing until the thread terminates (solid ground or the edge of the candidate's knowledge). Each stage's Resume-evidence line says whether it is anchored in the resume or probes past it.
 3. **Interviewer Usage Guide**: Progression principles, area priority, time allocation for 60/90-minute modes.
 4. **1-page Compressed Summary** (table): area name, main one-liner, drill-down stages, time — scannable at a glance.
 5. **Red / Green Flag Checklist**: signals for evaluating responses.
@@ -246,7 +236,7 @@ Bad mapping is worse than no mapping. Example: mapping medical-reservation concu
 
 **This is the corrected design.** Earlier versions made council an opt-in "quality gate" — that was wrong. Council is the DEFAULT final step.
 
-Send the interviewer-agreed draft through a multi-model council on the **10 review axes** (chain naturalness, resume-backing accuracy, happy-case senior discrimination, factual accuracy, depth appropriateness, utterance separation, difficulty calibration, question fairness, domain-mapping accuracy, area coverage — full definitions in `references/council-iteration.md`).
+Send the interviewer-agreed draft through a multi-model council on the **10 review axes** (chain naturalness, evidence-line honesty, happy-case senior discrimination, factual accuracy, depth appropriateness, utterance separation, difficulty calibration, question fairness, domain-mapping accuracy, area coverage — full definitions in `references/council-iteration.md`).
 
 **Do not expect one round.** Typically 3–7 rounds. "round-2-pass + minor polish" ≠ ship-ready.
 
@@ -265,7 +255,9 @@ Send the interviewer-agreed draft through a multi-model council on the **10 revi
 | "Company name appeared — auto-add domain mapping" | Domain mapping is opt-in. Auto-adding produces bad analogies and gets rejected. |
 | "This fact is common knowledge" | See the fact-check table. LLMs get these wrong often. |
 | "The interviewer will know to break it up" | A single visual block gets read aloud as one block. Use [Interviewer Guide] separators. |
-| "All stages must reach depth 3" | Depth 3 is a ceiling, not a floor. Stopping at depth 2 is normal — the ⚠️ marker signals it. |
+| "All stages must reach depth 3" | Depth is set by the thread, not a quota. A chain stops when no natural next question follows — that may be depth 2 or depth 5. Don't pad to a number. |
+| "The resume doesn't back this depth, so stop" | The resume is what they *claimed*, not the limit of what's worth probing. If a natural next question follows on the same thread, drill it — real understanding usually ends past the literal resume text. |
+| "They couldn't answer the deep one — mark them down" | Reaching the edge of one's knowledge is a clean terminus, not a deduction. Only a collapse on *claimed* territory (contradicting their own resume) is a negative signal. Keep "I don't know" cost-free. |
 
 ## Red Flags — Stop and Restart
 
@@ -275,12 +267,12 @@ If any of these appear, **stop and correct**:
 - Shipping without council validation — the default path requires council to unanimous APPROVE; opt-out fast mode requires exactly one silent round. Zero council rounds is ALWAYS a red flag.
 - Finalizing direction / keywords / evidence without asking the interviewer "이거 어때?"
 - Sibling-branch notation (`Q-A`, `Q-B`, `Q-C` used as follow-ups)
-- Any stage without a marker
 - Two or more questions packed into a single quote block
 - Domain-mapping area present when the user did not request one
 - Happy-case lists that are buzzword soup
-- All areas uniformly reach depth 3 regardless of resume backing strength
+- A chain stopped at the resume boundary while a natural next question on the same thread still existed (the collapse point was never reached)
+- All chains padded to the same depth regardless of where each thread naturally terminates
 
 ## Bottom Line
 
-This skill is a collaborative co-design loop, not a generator. Build the question set *with* the interviewer one question at a time (Rule 1a), keep every follow-up a true depth chain (Rule 2), then validate to unanimous council APPROVE (Rule 1b). The process and its granularity are the product — a finished artifact dumped in one shot, however polished, is the failure mode this skill exists to prevent.
+This skill is a collaborative co-design loop, not a generator. Build the question set *with* the interviewer one question at a time (Rule 1a), keep every follow-up a true depth chain drilled to where the candidate's understanding actually ends (Rule 2), then validate to unanimous council APPROVE (Rule 1b). The process and its granularity are the product — a finished artifact dumped in one shot, however polished, is the failure mode this skill exists to prevent.

--- a/skills/mock-interview/SKILL.md
+++ b/skills/mock-interview/SKILL.md
@@ -52,7 +52,7 @@ Default LLM behavior is to produce a branching tree when asked for "3-level foll
 |------------------------|--------------------------|
 | Q → Q-A / Q-B / Q-C (3 keyword branches) → each branches again | Q → natural next question from Q's answer → natural next question from that answer → … |
 | Interviewer jumps onto a different path based on answer keyword | Interviewer goes one level deeper on the same thread |
-| Tree depth = 2–3, but each path is shallow | Chain depth = 2–3, each level deepens the same topic |
+| Spreads into sibling branches — each path stays shallow | One thread, each level deepening it to its natural terminus (see Chain Depth Decision) |
 
 **Test**: If Q3 would still make sense without hearing the Q2 answer, it is a sibling branch, not a depth chain.
 

--- a/skills/mock-interview/references/council-iteration.md
+++ b/skills/mock-interview/references/council-iteration.md
@@ -67,10 +67,10 @@ When validating an interview-question artifact, the council prompt MUST instruct
 | # | Axis | What the reviewer checks | Defect class it catches |
 |---|------|--------------------------|-------------------------|
 | 1 | **Chain naturalness** | Is each stage a natural next question to the prior answer, or a sibling branch? Would stage-N still make sense without hearing stage-(N-1)'s answer? | Fake chains (branching disguised as depth) |
-| 2 | **Resume-backing accuracy** | Does each ✅/⚠️ marker match the actual resume evidence? Any ✅ that the resume doesn't truly support? | Overclaimed backing → false negatives in interview |
+| 2 | **Evidence-line honesty** | Does each stage's Resume-evidence line honestly state whether it is anchored in the resume or probes past it? Any stage claiming a direct resume quote it does not actually have? | Mislabeled backing → interviewer misreads a failure |
 | 3 | **Happy-case senior discrimination** | Are keywords operational signals / dimensional reasoning / vendor nuance, or buzzword soup? | Keyword lists that any buzzword-dropper passes |
 | 4 | **Factual accuracy** | Any wrong technical fact in happy-case keywords? (Cross-check the Fact-Check High-Risk Areas table.) | Interviewer mis-scoring a correct candidate |
-| 5 | **Depth appropriateness** | Any stage forced to depth 3 without resume backing? Any ⚠️ stage mismarked ✅? | Grinding past what the resume supports |
+| 5 | **Depth appropriateness** | Does each chain drill to its natural terminus (solid ground or the edge of the candidate's knowledge), or stop short while a natural next question on the same thread still followed? Is any "deepening" actually a sibling branch? | Chains cut off before the Socratic collapse point |
 | 6 | **Utterance separation** | Are multi-question stages split into [Interviewer Guide] blocks, or packed into one quote block? | Interviewer reads 3 questions aloud at once |
 | 7 | **Difficulty calibration** | Is the difficulty right for the candidate's years of experience? Junior-too-shallow / staff-too-deep? | Wrong-level questions for the candidate |
 | 8 | **Question fairness** | Any no-win gotcha or hypothetical-escape framing? Any question with no winning answer? | Unfair questions that punish good candidates |


### PR DESCRIPTION
## 📌 Summary

mock-interview 스킬의 꼬리질문(drill-down) 모델을 **소크라테스식 심층 추궁**으로 재설계했습니다.

기존 모델은 "이력서가 받쳐주는 깊이"에서 체인을 멈추고 각 단계에 ✅/⚠️ 마커를 달았는데, 이 캡이 **후보의 진짜 이해도를 가르는 결정적 질문(이력서 텍스트 너머)을 잘라내고** 있었습니다. 이제 같은 맥락(thread)을 후보가 *단단한 바닥에 닿거나 무지를 인정할 때까지* 파고들고, **그 종착점 자체를 면접 신호로** 삼습니다.

변경 전후를 서브에이전트 베이스라인(RED)→재설계 검증(GREEN)으로 돌려 행동이 의도대로 반전됨을 확인했습니다.

## 🔧 Changes

### 1. Socratic telos 도입 + 깊이 결정 모델 교체
Chain Depth Decision의 "이력서-backing" 게이트를 제거하고 naturalness 게이트 하나로 단순화했습니다. 규칙은 단순해졌습니다 — *같은 thread에 자연스러운 다음 질문이 있으면 계속, 없으면 종료(=신호)*. 플로차트가 2게이트→1게이트로 줄었습니다.
- **영향 범위**: `skills/mock-interview/SKILL.md` (Overview, Core principle, Chain Depth Decision, Workflow, Bottom Line)

### 2. ✅/⚠️ 마커 컨벤션 제거
마커가 담던 "실패 해석"(이력서 직접 vs 너머)을 stage별 `Resume evidence` 줄이 흡수합니다. 마커는 그 줄의 중복 요약이었습니다.
- **영향 범위**: `skills/mock-interview/SKILL.md` (Marker Convention 섹션 삭제, Anatomy, Required Deliverable Structure, Red Flags)

### 3. 공정 가드(fairness guard) 추가
"모르겠습니다"의 비용을 0으로 유지. 깊은 추궁의 false-negative는 *질문 깊이*가 아니라 *면접관 반응*이 원인이므로, 깊이를 막지 말고 반응을 고치도록 했습니다.
- **영향 범위**: `skills/mock-interview/SKILL.md` (Chain Depth Decision)

### 4. council 리뷰 축 정합
axis 2 라벨을 `Resume-backing accuracy`→`Evidence-line honesty`로 개명(라벨이 재정의된 검사와 모순돼, 근거 없음을 결함으로 오판할 위험), axis 5 정의를 "종료점까지 드릴했는가" 기준으로 갱신.
- **영향 범위**: `skills/mock-interview/references/council-iteration.md`, `SKILL.md` (inline axis 목록)

## 💬 Review Points

### RP1. 이력서-backing 캡 제거 — 공정성을 "깊이 제한"이 아니라 "면접관 반응"으로 이동
- **배경 및 문제 상황**: 기존 스킬은 "이력서보다 깊이 파면 후보가 압박 속에 답을 지어내 false-negative가 는다"며 ⚠️로 깊이를 제한했습니다. 그런데 RED 베이스라인에서 두 에이전트 모두 `GET_LOCK`의 lease/TTL·hang 방어 질문(분산락을 진짜 이해했는지 가르는 결정적 질문)을 *이력서에 없다*는 이유로 stage-2에서 잘랐습니다.
- **해결 방안**: 깊이 결정(ASK)과 채점 해석(SCORE)을 분리. 드릴은 thread 종료까지 자유, false-negative는 "모르겠습니다를 cheap하게" 유지하는 공정 가드로 방어.
- **구현 세부사항**: 플로차트 2게이트→1게이트, 기존 "이력서보다 깊이 = false-negative" 경고 제거, 공정 가드 문단 추가.
- **선택과 트레이드오프**: 깊은 질문이 항상 공정하려면 "면접관이 모르겠습니다를 감점하지 않는다"는 전제에 의존합니다. 이 전제는 prose + 합리화 표로 보강했지만 *구조적으로(산출물 의무로)* 강제하진 않았습니다 — 자율성 vs 강제의 선택. 더 강하게 박을지 의견 환영합니다.

### RP2. ✅/⚠️ 마커 완전 제거 vs 유지
- **배경 및 문제 상황**: 마커는 "이 단계 실패 = 결함인가 / 천장인가"를 알려주는 장치였습니다. 하지만 `Resume evidence` 줄이 이미 "이력서 직접 / 이력서 너머"를 서술해, 마커는 그 줄의 derived summary였습니다. RED에서 두 에이전트가 *같은 stage*에 ✅/⚠️를 상반되게 부여 → 모호성도 입증됐습니다.
- **해결 방안**: 마커 통삭제, evidence 줄이 해석 역할 흡수.
- **선택과 트레이드오프**: 질문셋을 *다른 면접관*에게 넘기거나 *나중에* 볼 땐 glanceable 마커 컬럼이 스캔에 유리하다는 반론이 있었습니다. "단독·즉시 사용" 가정 하에 evidence 줄로 충분하다 판단해 제거했고, 다수 면접관 공유가 늘면 재도입 여지가 있습니다.

## ✅ Checklist

- [ ] Chain Depth Decision에 이력서-backing 게이트와 ✅/⚠️ 분기가 없다
  - `skills/mock-interview/SKILL.md`
- [ ] Marker Convention 섹션이 삭제됐고 stage 마커 잔재가 없다 (Happy-case good/bad 예시 표기는 별개)
  - `skills/mock-interview/SKILL.md`
- [ ] 각 stage의 `Resume evidence` 줄이 "이력서 직접 / 이력서 너머"를 서술하도록 템플릿이 갱신됐다
  - `skills/mock-interview/SKILL.md`
- [ ] council axis 2가 `Evidence-line honesty`로, axis 5 정의가 종료점 기준으로 갱신됐고 inline 목록과 정합한다
  - `skills/mock-interview/references/council-iteration.md`
  - `skills/mock-interview/SKILL.md`
- [ ] 변경은 markdown prose 한정이며 `make validate-schema`·`make typecheck` 통과

## 📎 References

해당 없음 (개인 스킬 레포, 외부 트래커 이슈 없음)