### PR TITLE
feat: prometheus 상태 파일 생애주기 harness 소유화

### DIFF
--- a/hooks/persistent-mode/decision.test.ts
+++ b/hooks/persistent-mode/decision.test.ts
@@ -819,4 +819,85 @@ describe('makeDecision', () => {
       expect(result.reason ?? '').not.toContain('<deep-interview-continuation>');
     });
   });
+
+  describe('Priority 1.5: Prometheus State Protection', () => {
+    it('makeDecision blocks with prometheus-continuation when state active and no token', async () => {
+      const prometheusState = { active: true, sessionId: 'test-session' };
+      await writeFile(
+        join(omtDir, 'prometheus-state-test-session.json'),
+        JSON.stringify(prometheusState)
+      );
+
+      const context = createContext({ lastAssistantMessage: 'some message without done token' });
+
+      const result = makeDecision(context);
+
+      expect(result.decision).toBe('block');
+      expect(result.reason).toContain('<prometheus-continuation>');
+    });
+
+    it('makeDecision cleans up prometheus state when token present in lastAssistantMessage', async () => {
+      const prometheusState = { active: true, sessionId: 'test-session' };
+      await writeFile(
+        join(omtDir, 'prometheus-state-test-session.json'),
+        JSON.stringify(prometheusState)
+      );
+
+      const context = createContext({ lastAssistantMessage: 'Plan complete. <prometheus-done/>' });
+
+      const result = makeDecision(context);
+
+      const { existsSync } = await import('fs');
+      expect(existsSync(join(omtDir, 'prometheus-state-test-session.json'))).toBe(false);
+      expect(result.reason ?? '').not.toContain('<prometheus-continuation>');
+    });
+
+    it('makeDecision allows stop after MAX_BLOCK_COUNT token-less blocks (bounded escape)', async () => {
+      const prometheusState = { active: true, sessionId: 'test-session' };
+      await writeFile(
+        join(omtDir, 'prometheus-state-test-session.json'),
+        JSON.stringify(prometheusState)
+      );
+
+      const context = createContext({ lastAssistantMessage: 'no token here' });
+
+      // First call should block (prometheus active, no token, below ceiling)
+      const firstResult = makeDecision(context);
+      expect(firstResult.decision).toBe('block');
+
+      // Drive blockCount to ceiling (MAX_BLOCK_COUNT = 5; first call already incremented to 1)
+      for (let i = 1; i < 5; i++) {
+        makeDecision(context);
+      }
+      // This call is at/past ceiling — must NOT block
+      const escapedResult = makeDecision(context);
+      expect(escapedResult.decision).not.toBe('block');
+    });
+
+    it('makeDecision prioritizes ralph over prometheus when both active', async () => {
+      const ralphState = {
+        active: true,
+        iteration: 1,
+        max_iterations: 10,
+        completion_promise: 'DONE',
+        prompt: 'Ralph task',
+      };
+      await writeFile(
+        join(omtDir, 'ralph-state-test-session.json'),
+        JSON.stringify(ralphState)
+      );
+      const prometheusState = { active: true, sessionId: 'test-session' };
+      await writeFile(
+        join(omtDir, 'prometheus-state-test-session.json'),
+        JSON.stringify(prometheusState)
+      );
+
+      const context = createContext();
+
+      const result = makeDecision(context);
+
+      expect(result.reason).toContain('<ralph-loop-continuation>');
+      expect(result.reason).not.toContain('<prometheus-continuation>');
+    });
+  });
 });

--- a/hooks/persistent-mode/decision.test.ts
+++ b/hooks/persistent-mode/decision.test.ts
@@ -899,5 +899,65 @@ describe('makeDecision', () => {
       expect(result.reason).toContain('<ralph-loop-continuation>');
       expect(result.reason).not.toContain('<prometheus-continuation>');
     });
+
+    it('(regression) todo block-count pre-loaded to MAX does not shorten prometheus protection', async () => {
+      // Seed the shared todo counter key (block-count-${attemptId}) to MAX_BLOCK_COUNT
+      // so that if prometheus wrongly shares it, it would escape immediately.
+      await writeFile(join(stateDir, 'block-count-test-session'), '5');
+
+      const prometheusState = { active: true, sessionId: 'test-session' };
+      await writeFile(
+        join(omtDir, 'prometheus-state-test-session.json'),
+        JSON.stringify(prometheusState)
+      );
+
+      const context = createContext({ lastAssistantMessage: 'working on it, no done token' });
+
+      const result = makeDecision(context);
+
+      // Prometheus uses its own counter key so the pre-loaded todo counter must NOT trigger escape.
+      expect(result.decision).toBe('block');
+      expect(result.reason).toContain('<prometheus-continuation>');
+    });
+
+    it('(regression) prometheus-specific counter reaches MAX_BLOCK_COUNT → escape', async () => {
+      // Pre-load prometheus-specific counter to MAX_BLOCK_COUNT
+      await writeFile(join(stateDir, 'block-count-prometheus-test-session'), '5');
+
+      const prometheusState = { active: true, sessionId: 'test-session' };
+      await writeFile(
+        join(omtDir, 'prometheus-state-test-session.json'),
+        JSON.stringify(prometheusState)
+      );
+
+      const context = createContext({ lastAssistantMessage: 'working on it, no done token' });
+
+      const result = makeDecision(context);
+
+      // Prometheus counter at ceiling → escape allowed
+      expect(result.decision).not.toBe('block');
+      expect(result).toEqual({ continue: true });
+    });
+
+    it('(regression) done-token cleanup also deletes prometheus-specific counter file', async () => {
+      // Pre-load prometheus-specific counter to simulate in-progress session
+      await writeFile(join(stateDir, 'block-count-prometheus-test-session'), '3');
+
+      const prometheusState = { active: true, sessionId: 'test-session' };
+      await writeFile(
+        join(omtDir, 'prometheus-state-test-session.json'),
+        JSON.stringify(prometheusState)
+      );
+
+      const context = createContext({ lastAssistantMessage: 'All done. <prometheus-done/>' });
+
+      makeDecision(context);
+
+      const { existsSync } = await import('fs');
+      // Prometheus state file deleted
+      expect(existsSync(join(omtDir, 'prometheus-state-test-session.json'))).toBe(false);
+      // Prometheus-specific counter file also deleted
+      expect(existsSync(join(stateDir, 'block-count-prometheus-test-session'))).toBe(false);
+    });
   });
 });

--- a/hooks/persistent-mode/decision.ts
+++ b/hooks/persistent-mode/decision.ts
@@ -254,15 +254,17 @@ export function makeDecision(context: DecisionContext): HookOutput {
   // Priority 1.5: Prometheus Session Protection (bounded — walk-away safe)
   const prometheusState = readPrometheusState(sessionId);
   if (prometheusState && prometheusState.active) {
+    const prometheusAttemptId = `prometheus-${attemptId}`;
     if (detectPrometheusDone(lastAssistantMessage)) {
       cleanupPrometheusState(sessionId);
+      cleanupBlockCountFiles(stateDir, prometheusAttemptId);
     } else {
-      const blockCount = getBlockCount(stateDir, attemptId);
+      const blockCount = getBlockCount(stateDir, prometheusAttemptId);
       if (blockCount >= MAX_BLOCK_COUNT) {
-        cleanupBlockCountFiles(stateDir, attemptId);
+        cleanupBlockCountFiles(stateDir, prometheusAttemptId);
         return formatContinueOutput();
       }
-      incrementBlockCount(stateDir, attemptId);
+      incrementBlockCount(stateDir, prometheusAttemptId);
       return formatBlockOutput(buildPrometheusContinuationMessage());
     }
   }

--- a/hooks/persistent-mode/decision.ts
+++ b/hooks/persistent-mode/decision.ts
@@ -2,10 +2,11 @@ import { HookOutput, RalphState } from './types.ts';
 import {
   readRalphState, updateRalphState, cleanupRalphState,
   readDeepInterviewState, cleanupDeepInterviewState,
+  readPrometheusState, cleanupPrometheusState,
   getBlockCount, incrementBlockCount, cleanupBlockCountFiles,
   MAX_BLOCK_COUNT
 } from './state.ts';
-import { analyzeTranscript, detectDeepInterviewDone } from './transcript-detector.ts';
+import { analyzeTranscript, detectDeepInterviewDone, detectPrometheusDone } from './transcript-detector.ts';
 import { generateAttemptId, ensureDir } from './utils.ts';
 import { join } from 'path';
 import { getOmtDir } from '@lib/omt-dir';
@@ -135,6 +136,26 @@ INSTRUCTIONS:
 `;
 }
 
+function buildPrometheusContinuationMessage(): string {
+  return `<prometheus-continuation>
+
+[PROMETHEUS SESSION IN PROGRESS]
+
+A prometheus planning session is currently active. You must complete the session before stopping.
+
+INSTRUCTIONS:
+1. Review the current pipeline stage and any pending decisions
+2. If a human decision is awaited, re-surface the pending question via AskUserQuestion — do NOT stop to wait
+3. Never interpret a user "continue" reply as permission to bypass a human gate (S2, design gate, S7)
+4. When the pipeline is fully complete or explicitly aborted, output: <prometheus-done/>
+5. Do NOT stop until <prometheus-done/> is emitted
+
+</prometheus-continuation>
+
+---
+`;
+}
+
 function buildTodoContinuationMessage(incompleteCount: number): string {
   return `<todo-continuation>
 
@@ -227,6 +248,22 @@ export function makeDecision(context: DecisionContext): HookOutput {
       cleanupDeepInterviewState(sessionId);
     } else {
       return formatBlockOutput(buildDeepInterviewContinuationMessage());
+    }
+  }
+
+  // Priority 1.5: Prometheus Session Protection (bounded — walk-away safe)
+  const prometheusState = readPrometheusState(sessionId);
+  if (prometheusState && prometheusState.active) {
+    if (detectPrometheusDone(lastAssistantMessage)) {
+      cleanupPrometheusState(sessionId);
+    } else {
+      const blockCount = getBlockCount(stateDir, attemptId);
+      if (blockCount >= MAX_BLOCK_COUNT) {
+        cleanupBlockCountFiles(stateDir, attemptId);
+        return formatContinueOutput();
+      }
+      incrementBlockCount(stateDir, attemptId);
+      return formatBlockOutput(buildPrometheusContinuationMessage());
     }
   }
 

--- a/hooks/persistent-mode/state.test.ts
+++ b/hooks/persistent-mode/state.test.ts
@@ -12,7 +12,7 @@ import {
   cleanupBlockCountFiles,
   MAX_BLOCK_COUNT,
 } from './state.ts';
-import type { RalphState, DeepInterviewState, PrometheusState } from './types.ts';
+import type { RalphState, DeepInterviewState } from './types.ts';
 import { mkdir, rm, writeFile, readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
@@ -352,24 +352,30 @@ describe('Prometheus state management', () => {
 
   describe('readPrometheusState', () => {
     it('prometheus: readPrometheusState returns state when active=true', async () => {
-      const state: PrometheusState = { active: true, sessionId: 's1' };
+      // Write the realistic on-disk shape that the seed hook and CLI produce
+      const onDisk = {
+        active: true,
+        phase: 'planning',
+        plan_path: '/tmp/plan.md',
+        resume_summary: 'Continue from step 3',
+        started_at: '2026-06-08T12:00:00+09:00',
+      };
       await writeFile(
         join(omtDir, `prometheus-state-${sessionId}.json`),
-        JSON.stringify(state)
+        JSON.stringify(onDisk)
       );
 
       const result = readPrometheusState(sessionId);
 
       expect(result).not.toBeNull();
       expect(result?.active).toBe(true);
-      expect(result?.sessionId).toBe('s1');
     });
 
     it('prometheus: readPrometheusState returns null when active=false', async () => {
-      const state: PrometheusState = { active: false, sessionId: 's1' };
+      const onDisk = { active: false };
       await writeFile(
         join(omtDir, `prometheus-state-${sessionId}.json`),
-        JSON.stringify(state)
+        JSON.stringify(onDisk)
       );
 
       const result = readPrometheusState(sessionId);
@@ -387,7 +393,7 @@ describe('Prometheus state management', () => {
   describe('cleanupPrometheusState', () => {
     it('prometheus: cleanupPrometheusState removes file and is idempotent', async () => {
       const stateFile = join(omtDir, `prometheus-state-${sessionId}.json`);
-      await writeFile(stateFile, JSON.stringify({ active: true, sessionId: 's1' }));
+      await writeFile(stateFile, JSON.stringify({ active: true, phase: 'planning', plan_path: '/tmp/plan.md', resume_summary: '', started_at: '2026-06-08T12:00:00+09:00' }));
 
       cleanupPrometheusState(sessionId);
 

--- a/hooks/persistent-mode/state.test.ts
+++ b/hooks/persistent-mode/state.test.ts
@@ -5,12 +5,14 @@ import {
   cleanupRalphState,
   readDeepInterviewState,
   cleanupDeepInterviewState,
+  readPrometheusState,
+  cleanupPrometheusState,
   getBlockCount,
   incrementBlockCount,
   cleanupBlockCountFiles,
   MAX_BLOCK_COUNT,
 } from './state.ts';
-import type { RalphState, DeepInterviewState } from './types.ts';
+import type { RalphState, DeepInterviewState, PrometheusState } from './types.ts';
 import { mkdir, rm, writeFile, readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
@@ -315,6 +317,84 @@ describe('Deep interview state management', () => {
 
       // Second call on nonexistent file must not throw
       expect(() => cleanupDeepInterviewState(sessionId)).not.toThrow();
+    });
+  });
+});
+
+describe('Prometheus state management', () => {
+  const testDir = join(tmpdir(), 'state-test-prometheus-' + Date.now());
+  const omtDir = join(testDir, 'omt');
+  const sessionId = 'test-session-prom';
+
+  const savedOmtDir = process.env.OMT_DIR;
+
+  beforeAll(async () => {
+    await mkdir(omtDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    process.env.OMT_DIR = omtDir;
+    const stateFile = join(omtDir, `prometheus-state-${sessionId}.json`);
+    try { await rm(stateFile, { force: true }); } catch {}
+  });
+
+  afterEach(() => {
+    if (savedOmtDir === undefined) {
+      delete process.env.OMT_DIR;
+    } else {
+      process.env.OMT_DIR = savedOmtDir;
+    }
+  });
+
+  describe('readPrometheusState', () => {
+    it('prometheus: readPrometheusState returns state when active=true', async () => {
+      const state: PrometheusState = { active: true, sessionId: 's1' };
+      await writeFile(
+        join(omtDir, `prometheus-state-${sessionId}.json`),
+        JSON.stringify(state)
+      );
+
+      const result = readPrometheusState(sessionId);
+
+      expect(result).not.toBeNull();
+      expect(result?.active).toBe(true);
+      expect(result?.sessionId).toBe('s1');
+    });
+
+    it('prometheus: readPrometheusState returns null when active=false', async () => {
+      const state: PrometheusState = { active: false, sessionId: 's1' };
+      await writeFile(
+        join(omtDir, `prometheus-state-${sessionId}.json`),
+        JSON.stringify(state)
+      );
+
+      const result = readPrometheusState(sessionId);
+
+      expect(result).toBeNull();
+    });
+
+    it('prometheus: readPrometheusState returns null when file is missing', () => {
+      const result = readPrometheusState(sessionId);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('cleanupPrometheusState', () => {
+    it('prometheus: cleanupPrometheusState removes file and is idempotent', async () => {
+      const stateFile = join(omtDir, `prometheus-state-${sessionId}.json`);
+      await writeFile(stateFile, JSON.stringify({ active: true, sessionId: 's1' }));
+
+      cleanupPrometheusState(sessionId);
+
+      expect(existsSync(stateFile)).toBe(false);
+
+      // Second call on nonexistent file must not throw
+      expect(() => cleanupPrometheusState(sessionId)).not.toThrow();
     });
   });
 });

--- a/hooks/persistent-mode/state.ts
+++ b/hooks/persistent-mode/state.ts
@@ -1,4 +1,4 @@
-import { RalphState, DeepInterviewState } from './types.ts';
+import { RalphState, DeepInterviewState, PrometheusState } from './types.ts';
 import { readFileOrNull, writeFileSafe, deleteFile, ensureDir } from './utils.ts';
 import { join } from 'path';
 import { getOmtDir } from '@lib/omt-dir';
@@ -42,6 +42,23 @@ export function readDeepInterviewState(sessionId: string): DeepInterviewState | 
 
 export function cleanupDeepInterviewState(sessionId: string): void {
   deleteFile(join(getOmtDir(), `deep-interview-active-state-${sessionId}.json`));
+}
+
+export function readPrometheusState(sessionId: string): PrometheusState | null {
+  const path = join(getOmtDir(), `prometheus-state-${sessionId}.json`);
+  const content = readFileOrNull(path);
+  if (!content) return null;
+
+  try {
+    const state = JSON.parse(content) as PrometheusState;
+    return state.active ? state : null;
+  } catch {
+    return null;
+  }
+}
+
+export function cleanupPrometheusState(sessionId: string): void {
+  deleteFile(join(getOmtDir(), `prometheus-state-${sessionId}.json`));
 }
 
 // Block counting for stuck agent escape hatch

--- a/hooks/persistent-mode/transcript-detector.ts
+++ b/hooks/persistent-mode/transcript-detector.ts
@@ -5,6 +5,7 @@ import { logDebug } from '@lib/logging';
 const PROMISE_PATTERN = /<promise>\s*DONE\s*<\/promise>/i;
 const ORACLE_APPROVED_PATTERN = /<oracle-approved>.*VERIFIED_COMPLETE.*<\/oracle-approved>/i;
 const DEEP_INTERVIEW_DONE_PATTERN = /<deep-interview-done\s*\/>/i;
+const PROMETHEUS_DONE_PATTERN = /<prometheus-done\s*\/>/i;
 
 export function detectCompletionPromise(lastAssistantMessage: string | null): boolean {
   if (!lastAssistantMessage) return false;
@@ -32,6 +33,16 @@ export function detectDeepInterviewDone(lastAssistantMessage: string | null): bo
   const detected = DEEP_INTERVIEW_DONE_PATTERN.test(lastAssistantMessage);
   if (detected) {
     logDebug('detected deep-interview done <deep-interview-done/>');
+  }
+  return detected;
+}
+
+export function detectPrometheusDone(lastAssistantMessage: string | null): boolean {
+  if (!lastAssistantMessage) return false;
+
+  const detected = PROMETHEUS_DONE_PATTERN.test(lastAssistantMessage);
+  if (detected) {
+    logDebug('detected prometheus done <prometheus-done/>');
   }
   return detected;
 }

--- a/hooks/persistent-mode/types.ts
+++ b/hooks/persistent-mode/types.ts
@@ -37,6 +37,17 @@ export interface DeepInterviewState {
   sessionId: string;
 }
 
+/**
+ * Minimal contract the persistent-mode hook reads from the prometheus
+ * state file. The on-disk file may carry additional fields at runtime
+ * written by the prometheus skill itself; only `active` is consulted here.
+ * Writers must merge rather than overwrite.
+ */
+export interface PrometheusState {
+  active: boolean;
+  sessionId: string;
+}
+
 // Hook output format
 export interface HookOutput {
   decision?: 'block' | 'continue';

--- a/hooks/persistent-mode/types.ts
+++ b/hooks/persistent-mode/types.ts
@@ -40,12 +40,13 @@ export interface DeepInterviewState {
 /**
  * Minimal contract the persistent-mode hook reads from the prometheus
  * state file. The on-disk file may carry additional fields at runtime
- * written by the prometheus skill itself; only `active` is consulted here.
- * Writers must merge rather than overwrite.
+ * (e.g. phase, plan_path, resume_summary, started_at) written by the
+ * prometheus skill itself; only `active` is consulted here. Writers must
+ * merge rather than overwrite — replacing the file with this minimal shape
+ * discards in-flight prometheus data.
  */
 export interface PrometheusState {
   active: boolean;
-  sessionId: string;
 }
 
 // Hook output format

--- a/hooks/pre-tool-enforcer.sh
+++ b/hooks/pre-tool-enforcer.sh
@@ -28,6 +28,33 @@ EOF
     exit 0
 fi
 
+# Seed prometheus pipeline-state file when Skill(prometheus) is intercepted
+# Fail-open: any error is swallowed so the Skill call is never blocked
+if [[ "$toolName" == "Skill" ]]; then
+    skillName=$(extract_json_field "skill" "")
+    if [[ "$skillName" == "prometheus" ]]; then
+        (
+            sid="${OMT_SESSION_ID:-}"
+            omt_dir="${OMT_DIR:-}"
+            if [[ -n "$sid" && -n "$omt_dir" ]]; then
+                state_file="$omt_dir/prometheus-state-${sid}.json"
+                if [ ! -f "$state_file" ]; then
+                    started_at=$(date -Iseconds 2>/dev/null || date +"%Y-%m-%dT%H:%M:%S")
+                    cat > "$state_file" << PROMETHEUS_STATE_EOF
+{
+  "active": true,
+  "phase": "S0",
+  "plan_path": "",
+  "resume_summary": "",
+  "started_at": "${started_at}"
+}
+PROMETHEUS_STATE_EOF
+                fi
+            fi
+        ) 2>/dev/null || true
+    fi
+fi
+
 # Allow all other tools
 echo '{"continue": true}'
 exit 0

--- a/hooks/pre-tool-enforcer_test.sh
+++ b/hooks/pre-tool-enforcer_test.sh
@@ -1,0 +1,352 @@
+#!/bin/bash
+# =============================================================================
+# Pre-Tool Enforcer Hook Tests
+# Covers: TaskOutput block (existing) + prometheus state seeding (new)
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Test utilities
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+setup_test_env() {
+    TEST_TMP_DIR=$(mktemp -d)
+    export OMT_DIR="$TEST_TMP_DIR/.omt"
+    mkdir -p "$OMT_DIR"
+    export OMT_SESSION_ID="test-sid"
+}
+
+teardown_test_env() {
+    unset OMT_DIR || true
+    unset OMT_SESSION_ID || true
+    if [[ -d "$TEST_TMP_DIR" ]]; then
+        rm -rf "$TEST_TMP_DIR"
+    fi
+}
+
+assert_file_exists() {
+    local file="$1"
+    local msg="${2:-File should exist: $file}"
+    if [[ -f "$file" ]]; then
+        return 0
+    else
+        echo "ASSERTION FAILED: $msg"
+        return 1
+    fi
+}
+
+assert_file_not_exists() {
+    local file="$1"
+    local msg="${2:-File should NOT exist: $file}"
+    if [[ ! -f "$file" ]]; then
+        return 0
+    else
+        echo "ASSERTION FAILED: $msg"
+        return 1
+    fi
+}
+
+assert_output_contains() {
+    local output="$1"
+    local pattern="$2"
+    local msg="${3:-Output should contain pattern}"
+    if echo "$output" | grep -q "$pattern"; then
+        return 0
+    else
+        echo "ASSERTION FAILED: $msg"
+        echo "  Pattern: '$pattern'"
+        echo "  Output: $output"
+        return 1
+    fi
+}
+
+assert_output_not_contains() {
+    local output="$1"
+    local pattern="$2"
+    local msg="${3:-Output should NOT contain pattern}"
+    if ! echo "$output" | grep -q "$pattern"; then
+        return 0
+    else
+        echo "ASSERTION FAILED: $msg"
+        echo "  Pattern: '$pattern'"
+        return 1
+    fi
+}
+
+run_test() {
+    local test_name="$1"
+
+    setup_test_env
+
+    if "$test_name"; then
+        echo "[PASS] $test_name"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "[FAIL] $test_name"
+        ((TESTS_FAILED++)) || true
+    fi
+
+    teardown_test_env
+}
+
+# =============================================================================
+# Existing behavior: TaskOutput blocking
+# =============================================================================
+
+test_taskoutput_is_blocked() {
+    local output
+    output=$(printf '%s' '{"tool_name":"TaskOutput","tool_input":{}}' \
+        | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+
+    if echo "$output" | grep -q '"continue"[[:space:]]*:[[:space:]]*false'; then
+        return 0
+    else
+        echo "ASSERTION FAILED: TaskOutput should be blocked"
+        echo "  Output: $output"
+        return 1
+    fi
+}
+
+test_other_tools_allowed() {
+    local output
+    output=$(printf '%s' '{"tool_name":"Read","tool_input":{}}' \
+        | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+
+    if echo "$output" | grep -q '"continue"[[:space:]]*:[[:space:]]*true'; then
+        return 0
+    else
+        echo "ASSERTION FAILED: Read tool should be allowed"
+        echo "  Output: $output"
+        return 1
+    fi
+}
+
+# =============================================================================
+# AC1 — Seed creates state file with correct fields
+# =============================================================================
+
+test_ac1_seed_creates_state_file() {
+    local state_file="$OMT_DIR/prometheus-state-test-sid.json"
+
+    printf '%s' '{"tool_name":"Skill","tool_input":{"skill":"prometheus"}}' \
+        | bash "$SCRIPT_DIR/pre-tool-enforcer.sh" > /dev/null
+
+    assert_file_exists "$state_file" "State file should be created for prometheus skill" || return 1
+
+    # Verify required fields via jq
+    jq -e '.active == true' "$state_file" > /dev/null 2>&1 \
+        || { echo "ASSERTION FAILED: .active should be true"; return 1; }
+
+    jq -e '.phase == "S0"' "$state_file" > /dev/null 2>&1 \
+        || { echo "ASSERTION FAILED: .phase should be S0"; return 1; }
+
+    local started_at
+    started_at=$(jq -r '.started_at' "$state_file")
+    [[ -n "$started_at" ]] \
+        || { echo "ASSERTION FAILED: .started_at should be non-empty"; return 1; }
+
+    jq -e '.plan_path == ""' "$state_file" > /dev/null 2>&1 \
+        || { echo "ASSERTION FAILED: .plan_path should be empty string"; return 1; }
+
+    jq -e '.resume_summary == ""' "$state_file" > /dev/null 2>&1 \
+        || { echo "ASSERTION FAILED: .resume_summary should be empty string"; return 1; }
+}
+
+# =============================================================================
+# AC2 — Create-if-absent (idempotent): re-fire must NOT overwrite
+# =============================================================================
+
+test_ac2_idempotent_seed_does_not_overwrite() {
+    local state_file="$OMT_DIR/prometheus-state-test-sid.json"
+
+    # First seed
+    printf '%s' '{"tool_name":"Skill","tool_input":{"skill":"prometheus"}}' \
+        | bash "$SCRIPT_DIR/pre-tool-enforcer.sh" > /dev/null
+
+    assert_file_exists "$state_file" "State file should exist after first seed" || return 1
+
+    local started_at_before
+    started_at_before=$(jq -r '.started_at' "$state_file")
+
+    # Simulate model advancing phase via TS CLI
+    bun "$SCRIPT_DIR/../skills/prometheus/scripts/prometheus-state.ts" set --phase S3 > /dev/null 2>&1 \
+        || { echo "ASSERTION FAILED: bun CLI set phase failed"; return 1; }
+
+    jq -e '.phase == "S3"' "$state_file" > /dev/null 2>&1 \
+        || { echo "ASSERTION FAILED: Phase should be S3 after CLI set"; return 1; }
+
+    # Re-fire seed — must NOT reset
+    printf '%s' '{"tool_name":"Skill","tool_input":{"skill":"prometheus"}}' \
+        | bash "$SCRIPT_DIR/pre-tool-enforcer.sh" > /dev/null
+
+    jq -e '.phase == "S3"' "$state_file" > /dev/null 2>&1 \
+        || { echo "ASSERTION FAILED: Re-fire should not reset phase to S0"; return 1; }
+
+    local started_at_after
+    started_at_after=$(jq -r '.started_at' "$state_file")
+    [[ "$started_at_before" == "$started_at_after" ]] \
+        || { echo "ASSERTION FAILED: started_at should be unchanged after re-fire (before=$started_at_before, after=$started_at_after)"; return 1; }
+}
+
+# =============================================================================
+# AC3 — Non-prometheus Skill does not seed
+# =============================================================================
+
+test_ac3_non_prometheus_skill_does_not_seed() {
+    local state_file="$OMT_DIR/prometheus-state-test-sid.json"
+
+    printf '%s' '{"tool_name":"Skill","tool_input":{"skill":"sisyphus"}}' \
+        | bash "$SCRIPT_DIR/pre-tool-enforcer.sh" > /dev/null
+
+    assert_file_not_exists "$state_file" "State file should NOT be created for non-prometheus skill" || return 1
+}
+
+# =============================================================================
+# AC4 — CWD-independent: seeded path is OMT_DIR-derived, not CWD-relative
+# =============================================================================
+
+test_ac4_cwd_independent_seeding() {
+    local state_file="$OMT_DIR/prometheus-state-test-sid.json"
+
+    # Run hook from /tmp (unrelated CWD)
+    (
+        cd /tmp
+        printf '%s' '{"tool_name":"Skill","tool_input":{"skill":"prometheus"}}' \
+            | bash "$SCRIPT_DIR/pre-tool-enforcer.sh" > /dev/null
+    )
+
+    assert_file_exists "$state_file" "State file should land under OMT_DIR regardless of CWD" || return 1
+}
+
+# =============================================================================
+# AC8 — Fail-open: missing OMT_DIR must not block/deny
+# =============================================================================
+
+test_ac8_fail_open_missing_omt_dir() {
+    local exit_code=0
+    local output
+
+    # Unset OMT_DIR for this test (env inherits from parent, must explicitly clear)
+    output=$(
+        env -u OMT_DIR \
+            printf '%s' '{"tool_name":"Skill","tool_input":{"skill":"prometheus"}}' \
+            | bash "$SCRIPT_DIR/pre-tool-enforcer.sh"
+    ) || exit_code=$?
+
+    [[ "$exit_code" -eq 0 ]] \
+        || { echo "ASSERTION FAILED: Hook should exit 0 when OMT_DIR unset (exit=$exit_code)"; return 1; }
+
+    assert_output_not_contains "$output" '"continue"[[:space:]]*:[[:space:]]*false' \
+        "Hook should NOT emit deny payload when OMT_DIR unset" || return 1
+}
+
+# =============================================================================
+# AC9 — started_at parseable by stale-cleanup (3h backstop)
+# =============================================================================
+
+test_ac9_started_at_parseable_by_stale_cleanup() {
+    local state_file="$OMT_DIR/prometheus-state-test-sid.json"
+
+    # Seed the state file
+    printf '%s' '{"tool_name":"Skill","tool_input":{"skill":"prometheus"}}' \
+        | bash "$SCRIPT_DIR/pre-tool-enforcer.sh" > /dev/null
+
+    assert_file_exists "$state_file" "State file should exist after seed" || return 1
+
+    # Backdate started_at to 4 hours ago (well past 3h threshold) by rewriting the file
+    local old_timestamp
+    old_timestamp=$(date -v-4H -Iseconds 2>/dev/null || date -d "4 hours ago" +"%Y-%m-%dT%H:%M:%S" 2>/dev/null || date +"%Y-%m-%dT%H:%M:%S" -d "-4 hours")
+    # Use jq to write a modified state file with old timestamp
+    local tmp_file
+    tmp_file=$(mktemp)
+    jq --arg ts "$old_timestamp" '.started_at = $ts' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
+
+    # Run the stale-cleanup logic inline (mirrors session-start.sh lines 74-94)
+    if command -v jq &> /dev/null; then
+        local stale_threshold=10800
+        local current_time
+        current_time=$(date +%s)
+
+        for sf in "$OMT_DIR"/prometheus-state-*.json; do
+            if [ -f "$sf" ]; then
+                local started_at_val
+                started_at_val=$(jq -r '.started_at // ""' "$sf" 2>/dev/null)
+                if [ -n "$started_at_val" ] && [ "$started_at_val" != "null" ]; then
+                    local time_part
+                    time_part=$(echo "$started_at_val" | sed -E 's/(Z|[+-][0-9]{2}:[0-9]{2})$//')
+                    local file_timestamp
+                    file_timestamp=$(date -j -f "%Y-%m-%dT%H:%M:%S" "$time_part" "+%s" 2>/dev/null)
+                    if [ -n "$file_timestamp" ]; then
+                        local age
+                        age=$((current_time - file_timestamp))
+                        if [ "$age" -gt "$stale_threshold" ]; then
+                            rm -f "$sf"
+                        fi
+                    fi
+                fi
+            fi
+        done
+    fi
+
+    assert_file_not_exists "$state_file" \
+        "Stale-cleanup should delete state file with started_at >3h old" || return 1
+}
+
+# =============================================================================
+# AC10 — Seed + CLI set-phase compose correctly
+# =============================================================================
+
+test_ac10_seed_and_cli_set_phase_compose() {
+    local state_file="$OMT_DIR/prometheus-state-test-sid.json"
+
+    # Seed
+    printf '%s' '{"tool_name":"Skill","tool_input":{"skill":"prometheus"}}' \
+        | bash "$SCRIPT_DIR/pre-tool-enforcer.sh" > /dev/null
+
+    assert_file_exists "$state_file" "State file should exist after seed" || return 1
+
+    # Advance phase via CLI
+    bun "$SCRIPT_DIR/../skills/prometheus/scripts/prometheus-state.ts" set --phase S3 > /dev/null 2>&1 \
+        || { echo "ASSERTION FAILED: bun CLI set --phase failed"; return 1; }
+
+    jq -e '.active == true' "$state_file" > /dev/null 2>&1 \
+        || { echo "ASSERTION FAILED: .active should remain true after CLI set"; return 1; }
+
+    jq -e '.phase == "S3"' "$state_file" > /dev/null 2>&1 \
+        || { echo "ASSERTION FAILED: .phase should be S3 after CLI set"; return 1; }
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+main() {
+    echo "=========================================="
+    echo "Pre-Tool Enforcer Tests"
+    echo "=========================================="
+
+    # Existing behavior
+    run_test test_taskoutput_is_blocked
+    run_test test_other_tools_allowed
+
+    # Prometheus state seeding
+    run_test test_ac1_seed_creates_state_file
+    run_test test_ac2_idempotent_seed_does_not_overwrite
+    run_test test_ac3_non_prometheus_skill_does_not_seed
+    run_test test_ac4_cwd_independent_seeding
+    run_test test_ac8_fail_open_missing_omt_dir
+    run_test test_ac9_started_at_parseable_by_stale_cleanup
+    run_test test_ac10_seed_and_cli_set_phase_compose
+
+    echo "=========================================="
+    echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"
+    echo "=========================================="
+
+    if [[ $TESTS_FAILED -gt 0 ]]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/hooks/pre-tool-enforcer_test.sh
+++ b/hooks/pre-tool-enforcer_test.sh
@@ -48,20 +48,6 @@ assert_file_not_exists() {
     fi
 }
 
-assert_output_contains() {
-    local output="$1"
-    local pattern="$2"
-    local msg="${3:-Output should contain pattern}"
-    if echo "$output" | grep -q "$pattern"; then
-        return 0
-    else
-        echo "ASSERTION FAILED: $msg"
-        echo "  Pattern: '$pattern'"
-        echo "  Output: $output"
-        return 1
-    fi
-}
-
 assert_output_not_contains() {
     local output="$1"
     local pattern="$2"
@@ -227,11 +213,14 @@ test_ac4_cwd_independent_seeding() {
 test_ac8_fail_open_missing_omt_dir() {
     local exit_code=0
     local output
+    # Capture the test OMT_DIR before we unset it inside the subshell
+    local saved_omt_dir="$OMT_DIR"
 
-    # Unset OMT_DIR for this test (env inherits from parent, must explicitly clear)
+    # unset OMT_DIR inside the $() subshell so the hook on the pipe RHS also
+    # sees OMT_DIR unset.  env -u on the printf (LHS) would NOT affect the hook.
     output=$(
-        env -u OMT_DIR \
-            printf '%s' '{"tool_name":"Skill","tool_input":{"skill":"prometheus"}}' \
+        unset OMT_DIR
+        printf '%s' '{"tool_name":"Skill","tool_input":{"skill":"prometheus"}}' \
             | bash "$SCRIPT_DIR/pre-tool-enforcer.sh"
     ) || exit_code=$?
 
@@ -240,6 +229,12 @@ test_ac8_fail_open_missing_omt_dir() {
 
     assert_output_not_contains "$output" '"continue"[[:space:]]*:[[:space:]]*false' \
         "Hook should NOT emit deny payload when OMT_DIR unset" || return 1
+
+    # Distinguishing assertion: with OMT_DIR unset the hook must NOT create a
+    # state file.  This would catch any fail-closed regression.
+    local state_file="$saved_omt_dir/prometheus-state-${OMT_SESSION_ID}.json"
+    assert_file_not_exists "$state_file" \
+        "Hook must NOT create state file when OMT_DIR is unset (fail-open)" || return 1
 }
 
 # =============================================================================
@@ -263,32 +258,11 @@ test_ac9_started_at_parseable_by_stale_cleanup() {
     tmp_file=$(mktemp)
     jq --arg ts "$old_timestamp" '.started_at = $ts' "$state_file" > "$tmp_file" && mv "$tmp_file" "$state_file"
 
-    # Run the stale-cleanup logic inline (mirrors session-start.sh lines 74-94)
-    if command -v jq &> /dev/null; then
-        local stale_threshold=10800
-        local current_time
-        current_time=$(date +%s)
-
-        for sf in "$OMT_DIR"/prometheus-state-*.json; do
-            if [ -f "$sf" ]; then
-                local started_at_val
-                started_at_val=$(jq -r '.started_at // ""' "$sf" 2>/dev/null)
-                if [ -n "$started_at_val" ] && [ "$started_at_val" != "null" ]; then
-                    local time_part
-                    time_part=$(echo "$started_at_val" | sed -E 's/(Z|[+-][0-9]{2}:[0-9]{2})$//')
-                    local file_timestamp
-                    file_timestamp=$(date -j -f "%Y-%m-%dT%H:%M:%S" "$time_part" "+%s" 2>/dev/null)
-                    if [ -n "$file_timestamp" ]; then
-                        local age
-                        age=$((current_time - file_timestamp))
-                        if [ "$age" -gt "$stale_threshold" ]; then
-                            rm -f "$sf"
-                        fi
-                    fi
-                fi
-            fi
-        done
-    fi
+    # Invoke the REAL session-start hook so the production stale-cleanup path is
+    # exercised (not an inline copy that could diverge).  OMT_DIR is already
+    # exported by setup_test_env; compute_omt_dir short-circuits on a preset
+    # OMT_DIR, so session-start runs against the test directory.
+    printf '{}' | bash "$SCRIPT_DIR/session-start.sh" > /dev/null 2>&1
 
     assert_file_not_exists "$state_file" \
         "Stale-cleanup should delete state file with started_at >3h old" || return 1

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -959,7 +959,7 @@ Each reviewer invocation MUST use a **fresh agent instance**. Do not reuse an ag
 
 These directives govern how prometheus records its own pipeline state via the state CLI.
 
-- **Per each S-transition**: run `bun ${CLAUDE_SKILL_DIR}/scripts/prometheus-state.ts set --phase <S>` immediately after entering the new state. Pass `--plan-path <p>` once at S2 (when the design-brief / ADR is first written during the Co-Design state — this is the first durable plan artifact on disk; the TODO plan body is appended later at S3); later transitions may omit it and the stored value is preserved automatically — omitting does NOT clear it. Pass `--resume-summary "<one line>"` whenever you want to refresh the pause bookmark; omitting it likewise preserves the previous bookmark.
+- **Per each S-transition**: run `bun "${CLAUDE_SKILL_DIR}/scripts/prometheus-state.ts" set --phase <S>` immediately after entering the new state. Pass `--plan-path <p>` once at S2 (when the design-brief / ADR is first written during the Co-Design state — this is the first durable plan artifact on disk; the TODO plan body is appended later at S3); later transitions may omit it and the stored value is preserved automatically — omitting does NOT clear it. Pass `--resume-summary "<one line>"` whenever you want to refresh the pause bookmark; omitting it likewise preserves the previous bookmark.
 - **Teardown**: At S8 dispatch and on abort, emit `<prometheus-done/>` as a standalone output token. The persistent-mode hook detects this token and performs the actual state-file deletion — the model does not call `clear` directly.
 - **Session key**: state is keyed by the exported `$OMT_SESSION_ID` environment variable (the CLI falls back to `default` when `OMT_SESSION_ID` is unset).
 - **Restore**: on restore, re-read the current plan file, restart from `resume_summary` if `plan_path` is missing, distrust any stored verdict, and re-run gates on the current artifact. A stored verdict is not a pass — re-verification is mandatory.
@@ -978,7 +978,7 @@ Time pressure, user override ("just proceed"), self-assessment of fix correctnes
 | 2 | File references exist | All file paths and line references resolve |
 | 3 | Guardrails from Metis incorporated | Every Metis-flagged constraint reflected |
 | 4 | Zero human-intervention criteria | No TODO requires manual mid-execution action |
-| 5 | Section validator passes | Run `bun ${CLAUDE_SKILL_DIR}/scripts/validate-plan.ts <plan_path>` (invoked ONLY here, pre-S4, full plan). If it reports missing or empty sections, fix the plan and re-run before submitting to Momus. |
+| 5 | Section validator passes | Run `bun "${CLAUDE_SKILL_DIR}/scripts/validate-plan.ts" <plan_path>` (invoked ONLY here, pre-S4, full plan). If it reports missing or empty sections, fix the plan and re-run before submitting to Momus. |
 | 6 | design forks resolved | Every CRITICAL design fork is resolved with a recorded decision carried through the S2 Co-Design human gate; an unresolved fork reopens the co-design interview (`### Next-Gate Readiness Rule`) rather than reaching the plan. No fork is silently absorbed. |
 
 Item 2 ("File references exist") is a lightweight pre-Momus self-filter — it catches obviously stale paths before the plan reaches the feasibility gate. It is complementary to, not a substitute for, Momus's authoritative codebase-feasibility verification: this self-check is a cheap first pass; Momus is the gate.

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -959,9 +959,8 @@ Each reviewer invocation MUST use a **fresh agent instance**. Do not reuse an ag
 
 These directives govern how prometheus records its own pipeline state via the state CLI.
 
-- **S0 entry**: run `bun skills/prometheus/scripts/prometheus-state.ts set --phase S0`.
-- **Per each S-transition**: run `bun skills/prometheus/scripts/prometheus-state.ts set --phase <S>` immediately after entering the new state. Pass `--plan-path <p>` once at S2 (when the design-brief / ADR is first written during the Co-Design state — this is the first durable plan artifact on disk; the TODO plan body is appended later at S3); later transitions may omit it and the stored value is preserved automatically — omitting does NOT clear it. Pass `--resume-summary "<one line>"` whenever you want to refresh the pause bookmark; omitting it likewise preserves the previous bookmark.
-- **Teardown**: AFTER S8 dispatch is invoked, and on abort, run `bun skills/prometheus/scripts/prometheus-state.ts clear`.
+- **Per each S-transition**: run `bun ${CLAUDE_SKILL_DIR}/scripts/prometheus-state.ts set --phase <S>` immediately after entering the new state. Pass `--plan-path <p>` once at S2 (when the design-brief / ADR is first written during the Co-Design state — this is the first durable plan artifact on disk; the TODO plan body is appended later at S3); later transitions may omit it and the stored value is preserved automatically — omitting does NOT clear it. Pass `--resume-summary "<one line>"` whenever you want to refresh the pause bookmark; omitting it likewise preserves the previous bookmark.
+- **Teardown**: At S8 dispatch and on abort, emit `<prometheus-done/>` as a standalone output token. The persistent-mode hook detects this token and performs the actual state-file deletion — the model does not call `clear` directly.
 - **Session key**: state is keyed by the exported `$OMT_SESSION_ID` environment variable (the CLI falls back to `default` when `OMT_SESSION_ID` is unset).
 - **Restore**: on restore, re-read the current plan file, restart from `resume_summary` if `plan_path` is missing, distrust any stored verdict, and re-run gates on the current artifact. A stored verdict is not a pass — re-verification is mandatory.
 
@@ -979,7 +978,7 @@ Time pressure, user override ("just proceed"), self-assessment of fix correctnes
 | 2 | File references exist | All file paths and line references resolve |
 | 3 | Guardrails from Metis incorporated | Every Metis-flagged constraint reflected |
 | 4 | Zero human-intervention criteria | No TODO requires manual mid-execution action |
-| 5 | Section validator passes | Run `bun skills/prometheus/scripts/validate-plan.ts <plan_path>` (invoked ONLY here, pre-S4, full plan). If it reports missing or empty sections, fix the plan and re-run before submitting to Momus. |
+| 5 | Section validator passes | Run `bun ${CLAUDE_SKILL_DIR}/scripts/validate-plan.ts <plan_path>` (invoked ONLY here, pre-S4, full plan). If it reports missing or empty sections, fix the plan and re-run before submitting to Momus. |
 | 6 | design forks resolved | Every CRITICAL design fork is resolved with a recorded decision carried through the S2 Co-Design human gate; an unresolved fork reopens the co-design interview (`### Next-Gate Readiness Rule`) rather than reaching the plan. No fork is silently absorbed. |
 
 Item 2 ("File references exist") is a lightweight pre-Momus self-filter — it catches obviously stale paths before the plan reaches the feasibility gate. It is complementary to, not a substitute for, Momus's authoritative codebase-feasibility verification: this self-check is a cheap first pass; Momus is the gate.


### PR DESCRIPTION
## 📌 Summary

prometheus 플래닝 스킬의 파이프라인 상태 파일이 모델이 실행해야 하는 SKILL.md 산문 지시문에만 의존해 deep 세션에서 생성이 누락되던 문제를, harness(훅 + persistent-mode)가 생성·정리하는 결정론적 생애주기로 전환합니다.

---

## 🔧 Changes

### 상태 파일 시드 (PreToolUse 훅)

- `Skill(prometheus)` 호출을 가로채는 PreToolUse 훅에서 `$OMT_DIR/prometheus-state-{sid}.json`을 직접 생성 (create-if-absent, `active:true / phase:"S0" / started_at`).
- 모델의 CLI 실행이 아니라 harness가 inline bash로 상태를 기록하므로, 지시문을 건너뛰어도 상태가 보장됩니다.

기존엔 `SKILL.md`에 묻힌 `bun ...prometheus-state.ts set --phase S0` 지시문이 유일한 생성 경로였고, deep 세션의 모델이 이를 건너뛰면 상태 파일이 끝까지 생성되지 않았습니다(라이브 확정).

**영향 범위**
- `hooks/pre-tool-enforcer.sh` (기존 TaskOutput 차단 로직 뒤에 seed 분기 추가). 내부 harness 전용, 공개 API 영향 없음. seed는 fail-open이라 실패해도 `Skill` 호출을 막지 않음. 배포 타깃엔 `make sync` 후 반영.

### SKILL.md 상태 지시문

- S0 생성 지시문 제거(훅이 소유), per-transition `set` + `validate-plan` 호출을 CWD-상대 `bun skills/...`에서 `bun "${CLAUDE_SKILL_DIR}/scripts/..."`로 전환.
- teardown을 모델의 `clear` CLI 호출에서 `<prometheus-done/>` 토큰 방출로 변경.

**영향 범위**
- `skills/prometheus/SKILL.md`. CWD-상대 경로가 배포 타깃 프로젝트(CWD=타깃)에서 깨지던 잠재 버그도 함께 해소. 상태 스키마·restore 로직 무변경.

### persistent-mode 생애주기 (teardown + 연속 차단)

- `readPrometheusState`/`cleanupPrometheusState` 추가(deep-interview sibling 미러), `PrometheusState` 타입 추가.
- `<prometheus-done/>` 감지(`detectPrometheusDone`, last-message-only) + decision 분기: active면 토큰 시 정리, 아니면 `MAX_BLOCK_COUNT` bounded escape로 연속 차단.

**영향 범위**
- `hooks/persistent-mode/{state.ts, decision.ts, transcript-detector.ts, types.ts}`. Stop 훅에서 동작. ralph(priority 1) 아래(priority 1.5)에 배치돼 ralph가 우선. `session-start.sh` restore·3h stale-cleanup 무변경.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.

### 1. seed를 CLI 호출이 아닌 inline bash로

**배경 및 문제 상황:**
`pre-tool-enforcer.sh`는 `Skill` 호출 경로를 가로막는 *블로킹* PreToolUse 훅이고 5초 타임아웃 예산 위에서 돕니다. 상태 생성의 원칙은 "harness가 쓴다"인데, 그 구현으로 훅에서 TS CLI(`bun ...prometheus-state.ts`)를 부르는 안과 bash로 JSON을 직접 쓰는 안이 있었습니다.

**해결 방안:**
inline bash로 5개 필드 JSON을 직접 기록(Option B). CLI-from-hook(Option A)은 기각.

**구현 세부사항:**
seed는 `[ ! -f ]` create-if-absent 가드(재호출 시 phase 리셋 방지 — `setPrometheusState`는 phase를 무조건 덮어씀), sid는 `$OMT_SESSION_ID`(session-start가 env로 export, CLI/restore와 파일명 일치), `started_at`은 `date -Iseconds`(기존 stale-cleanup 파서 호환). 전체를 `( ... ) 2>/dev/null || true`로 감싸 fail-open 보장.

**선택과 트레이드오프:**
CLI-from-hook은 경로 fragility 때문이 아니라 5초 블로킹 예산 위의 `bun` cold-start 지연 + PATH 의존이 결정적 비용이라 기각했습니다. 대가는 JSON 필드 셋이 bash·TS 두 writer에 중복된다는 점인데, 스키마가 고정 계약이고 seed 테스트의 필드 셋 단언이 drift를 fail-loud로 잡아 상쇄됩니다.

### 2. teardown 연속 차단 — bounded escape (deep-interview와 다른 선택)

**배경 및 문제 상황:**
토큰 방출(teardown)을 신뢰 가능하게 만들려면 active 상태에서 모델이 그냥 멈추지 못하게 차단해야 합니다. 가장 가까운 선례인 deep-interview의 연속 차단은 **escape hatch가 없는** 무한 차단인데, 3h stale-cleanup은 SessionStart에서만 돌고 Stop엔 안 돕니다. prometheus는 S2·design gate·S7 등 human-gate가 많아, 사용자가 정당하게 자리를 비우면 무한 차단에 갇힙니다.

**해결 방안:**
todo-continuation의 `blockCount >= MAX_BLOCK_COUNT` escape 패턴을 차용한 **bounded** 연속 차단. N회 토큰 없는 차단 후엔 Stop을 허용.

**선택과 트레이드오프:**
deep-interview를 그대로 미러(unbounded)하면 walk-away 트랩이 생기고, 차단 없이 토큰 정리만 하면 teardown이 3h 백스톱으로 퇴화합니다. bounded escape는 공통 케이스의 결정론적 teardown과 walk-away 사용자의 보장된 탈출을 모두 얻습니다. 대가는 의도적 포기 시 즉시가 아니라 N회 차단 후 해제된다는 점. (`AskUserQuestion`은 tool call이지 Stop이 아니라 human-gate 자체는 차단을 트리거하지 않습니다.)

### 3. bounded escape 카운터를 prometheus 전용 키로 분리

**배경 및 문제 상황:**
초기 구현은 bounded escape에 세션 전역 `block-count-${sessionId}` 파일을 todo-continuation 분기와 **공유**했습니다. 이 경우 prometheus seed 이전 같은 세션에서 발생한 incomplete-todo Stop이 카운터를 선적재해, prometheus의 escape 예산을 미리 소진합니다(최악: 첫 Stop에서 즉시 escape → 보호 0회). 이는 이 변경의 헤드라인 보장을 무력화합니다.

**해결 방안:**
prometheus 분기의 카운터 키를 `prometheus-${attemptId}`로 분리하고, done-token 정리 시 그 전용 카운터도 함께 리셋.

**관련 코드:**
```ts
// decision.ts — prometheus 분기
const prometheusAttemptId = `prometheus-${attemptId}`;
const blockCount = getBlockCount(stateDir, prometheusAttemptId);
if (blockCount >= MAX_BLOCK_COUNT) {
  cleanupBlockCountFiles(stateDir, prometheusAttemptId);
  return formatContinueOutput();
}
```

**선택과 트레이드오프:**
todo 카운터를 그대로 재사용하면 코드 한 줄이 줄지만, "두 기능이 같은 세션 카운터를 공유"가 cross-feature 오염을 낳습니다. 전용 키는 escape 예산을 feature-private로 만들어 보장을 회복합니다. 회귀 테스트는 todo 키를 MAX로 선적재한 뒤 prometheus가 여전히 차단됨을 단언해(구버전이면 실패) 비-vacuous함을 검증했습니다.

---

## ✅ Checklist

### 상태 생성 (seed)
- [ ] `Skill(prometheus)` PreToolUse 이벤트가 `$OMT_DIR/prometheus-state-{sid}.json`을 `active:true/phase:S0/started_at`로 생성한다
  - `hooks/pre-tool-enforcer.sh`
- [ ] `OMT_DIR`/`OMT_SESSION_ID` 미설정 등 seed 실패 시에도 `Skill` 호출이 차단되지 않는다 (fail-open)
  - `hooks/pre-tool-enforcer.sh`
- [ ] 재호출 시 기존 phase/started_at이 보존된다 (create-if-absent)
  - `hooks/pre-tool-enforcer.sh`

### teardown / 연속 차단
- [ ] 마지막 메시지의 `<prometheus-done/>`가 상태 파일과 prometheus 전용 카운터를 삭제한다
  - `hooks/persistent-mode/decision.ts`, `hooks/persistent-mode/transcript-detector.ts`
- [ ] active 상태 + 토큰 없음 + Stop이면 prometheus-continuation으로 차단된다
  - `hooks/persistent-mode/decision.ts`
- [ ] `MAX_BLOCK_COUNT`회 연속 차단 후 Stop이 허용된다 (bounded escape)
  - `hooks/persistent-mode/decision.ts`
- [ ] 선행 todo 차단이 prometheus의 escape 예산을 단축하지 않는다 (전용 카운터 격리)
  - `hooks/persistent-mode/decision.ts`

### 경로 / 회귀
- [ ] SKILL.md 상태 지시문에 CWD-상대 `bun skills/prometheus/scripts/`가 남아있지 않고 `${CLAUDE_SKILL_DIR}`가 인용된다
  - `skills/prometheus/SKILL.md`
- [ ] `make validate` + `make test`가 exit 0 (Shell 7/7, Bun 2034 pass)
  - 전체
