### PR TITLE
feat: pin 스킬 전역 실행 지원

### DIFF
--- a/lib/pin-cli/io.test.ts
+++ b/lib/pin-cli/io.test.ts
@@ -1,0 +1,120 @@
+import { describe, test, expect } from "bun:test";
+import { readEntityFromStdin } from "./io.ts";
+
+/**
+ * Tests for readEntityFromStdin() — specifically the C11 normalization:
+ * when a valid-shaped Entity arrives via stdin WITHOUT a `relations` field,
+ * the function must default it to [] before returning, so the engine's
+ * `for (const relation of fm.relations)` never throws a TypeError.
+ *
+ * The validator checks (in order): 1=type, 2=forbidden, 3=required, 4=enum,
+ * 5=relations. A valid entity reaching check 5 with relations=undefined throws.
+ * This test verifies normalization prevents that.
+ */
+
+/** A minimal valid Entity frontmatter (all required fields, no relations key). */
+const BASE_FRONTMATTER_WITHOUT_RELATIONS = {
+  id: "code-hello-world",
+  type: "code",
+  source: "github",
+  authority: "toong",
+  source_url: "https://github.com/example",
+  tier: "2",
+  tags: "backend",
+  sensitivity: "shared",
+  status: "active",
+  updated_at: "2024-01-01T00:00:00Z",
+  checked_at: "2024-01-01T00:00:00Z",
+  created_at: "2024-01-01T00:00:00Z",
+  // relations intentionally OMITTED — this is the C11 scenario
+};
+
+describe("readEntityFromStdin", () => {
+  test("normalizes missing relations to [] (C11 — stdin path omits relations)", async () => {
+    // Arrange: valid Entity shape but relations field absent
+    const payload = {
+      frontmatter: BASE_FRONTMATTER_WITHOUT_RELATIONS,
+      body: "## 한 줄 요지\n본문",
+    };
+
+    // Inject stdin
+    const originalStdin = process.stdin;
+    const { Readable } = await import("stream");
+
+    await new Promise<void>((resolve, reject) => {
+      const json = JSON.stringify(payload);
+      const chunks: string[] = [json];
+      let chunkIdx = 0;
+
+      const fakeStdin = new Readable({
+        read() {
+          if (chunkIdx < chunks.length) {
+            this.push(chunks[chunkIdx++]);
+            this.push(null); // signal end
+          }
+        },
+      });
+
+      (process as any).stdin = fakeStdin;
+
+      readEntityFromStdin()
+        .then((entity) => {
+          (process as any).stdin = originalStdin;
+          try {
+            // C11: relations must be normalized to [] when absent in stdin
+            expect(entity.frontmatter.relations).toEqual([]);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        })
+        .catch((err) => {
+          (process as any).stdin = originalStdin;
+          reject(err);
+        });
+    });
+  });
+
+  test("preserves existing relations when present", async () => {
+    const payload = {
+      frontmatter: {
+        ...BASE_FRONTMATTER_WITHOUT_RELATIONS,
+        relations: [{ target: "doc-some-ref", type: "related_to" }],
+      },
+      body: "## 한 줄 요지\n본문",
+    };
+
+    const originalStdin = process.stdin;
+    const { Readable } = await import("stream");
+
+    await new Promise<void>((resolve, reject) => {
+      const json = JSON.stringify(payload);
+
+      const fakeStdin = new Readable({
+        read() {
+          this.push(json);
+          this.push(null);
+        },
+      });
+
+      (process as any).stdin = fakeStdin;
+
+      readEntityFromStdin()
+        .then((entity) => {
+          (process as any).stdin = originalStdin;
+          try {
+            expect(entity.frontmatter.relations).toEqual([
+              { target: "doc-some-ref", type: "related_to" },
+            ]);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        })
+        .catch((err) => {
+          (process as any).stdin = originalStdin;
+          reject(err);
+        });
+    });
+  });
+});

--- a/lib/pin-cli/io.ts
+++ b/lib/pin-cli/io.ts
@@ -1,0 +1,141 @@
+/**
+ * Shared I/O orchestration helper for the pin-* skill scripts.
+ *
+ * This module is pure plumbing over the FROZEN pins engine (lib/pins/**). It
+ * centralizes the three cross-cutting concerns that would otherwise be hand-
+ * written in each of the five pin scripts (pin-audit, pin-query, pin-record,
+ * pin-wrap-up, and the absent/exit path shared by all):
+ *
+ *   1. Manifest resolution with the manifest-absent UX contract (D7).
+ *   2. stdin read + JSON-parse with fail-loud on malformed input (D6).
+ *   3. A small, explicit exit-code map.
+ *
+ * It imports the engine through the `@lib/pins/...` alias (never a relative
+ * path) so `make sync`'s dependency collector deploys the engine alongside the
+ * scripts that import this helper. It reimplements NO engine logic — validation,
+ * recording, querying, and parsing all stay in lib/pins/.
+ */
+
+import { resolveManifest, type PinsManifest } from '@lib/pins/manifest';
+import type { Entity } from '@lib/pins/types';
+
+/**
+ * Process exit codes for the pin scripts.
+ *
+ *   SUCCESS (0) — the script completed, OR the manifest was absent and the
+ *                 clean-absent UX path ran (D7). Absent is not an error.
+ *   MALFORMED_INPUT (1) — stdin could not be parsed or lacked required keys (D6).
+ *   ENGINE_ERROR (1) — an engine call (validation, record, query, ...) threw.
+ */
+export const EXIT = {
+  SUCCESS: 0,
+  MALFORMED_INPUT: 1,
+  ENGINE_ERROR: 1,
+} as const;
+
+/** Exact STDOUT line shown when no pins manifest exists in the project (D7). */
+export const ABSENT_MESSAGE =
+  'No pins manifest in this project — run pin-setup to initialize.';
+
+/**
+ * Resolve the pins manifest or take the clean-absent exit path (D7).
+ *
+ * On `{ kind: 'resolved' }` → returns the manifest so the caller proceeds.
+ * On `{ kind: 'absent' }`   → prints {@link ABSENT_MESSAGE} to STDOUT and exits 0.
+ *
+ * Because the absent branch terminates the process, the return type is narrowed
+ * to `PinsManifest`: callers can use the result directly without a kind check.
+ *
+ * `options` are forwarded verbatim to `resolveManifest` (projectRoot/userRoot
+ * default to the engine's git-root-then-$OMT_DIR search).
+ */
+export async function requireManifest(
+  options?: Parameters<typeof resolveManifest>[0],
+): Promise<PinsManifest> {
+  const result = await resolveManifest(options);
+
+  if (result.kind === 'absent') {
+    // Caller-facing, not a diagnostic: stdout + clean exit 0.
+    process.stdout.write(`${ABSENT_MESSAGE}\n`);
+    process.exit(EXIT.SUCCESS);
+  }
+
+  return result.manifest;
+}
+
+/** Read all of STDIN to a string. */
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+/** Whether `value` has the structural shape of an {@link Entity}. */
+function isEntityShape(value: unknown): value is Entity {
+  if (value === null || typeof value !== 'object') return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.frontmatter === 'object' &&
+    obj.frontmatter !== null &&
+    typeof obj.body === 'string'
+  );
+}
+
+/**
+ * Read an {@link Entity} from STDIN, failing LOUD on bad input (D6).
+ *
+ * Reads ALL of stdin, then `JSON.parse` inside try/catch. On a parse failure OR
+ * a payload missing the required `frontmatter` / `body` keys, writes a clear
+ * message to STDERR and exits with {@link EXIT.MALFORMED_INPUT}. Malformed input
+ * is NEVER silently coerced into an empty entity or a no-op.
+ *
+ * This validates only the transport-level Entity SHAPE. Field-level validation
+ * (id/type/source/...) stays in the engine's record path.
+ */
+export async function readEntityFromStdin(): Promise<Entity> {
+  const raw = await readStdin();
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return failMalformed(`stdin is not valid JSON: ${detail}`);
+  }
+
+  if (!isEntityShape(parsed)) {
+    return failMalformed(
+      "stdin JSON is missing required Entity keys 'frontmatter' (object) and 'body' (string)",
+    );
+  }
+
+  return parsed;
+}
+
+/**
+ * Write a malformed-input diagnostic to STDERR and exit non-zero (D6).
+ *
+ * Return type is `never` so callers can `return failMalformed(...)` inside a
+ * function that must otherwise produce a value.
+ */
+function failMalformed(message: string): never {
+  process.stderr.write(`[pin] malformed input: ${message}\n`);
+  process.exit(EXIT.MALFORMED_INPUT);
+}
+
+/**
+ * Write an engine-error diagnostic to STDERR and exit non-zero.
+ *
+ * Use at a script's top-level catch around engine calls so failures surface
+ * with a clear message and a non-zero status instead of an unhandled rejection.
+ */
+export function failEngine(message: string): never {
+  process.stderr.write(`[pin] engine error: ${message}\n`);
+  process.exit(EXIT.ENGINE_ERROR);
+}

--- a/lib/pin-cli/io.ts
+++ b/lib/pin-cli/io.ts
@@ -118,6 +118,12 @@ export async function readEntityFromStdin(): Promise<Entity> {
     );
   }
 
+  // C11: normalize missing relations to [] so the engine's relation iteration
+  // never throws a TypeError. The disk-read path (entity.ts:parse) already
+  // applies `?? []`; stdin bypasses that, so we do it here instead.
+  const fm = parsed.frontmatter as unknown as Record<string, unknown>;
+  if (fm.relations === undefined) fm.relations = [];
+
   return parsed;
 }
 

--- a/lib/pin-cli/io.ts
+++ b/lib/pin-cli/io.ts
@@ -10,14 +10,17 @@
  *   2. stdin read + JSON-parse with fail-loud on malformed input (D6).
  *   3. A small, explicit exit-code map.
  *
- * It imports the engine through the `@lib/pins/...` alias (never a relative
- * path) so `make sync`'s dependency collector deploys the engine alongside the
- * scripts that import this helper. It reimplements NO engine logic — validation,
- * recording, querying, and parsing all stay in lib/pins/.
+ * It imports the engine via relative paths (`../pins/...`) rather than the
+ * `@lib/` alias because this module lives under `lib/` and the sync
+ * alias-rewriter skips `lib/**` files — a deployed `@lib/` alias here would
+ * never be rewritten and would crash at import. Relative imports match the
+ * intra-`lib/` convention, and `make sync`'s dependency collector follows them
+ * to deploy the engine alongside this helper. It reimplements NO engine logic —
+ * validation, recording, querying, and parsing all stay in lib/pins/.
  */
 
-import { resolveManifest, type PinsManifest } from '@lib/pins/manifest';
-import type { Entity } from '@lib/pins/types';
+import { resolveManifest, type PinsManifest } from '../pins/manifest';
+import type { Entity } from '../pins/types';
 
 /**
  * Process exit codes for the pin scripts.

--- a/lib/review-skill-consistency.test.ts
+++ b/lib/review-skill-consistency.test.ts
@@ -76,14 +76,14 @@ function implResumeForm(jobTs: string): ArgForm | null {
 function docResumeForms(skillMd: string): ArgForm[] {
   return readFileSync(skillMd, "utf-8")
     .split("\n")
-    .filter((l) => /job\.ts resume-member\s/.test(l))
+    .filter((l) => /job\.ts"? resume-member\s/.test(l))
     .map((l) => (/--(?:job|member|prompt)\b/.test(l) ? "flag" : "positional"));
 }
 
 /** Subcommands referenced anywhere in the SKILL.md body. */
 function bodySubcommands(skillMd: string): Set<string> {
   const subs = new Set<string>();
-  const re = new RegExp(`job\\.ts (${SUBCOMMAND})\\b`, "g");
+  const re = new RegExp(`job\\.ts"? (${SUBCOMMAND})\\b`, "g");
   for (const m of readFileSync(skillMd, "utf-8").matchAll(re)) subs.add(m[1]);
   return subs;
 }
@@ -97,7 +97,7 @@ function whitelistSubcommands(skillMd: string): Set<string> | null {
   const start = lines.findIndex((l) => /^#{1,6}\s+Allowed Bash Usage/.test(l));
   if (start === -1) return null;
   const subs = new Set<string>();
-  const re = new RegExp(`job\\.ts (${SUBCOMMAND})\\b`, "g");
+  const re = new RegExp(`job\\.ts"? (${SUBCOMMAND})\\b`, "g");
   for (let i = start + 1; i < lines.length; i++) {
     if (/^#{1,6}\s/.test(lines[i])) break; // next heading ends the section
     for (const m of lines[i].matchAll(re)) subs.add(m[1]);

--- a/skills/pin-audit/SKILL.md
+++ b/skills/pin-audit/SKILL.md
@@ -9,18 +9,8 @@ Run a read-only health check over the pin knowledge graph by calling `audit(inpu
 
 ## Invocation
 
-```ts
-import { audit } from "lib/pins/audit.ts";
-import { resolveManifest } from "lib/pins/manifest.ts";
-
-const result = await resolveManifest();
-if (result.kind !== "resolved") throw new Error("pins manifest absent");
-
-const report: AuditReport = await audit(
-  result.manifest.location, // string path resolved from pins.yaml — or an Entity[] array for scoped checks
-  { now: new Date() }       // required for stale detection; omit to skip stale checks entirely
-);
-// report.findings: AuditFinding[]
+```bash
+bun "${CLAUDE_SKILL_DIR}/scripts/audit.ts"
 ```
 
 `audit` is read-only. It does not write, delete, or modify any file.

--- a/skills/pin-audit/scripts/audit.ts
+++ b/skills/pin-audit/scripts/audit.ts
@@ -1,0 +1,16 @@
+#!/usr/bin/env bun
+import { audit } from '@lib/pins/audit';
+import { requireManifest, failEngine } from '@lib/pin-cli/io';
+
+if (import.meta.main) {
+  const manifest = await requireManifest();
+
+  let result;
+  try {
+    result = await audit(manifest.location, { now: new Date() });
+  } catch (err) {
+    failEngine(err instanceof Error ? err.message : String(err));
+  }
+
+  console.log(JSON.stringify(result.findings, null, 2));
+}

--- a/skills/pin-query/SKILL.md
+++ b/skills/pin-query/SKILL.md
@@ -15,21 +15,13 @@ The full entity set is always covered, including pins with no outgoing relations
 
 ## Invocation
 
-Resolve `pinsDir` from the manifest before calling `query`:
+Run the bundled script from the deployed skill directory:
 
-```ts
-import { resolveManifest } from "lib/pins/manifest.ts";
-import { query } from "lib/pins/query.ts";
-
-const result = await resolveManifest();
-if (result.kind === 'absent') { /* handle missing manifest */ }
-const pinsDir = result.manifest.location;
-
-const results = query(pinsDir, { type: 'code', tags: ['auth'] });
-// returns QueryResult[]  — each: { id: string, frontmatter: Frontmatter }
+```bash
+bun "${CLAUDE_SKILL_DIR}/scripts/query.ts" [--type <type>] [--tags <tag1,tag2>] [--source <source>]
 ```
 
-`pinsDir` is `manifest.location` as resolved by `resolveManifest()` (from `lib/pins/manifest.ts`). Omit any criterion to leave that field unrestricted.
+`--tags` accepts a comma-separated list; all tags must match (AND semantics). Omit any flag to leave that field unrestricted. The script resolves the manifest automatically — if no manifest exists it prints the absent message and exits 0.
 
 ## Presenting results
 

--- a/skills/pin-query/scripts/query.ts
+++ b/skills/pin-query/scripts/query.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env bun
+/**
+ * CLI wrapper for lib/pins/query — retrieves matching pin entries from the
+ * knowledge graph and prints them as a JSON array to stdout.
+ *
+ * Usage:
+ *   bun "${CLAUDE_SKILL_DIR}/scripts/query.ts" [--type <type>] [--tags <a,b>] [--source <source>]
+ *
+ * Flags:
+ *   --type    EntityType filter (e.g. "code", "decision")
+ *   --tags    Comma-separated tag list; all must match (AND semantics)
+ *   --source  PinSource filter (e.g. "inline", "url")
+ *
+ * Exit codes:
+ *   0 — success, or manifest absent (prints the absent message)
+ *   1 — engine error
+ */
+
+import { query, type QueryCriteria } from '@lib/pins/query';
+import { requireManifest, failEngine } from '@lib/pin-cli/io';
+
+if (import.meta.main) {
+  const args = process.argv.slice(2);
+
+  // Parse --flag value pairs
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith('--') && i + 1 < args.length) {
+      flags[arg.slice(2)] = args[i + 1];
+      i++;
+    }
+  }
+
+  // requireManifest handles the absent case: prints the absent line + exits 0
+  const manifest = await requireManifest();
+
+  const criteria: QueryCriteria = {};
+  if (flags['type'] !== undefined) {
+    criteria.type = flags['type'] as QueryCriteria['type'];
+  }
+  if (flags['tags'] !== undefined) {
+    criteria.tags = flags['tags'].split(',').map((t) => t.trim()).filter(Boolean);
+  }
+  if (flags['source'] !== undefined) {
+    criteria.source = flags['source'] as QueryCriteria['source'];
+  }
+
+  let results;
+  try {
+    results = query(manifest.location, criteria);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    failEngine(message);
+  }
+
+  console.log(JSON.stringify(results, null, 2));
+}

--- a/skills/pin-record/SKILL.md
+++ b/skills/pin-record/SKILL.md
@@ -9,14 +9,14 @@ Record a single canonical entity to the pins knowledge graph via `lib/pins/recor
 
 ## API
 
-```ts
-import { record } from 'lib/pins/record.ts';
-
-await record(entity, { location });
+```bash
+printf '%s' "$ENTITY_JSON" | bun "${CLAUDE_SKILL_DIR}/scripts/record.ts"
 ```
 
-- `entity` — an `Entity` object with `frontmatter` + `body` (see `lib/pins/types.ts`)
-- `location` — the manifest-resolved pins directory (from `pins.yaml`)
+Pipe the JSON-serialized `Entity` object (`{ frontmatter, body }`) to stdin. The script resolves the manifest, calls `record()`, and prints `{"id":"<id>","status":"recorded"|"escaped"}` to stdout.
+
+- `ENTITY_JSON` — a JSON-serialized `Entity` with `frontmatter` + `body` (see `lib/pins/types.ts`)
+- The manifest supplies `location` — the manifest-resolved pins directory (from `pins.yaml`)
 
 `record()` validates first. If invalid, the entity is appended to `<location>/.escape.jsonl` and no `.md` file is written. If valid:
 - Fresh write: sets `status='active'`; `updated_at` defaults to `created_at` if not provided. Uses `O_EXCL` (`wx` flag) for atomic create.

--- a/skills/pin-record/scripts/record.test.ts
+++ b/skills/pin-record/scripts/record.test.ts
@@ -1,0 +1,167 @@
+#!/usr/bin/env bun
+
+/**
+ * Integration tests for the record.ts CLI wrapper.
+ *
+ * C10: invalid entity whose id.md already exists must report "escaped", not "recorded".
+ * Valid entity must report "recorded".
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const RECORD_PATH = path.join(import.meta.dirname, 'record.ts');
+
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'pin-record-test-'));
+}
+
+/** Write a minimal pins.yaml into dir so requireManifest can resolve it. */
+function writePinsYaml(dir: string, pinsDir: string): void {
+  fs.writeFileSync(
+    path.join(dir, 'pins.yaml'),
+    `location: ${pinsDir}\nscope: private\n`,
+    'utf8',
+  );
+}
+
+/**
+ * Spawn record.ts with the given JSON payload as stdin.
+ * cwd and OMT_DIR are both set to projectDir so requireManifest finds pins.yaml there.
+ */
+async function runRecord(
+  projectDir: string,
+  entityJson: string,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(['bun', RECORD_PATH], {
+    cwd: projectDir,
+    stdin: new TextEncoder().encode(entityJson),
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: { ...process.env, OMT_DIR: projectDir },
+  });
+  const exitCode = await proc.exited;
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  return { exitCode, stdout, stderr };
+}
+
+/** Minimal valid Frontmatter that passes tbox validation. */
+function validFrontmatter(id: string) {
+  return {
+    id,
+    type: 'code',
+    source: 'github',
+    authority: 'test',
+    source_url: 'https://example.com',
+    tier: '1',
+    tags: 'test',
+    sensitivity: 'private',
+    status: 'active' as const,
+    updated_at: '2026-01-01T00:00:00Z',
+    checked_at: '2026-01-01T00:00:00Z',
+    created_at: '2026-01-01T00:00:00Z',
+    relations: [],
+  };
+}
+
+/** Frontmatter with an invalid type — triggers unknown_type validation failure. */
+function invalidFrontmatter(id: string) {
+  return {
+    ...validFrontmatter(id),
+    type: 'not-a-real-type',
+  };
+}
+
+// ── C10: existing .md + invalid entity → escaped, not recorded ───────────────
+
+describe('C10 — existing id.md + invalid entity reports escaped', () => {
+  let tmpDir: string;
+  let pinsDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    pinsDir = path.join(tmpDir, 'pins');
+    fs.mkdirSync(pinsDir, { recursive: true });
+    writePinsYaml(tmpDir, pinsDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('reports escaped when id.md exists and entity is invalid', async () => {
+    const id = 'test-entity-c10';
+
+    // Pre-create the .md file to simulate an existing pin
+    fs.writeFileSync(path.join(pinsDir, `${id}.md`), '# existing pin\n', 'utf8');
+
+    const payload = JSON.stringify({
+      frontmatter: invalidFrontmatter(id),
+      body: '## 한 줄 요지\ntest',
+    });
+
+    const { exitCode, stdout } = await runRecord(tmpDir, payload);
+
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout.trim());
+    expect(result.id).toBe(id);
+    // C10: must be "escaped", not "recorded"
+    expect(result.status).toBe('escaped');
+  });
+
+  test('.escape.jsonl grows when entity is invalid', async () => {
+    const id = 'test-entity-c10-size';
+
+    fs.writeFileSync(path.join(pinsDir, `${id}.md`), '# existing pin\n', 'utf8');
+
+    const escapePath = path.join(pinsDir, '.escape.jsonl');
+    const sizeBefore = fs.existsSync(escapePath) ? fs.statSync(escapePath).size : 0;
+
+    const payload = JSON.stringify({
+      frontmatter: invalidFrontmatter(id),
+      body: '## 한 줄 요지\ntest',
+    });
+
+    await runRecord(tmpDir, payload);
+
+    const sizeAfter = fs.existsSync(escapePath) ? fs.statSync(escapePath).size : 0;
+    expect(sizeAfter).toBeGreaterThan(sizeBefore);
+  });
+});
+
+// ── Valid entity with no existing .md → recorded ─────────────────────────────
+
+describe('Valid entity reports recorded', () => {
+  let tmpDir: string;
+  let pinsDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    pinsDir = path.join(tmpDir, 'pins');
+    fs.mkdirSync(pinsDir, { recursive: true });
+    writePinsYaml(tmpDir, pinsDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('reports recorded when entity is valid and no existing .md', async () => {
+    const id = 'test-entity-valid-new';
+
+    const payload = JSON.stringify({
+      frontmatter: validFrontmatter(id),
+      body: '## 한 줄 요지\ntest\n## SSOT 위치\nhere\n## 전후 컨텍스트\nctx\n## 관련 cross-link\nnone',
+    });
+
+    const { exitCode, stdout } = await runRecord(tmpDir, payload);
+
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout.trim());
+    expect(result.id).toBe(id);
+    expect(result.status).toBe('recorded');
+  });
+});

--- a/skills/pin-record/scripts/record.ts
+++ b/skills/pin-record/scripts/record.ts
@@ -20,12 +20,15 @@
 
 import { record } from '@lib/pins/record';
 import { requireManifest, readEntityFromStdin, failEngine } from '@lib/pin-cli/io';
-import { existsSync } from 'fs';
+import { existsSync, statSync } from 'fs';
 import { join } from 'path';
 
 if (import.meta.main) {
   const entity = await readEntityFromStdin();
   const manifest = await requireManifest();
+
+  const escapePath = join(manifest.location, '.escape.jsonl');
+  const escapeSizeBefore = existsSync(escapePath) ? statSync(escapePath).size : 0;
 
   try {
     await record(entity, { location: manifest.location });
@@ -34,8 +37,8 @@ if (import.meta.main) {
   }
 
   const id = entity.frontmatter.id;
-  const pinPath = join(manifest.location, `${id}.md`);
-  const status = existsSync(pinPath) ? 'recorded' : 'escaped';
+  const escapeSizeAfter = existsSync(escapePath) ? statSync(escapePath).size : 0;
+  const status = escapeSizeAfter > escapeSizeBefore ? 'escaped' : 'recorded';
 
   process.stdout.write(JSON.stringify({ id, status }) + '\n');
 }

--- a/skills/pin-record/scripts/record.ts
+++ b/skills/pin-record/scripts/record.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env bun
+/**
+ * CLI wrapper for lib/pins/record — reads an Entity from stdin, validates,
+ * and writes a canonical .md file to the manifest-resolved location.
+ *
+ * Usage:
+ *   printf '%s' "$ENTITY_JSON" | bun "${CLAUDE_SKILL_DIR}/scripts/record.ts"
+ *
+ * Stdin:
+ *   A JSON-serialized Entity object { frontmatter: Frontmatter, body: string }.
+ *   Malformed input writes to stderr and exits non-zero (D6/AC9).
+ *
+ * Stdout (on success):
+ *   A single JSON line: { "id": "<id>", "status": "recorded" | "escaped" }
+ *
+ * Exit codes:
+ *   0 — success, or manifest absent (prints the absent message)
+ *   1 — malformed stdin, or engine error
+ */
+
+import { record } from '@lib/pins/record';
+import { requireManifest, readEntityFromStdin, failEngine } from '@lib/pin-cli/io';
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+if (import.meta.main) {
+  const entity = await readEntityFromStdin();
+  const manifest = await requireManifest();
+
+  try {
+    await record(entity, { location: manifest.location });
+  } catch (err) {
+    failEngine(err instanceof Error ? err.message : String(err));
+  }
+
+  const id = entity.frontmatter.id;
+  const pinPath = join(manifest.location, `${id}.md`);
+  const status = existsSync(pinPath) ? 'recorded' : 'escaped';
+
+  process.stdout.write(JSON.stringify({ id, status }) + '\n');
+}

--- a/skills/pin-setup/SKILL.md
+++ b/skills/pin-setup/SKILL.md
@@ -62,10 +62,8 @@ Confirm the path is correct and the user understands that all pins API calls wil
 
 If the project has legacy pin files (frontmatter with `slug` instead of `id`, no `type` field), run migration after setup:
 
-```ts
-import { migrate } from 'lib/pins/migrate.ts';
-
-await migrate({ location });
+```bash
+bun "${CLAUDE_SKILL_DIR}/scripts/setup.ts" --location "$LOC" --scope "$SCOPE" [--git true|false]
 ```
 
-`migrate()` is idempotent — re-running it is safe. Each legacy file gets a `.bak` sibling before conversion.
+The script writes `pins.yaml` into the current working directory and then runs `migrate()` against the just-written location. `migrate()` is idempotent — re-running it is safe. Each legacy file gets a `.bak` sibling before conversion.

--- a/skills/pin-setup/scripts/setup.test.ts
+++ b/skills/pin-setup/scripts/setup.test.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env bun
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { parse as parseYaml } from 'yaml';
+
+const SETUP_PATH = path.join(import.meta.dirname, 'setup.ts');
+
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'pin-setup-test-'));
+}
+
+/**
+ * Runs setup.ts as a subprocess in cwd=projectDir with the given extra args.
+ * Returns { exitCode, stdout, stderr }.
+ */
+async function runSetup(
+  projectDir: string,
+  args: string[],
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(['bun', SETUP_PATH, ...args], {
+    cwd: projectDir,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    // Ensure non-git temp dir is NOT influenced by outer OMT_DIR.
+    env: { ...process.env, OMT_DIR: undefined as unknown as string },
+  });
+  const exitCode = await proc.exited;
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  return { exitCode, stdout, stderr };
+}
+
+// ── C6: non-existent location does not crash ────────────────────────────────
+
+describe('C6 — missing location directory', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('exits 0 when --location directory does not exist', async () => {
+    const missingLocation = path.join(tmpDir, 'pins-not-yet-created');
+    // Do NOT create missingLocation on disk.
+
+    const { exitCode, stderr } = await runSetup(tmpDir, [
+      '--location', missingLocation,
+      '--scope', 'private',
+    ]);
+
+    expect(stderr).not.toContain('ENOENT');
+    expect(exitCode).toBe(0);
+  });
+});
+
+// ── C7: pins.yaml written to resolveProjectRoot(), not bare cwd ─────────────
+
+describe('C7 — pins.yaml written to project root', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('creates pins.yaml in cwd (project root fallback for non-git dir)', async () => {
+    // tmpDir is not a git repo → resolveProjectRoot() falls back to cwd.
+    const missingLocation = path.join(tmpDir, 'pins');
+
+    const { exitCode } = await runSetup(tmpDir, [
+      '--location', missingLocation,
+      '--scope', 'private',
+    ]);
+
+    expect(exitCode).toBe(0);
+    const manifestPath = path.join(tmpDir, 'pins.yaml');
+    expect(fs.existsSync(manifestPath)).toBe(true);
+  });
+});
+
+// ── C8: special characters in location survive yaml round-trip ──────────────
+
+describe('C8 — special characters in location', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('location with # is preserved after yaml round-trip', async () => {
+    // Path containing a hash — would be mis-parsed as a comment by naive interpolation.
+    const hashLocation = path.join(tmpDir, 'pins #1');
+
+    const { exitCode } = await runSetup(tmpDir, [
+      '--location', hashLocation,
+      '--scope', 'private',
+    ]);
+
+    expect(exitCode).toBe(0);
+    const manifestPath = path.join(tmpDir, 'pins.yaml');
+    const text = fs.readFileSync(manifestPath, 'utf8');
+    const parsed = parseYaml(text) as { location: string; scope: string };
+    expect(parsed.location).toBe(hashLocation);
+  });
+
+  test('location with leading/trailing spaces is preserved after yaml round-trip', async () => {
+    // Use a symlink-style indirect test: the path itself contains a space (common).
+    const spaceLocation = path.join(tmpDir, 'my pins');
+
+    const { exitCode } = await runSetup(tmpDir, [
+      '--location', spaceLocation,
+      '--scope', 'private',
+    ]);
+
+    expect(exitCode).toBe(0);
+    const manifestPath = path.join(tmpDir, 'pins.yaml');
+    const text = fs.readFileSync(manifestPath, 'utf8');
+    const parsed = parseYaml(text) as { location: string; scope: string };
+    expect(parsed.location).toBe(spaceLocation);
+  });
+});

--- a/skills/pin-setup/scripts/setup.ts
+++ b/skills/pin-setup/scripts/setup.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env bun
+/**
+ * pin-setup: write pins.yaml into the current project, then migrate legacy pins.
+ *
+ * Usage:
+ *   bun setup.ts --location <abs-path> --scope <private|shared> [--git <true|false>]
+ *
+ * Argv-driven and non-interactive. The AI skill gathers values via interview,
+ * then invokes this script. This is the ONLY script that creates pins.yaml —
+ * it does NOT call resolveManifest (D3 exception: setup writes, not reads).
+ *
+ * D8 write-safety: migrate() receives exactly the location written to pins.yaml,
+ * never an inferred cwd path.
+ */
+
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+import { migrate } from '@lib/pins/migrate';
+import { failEngine } from '@lib/pin-cli/io';
+
+// ── Argv parsing ──────────────────────────────────────────────────────────────
+
+function parseArgs(): { location: string; scope: string; git: boolean | null } {
+  const args = process.argv.slice(2);
+  let location: string | null = null;
+  let scope: string | null = null;
+  let git: boolean | null = null;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--location' && args[i + 1]) {
+      location = args[++i];
+    } else if (args[i] === '--scope' && args[i + 1]) {
+      scope = args[++i];
+    } else if (args[i] === '--git' && args[i + 1]) {
+      const val = args[++i];
+      git = val === 'true';
+    }
+  }
+
+  if (!location) {
+    process.stderr.write('[pin-setup] --location is required\n');
+    process.exit(1);
+  }
+  if (!scope || (scope !== 'private' && scope !== 'shared')) {
+    process.stderr.write('[pin-setup] --scope must be "private" or "shared"\n');
+    process.exit(1);
+  }
+
+  return { location, scope, git };
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+if (import.meta.main) {
+  const { location, scope, git } = parseArgs();
+
+  // Write pins.yaml into cwd using the canonical template format.
+  const gitLine = git !== null ? `\ngit: ${git}` : '';
+  const manifest = `# pins.yaml — knowledge graph storage manifest\nlocation: ${location}\nscope: ${scope}${gitLine}\n`;
+
+  const manifestPath = join(process.cwd(), 'pins.yaml');
+  writeFileSync(manifestPath, manifest, 'utf8');
+  process.stdout.write(`[pin-setup] manifest created: ${manifestPath}\n`);
+
+  // Migrate legacy pins at the just-written location (D8: exact same value).
+  try {
+    await migrate({ location });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    failEngine(`migrate failed: ${detail}`);
+  }
+
+  process.stdout.write(`[pin-setup] migration complete: ${location}\n`);
+}

--- a/skills/pin-setup/scripts/setup.ts
+++ b/skills/pin-setup/scripts/setup.ts
@@ -13,10 +13,12 @@
  * never an inferred cwd path.
  */
 
-import { writeFileSync } from 'fs';
+import { writeFileSync, existsSync } from 'fs';
 import { join } from 'path';
+import { stringify as stringifyYaml } from 'yaml';
 import { migrate } from '@lib/pins/migrate';
 import { failEngine } from '@lib/pin-cli/io';
+import { resolveProjectRoot } from '@lib/omt-dir';
 
 // ── Argv parsing ──────────────────────────────────────────────────────────────
 
@@ -54,17 +56,21 @@ function parseArgs(): { location: string; scope: string; git: boolean | null } {
 if (import.meta.main) {
   const { location, scope, git } = parseArgs();
 
-  // Write pins.yaml into cwd using the canonical template format.
-  const gitLine = git !== null ? `\ngit: ${git}` : '';
-  const manifest = `# pins.yaml — knowledge graph storage manifest\nlocation: ${location}\nscope: ${scope}${gitLine}\n`;
+  // Write pins.yaml into the project root (C7: aligns write with resolveManifest read path).
+  const manifestObj: Record<string, unknown> = { location, scope };
+  if (git !== null) manifestObj.git = git;
+  const manifest = `# pins.yaml — knowledge graph storage manifest\n${stringifyYaml(manifestObj)}`;
 
-  const manifestPath = join(process.cwd(), 'pins.yaml');
+  const manifestPath = join(resolveProjectRoot(), 'pins.yaml');
   writeFileSync(manifestPath, manifest, 'utf8');
   process.stdout.write(`[pin-setup] manifest created: ${manifestPath}\n`);
 
   // Migrate legacy pins at the just-written location (D8: exact same value).
+  // C6: skip migrate when location does not yet exist — first record() call creates it.
   try {
-    await migrate({ location });
+    if (existsSync(location)) {
+      await migrate({ location });
+    }
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     failEngine(`migrate failed: ${detail}`);

--- a/skills/pin-wrap-up/SKILL.md
+++ b/skills/pin-wrap-up/SKILL.md
@@ -29,24 +29,17 @@ Show this list to the user before recording. Confirm or prune before writing any
 
 ### 3. Validate, then record confirmed entities
 
-For each confirmed candidate, call `validate()` from `lib/pins/validator.ts` before writing:
+For each confirmed candidate, pipe the JSON-serialized entity to the deployed script:
 
-```ts
-import { validate } from 'lib/pins/validator.ts';
-import { record } from 'lib/pins/record.ts';
-
-const result = await validate(entity);
-if (!result.valid) {
-  // Report failure to the user — do NOT call record()
-  // result.reason and result.message describe the problem
-} else {
-  await record(entity, { location });
-}
+```bash
+printf '%s' "$ENTITY_JSON" | bun "${CLAUDE_SKILL_DIR}/scripts/wrap-up.ts"
 ```
+
+The script validates first. On FAIL it prints `{"valid":false,"reason":"...","message":"..."}` and stops — record is never called. On PASS it records and prints `{"id":"...","status":"recorded"}`.
 
 Build the `entity` with the required body sections and complete frontmatter — see the `pin-record` skill for the body structure and full field reference.
 
-`record()` returns `Promise<void>` — there is no return value to inspect. If validation passed and no exception is thrown, the pin was written.
+If the script exits 0 and prints `"status":"recorded"`, the pin was written.
 
 ### 4. Report
 

--- a/skills/pin-wrap-up/scripts/wrap-up.ts
+++ b/skills/pin-wrap-up/scripts/wrap-up.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env bun
+/**
+ * CLI wrapper for the validate+record pair used by pin-wrap-up.
+ *
+ * Reads an Entity from stdin, validates it against the T-Box schema, and
+ * records it only on a PASS (D5). A FAIL is reported as structured JSON and
+ * the script stops — record() is NEVER called for an invalid entity.
+ *
+ * Usage:
+ *   printf '%s' "$ENTITY_JSON" | bun "${CLAUDE_SKILL_DIR}/scripts/wrap-up.ts"
+ *
+ * Stdin:
+ *   A JSON-serialized Entity object { frontmatter: Frontmatter, body: string }.
+ *   Malformed input writes to stderr and exits non-zero (D6).
+ *
+ * Stdout:
+ *   On validation FAIL: { "valid": false, "reason": "...", "message": "..." }
+ *   On validation PASS: { "id": "<id>", "status": "recorded" }
+ *
+ * Exit codes:
+ *   0 — recorded successfully, or manifest absent (prints the absent message)
+ *   1 — malformed stdin, validation failure, or engine error
+ */
+
+import { validate } from '@lib/pins/validator';
+import { record } from '@lib/pins/record';
+import { requireManifest, readEntityFromStdin, failEngine } from '@lib/pin-cli/io';
+
+if (import.meta.main) {
+  const entity = await readEntityFromStdin();
+  const manifest = await requireManifest();
+
+  let result;
+  try {
+    result = await validate(entity);
+  } catch (err) {
+    failEngine(err instanceof Error ? err.message : String(err));
+  }
+
+  if (!result.valid) {
+    // D5: report and stop — do NOT call record()
+    process.stdout.write(
+      JSON.stringify({ valid: false, reason: result.reason, message: result.message }) + '\n',
+    );
+    process.exit(1);
+  }
+
+  try {
+    await record(entity, { location: manifest.location });
+  } catch (err) {
+    failEngine(err instanceof Error ? err.message : String(err));
+  }
+
+  process.stdout.write(JSON.stringify({ id: entity.frontmatter.id, status: 'recorded' }) + '\n');
+}

--- a/sync.yaml
+++ b/sync.yaml
@@ -2,11 +2,16 @@ path: "~"
 skills:
   items:
     - hud
-    - pin-record
-    - pin-query
-    - pin-audit
-    - pin-wrap-up
-    - pin-setup
+    - component: pin-record
+      platforms: [claude]
+    - component: pin-query
+      platforms: [claude]
+    - component: pin-audit
+      platforms: [claude]
+    - component: pin-wrap-up
+      platforms: [claude]
+    - component: pin-setup
+      platforms: [claude]
     - using-maestro
     - mock-interview
     - scan-pdf-to-notes

--- a/tools/adapters/ts-lib-deps.test.ts
+++ b/tools/adapters/ts-lib-deps.test.ts
@@ -6,6 +6,7 @@ import os from "os";
 import {
   resolveTsLibDependencies,
   collectRequiredLibModules,
+  collectLibDataFiles,
   findRelativeLibImports,
 } from "./ts-lib-deps.ts";
 
@@ -320,6 +321,51 @@ describe("relative import tracking inside lib modules", () => {
     expect(result.has(bLib)).toBe(true);
     expect(result.has(cLib)).toBe(true);
     expect(result.size).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectLibDataFiles (static data-file reference trace)
+// ---------------------------------------------------------------------------
+
+describe("collectLibDataFiles", () => {
+  it('`join(import.meta.dir, "data.yaml")` 패턴 → data.yaml로 끝나는 데이터 파일 추적', async () => {
+    const dataFile = path.join(libDir, "data.yaml");
+    await writeFile(dataFile, "key: value\n");
+
+    const loaderFile = path.join(libDir, "loader.ts");
+    await writeFile(
+      loaderFile,
+      'import { join } from "path";\nconst P = join(import.meta.dir, "data.yaml");\n',
+    );
+
+    const result = await collectLibDataFiles(libDir);
+    const traced = [...result];
+    expect(traced.length).toBe(1);
+    expect(traced[0].endsWith("data.yaml")).toBe(true);
+    expect(result.has(dataFile)).toBe(true);
+  });
+
+  it("`import.meta.dir`/`import.meta.dirname` 패턴이 없는 .ts → 빈 Set", async () => {
+    const plainFile = path.join(libDir, "plain.ts");
+    await writeFile(plainFile, "export const foo = 42;\n");
+
+    const result = await collectLibDataFiles(libDir);
+    expect(result.size).toBe(0);
+  });
+
+  it("`path.join(import.meta.dirname, 'x.yaml')` (dirname + 싱글쿼트) 변형 매칭", async () => {
+    const dataFile = path.join(libDir, "x.yaml");
+    await writeFile(dataFile, "k: v\n");
+
+    const loaderFile = path.join(libDir, "loader.ts");
+    await writeFile(
+      loaderFile,
+      "import path from 'path';\nconst P = path.join(import.meta.dirname, 'x.yaml');\n",
+    );
+
+    const result = await collectLibDataFiles(libDir);
+    expect(result.has(dataFile)).toBe(true);
   });
 });
 

--- a/tools/adapters/ts-lib-deps.test.ts
+++ b/tools/adapters/ts-lib-deps.test.ts
@@ -367,6 +367,23 @@ describe("collectLibDataFiles", () => {
     const result = await collectLibDataFiles(libDir);
     expect(result.has(dataFile)).toBe(true);
   });
+
+  it("data-ref가 libSourceDir 밖을 가리키면 수집하지 않는다", async () => {
+    // Fixture: lib/loader.ts references ../outside.yaml which resolves outside libDir
+    const loaderFile = path.join(libDir, "loader.ts");
+    await writeFile(
+      loaderFile,
+      'import { join } from "path";\nconst P = join(import.meta.dir, "../outside.yaml");\n',
+    );
+
+    // Create the outside file so it would be picked up if the confinement guard were missing
+    const outsideFile = path.join(tmpDir, "outside.yaml");
+    await writeFile(outsideFile, "outside: true\n");
+
+    const result = await collectLibDataFiles(libDir);
+    // outsideFile must NOT be collected — it escapes libDir
+    expect(result.has(outsideFile)).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tools/adapters/ts-lib-deps.ts
+++ b/tools/adapters/ts-lib-deps.ts
@@ -8,6 +8,16 @@ import { logWarn } from "../lib/logger.ts";
 // Matches: from './x', from '../x', import './x', import('../x'), side-effects.
 const RELATIVE_IMPORT_RE = /(?:from|import)\s*[\s(]["'](\.\.?\/[^"']+)["']/g;
 
+// Single source of truth for the static data-file reference matcher. Sibling of
+// RELATIVE_IMPORT_RE; same fresh-RegExp-per-scan rule (build a new
+// `new RegExp(DATA_REF_RE.source, "g")` so `lastIndex` is never shared).
+// Matches a join/path call where `import.meta.dir` (or `import.meta.dirname`) is
+// immediately followed by a STRING LITERAL filename, e.g.
+//   join(import.meta.dir, "tbox.yaml")
+//   path.join(import.meta.dirname, 'x.yaml')
+// Captures the literal filename. Computed/template/variable args don't match.
+const DATA_REF_RE = /import\.meta\.dir(?:name)?\s*,\s*["']([^"']+)["']/g;
+
 /**
  * Recursively resolve `@lib/` import dependencies for a .ts file.
  *
@@ -191,6 +201,75 @@ async function collectTsFiles(dir: string, root: string): Promise<string[]> {
     }
   }
   return results;
+}
+
+/**
+ * Trace static data-file references in a single .ts file.
+ *
+ * Scans for `import.meta.dir`/`import.meta.dirname` immediately followed by a
+ * string-literal filename inside a join/path call (see DATA_REF_RE), e.g.
+ *   join(import.meta.dir, "tbox.yaml")
+ * Each captured literal is resolved against the .ts file's own source directory
+ * and returned as an absolute path (existence on disk is verified).
+ *
+ * Only literal filenames are followed; computed/template/variable args are out
+ * of scope and ignored.
+ */
+async function resolveTsDataReferences(filePath: string): Promise<string[]> {
+  if (filePath.endsWith(".test.ts")) return [];
+
+  let content: string;
+  try {
+    content = await fs.readFile(filePath, "utf8");
+  } catch {
+    return [];
+  }
+
+  const re = new RegExp(DATA_REF_RE.source, "g");
+  const sourceDir = path.dirname(filePath);
+  const dataFiles: string[] = [];
+
+  for (const line of content.split("\n")) {
+    if (line.trimStart().startsWith("//")) continue;
+
+    let match: RegExpExecArray | null;
+    re.lastIndex = 0;
+    while ((match = re.exec(line)) !== null) {
+      const absPath = path.normalize(path.join(sourceDir, match[1]));
+      try {
+        await fs.stat(absPath);
+      } catch {
+        continue;
+      }
+      dataFiles.push(absPath);
+    }
+  }
+
+  return dataFiles;
+}
+
+/**
+ * Scan all .ts files under platformDir and return the deduplicated set of
+ * absolute data-file paths each .ts statically references via
+ * `import.meta.dir`/`import.meta.dirname` + string literal.
+ *
+ * Contract for T2 (syncLib): this is a SEPARATE set from the `.ts` module set
+ * returned by collectRequiredLibModules — that module API is untouched. Each
+ * path is resolved against its referencing .ts file's own source dir.
+ *
+ * Excludes the lib/ subdirectory and *.test.ts files (same as collectTsFiles).
+ */
+export async function collectLibDataFiles(
+  platformDir: string,
+): Promise<Set<string>> {
+  const result = new Set<string>();
+  const tsFiles = await collectTsFiles(platformDir, platformDir);
+  for (const filePath of tsFiles) {
+    for (const dataFile of await resolveTsDataReferences(filePath)) {
+      result.add(dataFile);
+    }
+  }
+  return result;
 }
 
 /**

--- a/tools/adapters/ts-lib-deps.ts
+++ b/tools/adapters/ts-lib-deps.ts
@@ -215,7 +215,7 @@ async function collectTsFiles(dir: string, root: string): Promise<string[]> {
  * Only literal filenames are followed; computed/template/variable args are out
  * of scope and ignored.
  */
-async function resolveTsDataReferences(filePath: string): Promise<string[]> {
+async function resolveTsDataReferences(filePath: string, libSourceDir: string): Promise<string[]> {
   if (filePath.endsWith(".test.ts")) return [];
 
   let content: string;
@@ -236,6 +236,10 @@ async function resolveTsDataReferences(filePath: string): Promise<string[]> {
     re.lastIndex = 0;
     while ((match = re.exec(line)) !== null) {
       const absPath = path.normalize(path.join(sourceDir, match[1]));
+      // Confine to libSourceDir — skip paths that escape it
+      if (!absPath.startsWith(libSourceDir + path.sep) && absPath !== libSourceDir) {
+        continue;
+      }
       try {
         await fs.stat(absPath);
       } catch {
@@ -265,7 +269,7 @@ export async function collectLibDataFiles(
   const result = new Set<string>();
   const tsFiles = await collectTsFiles(platformDir, platformDir);
   for (const filePath of tsFiles) {
-    for (const dataFile of await resolveTsDataReferences(filePath)) {
+    for (const dataFile of await resolveTsDataReferences(filePath, platformDir)) {
       result.add(dataFile);
     }
   }

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -1655,6 +1655,43 @@ describe("syncLib", () => {
     expect(await exists(path.join(libDest, "foo", "other.yaml"))).toBe(false);
   });
 
+  it("lists source-traced data files in dry-run even when no @lib/ imports exist (AC8)", async () => {
+    const libSrc = path.join(rootDir, "lib");
+    // A lib module that statically references a sibling data file via import.meta.dir,
+    // plus the data file itself. This is traced from the SOURCE tree, independent of
+    // whatever the deployed .claude/ tree imports.
+    await writeFile(
+      path.join(libSrc, "pins", "store.ts"),
+      'import { join } from "path";\nexport const P = join(import.meta.dir, "tbox.yaml");\n',
+    );
+    await writeFile(path.join(libSrc, "pins", "tbox.yaml"), "schema: 1\n");
+
+    // The deployed .claude/ tree has NO @lib/ imports → requiredModules is empty.
+    // In dry-run nothing is copied, so collectRequiredLibModules scans this stale
+    // tree and returns 0 modules — the exact AC8 condition.
+    const claudeDir = path.join(targetPath, ".claude");
+    await writeFile(
+      path.join(claudeDir, "agents", "plain.ts"),
+      "export const hello = 'world';\n",
+    );
+
+    const lines: string[] = [];
+    const origStderr = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk: string | Uint8Array) => {
+      if (typeof chunk === "string") lines.push(chunk);
+      return true;
+    };
+    const context = makeContext({ dryRun: true });
+    try {
+      await syncLib(context, targetPath, rootDir, ["claude"]);
+    } finally {
+      process.stderr.write = origStderr;
+    }
+
+    // The dry-run enumeration must still list the source-traced data file.
+    expect(lines.some((l) => l.includes(path.join("pins", "tbox.yaml")))).toBe(true);
+  });
+
   it("rewrites @lib/* import aliases to relative paths via `syncLib`", async () => {
     const libSrc = path.join(rootDir, "lib");
     await fs.mkdir(libSrc, { recursive: true });

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -1624,6 +1624,37 @@ describe("syncLib", () => {
     expect(await exists(path.join(targetPath, ".claude", "lib", "helper.ts"))).toBe(false);
   });
 
+  it("deploys traced static data files (import.meta.dir) but not unreferenced ones via `syncLib`", async () => {
+    const libSrc = path.join(rootDir, "lib");
+    // A lib module that statically references a sibling data file via import.meta.dir.
+    await writeFile(
+      path.join(libSrc, "foo", "x.ts"),
+      'import { join } from "path";\nconst P = join(import.meta.dir, "data.yaml");\nexport const x = P;\n',
+    );
+    // The referenced data file (should deploy) and an unreferenced sibling (should not).
+    await writeFile(path.join(libSrc, "foo", "data.yaml"), "key: value\n");
+    await writeFile(path.join(libSrc, "foo", "other.yaml"), "key: other\n");
+
+    // A deployed component that imports the lib module, so it is collected for deployment.
+    const claudeDir = path.join(targetPath, ".claude");
+    await writeFile(
+      path.join(claudeDir, "agents", "oracle.ts"),
+      "import { x } from '@lib/foo/x';\n",
+    );
+
+    const context = makeContext();
+
+    await syncLib(context, targetPath, rootDir, ["claude"]);
+
+    const libDest = path.join(targetPath, ".claude", "lib");
+    // The .ts module deploys (existing behavior, structure preserved).
+    expect(await exists(path.join(libDest, "foo", "x.ts"))).toBe(true);
+    // The referenced data file deploys, preserving directory structure.
+    expect(await exists(path.join(libDest, "foo", "data.yaml"))).toBe(true);
+    // The unreferenced data file does NOT deploy (no directory sweep).
+    expect(await exists(path.join(libDest, "foo", "other.yaml"))).toBe(false);
+  });
+
   it("rewrites @lib/* import aliases to relative paths via `syncLib`", async () => {
     const libSrc = path.join(rootDir, "lib");
     await fs.mkdir(libSrc, { recursive: true });

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -439,6 +439,14 @@ export async function syncLib(
     return;
   }
 
+  // Static data files a lib module references at runtime via import.meta.dir
+  // (e.g. lib/pins/tbox.yaml). Traced from the lib source tree, never globbed.
+  // Copied verbatim (no alias rewrite — rewriteLibAliases only touches .ts).
+  // Collected BEFORE the early-skip: it traces from SOURCE (independent of the
+  // deployed tree), so a data file can be present even when requiredModules is
+  // empty (notably in dry-run, where the stale prior deployment has no @lib/).
+  const dataFiles = await collectLibDataFiles(libSrc);
+
   for (const platform of platforms) {
     const platformDir = path.join(targetPath, `.${platform}`);
     const libDest = path.join(platformDir, "lib");
@@ -457,14 +465,6 @@ export async function syncLib(
     }
 
     const requiredModules = await collectRequiredLibModules(platformDir, libSrc);
-
-    // Static data files a lib module references at runtime via import.meta.dir
-    // (e.g. lib/pins/tbox.yaml). Traced from the lib source tree, never globbed.
-    // Copied verbatim (no alias rewrite — rewriteLibAliases only touches .ts).
-    // Collected BEFORE the early-skip: it traces from SOURCE (independent of the
-    // deployed tree), so a data file can be present even when requiredModules is
-    // empty (notably in dry-run, where the stale prior deployment has no @lib/).
-    const dataFiles = await collectLibDataFiles(libSrc);
 
     if (requiredModules.size === 0 && dataFiles.size === 0) {
       logInfo(`No @lib/ imports found in .${platform}/, skipping lib deployment`);

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -458,15 +458,18 @@ export async function syncLib(
 
     const requiredModules = await collectRequiredLibModules(platformDir, libSrc);
 
-    if (requiredModules.size === 0) {
-      logInfo(`No @lib/ imports found in .${platform}/, skipping lib deployment`);
-      continue;
-    }
-
     // Static data files a lib module references at runtime via import.meta.dir
     // (e.g. lib/pins/tbox.yaml). Traced from the lib source tree, never globbed.
     // Copied verbatim (no alias rewrite — rewriteLibAliases only touches .ts).
+    // Collected BEFORE the early-skip: it traces from SOURCE (independent of the
+    // deployed tree), so a data file can be present even when requiredModules is
+    // empty (notably in dry-run, where the stale prior deployment has no @lib/).
     const dataFiles = await collectLibDataFiles(libSrc);
+
+    if (requiredModules.size === 0 && dataFiles.size === 0) {
+      logInfo(`No @lib/ imports found in .${platform}/, skipping lib deployment`);
+      continue;
+    }
 
     if (context.dryRun) {
       logDry(`Deploy lib modules to ${libDest}/:`);

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -34,7 +34,7 @@ import {
 import { generateBackupSessionId, backupCategory, cleanupOldBackups } from "./lib/backup.ts";
 import { logInfo, logWarn, logError, logDry, logSuccess } from "./lib/logger.ts";
 import { syncDirectory } from "./lib/sync-directory.ts";
-import { collectRequiredLibModules } from "./adapters/ts-lib-deps.ts";
+import { collectRequiredLibModules, collectLibDataFiles } from "./adapters/ts-lib-deps.ts";
 import { ClaudeAdapter } from "./adapters/claude.ts";
 import { GeminiAdapter } from "./adapters/gemini.ts";
 import { CodexAdapter } from "./adapters/codex.ts";
@@ -463,10 +463,18 @@ export async function syncLib(
       continue;
     }
 
+    // Static data files a lib module references at runtime via import.meta.dir
+    // (e.g. lib/pins/tbox.yaml). Traced from the lib source tree, never globbed.
+    // Copied verbatim (no alias rewrite — rewriteLibAliases only touches .ts).
+    const dataFiles = await collectLibDataFiles(libSrc);
+
     if (context.dryRun) {
       logDry(`Deploy lib modules to ${libDest}/:`);
       for (const dep of requiredModules) {
         logDry(`  ${path.relative(libSrc, dep)}`);
+      }
+      for (const file of dataFiles) {
+        logDry(`  ${path.relative(libSrc, file)}`);
       }
       logDry(`Rewrite @lib/* aliases in ${platformDir}/`);
     } else {
@@ -476,6 +484,12 @@ export async function syncLib(
         const destFile = path.join(libDest, relPath);
         await fs.mkdir(path.dirname(destFile), { recursive: true });
         await fs.copyFile(dep, destFile);
+      }
+      for (const file of dataFiles) {
+        const relPath = path.relative(libSrc, file);
+        const destFile = path.join(libDest, relPath);
+        await fs.mkdir(path.dirname(destFile), { recursive: true });
+        await fs.copyFile(file, destFile);
       }
       logInfo(`Deployed shared lib to .${platform}/lib/`);
       await rewriteLibAliases(platformDir);


### PR DESCRIPTION
## 📌 Summary

5개 pin 스킬(audit/query/record/setup/wrap-up)을 OMT 레포 밖 임의 프로젝트 cwd에서도 실행 가능하게 전환합니다. 각 스킬에 `@lib` 별칭으로 엔진을 import하는 번들 스크립트를 추가하고, sync 엔진이 엔진의 정적 데이터 파일(`tbox.yaml`)을 정밀 reference-trace로 배포하도록 확장했습니다. 엔진(`lib/pins`)은 동결 상태로 미수정합니다.

---

## 🔧 Changes

### sync 엔진 — 정적 데이터 파일 배포

- `ts-lib-deps` collector가 `import.meta.dir`/`import.meta.dirname` + 문자열 리터럴 데이터 참조를 추적(`collectLibDataFiles`)
- `syncLib`이 추적된 데이터 파일을 `.ts` 모듈과 함께 구조 보존 복사 + dry-run 열거

배경: `tbox-loader.ts`가 런타임에 `join(import.meta.dir, "tbox.yaml")`로 읽는 데이터 파일은 `.ts` import가 아니라 lib-collector가 따라가지 못해 배포에서 누락됐고, `validate()`에 도달하는 모든 스크립트가 배포 환경에서 `tbox.yaml` 부재로 크래시했습니다.

**영향 범위**
신규 프레임워크 capability. 기존 컴포넌트의 배포 `.ts` 집합은 불변(G3). 데이터 참조가 없는 컴포넌트는 무영향. `collectLibDataFiles`는 플랫폼 루프 밖으로 hoist되어 플랫폼당 1회가 아닌 sync당 1회 스캔.

### 공유 I/O 헬퍼 — `@lib/pin-cli/io`

- manifest 해석 + 부재 UX(stdout 안내, exit 0), stdin JSON fail-loud(stderr, exit≠0), exit-code 맵을 단일 모듈로 중앙화
- 5개 스크립트는 verb-body(엔진 호출 1회)만 남기고 이 헬퍼를 공유

**영향 범위**
신규 모듈. 동결된 `lib/pins` 트리 외부(G1 미저촉). lib 내부 모듈이라 엔진을 상대경로로 import.

### 5개 pin 스킬 — 번들 스크립트 + SKILL 전환

- 각 스킬에 `scripts/<verb>.ts` 추가(엔진 `@lib` import, 단일 호출, JSON 출력), `SKILL.md`는 `bun "${CLAUDE_SKILL_DIR}/scripts/<verb>.ts"`로 호출
- 판단 프로즈(pin-record 핀잉 루브릭, pin-wrap-up HITL 스윕)는 보존
- `sync.yaml`에서 5개 스킬을 `platforms: [claude]`로 제한

**영향 범위**
pin 스킬의 cwd 의존 제거. 비-claude 플랫폼(gemini/codex/opencode)엔 미배포.

### 코드리뷰 후속 수정 (CONFIRMED 5 + PLAUSIBLE 2)

- pin-setup: 미존재 location ENOENT 가드 + `resolveProjectRoot()` 작성 정렬 + yaml 직렬화
- pin-cli: stdin `relations` 누락 시 `[]` 정규화
- pin-record: `.escape.jsonl` 크기 델타로 recorded/escaped 판정
- 회귀 테스트 3종 신규(setup/io/record), RED→GREEN 실증

**영향 범위**
첫 실행·재기록·플랫폼 배포 경계의 버그 해소. 엔진 무수정.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 정적 데이터 파일 배포 — 디렉터리 sweep이 아닌 정밀 reference-trace

**배경 및 문제 상황:**
pin 스킬을 전역화하려면 sync가 엔진 `.ts`뿐 아니라 엔진이 런타임에 읽는 정적 데이터(`tbox.yaml`, validation 룰북)도 배포해야 합니다. 그런데 데이터 파일은 `.ts` import가 아니라 lib-collector가 추적하지 않아, `validate()`를 호출하는 스크립트가 배포 환경에서 전부 크래시합니다.

**해결 방안:**
엔진 옆 파일을 전부 복사하는 디렉터리 sweep이 아니라, 배포된 `.ts`가 `import.meta.dir`로 *실제 참조하는* 파일만 정밀 추적해 복사합니다. 엔진은 기존 `readFileSync` 관용구를 읽기만 할 뿐 미수정(G1).

**구현 세부사항:**
`ts-lib-deps`에 `DATA_REF_RE`(`import.meta.dir(name)?` + 리터럴) 매처를 `.ts` 모듈 collector와 분리된 별도 집합으로 추가하고, `syncLib`이 동일 복사 루프에서 구조 보존 복사 + dry-run 열거 패리티를 보장합니다.

**선택과 트레이드오프:**
sweep은 allowlist·`__fixtures__` 제외·depth 가드가 필요한 footgun(엔진 옆 무관 파일이 전 프로젝트로 배포)이라 기각했고, reference-trace는 그 가드가 0개입니다. 다만 현 구현은 `../` traversal 봉쇄와 `isFile()` 체크가 없어(형제 resolver엔 둘 다 있음) 향후 `join(import.meta.dir, "../x")`나 디렉터리-리터럴이 들어오면 lib 밖 복사 또는 sync 중단 가능성이 있습니다. 현재 트리거는 없으나(유일 참조가 단일 `"tbox.yaml"`) 심층 방어로 후속 보강 후보로 봅니다 — 리뷰어 의견 환영합니다.

### 2. 공유 `@lib/pin-cli/io` 헬퍼와 엔진 동결(G1)

**배경 및 문제 상황:**
5개 스크립트가 동일한 I/O 계약(manifest 부재 UX, stdin fail-loud, exit-code)을 손으로 5벌 복제하면 가장 드리프트하기 쉬운 부분이 5곳으로 흩어집니다. 엔진(`lib/pins`)은 이미 구현·테스트 완료라 동결 대상입니다.

**해결 방안:**
I/O 계약을 동결 트리 밖 `lib/pin-cli/io.ts` 단일 모듈로 모으고, 5개 스크립트는 verb-body만 남깁니다.

**구현 세부사항:**
`io.ts`는 `lib/` 내부라 엔진을 `@lib/`가 아닌 상대경로(`../pins/...`)로 import합니다 — 별칭 리라이터가 `lib/**`를 건너뛰어 여기서 `@lib/`를 쓰면 리라이트되지 않은 채 배포돼 import 크래시(개발 중 `84f2684`로 교정한 FALSE-GREEN). 반대로 스크립트는 `lib/` 밖이라 `@lib/`를 씁니다.

**선택과 트레이드오프:**
단일 `pins` CLI 멀티플렉서 안은 cross-skill `${CLAUDE_SKILL_DIR}/../` 참조(silent-fallback 트랩)를 강제해 기각했습니다. 헬퍼 1개 + 얇은 바디 5개가 손작성 계약 5벌보다 총 표면이 작습니다.

### 3. pin 스킬 claude 전용 배포 결정

**배경 및 문제 상황:**
번들 스크립트는 skills 카테고리라 4개 플랫폼에 배포되지만, `@lib` 엔진은 lib 플랫폼 집합(`[claude]`)으로 claude에만 배포됩니다. 그 결과 gemini/codex/opencode엔 리라이트 안 된 `@lib` import 스크립트만 깔려 import 크래시합니다(코드리뷰에서 `~/.codex/skills/pin-*` 디스크 실증).

**해결 방안:**
pins는 claude 바운드(SessionStart 훅도 claude 전용)이므로, 비-claude 배포를 `sync.yaml`의 `platforms: [claude]`로 소스에서 차단합니다.

**선택과 트레이드오프:**
엔진을 4플랫폼에 co-deploy하는 대안(`feature-platforms.lib` union)은 현재 비-claude 사용자가 없어 표면만 늘려 기각했습니다. 소스 차단은 *앞으로의* 배포만 막으므로, 개발 중 이미 배포된 `~/.codex|.gemini|.opencode/skills/pin-*` 스테일 카피는 머지 후 `make sync` 재배포로 정리가 필요합니다(후속 작업). 향후 `@lib` import 번들 스크립트가 늘면 `libPlatforms`를 skills/scripts 집합의 union으로 계산하는 편이 더 견고합니다 — 리뷰어 의견 환영합니다.

---

## ✅ Checklist

### 전역 실행
- [ ] 비-레포 cwd에서 각 pin 스크립트가 엔진을 resolve하고 동작한다 (`Cannot find module` 없음)
  - `skills/pin-audit/scripts/audit.ts`, `skills/pin-query/scripts/query.ts`, `skills/pin-record/scripts/record.ts`, `skills/pin-setup/scripts/setup.ts`, `skills/pin-wrap-up/scripts/wrap-up.ts`
- [ ] `make sync` 후 `tbox.yaml`이 loader가 읽는 경로(`~/.claude/lib/pins/tbox.yaml`)에 존재한다
  - `tools/adapters/ts-lib-deps.ts`, `tools/sync.ts`

### 데이터 파일 배포 정밀성
- [ ] reference-trace가 참조된 파일만 복사하고 무관 데이터 파일은 배포하지 않는다
  - `tools/adapters/ts-lib-deps.ts`
- [ ] `make sync-dry`가 데이터 파일 복사를 열거한다 (배포 패리티)
  - `tools/sync.ts`
- [ ] 기존 컴포넌트의 배포 `.ts` 집합이 변경 전후 동일하다 (G3)
  - `tools/sync.ts`

### 엔진 동결 (G1)
- [ ] `lib/pins/*.ts`가 바이트 단위로 무변경이다
  - `lib/pins/`

### I/O 계약
- [ ] manifest 부재 시 stdout 안내 + exit 0, malformed stdin은 stderr + exit≠0
  - `lib/pin-cli/io.ts`
- [ ] `relations` 누락 엔티티가 engine-error 없이 처리된다
  - `lib/pin-cli/io.ts`, `lib/pin-cli/io.test.ts`

### 코드리뷰 후속 수정
- [ ] 미존재 location으로 pin-setup 실행 시 ENOENT 없이 `pins.yaml`이 생성된다
  - `skills/pin-setup/scripts/setup.ts`, `skills/pin-setup/scripts/setup.test.ts`
- [ ] 기존 `.md`가 있는 id에 invalid 엔티티를 기록하면 `escaped`로 보고된다
  - `skills/pin-record/scripts/record.ts`, `skills/pin-record/scripts/record.test.ts`
- [ ] pin 스킬이 claude에만 배포된다 (`make sync-dry`에 비-claude `pin-*` 없음)
  - `sync.yaml`

### 통합 검증
- [ ] `make validate` + `make test`가 green이다