### PR TITLE
feat(deep-interview): 실행 브리지 적응형 라우팅 추천

### DIFF
--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -7,7 +7,7 @@ level: 3
 ---
 
 <Purpose>
-Deep Interview implements Ouroboros-inspired Socratic questioning with mathematical ambiguity scoring. It replaces vague ideas with crystal-clear specifications by asking targeted questions that expose hidden assumptions, measuring clarity across weighted dimensions, and refusing to proceed until ambiguity drops below the resolved threshold for this run. The output feeds into a planning step: **deep-interview → prometheus (planning → execution)**, ensuring maximum clarity at every stage.
+Deep Interview implements Ouroboros-inspired Socratic questioning with mathematical ambiguity scoring. It replaces vague ideas with crystal-clear specifications by asking targeted questions that expose hidden assumptions, measuring clarity across weighted dimensions, and refusing to proceed until ambiguity drops below the resolved threshold for this run. The output feeds into an execution route chosen from the spec itself: **deep-interview → planning/execution (prometheus, sisyphus, or a directly matching skill)**, ensuring maximum clarity at every stage.
 </Purpose>
 
 <Use_When>
@@ -346,21 +346,25 @@ Spec structure:
 
 ## Phase 5: Execution Bridge
 
-After the spec is written, present execution options via `AskUserQuestion`:
+After the spec is written, choose the recommended execution route from the spec's own characteristics, then present options via `AskUserQuestion`.
+
+**Recommend the route by judging the spec you just wrote — its output shape and how much HOW-uncertainty the interview left open:**
+- If the spec's output maps cleanly to a single domain skill available in this session (e.g., documentation → `technical-writing`, slides → `create-slides`), recommend that skill directly. Read the live available-skills list to find the match — do NOT hardcode a skill catalog here, because the available skills change.
+- Else if scope is settled but the *approach, architecture, or risk* is still open and the work is code that benefits from AC-gated planning, recommend **prometheus**.
+- Else (scope and approach are both settled and the remaining work is multi-step execution/orchestration), recommend **sisyphus**.
+
+A clean interview often closes HOW as well as WHAT, which makes `sisyphus` the right default at least as often as `prometheus`. Do not reflexively recommend `prometheus` just because the interview produced a spec — its core value, requirements clarification, is exactly what this phase already delivered.
 
 **Question:** "Your spec is ready (ambiguity: {score}%). How would you like to proceed?"
 
-**Options:**
+**Build the options like this** (recommended route first, tagged "(Recommended)", with a one-sentence rationale tied to THIS spec):
+- The recommended route from the rule above.
+- Both `prometheus` and `sisyphus` are always present as options; whichever is not the recommended route is offered untagged so the user can override (this override is exactly what the default sometimes gets wrong). When a domain skill is the recommended route, offer both prometheus and sisyphus as the override options.
+- **Continue interviewing** — "Continue interviewing to improve clarity (current: {score}%)" → return to the Phase 2 loop.
 
-1. **Plan with prometheus (Recommended)**
-   - Description: "Generate a detailed work plan from this spec with TODO decomposition, wave parallelization, and QA scenarios. Best for complex specs."
-   - Action: Invoke `Skill(skill: "prometheus")` with the spec file path as context. Prometheus will handle the plan → execution pipeline from there.
+Each execution option's Action: invoke `Skill(skill: "{chosen}")` with the spec file path as context.
 
-2. **Continue interviewing**
-   - Description: "Continue interviewing to improve clarity (current: {score}%)"
-   - Action: Return to Phase 2 interview loop.
-
-**IMPORTANT:** On execution selection, **MUST** invoke the chosen skill via `Skill()`. Do NOT implement directly. The deep-interview agent is a requirements agent, not an execution agent. If oversized initial context was summarized, pass the spec and prompt-safe summary forward, not the raw oversized source material.
+**IMPORTANT:** On execution selection, **MUST** invoke the chosen skill via `Skill()`. Do NOT implement directly. The deep-interview agent is a requirements agent, not an execution agent. Pass the spec file path forward (and the prompt-safe summary, if the initial context was summarized) — never the raw oversized source material.
 
 </Steps>
 
@@ -533,7 +537,7 @@ Prometheus: "Your request is quite open-ended. Would you like to run a deep inte
   [Yes, interview first] [No, expand directly]
 ```
 
-If the user chooses interview, prometheus invokes `/deep-interview`. When the interview completes and the user selects "Plan with prometheus", the spec becomes Phase 0 output and prometheus continues from planning.
+If the user chooses interview, prometheus invokes `/deep-interview`. When the interview completes and the user selects the prometheus route at the execution bridge, the spec becomes Phase 0 output and prometheus continues from planning.
 
 ## Brownfield vs Greenfield Weights
 


### PR DESCRIPTION
### 📌 Summary

deep-interview의 Phase 5(Execution Bridge)가 인터뷰 완료 후 **항상 prometheus를 단독 추천**하던 것을, spec의 성격을 보고 prometheus / sisyphus / 직결 도메인 스킬 중 **적응적으로 추천**하도록 변경한다. 인터뷰가 이미 요구사항 명확화를 끝낸 상황에서 무거운 계획 단계를 반사적으로 권하던 미스매치를 해소한다.

### 🔧 Changes

#### Phase 5 실행 브리지를 적응형 추천으로 전환
- prometheus 단독 추천 → spec의 산출물 형태와 잔여 HOW-불확실성으로 루트 선택:
  - 산출물이 단일 도메인 스킬에 명백히 매칭(docs→`technical-writing`, slides→`create-slides`) → 그 스킬
  - 접근법·아키텍처·리스크가 열린 코드 → `prometheus`
  - 스코프·접근법 확정, 다단계 실행만 남음 → `sisyphus`
- `prometheus`·`sisyphus`는 항상 옵션으로 노출(추천 안 된 쪽은 오버라이드용), AskUserQuestion 옵션 ≤4 유지
- 스킬 매핑 하드코딩 없이 런타임 available-skills 목록으로 판단
- **영향 범위**: `skills/deep-interview/SKILL.md`의 Phase 5. 핸드오프 동작만 변경되며 스코어링·인터뷰 루프·spec 생성 로직은 불변.

#### prometheus 하드코딩 참조 정리
- Purpose 라인: `deep-interview → prometheus` → `planning/execution (prometheus, sisyphus, or a directly matching skill)`
- Integration 섹션의 stale 라벨 `"Plan with prometheus"` → `the prometheus route at the execution bridge`
- **영향 범위**: 같은 파일 내 설명 텍스트. 동작 영향 없음.

### 💬 Review Points

#### 실행 브리지의 "다른 스킬 제안" 범위를 Bounded로 한정
1. **배경 및 문제 상황**: 인터뷰가 깨끗이 끝나면 prometheus의 핵심 가치(요구사항 명확화)는 이미 소진된 상태인데 브리지는 매번 prometheus를 1순위로 추천했다. 게다가 스킬의 다른 부분(`Do_Not_Use_When`, 오버사이즈 가드)은 이미 sisyphus를 정당한 다운스트림으로 인정하고 있어 브리지만 단독으로 어긋난 내부 모순이었다.
2. **해결 방안**: 브리지가 spec 성격으로 추천 루트를 적응 결정하고, "다른 스킬 제안"의 범위는 산출물 유형이 명백히 매칭되는 도메인 스킬로 한정(Bounded).
3. **구현 세부사항**: 추천 규칙을 3줄짜리 결정 원칙으로 작성하고 판단은 모델에 위임. available-skills 목록은 런타임에 읽는다.
4. **선택과 트레이드오프**: full catalog scan(가용 스킬 전체 best-match 탐색)도 후보였으나, 스킬이 늘 때마다 prose가 stale되고 엉뚱한 추천(환각) 위험이 있어 기각. Bounded는 "런타임 목록을 읽되 명백한 매칭만"으로 좁혀 prose 안정성을 유지하며, 가변 값을 prose에 하드코딩하지 않는 레포 원칙과도 정합한다.

### ✅ Checklist
- [ ] Phase 5가 prometheus/sisyphus/도메인 스킬을 spec 성격으로 적응 추천한다
  - `skills/deep-interview/SKILL.md`
- [ ] prometheus·sisyphus가 항상 옵션으로 노출되어 사용자가 추천을 오버라이드할 수 있다
  - `skills/deep-interview/SKILL.md`
- [ ] 스킬 카탈로그가 prose에 하드코딩되지 않고 런타임 목록 기반으로 판단한다
  - `skills/deep-interview/SKILL.md`
- [ ] AskUserQuestion 옵션이 최대 4개를 넘지 않는다
  - `skills/deep-interview/SKILL.md`
- [ ] `make validate` 통과 (schema + components + lib-import)
