### PR TITLE
fix: Recommendations를 검증된 finding 기반으로 재정의

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -549,9 +549,10 @@ Fallback (verifier failed): If a verifier subagent errored or timed out for a ca
 [Only if one or more verifiers errored or timed out. Candidates listed with the finder's text and a count, explicitly NOT verdict-labeled — coverage gaps, not findings. Omit the section entirely when every candidate was verified.]
 
 ## Recommendations
-[Optional. Among the verified findings, the ones worth resolving — where
-resolving carries real benefit: it preserves a requirement, removes a bug,
-or improves maintainability. Recommend those; omit if none.]
+[Optional. From the `## Findings` section above only (not Out of Scope or
+Unverified), the ones worth resolving — where resolving carries real
+benefit: it preserves a requirement, removes a bug, or improves
+maintainability. Recommend those; omit if none.]
 ```
 
 There is no Assessment / "Ready to merge" section. This review reports; it does not gate.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -549,7 +549,9 @@ Fallback (verifier failed): If a verifier subagent errored or timed out for a ca
 [Only if one or more verifiers errored or timed out. Candidates listed with the finder's text and a count, explicitly NOT verdict-labeled — coverage gaps, not findings. Omit the section entirely when every candidate was verified.]
 
 ## Recommendations
-[Optional, non-finding suggestions for the author. Omit if none.]
+[Optional. Among the verified findings, the ones worth resolving — where
+resolving carries real benefit: it preserves a requirement, removes a bug,
+or improves maintainability. Recommend those; omit if none.]
 ```
 
 There is no Assessment / "Ready to merge" section. This review reports; it does not gate.

--- a/skills/code-review/references/output-example.md
+++ b/skills/code-review/references/output-example.md
@@ -162,7 +162,7 @@ sequenceDiagram
 - The idempotency lookup added in this PR reads `inventory_reservations` by `order_id`, but the column has no index, so reads are full scans. Not introduced here, but this PR is the first heavy reader. Noted, not blocking.
 
 ## Recommendations
-- Introduce a `PaymentApplicationService` between controllers and adapters to own transaction boundaries.
-- Configure a dead-letter topic for the `payment-events` consumer group so failed messages are recoverable.
-- Propagate a correlation ID through HTTP headers → Kafka message headers → consumer MDC for end-to-end tracing.
+- Resolve the `@Transactional`-over-Stripe finding (`OrderPaymentController.kt:34`) — removes a bug that exhausts the connection pool under normal load.
+- Add the webhook amount re-check (`OrderPaymentController.kt:88`) — preserves the requirement that an order is never marked PAID for less than its total.
+- Replace the inline money conversion with `MoneyUtils.toMinorUnits` (`PaymentRecord.kt:21`) — improves maintainability and removes the latent zero-decimal-currency bug.
 ````


### PR DESCRIPTION
## 📌 Summary

`code-review` 스킬 출력 계약의 `## Recommendations` 섹션 정의를 **"non-finding suggestions for the author"** → **"검증된 findings 중 해결 시 실제 이득이 있는 것"**으로 재정의합니다. 기존 정의는 finder/verifier 파이프라인 어디서도 산출되지 않는 항목이라, orchestrator가 코드 근거 없이 채울 수밖에 없는 ungrounded 카테고리였습니다.

## 🔧 Changes

### Recommendations 정의 교체 — `skills/code-review/SKILL.md`
- `## Recommendations` 설명을 "비-finding 제안" → **"검증된 findings 중 해결 시 이득(요구사항 보존·버그 제거·유지보수성↑)이 있는 것 추천"**으로 변경.
- 의견은 내되(neutral 폐기) 머지를 막지 않는 soft 성격은 유지. `SKILL.md:555`의 *"This review reports; it does not gate"*는 불변.
- **영향 범위**: 리뷰 출력의 Recommendations 섹션 의미. finder/verifier 검증 로직과 다른 출력 섹션(Findings/Out of Scope/Unverified)은 무변경.

### 출력 예시 정합 — `skills/code-review/references/output-example.md`
- 비-finding 아키텍처 제안 3줄(dead-letter topic, correlation ID 등) → 그 예시의 실제 finding 참조로 교체. out-of-scope pre-existing 항목은 추천에서 제외해 기준을 시연.
- **영향 범위**: 예시 문서뿐. 런타임 동작 영향 없음(정의와의 일관성 확보용).

## 💬 Review Points

### Recommendations 정의의 grounding 재정착
- **배경 및 문제 상황**: 기존 "non-finding suggestions"는 finder(결함/cleanup 후보만 탐색)와 verifier 어디서도 산출되지 않는 카테고리였습니다. 따라서 그 자리는 orchestrator가 코드를 읽지 않고 채우는 추측으로만 채워질 수 있었고, 이는 스킬이 명시적으로 금지한 *"Armchair analysis: advice without reading code"*와 정면으로 충돌했습니다.
- **해결 방안**: Recommendations를 이미 검증된 findings 위에 재정착시키고, "해결 시 이득이 있는가"라는 임팩트 기준으로 그중 일부를 추천하도록 변경.
- **구현 세부사항**: 정의 문구를 요구사항 보존 / 버그 제거 / 유지보수성 향상이라는 benefit 기준으로 서술. 예시도 실제 finding을 참조하도록 교체하고, 범위 밖 pre-existing 항목은 추천에서 빼 경계를 드러냄.
- **선택과 트레이드오프**: neutral(의견 억제)은 버리되 gate(머지 차단)는 유지했습니다 — 둘은 별개 노브입니다. Recommendations 섹션 자체를 제거하는 안도 검토했으나, "검증된 것 중 무엇을 먼저 해결할지"라는 큐레이션 가치가 있어 재정의로 결정했습니다.

## ✅ Checklist
- [ ] `## Recommendations` 설명이 검증된 findings 기반 + benefit 기준(요구사항/버그/유지보수성)으로 서술되어 있다
  - `skills/code-review/SKILL.md`
- [ ] 출력 예시의 Recommendations가 비-finding 항목 없이 실제 finding을 참조한다
  - `skills/code-review/references/output-example.md`
- [ ] `"does not gate"` 선언이 보존되어 soft 추천과 공존한다
  - `skills/code-review/SKILL.md`
- [ ] `make validate` 통과

## 📎 References
- 없음