### PR TITLE
chore(sync): frontend-design 마켓플레이스 official 표준화

### DIFF
--- a/claude.yaml
+++ b/claude.yaml
@@ -50,6 +50,7 @@ plugins:
     - context7
     - superpowers
     - code-review
+    - frontend-design
     - name: plannotator@plannotator
       check: jq -e '.plugins["plannotator@plannotator"]' ~/.claude/plugins/installed_plugins.json >/dev/null 2>&1
       pre-commands:

--- a/projects/oh-my-resume/claude.yaml
+++ b/projects/oh-my-resume/claude.yaml
@@ -5,10 +5,10 @@ hooks:
 
 plugins:
   items:
-    - name: frontend-design@claude-code-plugins
-      check: jq -e '.plugins["frontend-design@claude-code-plugins"]' ~/.claude/plugins/installed_plugins.json >/dev/null 2>&1
+    - name: frontend-design@claude-plugins-official
+      check: jq -e '.plugins["frontend-design@claude-plugins-official"]' ~/.claude/plugins/installed_plugins.json >/dev/null 2>&1
       pre-commands:
-        - claude plugin marketplace add anthropics/claude-code
+        - claude plugin marketplace add anthropics/claude-plugins-official
     - name: insane-search@gptaku-plugins
       check: jq -e '.plugins["insane-search@gptaku-plugins"]' ~/.claude/plugins/installed_plugins.json >/dev/null 2>&1
       pre-commands:

--- a/projects/resume-manage/claude.yaml
+++ b/projects/resume-manage/claude.yaml
@@ -17,10 +17,10 @@ config:
 
 plugins:
   items:
-    - name: frontend-design@claude-code-plugins
-      check: jq -e '.plugins["frontend-design@claude-code-plugins"]' ~/.claude/plugins/installed_plugins.json >/dev/null 2>&1
+    - name: frontend-design@claude-plugins-official
+      check: jq -e '.plugins["frontend-design@claude-plugins-official"]' ~/.claude/plugins/installed_plugins.json >/dev/null 2>&1
       pre-commands:
-        - claude plugin marketplace add anthropics/claude-code
+        - claude plugin marketplace add anthropics/claude-plugins-official
     - name: insane-search@gptaku-plugins
       check: jq -e '.plugins["insane-search@gptaku-plugins"]' ~/.claude/plugins/installed_plugins.json >/dev/null 2>&1
       pre-commands:

--- a/skills/sisyphus/hooks/skill-catalog/catalog.test.ts
+++ b/skills/sisyphus/hooks/skill-catalog/catalog.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'bun:test';
 import { SITUATIONS, SKILL_HASHMAP, buildCatalog, formatCatalog } from './catalog.ts';
 
 const SUPERPOWERS_PLUGIN = 'superpowers@claude-plugins-official';
-const FRONTEND_DESIGN_PLUGIN = 'frontend-design@claude-code-plugins';
+const FRONTEND_DESIGN_PLUGIN = 'frontend-design@claude-plugins-official';
 
 describe('SITUATIONS', () => {
   it('5개의 상황이 정의되어 있다', () => {

--- a/skills/sisyphus/hooks/skill-catalog/catalog.ts
+++ b/skills/sisyphus/hooks/skill-catalog/catalog.ts
@@ -58,7 +58,7 @@ export const SKILL_HASHMAP: Map<string, HashmapSkillEntry> = new Map([
     'frontend-design',
     {
       description: 'Frontend design skill — UI component design and visual implementation',
-      pluginId: 'frontend-design@claude-code-plugins',
+      pluginId: 'frontend-design@claude-plugins-official',
       situationIds: ['design'],
     },
   ],


### PR DESCRIPTION
## 📌 Summary
frontend-design 플러그인을 공식 마켓플레이스(`claude-plugins-official`)로 표준화한다. 전역(root `claude.yaml`)에 신규 등록하고, 기존 프로젝트 설정 두 곳이 참조하던 비표준 마켓플레이스(`claude-code-plugins`)를 official로 통일한다.

---

## 🔧 Changes

### 전역 플러그인 등록 — `claude.yaml`
- `plugins.items`에 `frontend-design` 추가 (bare-string)
- 기존 official 플러그인(`context7`·`superpowers`·`code-review`)과 동일 형식. `claude-plugins-official` 마켓플레이스가 이미 등록돼 있어 install 시 `@claude-plugins-official`로 자동 resolve된다.

**영향 범위**
전역 Claude 설정. 다음 세션부터 frontend-design 스킬 트리거 활성. additive 변경이라 기존 플러그인/스킬에 영향 없음. `make sync` 시 idempotent check로 재설치를 스킵한다.

### 프로젝트 설정 마켓플레이스 통일 — `resume-manage`, `oh-my-resume`
- frontend-design 항목을 `@claude-code-plugins`(`anthropics/claude-code`) → `@claude-plugins-official`(`anthropics/claude-plugins-official`)로 변경
- `name`·`check`·`pre-commands` 3곳 일괄 수정. 이 변경으로 불필요해진 `anthropics/claude-code` 마켓플레이스 등록을 제거.

**영향 범위**
두 프로젝트의 claude 설정만. 같은 파일의 playwright 항목과 동일한 형식으로 정렬됨. `anthropics/claude-code` 마켓플레이스는 더 이상 참조되지 않아 등록 1건 감소.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.

### 1. frontend-design 배포 단위: standalone vs example-skills 번들

**배경 및 문제 상황:**
frontend-design은 두 경로로 제공된다 — (a) `claude-plugins-official`의 standalone 플러그인, (b) `anthropics/skills`의 `example-skills` 번들(12개 스킬 묶음). 그리고 webapp-testing·web-artifacts-builder는 단독 플러그인이 없어 오직 이 번들로만 받을 수 있다.

**해결 방안:**
standalone(`claude-plugins-official`) 채택. webapp-testing/web-artifacts-builder는 도입 보류.

**구현 세부사항:**
root는 bare-string으로 등록해 official로 자동 resolve시키고, 프로젝트 설정은 명시적 object 형식(`check` + marketplace add `pre-command`)으로 fresh 머신 동기화에 대응한다.

**선택과 트레이드오프:**
번들은 frontend-design 외에 안 쓰는 9개 스킬과 이미 설치된 skill-creator 중복을 끌고 온다 → Simplicity First로 standalone 선택. 트레이드오프: webapp-testing/web-artifacts-builder가 필요해지면 별도 도입 결정이 필요하다(번들은 all-or-nothing이라 cherry-pick 불가).

### 2. 통일 대상으로 claude-plugins-official을 택한 근거

**배경 및 문제 상황:**
프로젝트 설정의 frontend-design은 2026-04-02 커밋(`5905ea2`) 당시 알려진 경로였던 `claude-code-plugins`(`anthropics/claude-code`)를 참조했다. 이후 official 마켓플레이스로 통합됐으나 이 항목만 갱신이 누락됐고(같은 파일 playwright는 이미 `claude-plugins-official` 사용), 실제로는 한 번도 설치된 적 없는 stale 참조였다.

**해결 방안:**
`claude-plugins-official`로 통일.

**구현 세부사항:**
`claude-code-plugins` 마켓플레이스도 frontend-design을 여전히 제공하지만(유효함), 통일 기준은 "정규 공식 마켓플레이스 + 파일 내 일관성"이다. 통일 후 frontend-design 항목이 playwright와 동형이 되고, 중복 marketplace add가 1건 줄어든다.

**선택과 트레이드오프:**
두 마켓플레이스 모두 같은 스킬을 제공해 기능 차이는 없다. official 선택의 실익은 일관성과 중복 마켓플레이스 제거이며, `claude-code-plugins`를 유지할 이유가 없어 제거했다.

---

## ✅ Checklist

### 전역 등록
- [ ] `make validate-schema`가 통과한다
  - `claude.yaml`
- [ ] installed_plugins.json에 `frontend-design@claude-plugins-official` 항목이 존재한다
  - `claude.yaml`

### 프로젝트 통일
- [ ] repo 전체에 `claude-code-plugins` / `anthropics/claude-code` 잔여 참조가 0건이다
  - `projects/resume-manage/claude.yaml`
  - `projects/oh-my-resume/claude.yaml`
- [ ] 두 프로젝트의 frontend-design 항목이 같은 파일 playwright 항목과 동일한 `@claude-plugins-official` 형식이다
  - `projects/resume-manage/claude.yaml`
  - `projects/oh-my-resume/claude.yaml`

---

## 📎 References
- [claude-plugins-official 마켓플레이스](https://github.com/anthropics/claude-plugins-official)