### PR TITLE
feat: codex MCP overlay null 삭제 마커 지원

### DIFF
--- a/tools/adapters/codex.test.ts
+++ b/tools/adapters/codex.test.ts
@@ -311,6 +311,26 @@ describe("CodexAdapter", () => {
       expect(content).toContain("other-server");
     });
 
+    it("skips a server whose overlay value is null via `syncPlatformYaml`", async () => {
+      const yaml = {
+        mcps: {
+          "keep-server": { command: "npx", args: ["-y", "keep"] },
+          "drop-server": null,
+        },
+      };
+      const result = await adapter.syncPlatformYaml(
+        tmpDir,
+        yaml as unknown as Parameters<typeof adapter.syncPlatformYaml>[1],
+        false,
+      );
+      expect(result.processedSections).toContain("mcps");
+
+      const configFile = path.join(tmpDir, ".codex", "config.toml");
+      const content = await fs.readFile(configFile, "utf-8");
+      expect(content).toContain("keep-server");
+      expect(content).not.toContain("drop-server");
+    });
+
     it("processes config, mcps, and model-map sections together via `syncPlatformYaml`", async () => {
       const yaml = {
         config: { model: "o4-mini" },

--- a/tools/adapters/codex.ts
+++ b/tools/adapters/codex.ts
@@ -392,7 +392,14 @@ export class CodexAdapter implements PlatformAdapter {
 
     // --- mcps ---
     if (yaml.mcps != null) {
-      for (const [name, server] of Object.entries(yaml.mcps)) {
+      // After overlay merge a server value can be null: a local override file
+      // uses `<name>: null` as a deletion marker to drop a server inherited from
+      // the base config. Skip those so the managed block omits them entirely.
+      const entries = Object.entries(yaml.mcps) as Array<
+        [string, Record<string, unknown> | null]
+      >;
+      for (const [name, server] of entries) {
+        if (server == null) continue;
         this.accumulateMcp(name, server);
         if (!dryRun) {
           logInfo(`MCP accumulated: ${name}`);

--- a/tools/validators/schema.test.ts
+++ b/tools/validators/schema.test.ts
@@ -424,6 +424,26 @@ model-map:
       expect(result.warnings).toHaveLength(0);
     });
 
+    it("allows mcps.<name>: null as a codex deletion marker via `validatePlatformYaml`", () => {
+      const path = writeYaml(dir, "codex.local.yaml", `
+mcps:
+  keep:
+    command: npx
+  notion: null
+`);
+      const result = validatePlatformYaml(path, "codex");
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("rejects mcps.<name>: null for non-codex platforms via `validatePlatformYaml`", () => {
+      const path = writeYaml(dir, "claude.local.yaml", `
+mcps:
+  notion: null
+`);
+      const result = validatePlatformYaml(path, "claude");
+      expect(result.errors.some((e) => e.includes("mcps.notion"))).toBe(true);
+    });
+
     it("produces no errors or warnings when opencode.yaml has only allowed sections", () => {
       const path = writeYaml(dir, "opencode.yaml", `
 config:

--- a/tools/validators/schema.ts
+++ b/tools/validators/schema.ts
@@ -376,6 +376,9 @@ function validatePlatformYamlData(data: Record<string, unknown>, platformYamlPat
     result.errors.push(`${label}: mcps는 object 형식이어야 합니다`);
   } else if (isObject(data.mcps)) {
     for (const [name, value] of Object.entries(data.mcps)) {
+      // codex treats `<name>: null` as an overlay deletion marker that drops an
+      // inherited server; other platforms require a concrete server object.
+      if (value === null && platform === "codex") continue;
       if (!isObject(value)) {
         result.errors.push(`${label}: mcps.${name}의 값은 object이어야 합니다`);
       }


### PR DESCRIPTION
## 📌 Summary

Codex는 실행 디렉터리의 프로젝트 `.codex/config.toml`을 전역 설정 위에 레이어링하며 MCP 서버를 **이름 기준으로 병합**한다. 이름이 같고 transport가 다른 서버(예: 전역 stdio `notion` + 프로젝트 hosted url `notion`)가 병합되면 한 엔트리에 `command`와 `url`이 섞여 config 로드가 실패한다.

그런데 OMT의 overlay 병합(`deepMergeOverlay`)은 **additive**라 상속된 MCP 서버를 제거할 방법이 없었다. 이 PR은 **codex 한정**으로 `mcps.<name>: null`을 "삭제 마커"로 처리해, device-local `codex.local.yaml`에서 상속된 특정 MCP 서버를 끌 수 있게 한다.

## 🔧 Changes

### 1. codex 어댑터 — null 서버 skip
`syncPlatformYaml`의 mcps 누적 루프에서 값이 `null`인 서버를 건너뛴다. overlay 병합 후 값이 null인 서버는 관리 블록 생성에서 제외된다.
- **영향 범위**: `tools/adapters/codex.ts`. codex 플랫폼의 `.codex/config.toml` MCP 관리 블록 생성 경로에만 영향. 공유 타입은 비-null 유지(루프에서 국소 캐스팅 후 narrow)라 타 어댑터·기존 동작 불변.

### 2. 스키마 검증 — codex 한정 null 허용
`mcps.<name>: null`을 codex 플랫폼에서만 valid로 통과시킨다. 다른 플랫폼은 여전히 object를 강제(거부).
- **영향 범위**: `tools/validators/schema.ts`, `make validate-schema`. codex 외 플랫폼 검증 동작 불변.

### 3. 테스트
null 삭제 마커 동작과 스코핑을 고정.
- **영향 범위**: `tools/adapters/codex.test.ts`(null 서버가 블록에서 제외), `tools/validators/schema.test.ts`(codex 허용 / 비-codex 거부).

## 💬 Review Points

### 1. null을 "삭제 마커"로 선택 — additive overlay의 한계 우회
- **배경 및 문제 상황**: `deepMergeOverlay`는 base+local을 합집합으로 병합하고 **키 삭제 경로가 없다**(실수로 base 컴포넌트가 사라지는 사고 방지를 위한 의도된 설계). 그래서 overlay로는 상속된 MCP 서버를 끌 수 없었다. 빈 객체(`mcps: {}`)는 base를 보존하고, 서버 override는 필드를 union해 오히려 깨진 엔트리를 만든다.
- **해결 방안**: 값이 `null`인 서버를 "삭제" 신호로 해석. overlay의 `notion: null` → 병합 결과 notion=null → 어댑터가 skip → 블록에서 제외.
- **구현 세부사항**: `deepMergeOverlay`의 else 분기가 null을 그대로 대입하므로 병합 로직 변경 없이 어댑터 루프에 `if (server == null) continue` 한 줄로 처리. 공유 타입(`PlatformYaml.mcps`)은 비-null 유지하고 codex.ts에서 `Object.entries`를 `Array<[string, Record | null]>`로 국소 캐스팅 후 narrow.
- **선택과 트레이드오프**: 대안 (a) 공유 타입을 `Record | null`로 변경 → claude/gemini/opencode 3개 어댑터에 파급(각자 null 처리 필요)되어 codex-only·surgical 원칙 위배. (b) 섹션 전체 `mcps: null`로 전 서버 끄기 → 서버 단위 삭제 불가. → 국소 캐스팅 + null-skip이 파급 0이면서 서버 단위 삭제 표현력 확보.

### 2. null 허용을 codex 플랫폼으로 한정
- **배경 및 문제 상황**: null-skip은 codex 어댑터만 구현한다. 스키마가 null을 전 플랫폼에 허용하면 claude/gemini/opencode `.local.yaml`의 `<name>: null`이 검증은 통과하나 해당 어댑터가 처리 못 해 **sync에서 깨지는 foot-gun**이 생긴다.
- **해결 방안**: 검증기에서 `value === null && platform === "codex"`일 때만 통과, 그 외엔 기존대로 object 강제.
- **선택과 트레이드오프**: "삭제 마커"를 전 플랫폼 공통 오버레이 기능으로 일반화할 수도 있으나, 3개 어댑터에 동일 null-skip 구현이 선행돼야 한다. 현 요구가 codex 한정이라 스키마도 구현 현실에 맞춰 좁혔다. 추후 타 어댑터 지원 시 확장.

## ✅ Checklist
- [ ] codex `mcps.<name>: null`이 관리 블록에서 해당 서버를 제외한다
  - `tools/adapters/codex.ts`
- [ ] codex 플랫폼에서 `mcps.<name>: null`이 스키마 검증을 통과한다
  - `tools/validators/schema.ts`
- [ ] 비-codex 플랫폼에서 `mcps.<name>: null`은 스키마 오류를 낸다
  - `tools/validators/schema.ts`
- [ ] `make validate` 통과 (schema/components/lib-imports/typecheck)
- [ ] `make test` 전체 통과
  - `tools/adapters/codex.test.ts`, `tools/validators/schema.test.ts`

## 📎 References
- 해당 없음