### PR TITLE
fix: state lifecycle 2차 리뷰 후속 하드닝

### DIFF
--- a/hooks/keyword-detector.sh
+++ b/hooks/keyword-detector.sh
@@ -118,7 +118,7 @@ fi
 # Check for deep-interview keywords (third priority)
 if echo "$PROMPT_LOWER" | grep -qiE '\b(deep[- ]?interview|ouroboros)\b|딥인터뷰'; then
   cat << 'EOF'
-{"continue": true, "hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": "<deep-interview-mode>\n\n**DEEP INTERVIEW MODE ACTIVATED** (deep-interview)\n\nYou are now in deep interview mode. Conduct a thorough, structured interview:\n1. Ask one focused question at a time\n2. Listen carefully and probe deeper based on responses\n3. Synthesize insights across the conversation\n4. Surface assumptions and validate them explicitly\n\nRemain in deep interview mode until the session is explicitly concluded.\n\n</deep-interview-mode>\n\n---\n"}}
+{"continue": true, "hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": "<deep-interview-mode>\n\n**DEEP INTERVIEW REQUESTED** — you MUST invoke `Skill(deep-interview)` before responding. Do NOT conduct the interview directly. The skill invocation activates state tracking and stop protection.\n\n</deep-interview-mode>\n\n---\n"}}
 EOF
   exit 0
 fi

--- a/hooks/keyword-detector_test.sh
+++ b/hooks/keyword-detector_test.sh
@@ -482,8 +482,10 @@ test_deep_interview_english_keyword_activates_mode() {
     local output
     output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$session_id"'", "prompt": "deep interview about auth"}' | "$SCRIPT_DIR/keyword-detector.sh" 2>&1) || true
 
-    assert_output_contains "$output" "DEEP INTERVIEW MODE ACTIVATED" "Should activate deep interview mode" || return 1
+    assert_output_contains "$output" "DEEP INTERVIEW REQUESTED" "Should say REQUESTED, not ACTIVATED" || return 1
+    assert_output_contains "$output" "Skill(deep-interview)" "Should mandate calling Skill(deep-interview)" || return 1
     assert_output_contains "$output" "deep-interview-mode" "Output should contain deep-interview-mode tag" || return 1
+    assert_output_not_contains "$output" "You are now in deep interview mode" "Should NOT instruct model to conduct the interview directly" || return 1
     # State file is NOT created by keyword-detector — creation moved to pre-tool-enforcer seed
     assert_file_not_exists "$TEST_TMP_DIR/.omt/deep-interview-active-state-${session_id}.json" "keyword-detector must NOT create state file (creation moved to seed)" || return 1
 }
@@ -495,7 +497,8 @@ test_deep_interview_ouroboros_keyword() {
     local output
     output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$session_id"'", "prompt": "ouroboros this conversation"}' | "$SCRIPT_DIR/keyword-detector.sh" 2>&1) || true
 
-    assert_output_contains "$output" "DEEP INTERVIEW MODE ACTIVATED" "Should activate deep interview mode for ouroboros keyword" || return 1
+    assert_output_contains "$output" "DEEP INTERVIEW REQUESTED" "Should say REQUESTED for ouroboros keyword" || return 1
+    assert_output_contains "$output" "Skill(deep-interview)" "Should mandate calling Skill(deep-interview) for ouroboros" || return 1
     assert_output_contains "$output" "deep-interview-mode" "Output should contain deep-interview-mode tag" || return 1
     # State file is NOT created by keyword-detector
     assert_file_not_exists "$TEST_TMP_DIR/.omt/deep-interview-active-state-${session_id}.json" "keyword-detector must NOT create state file for ouroboros" || return 1
@@ -508,7 +511,8 @@ test_deep_interview_korean_keyword() {
     local output
     output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$session_id"'", "prompt": "딥인터뷰 시작해줘"}' | "$SCRIPT_DIR/keyword-detector.sh" 2>&1) || true
 
-    assert_output_contains "$output" "DEEP INTERVIEW MODE ACTIVATED" "Should activate deep interview mode for Korean keyword 딥인터뷰" || return 1
+    assert_output_contains "$output" "DEEP INTERVIEW REQUESTED" "Should say REQUESTED for Korean keyword 딥인터뷰" || return 1
+    assert_output_contains "$output" "Skill(deep-interview)" "Should mandate calling Skill(deep-interview) for Korean keyword" || return 1
     assert_output_contains "$output" "deep-interview-mode" "Output should contain deep-interview-mode tag" || return 1
     # State file is NOT created by keyword-detector
     assert_file_not_exists "$TEST_TMP_DIR/.omt/deep-interview-active-state-${session_id}.json" "keyword-detector must NOT create state file for Korean keyword" || return 1
@@ -519,10 +523,9 @@ test_deep_interview_nested_loop_prevention() {
 
     # Simulate a prompt that contains only a prior assistant deep-interview-mode block (no new keyword)
     local nested_prompt="<deep-interview-mode>
-**DEEP INTERVIEW MODE ACTIVATED** (deep-interview)
+**DEEP INTERVIEW REQUESTED** — you MUST invoke Skill(deep-interview) before responding.
 
-You are now in deep interview mode. Conduct a thorough, structured interview:
-1. Ask one focused question at a time
+Do NOT conduct the interview directly. The skill invocation activates state tracking and stop protection.
 
 </deep-interview-mode>"
 
@@ -530,8 +533,8 @@ You are now in deep interview mode. Conduct a thorough, structured interview:
     local output
     output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$session_id"'", "prompt": "'"$(printf '%s' "$nested_prompt" | sed 's/"/\\"/g' | tr '\n' ' ')"'"}' | "$SCRIPT_DIR/keyword-detector.sh" 2>&1) || true
 
-    # Should NOT re-trigger deep-interview activation
-    assert_output_not_contains "$output" "DEEP INTERVIEW MODE ACTIVATED" "Nested deep-interview-mode tag should NOT re-trigger activation" || return 1
+    # Should NOT re-trigger deep-interview injection (tag is stripped before keyword check)
+    assert_output_not_contains "$output" "DEEP INTERVIEW REQUESTED" "Nested deep-interview-mode tag should NOT re-trigger injection" || return 1
 
     # State file should NOT be created (no incidental creation path remains)
     assert_file_not_exists "$TEST_TMP_DIR/.omt/deep-interview-active-state-${session_id}.json" "Deep interview state file should NOT be created for nested loop" || return 1

--- a/hooks/persistent-mode/decision.test.ts
+++ b/hooks/persistent-mode/decision.test.ts
@@ -129,7 +129,7 @@ describe('makeDecision', () => {
 
   describe('Priority 1.5: Deep Interview Protection', () => {
     it('makeDecision blocks with deep-interview-continuation when state active and no token', async () => {
-      const deepInterviewState = { active: true, sessionId: 'test-session' };
+      const deepInterviewState = { active: true, sessionId: 'test-session', state: { phase: 'in_progress' } };
       await writeFile(
         join(omtDir, 'deep-interview-active-state-test-session.json'),
         JSON.stringify(deepInterviewState)
@@ -144,7 +144,7 @@ describe('makeDecision', () => {
     });
 
     it('makeDecision cleans up deep-interview state when token present in lastAssistantMessage', async () => {
-      const deepInterviewState = { active: true, sessionId: 'test-session' };
+      const deepInterviewState = { active: true, sessionId: 'test-session', state: { phase: 'in_progress' } };
       await writeFile(
         join(omtDir, 'deep-interview-active-state-test-session.json'),
         JSON.stringify(deepInterviewState)
@@ -178,7 +178,7 @@ describe('makeDecision', () => {
 
     it('makeDecision preserves active:true marker and emits continuation (no done-token)', async () => {
       // An active interview with no done-token must still be blocked and the marker kept.
-      const deepInterviewState = { active: true, sessionId: 'test-session' };
+      const deepInterviewState = { active: true, sessionId: 'test-session', state: { phase: 'in_progress' } };
       const markerPath = join(omtDir, 'deep-interview-active-state-test-session.json');
       await writeFile(markerPath, JSON.stringify(deepInterviewState));
 
@@ -188,6 +188,50 @@ describe('makeDecision', () => {
 
       const { existsSync } = await import('fs');
       expect(existsSync(markerPath)).toBe(true);
+      expect(result.decision).toBe('block');
+      expect(result.reason).toContain('<deep-interview-continuation>');
+    });
+
+    // -------------------------------------------------------------------------
+    // Pristine deep-interview state: seed-only file (no rich `state` object)
+    // must be INERT — must NOT block session stop.
+    // -------------------------------------------------------------------------
+
+    it('pristine DI seed (no state key, active:true) does NOT block session stop', async () => {
+      // Seed-only file: written by pre-tool-enforcer.sh before the skill prose runs.
+      // If the skill call died (permission denial, ESC, crash) no rich `state` is ever
+      // written — the seed orphans. A pristine state is INERT to all consumers.
+      const markerPath = join(omtDir, 'deep-interview-active-state-test-session.json');
+      await writeFile(markerPath, JSON.stringify({
+        active: true,
+        started_at: '2025-01-01T00:00:00+00:00',
+        last_touched_at: '2025-01-01T00:00:00+00:00',
+        // no `state` key — this is the pristine definition per isPristine('deep-interview')
+      }));
+
+      const context = createContext({ lastAssistantMessage: 'some message without done token' });
+
+      const result = makeDecision(context);
+
+      // A pristine seed must NOT produce a block.
+      expect(result).toEqual({ continue: true });
+    });
+
+    it('non-pristine active DI state (has state key) still blocks session stop', async () => {
+      // A DI state with a rich `state` object is non-pristine — the interview is genuinely
+      // in progress and must continue blocking until the done-token or active:false.
+      const markerPath = join(omtDir, 'deep-interview-active-state-test-session.json');
+      await writeFile(markerPath, JSON.stringify({
+        active: true,
+        started_at: '2025-01-01T00:00:00+00:00',
+        last_touched_at: '2025-01-01T00:00:00+00:00',
+        state: { phase: 'in_progress', answers: {} },
+      }));
+
+      const context = createContext({ lastAssistantMessage: 'some message without done token' });
+
+      const result = makeDecision(context);
+
       expect(result.decision).toBe('block');
       expect(result.reason).toContain('<deep-interview-continuation>');
     });
@@ -621,7 +665,7 @@ describe('makeDecision', () => {
       });
       await writeFile(
         join(omtDir, 'deep-interview-active-state-test-session.json'),
-        JSON.stringify({ active: true, sessionId: 'test-session' })
+        JSON.stringify({ active: true, sessionId: 'test-session', state: { phase: 'in_progress' } })
       );
 
       const result = makeDecision(createContext({ lastAssistantMessage: 'no done token' }));
@@ -641,7 +685,7 @@ describe('makeDecision', () => {
       });
       await writeFile(
         join(omtDir, 'deep-interview-active-state-test-session.json'),
-        JSON.stringify({ active: true, sessionId: 'test-session' })
+        JSON.stringify({ active: true, sessionId: 'test-session', state: { phase: 'in_progress' } })
       );
 
       const result = makeDecision(createContext({ lastAssistantMessage: 'no done token' }));

--- a/hooks/persistent-mode/decision.ts
+++ b/hooks/persistent-mode/decision.ts
@@ -244,7 +244,12 @@ export function makeDecision(context: DecisionContext): HookOutput {
       cleanupDeepInterviewState(sessionId);
     } else if (detectDeepInterviewDone(lastAssistantMessage)) {
       cleanupDeepInterviewState(sessionId);
-    } else {
+    } else if (!isPristine('deep-interview', deepInterviewStateRaw as unknown as Record<string, unknown>)) {
+      // Pristine exception: a seed-only file (no rich `state` object) was written by the
+      // PreToolUse hook before the skill prose ran. If the skill died before `init`
+      // (permission denial, ESC, crash), the seed lingers. A pristine state is INERT to
+      // all consumers — it must not block session stop. The orphan ages toward TTL and is
+      // GC'd naturally.
       return formatBlockOutput(buildDeepInterviewContinuationMessage());
     }
   }

--- a/hooks/session-start_test.sh
+++ b/hooks/session-start_test.sh
@@ -727,7 +727,7 @@ test_gc_glob_only_managed_prefixes() {
 
     # Extract lines that reference "$OMT_DIR"/<prefix>-*.json
     glob_lines=$(echo "$gc_section" | grep -oE '"?\$\{?OMT_DIR\}?"?/[a-z-]+-\*\.json')
-    glob_count=$(echo "$glob_lines" | grep -c '.' 2>/dev/null || echo 0)
+    glob_count=$(echo "$glob_lines" | grep -c '.' 2>/dev/null || true)
 
     # Exact-set assertion: must be exactly 3 globs
     if [ "$glob_count" -ne 3 ]; then
@@ -743,7 +743,7 @@ test_gc_glob_only_managed_prefixes() {
     local prefix
     for prefix in goal-state prometheus-state deep-interview-active-state; do
         local count
-        count=$(echo "$glob_lines" | grep -c "$prefix" 2>/dev/null || echo 0)
+        count=$(echo "$glob_lines" | grep -c "$prefix" 2>/dev/null || true)
         if [ "$count" -ne 1 ]; then
             echo "ASSERTION FAILED: GC glob must contain '$prefix' exactly once, found $count"
             echo "  Glob lines: $glob_lines"

--- a/hooks/session-start_test.sh
+++ b/hooks/session-start_test.sh
@@ -718,23 +718,46 @@ EOF
     return 0
 }
 
-# glob: the GC for-loop glob must only include the 3 managed prefixes
+# glob: the GC for-loop glob must only include exactly the 3 managed prefixes
 test_gc_glob_only_managed_prefixes() {
     # Extract lines between "# GC:" marker and the first "# Check for active" block.
-    # The GC glob must contain only goal-state, prometheus-state, deep-interview-active-state.
-    local gc_section
+    # Then pull the glob prefix names from lines matching the OMT_DIR pattern.
+    local gc_section glob_lines glob_count
     gc_section=$(awk '/^# GC:/{found=1} found && /^# Check for active (prometheus|goal)/{found=0} found{print}' "$SCRIPT_DIR/session-start.sh")
-    if echo "$gc_section" | grep -qE 'state-\*\.json' && ! echo "$gc_section" | grep -qE '^[[:space:]]+".*goal-state|prometheus-state|deep-interview'; then
-        echo "ASSERTION FAILED: session-start.sh GC glob appears malformed"
-        echo "  GC section:"
+
+    # Extract lines that reference "$OMT_DIR"/<prefix>-*.json
+    glob_lines=$(echo "$gc_section" | grep -oE '"?\$\{?OMT_DIR\}?"?/[a-z-]+-\*\.json')
+    glob_count=$(echo "$glob_lines" | grep -c '.' 2>/dev/null || echo 0)
+
+    # Exact-set assertion: must be exactly 3 globs
+    if [ "$glob_count" -ne 3 ]; then
+        echo "ASSERTION FAILED: GC glob must have exactly 3 entries, found $glob_count"
+        echo "  Glob lines:"
+        echo "$glob_lines"
+        echo "  Full GC section:"
         echo "$gc_section" | head -20
         return 1
     fi
-    # Verify the deprecated retired-loop state prefix is absent from the GC glob
-    if echo "$gc_section" | grep -q 'retired-loop-state'; then
-        echo "ASSERTION FAILED: session-start.sh GC glob must NOT include retired-loop-state"
+
+    # Each expected prefix must appear exactly once
+    local prefix
+    for prefix in goal-state prometheus-state deep-interview-active-state; do
+        local count
+        count=$(echo "$glob_lines" | grep -c "$prefix" 2>/dev/null || echo 0)
+        if [ "$count" -ne 1 ]; then
+            echo "ASSERTION FAILED: GC glob must contain '$prefix' exactly once, found $count"
+            echo "  Glob lines: $glob_lines"
+            return 1
+        fi
+    done
+
+    # Deny-list: the historically removed ralph-state prefix (git af4dff6) must be absent
+    if echo "$gc_section" | grep -q 'ralph-state'; then
+        echo "ASSERTION FAILED: session-start.sh GC glob must NOT include ralph-state (retired)"
+        grep -n 'ralph-state' "$SCRIPT_DIR/session-start.sh" | head -5
         return 1
     fi
+
     return 0
 }
 
@@ -780,11 +803,11 @@ EOF
 
 # grep-0: session-start.sh must contain zero retired-loop restore references
 test_session_start_no_retired_loop_restore() {
-    # The retired loop state file prefix must not appear in any restore block.
-    # This verifies the loop's session-restore machinery has been fully removed.
-    if grep -qiE 'retired-loop-state|LOOP RESTORED' "$SCRIPT_DIR/session-start.sh" 2>/dev/null; then
-        echo "ASSERTION FAILED: session-start.sh must have 0 retired-loop restore references"
-        grep -niE 'retired-loop-state|LOOP RESTORED' "$SCRIPT_DIR/session-start.sh" | head -10
+    # Guard against re-introducing the ralph-loop restore block (git af4dff6 lines 99-115).
+    # Real historical tokens: ralph-state (file prefix) and [RALPH LOOP RESTORED] (restore banner).
+    if grep -qiE 'ralph-state|LOOP RESTORED' "$SCRIPT_DIR/session-start.sh" 2>/dev/null; then
+        echo "ASSERTION FAILED: session-start.sh must have 0 ralph-loop restore references"
+        grep -niE 'ralph-state|LOOP RESTORED' "$SCRIPT_DIR/session-start.sh" | head -10
         return 1
     fi
     return 0

--- a/hooks/stop-notify_test.sh
+++ b/hooks/stop-notify_test.sh
@@ -168,10 +168,11 @@ test_omt_dir_fallback_computed_from_git_repo() {
 
 # grep-0: stop-notify.sh must contain zero retired-loop gating references
 test_stop_notify_no_retired_loop_gating() {
-    # The retired loop state check and its file prefix must be absent from the hook.
-    if grep -qiE 'retired-loop-state|LOOP_ACTIVE' "$SCRIPT_DIR/stop-notify.sh" 2>/dev/null; then
-        echo "ASSERTION FAILED: stop-notify.sh must have 0 retired-loop gating references"
-        grep -niE 'retired-loop-state|LOOP_ACTIVE' "$SCRIPT_DIR/stop-notify.sh" | head -10
+    # The retired ralph-loop gate used RALPH_STATE_FILE and RALPH_ACTIVE (git af4dff6).
+    # Guard against exact historical tokens (case-insensitive) so re-adding that code fails.
+    if grep -qiE 'ralph[-_]?state|ralph[-_]?active' "$SCRIPT_DIR/stop-notify.sh" 2>/dev/null; then
+        echo "ASSERTION FAILED: stop-notify.sh must have 0 ralph-loop gating references"
+        grep -niE 'ralph[-_]?state|ralph[-_]?active' "$SCRIPT_DIR/stop-notify.sh" | head -10
         return 1
     fi
     return 0

--- a/lib/state-core.test.ts
+++ b/lib/state-core.test.ts
@@ -764,6 +764,24 @@ describe('listOthers — pristine 시드 제외', () => {
 });
 
 // ---------------------------------------------------------------------------
+// isPristine — prometheus resume_summary 비어있지 않으면 non-pristine
+// ---------------------------------------------------------------------------
+
+describe('isPristine — prometheus resume_summary 조건', () => {
+  test('resume_summary가 있으면 S0이라도 non-pristine이다', () => {
+    expect(isPristine('prometheus', { phase: 'S0', plan_path: '', resume_summary: '작업 중' })).toBe(false);
+  });
+
+  test('resume_summary가 없으면(undefined) S0+plan_path 빈값은 pristine이다', () => {
+    expect(isPristine('prometheus', { phase: 'S0', plan_path: '' })).toBe(true);
+  });
+
+  test('resume_summary가 빈 문자열이면 S0+plan_path 빈값은 pristine이다', () => {
+    expect(isPristine('prometheus', { phase: 'S0', plan_path: '', resume_summary: '' })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // adopt — pristine 소스는 r8으로 거부된다
 // ---------------------------------------------------------------------------
 

--- a/lib/state-core.test.ts
+++ b/lib/state-core.test.ts
@@ -25,6 +25,7 @@ import {
   adopt,
   writeFileNoCreate,
   isPristine,
+  restampAfterAdopt,
 } from './state-core.ts';
 
 // ---------------------------------------------------------------------------
@@ -657,6 +658,170 @@ describe('adopt', () => {
     const target = readState(omtDir, 'deep-interview-active-state-B.json') as Record<string, unknown>;
     const stateObj = target['state'] as Record<string, unknown> | undefined;
     expect(stateObj?.['initial_idea']).toBe('diving skills');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// r5 — restampAfterAdopt helper uses writeFileNoCreate (no-create semantics)
+// ---------------------------------------------------------------------------
+
+describe('restampAfterAdopt — writeFileNoCreate 의미론', () => {
+  let omtDir: string;
+
+  beforeEach(() => {
+    omtDir = mkdtempSync(join(tmpdir(), 'state-core-restamp-'));
+  });
+
+  afterEach(() => {
+    rmSync(omtDir, { recursive: true, force: true });
+  });
+
+  test('존재하는 파일에 last_touched_at을 갱신한다', () => {
+    const p = join(omtDir, 'goal-state-X.json');
+    const old = '2020-01-01T00:00:00+00:00';
+    writeFileSync(p, JSON.stringify({ active: true, last_touched_at: old, outcome: 'y' }, null, 2));
+    restampAfterAdopt(p);
+    const updated = JSON.parse(readFileSync(p, 'utf8')) as Record<string, unknown>;
+    expect(updated['outcome']).toBe('y');
+    expect(typeof updated['last_touched_at']).toBe('string');
+    expect(updated['last_touched_at'] as string > old).toBe(true);
+  });
+
+  test('파일이 없으면 파일을 생성하지 않는다 (ENOENT를 던지며 파일 미생성)', () => {
+    const p = join(omtDir, 'nonexistent-state.json');
+    expect(() => restampAfterAdopt(p)).toThrow();
+    expect(existsSync(p)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listOthers — pristine 시드는 후보에서 제외된다 (f9f3242 원칙 적용)
+// ---------------------------------------------------------------------------
+
+describe('listOthers — pristine 시드 제외', () => {
+  let omtDir: string;
+  const origOmtDir = process.env.OMT_DIR;
+  const origSid = process.env.OMT_SESSION_ID;
+
+  beforeEach(() => {
+    omtDir = mkdtempSync(join(tmpdir(), 'state-core-lo-pristine-'));
+    process.env.OMT_DIR = omtDir;
+    process.env.OMT_SESSION_ID = 'current';
+  });
+
+  afterEach(() => {
+    if (origOmtDir === undefined) delete process.env.OMT_DIR;
+    else process.env.OMT_DIR = origOmtDir;
+    if (origSid === undefined) delete process.env.OMT_SESSION_ID;
+    else process.env.OMT_SESSION_ID = origSid;
+    rmSync(omtDir, { recursive: true, force: true });
+  });
+
+  test('goal pristine 시드(outcome 빈값)는 listOthers 결과에서 제외된다', () => {
+    // pristine goal seed — outcome='', phase='planning', iteration=0
+    writeState(omtDir, 'goal-state-pristine.json', {
+      active: true,
+      outcome: '',
+      phase: 'planning',
+      iteration: 0,
+      started_at: isoSecondsAgo(60),
+      last_touched_at: isoSecondsAgo(30),
+    });
+    // rich goal state — should appear
+    writeState(omtDir, 'goal-state-rich.json', {
+      active: true,
+      outcome: 'ship the feature',
+      phase: 'pursuing',
+      iteration: 2,
+      started_at: isoSecondsAgo(300),
+      last_touched_at: isoSecondsAgo(60),
+    });
+    const results = listOthers('goal');
+    expect(results.find((r) => r.sid === 'pristine')).toBeUndefined();
+    expect(results.find((r) => r.sid === 'rich')).toBeDefined();
+  });
+
+  test('deep-interview pristine 시드(state 키 없음)는 listOthers 결과에서 제외된다', () => {
+    // pristine DI seed — no `state` key
+    writeState(omtDir, 'deep-interview-active-state-pristine.json', {
+      active: true,
+      current_phase: 'deep-interview',
+      started_at: isoSecondsAgo(60),
+      last_touched_at: isoSecondsAgo(30),
+    });
+    // rich DI state — should appear
+    writeState(omtDir, 'deep-interview-active-state-rich.json', {
+      active: true,
+      current_phase: 'deep-interview',
+      started_at: isoSecondsAgo(300),
+      last_touched_at: isoSecondsAgo(60),
+      state: { initial_idea: 'deep idea', interview_id: 'uid-99' },
+    });
+    const results = listOthers('deep-interview');
+    expect(results.find((r) => r.sid === 'pristine')).toBeUndefined();
+    expect(results.find((r) => r.sid === 'rich')).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// adopt — pristine 소스는 r8으로 거부된다
+// ---------------------------------------------------------------------------
+
+describe('adopt — pristine 소스 거부 (r8)', () => {
+  let omtDir: string;
+  const origOmtDir = process.env.OMT_DIR;
+  const origSid = process.env.OMT_SESSION_ID;
+
+  beforeEach(() => {
+    omtDir = mkdtempSync(join(tmpdir(), 'state-core-adopt-r8-'));
+    process.env.OMT_DIR = omtDir;
+    process.env.OMT_SESSION_ID = 'B';
+  });
+
+  afterEach(() => {
+    if (origOmtDir === undefined) delete process.env.OMT_DIR;
+    else process.env.OMT_DIR = origOmtDir;
+    if (origSid === undefined) delete process.env.OMT_SESSION_ID;
+    else process.env.OMT_SESSION_ID = origSid;
+    rmSync(omtDir, { recursive: true, force: true });
+  });
+
+  test('(r8) pristine goal 소스 adopt 시 throw하고 소스 파일은 변경되지 않는다', () => {
+    writeState(omtDir, 'goal-state-A.json', {
+      active: true,
+      outcome: '',
+      phase: 'planning',
+      iteration: 0,
+      started_at: isoSecondsAgo(30),
+      last_touched_at: isoSecondsAgo(10),
+    });
+    const srcBefore = readFileSync(join(omtDir, 'goal-state-A.json'), 'utf8');
+    expect(() => adopt('goal', 'A')).toThrow();
+    expect(readFileSync(join(omtDir, 'goal-state-A.json'), 'utf8')).toBe(srcBefore);
+  });
+
+  test('(r8) rich goal 소스는 정상 adopt된다', () => {
+    writeState(omtDir, 'goal-state-A.json', {
+      active: true,
+      outcome: 'ship it',
+      phase: 'pursuing',
+      iteration: 2,
+      started_at: isoSecondsAgo(300),
+      last_touched_at: isoSecondsAgo(60),
+    });
+    // pristine current B so adopt-over is allowed
+    writeState(omtDir, 'goal-state-B.json', {
+      active: true,
+      outcome: '',
+      phase: 'planning',
+      iteration: 0,
+      started_at: isoSecondsAgo(10),
+      last_touched_at: isoSecondsAgo(5),
+    });
+    expect(() => adopt('goal', 'A')).not.toThrow();
+    expect(existsSync(join(omtDir, 'goal-state-A.json'))).toBe(false);
+    const target = JSON.parse(readFileSync(join(omtDir, 'goal-state-B.json'), 'utf8')) as Record<string, unknown>;
+    expect(target['outcome']).toBe('ship it');
   });
 });
 

--- a/lib/state-core.ts
+++ b/lib/state-core.ts
@@ -262,7 +262,11 @@ export function writeFileNoCreate(path: string, content: string): void {
  */
 export function isPristine(type: StateType, parsed: Record<string, unknown>): boolean {
   if (type === 'prometheus') {
-    return parsed['phase'] === 'S0' && parsed['plan_path'] === '';
+    return (
+      parsed['phase'] === 'S0' &&
+      parsed['plan_path'] === '' &&
+      (parsed['resume_summary'] === '' || parsed['resume_summary'] === undefined)
+    );
   }
   if (type === 'goal') {
     return (
@@ -368,7 +372,7 @@ export function restampAfterAdopt(path: string): void {
 /**
  * Adopts the state from `srcSid` into the current session for `type`.
  *
- * Enforces ADR-2 rules r1–r7:
+ * Enforces ADR-2 rules r1–r8:
  *   r1: self-adopt refused
  *   r2: both sids safe-id validated
  *   r3: refused iff current exists AND (ACTIVE non-pristine OR malformed)

--- a/lib/state-core.ts
+++ b/lib/state-core.ts
@@ -10,8 +10,9 @@
  *   TERMINAL_TTL_SECONDS          — 1800 (30 minutes) — TS definition site
  *   isStateLive(parsed, nowEpoch) — Single liveness rule; fallback: last_touched_at → started_at
  *   STATE_PREFIX                  — type → filename prefix map
- *   listOthers(type)              — ACTIVE-live other-session candidates
- *   adopt(type, srcSid)           — atomic rename re-key, rules r1-r7
+ *   listOthers(type)              — ACTIVE-live non-pristine other-session candidates
+ *   adopt(type, srcSid)           — atomic rename re-key, rules r1-r8
+ *   restampAfterAdopt(path)       — post-rename heartbeat re-stamp via writeFileNoCreate
  *   writeFileNoCreate(path, s)    — single-syscall no-create write (ENOENT if absent)
  *   isPristine(type, parsed)      — true iff state is freshly seeded, safe for adoption overwrite
  *
@@ -19,7 +20,7 @@
  * This module does NOT create state files; adoption may only rename existing ones.
  */
 
-import { readdirSync, readFileSync, renameSync, writeFileSync, appendFileSync, existsSync, openSync, ftruncateSync, writeSync, closeSync } from 'fs';
+import { readdirSync, readFileSync, renameSync, appendFileSync, existsSync, openSync, ftruncateSync, writeSync, closeSync } from 'fs';
 import { join } from 'path';
 // lib-internal imports must be relative — deployed copies under .claude/lib/ have no @lib alias
 // (the sync alias-rewriter skips lib/** files). Relative imports let `make sync`'s dep collector
@@ -325,6 +326,8 @@ export function listOthers(type: StateType): AdoptionCandidate[] {
     // Only ACTIVE-live candidates (r7 source filter)
     if (parsed['active'] !== true) continue;
     if (!isStateLive(parsed as { active?: boolean; last_touched_at?: string; started_at?: string }, now)) continue;
+    // Pristine seeds are INERT to consumers (f9f3242): skip empty-purpose seeds
+    if (isPristine(type, parsed)) continue;
     const lta = String(parsed['last_touched_at'] ?? '');
     const touched = parseEpoch(lta);
     const idleSeconds = touched !== null ? Math.max(0, now - touched) : 0;
@@ -340,6 +343,25 @@ export function listOthers(type: StateType): AdoptionCandidate[] {
 }
 
 // ---------------------------------------------------------------------------
+// restampAfterAdopt
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads the file at `path`, updates `last_touched_at`, and writes it back using
+ * writeFileNoCreate — so it will throw ENOENT if the file has disappeared between
+ * the rename and this call, preventing accidental file creation.
+ *
+ * Called by adopt's r5 best-effort heartbeat re-stamp block; also exported for
+ * direct unit testing of the no-create invariant.
+ */
+export function restampAfterAdopt(path: string): void {
+  const content = readFileSync(path, 'utf8');
+  const parsed = JSON.parse(content) as Record<string, unknown>;
+  const stamped = { ...parsed, last_touched_at: nowStamp() };
+  writeFileNoCreate(path, JSON.stringify(stamped, null, 2));
+}
+
+// ---------------------------------------------------------------------------
 // adopt
 // ---------------------------------------------------------------------------
 
@@ -351,9 +373,10 @@ export function listOthers(type: StateType): AdoptionCandidate[] {
  *   r2: both sids safe-id validated
  *   r3: refused iff current exists AND (ACTIVE non-pristine OR malformed)
  *   r4: atomic fs.renameSync; ENOENT → throw, no mutation
- *   r5: post-rename best-effort heartbeat re-stamp (failure → stderr warn)
+ *   r5: post-rename best-effort heartbeat re-stamp via restampAfterAdopt (failure → stderr warn)
  *   r6: LIVE source adoptable (checked via isStateLive)
  *   r7: source must be ACTIVE-live (TERMINAL/stale/malformed refused)
+ *   r8: source must not be pristine (pristine seeds are INERT — f9f3242)
  *
  * Sid is derived from filename only — never reads session-id from file content.
  * Does NOT create any file; only renames an existing one.
@@ -397,6 +420,13 @@ export function adopt(type: StateType, srcSid: string): void {
     throw new Error(`adopt: source "${srcPath}" failed the liveness check (r7: TTL-expired or no parseable timestamp — only live sources are adoptable)`);
   }
 
+  // r8: source must not be pristine (pristine seeds are INERT to consumers — f9f3242)
+  if (isPristine(type, srcParsed)) {
+    throw new Error(
+      `adopt: source "${srcPath}" is a pristine seed with no real work (r8: pristine sources are refused — nothing to adopt).`
+    );
+  }
+
   // r3: check current session state
   if (existsSync(dstPath)) {
     const curParsed = readParsed(dstPath);
@@ -433,10 +463,7 @@ export function adopt(type: StateType, srcSid: string): void {
 
   // r5: post-rename heartbeat re-stamp of the renamed-to file (best-effort)
   try {
-    const content = readFileSync(dstPath, 'utf8');
-    const parsed = JSON.parse(content) as Record<string, unknown>;
-    const stamped = { ...parsed, last_touched_at: nowStamp() };
-    writeFileSync(dstPath, JSON.stringify(stamped, null, 2), 'utf8');
+    restampAfterAdopt(dstPath);
   } catch (e) {
     process.stderr.write(
       `adopt: warning: post-rename heartbeat re-stamp failed for "${dstPath}": ${String(e)}\n`

--- a/scripts/omt-cleanup/omt-cleanup.sh
+++ b/scripts/omt-cleanup/omt-cleanup.sh
@@ -66,16 +66,25 @@ is_residue() {
     return 1
 }
 
-has_any_state_file() {
-    # Returns 0 (true) iff dir contains at least one state file (live or dead) across the 3 managed prefixes.
-    local dir="$1"
-    local f
+list_state_files() {
+    # Echoes existing managed state files in $1, one per line.
+    local dir="$1" f
     for f in \
         "$dir"/goal-state-*.json \
         "$dir"/prometheus-state-*.json \
         "$dir"/deep-interview-active-state-*.json; do
-        [[ -f "$f" ]] && return 0
+        [[ -f "$f" ]] && echo "$f"
     done
+    return 0
+}
+
+has_any_state_file() {
+    # Returns 0 (true) iff dir contains at least one state file (live or dead) across the 3 managed prefixes.
+    local dir="$1"
+    local f
+    while IFS= read -r f; do
+        return 0
+    done < <(list_state_files "$dir")
     return 1
 }
 
@@ -84,15 +93,11 @@ has_live_state() {
     # Liveness is defined by is_state_live from hooks/lib/state-liveness.sh.
     local dir="$1"
     local f
-    for f in \
-        "$dir"/goal-state-*.json \
-        "$dir"/prometheus-state-*.json \
-        "$dir"/deep-interview-active-state-*.json; do
-        [[ -f "$f" ]] || continue
+    while IFS= read -r f; do
         if is_state_live "$f" "$CLEANUP_NOW"; then
             return 0
         fi
-    done
+    done < <(list_state_files "$dir")
     return 1
 }
 
@@ -152,13 +157,15 @@ for entry_path in "$OMT_DIR"/*/; do
     elif has_any_state_file "$OMT_DIR/$name" && ! has_live_state "$OMT_DIR/$name"; then
         # Unknown entry: has state files but ALL are dead — reap only the state files (file-level).
         # The directory is removed afterwards only if it is empty.
+        # Accumulate newline-separated so paths with spaces are not split on consumption.
         local_dir="$OMT_DIR/$name"
-        for f in \
-            "$local_dir"/goal-state-*.json \
-            "$local_dir"/prometheus-state-*.json \
-            "$local_dir"/deep-interview-active-state-*.json; do
-            [[ -f "$f" ]] && DEAD_STATE_FILES="$DEAD_STATE_FILES $f"
-        done
+        local_files="$(list_state_files "$local_dir")"
+        if [[ -n "$DEAD_STATE_FILES" ]]; then
+            DEAD_STATE_FILES="${DEAD_STATE_FILES}
+${local_files}"
+        else
+            DEAD_STATE_FILES="$local_files"
+        fi
     else
         # Unknown entry with no state files, or with live state — preserve (conservative)
         PRESERVE_LIST="$PRESERVE_LIST $name"
@@ -182,9 +189,9 @@ echo "--- DEAD-STATE (state files to reap) ---"
 if [[ -z "$DEAD_STATE_FILES" ]]; then
     echo "  (none)"
 else
-    for f in $DEAD_STATE_FILES; do
+    while IFS= read -r f; do
         echo "  DELETE  $f"
-    done
+    done <<< "$DEAD_STATE_FILES"
 fi
 
 echo ""
@@ -213,11 +220,13 @@ else
         rm -rf "$target"
     done
     # Dead-state: reap state files; remove directory only if empty
-    for f in $DEAD_STATE_FILES; do
-        echo "  reaping $f"
-        rm -f "$f"
-        dir="$(dirname "$f")"
-        rmdir "$dir" 2>/dev/null || true
-    done
+    if [[ -n "$DEAD_STATE_FILES" ]]; then
+        while IFS= read -r f; do
+            echo "  reaping $f"
+            rm -f "$f"
+            dir="$(dirname "$f")"
+            rmdir "$dir" 2>/dev/null || true
+        done <<< "$DEAD_STATE_FILES"
+    fi
     echo "=== done ==="
 fi

--- a/scripts/omt-cleanup/omt-cleanup.sh
+++ b/scripts/omt-cleanup/omt-cleanup.sh
@@ -136,6 +136,7 @@ echo "=== omt-cleanup: scanning $OMT_DIR ==="
 echo ""
 
 DELETE_LIST=""
+DEAD_STATE_FILES=""
 PRESERVE_LIST=""
 
 # Iterate top-level entries only
@@ -149,21 +150,40 @@ for entry_path in "$OMT_DIR"/*/; do
     elif is_residue "$name"; then
         DELETE_LIST="$DELETE_LIST $name"
     elif has_any_state_file "$OMT_DIR/$name" && ! has_live_state "$OMT_DIR/$name"; then
-        # Unknown entry: has state files but ALL are dead — do not preserve
-        DELETE_LIST="$DELETE_LIST $name"
+        # Unknown entry: has state files but ALL are dead — reap only the state files (file-level).
+        # The directory is removed afterwards only if it is empty.
+        local_dir="$OMT_DIR/$name"
+        for f in \
+            "$local_dir"/goal-state-*.json \
+            "$local_dir"/prometheus-state-*.json \
+            "$local_dir"/deep-interview-active-state-*.json; do
+            [[ -f "$f" ]] && DEAD_STATE_FILES="$DEAD_STATE_FILES $f"
+        done
     else
         # Unknown entry with no state files, or with live state — preserve (conservative)
         PRESERVE_LIST="$PRESERVE_LIST $name"
     fi
 done
 
-# Print DELETE section
+# Print RESIDUE section (full-directory deletions)
 echo "--- RESIDUE (to delete) ---"
 if [[ -z "$DELETE_LIST" ]]; then
     echo "  (none)"
 else
     for name in $DELETE_LIST; do
         echo "  DELETE  $name"
+    done
+fi
+
+echo ""
+
+# Print DEAD-STATE section (file-level reap)
+echo "--- DEAD-STATE (state files to reap) ---"
+if [[ -z "$DEAD_STATE_FILES" ]]; then
+    echo "  (none)"
+else
+    for f in $DEAD_STATE_FILES; do
+        echo "  DELETE  $f"
     done
 fi
 
@@ -186,10 +206,18 @@ if [[ $DRY_RUN -eq 1 ]]; then
     echo "=== dry-run complete — nothing deleted. Pass --execute to remove residue. ==="
 else
     echo "=== executing deletions ==="
+    # Residue: full directory removal
     for name in $DELETE_LIST; do
         target="$OMT_DIR/$name"
         echo "  removing $target"
         rm -rf "$target"
+    done
+    # Dead-state: reap state files; remove directory only if empty
+    for f in $DEAD_STATE_FILES; do
+        echo "  reaping $f"
+        rm -f "$f"
+        dir="$(dirname "$f")"
+        rmdir "$dir" 2>/dev/null || true
     done
     echo "=== done ==="
 fi

--- a/scripts/omt-cleanup/omt-cleanup_test.sh
+++ b/scripts/omt-cleanup/omt-cleanup_test.sh
@@ -455,6 +455,103 @@ EOF
     return 0
 }
 
+# ---------------------------------------------------------------------------
+# (A) DEAD_STATE_FILES word-split regression — HOME path with spaces
+# If DEAD_STATE_FILES is consumed unquoted, paths like
+#   /tmp/John Doe/.omt/proj/goal-state-x.json
+# split into three tokens and rm -f is called on fragments.
+# ---------------------------------------------------------------------------
+
+# dry-run: state file path appears verbatim (with spaces) in output
+test_dead_state_space_in_home_dryrun_shows_full_path() {
+    local stale_ts
+    stale_ts=$(date -j -v-7H "+%Y-%m-%dT%H:%M:%S" 2>/dev/null || date -d "7 hours ago" "+%Y-%m-%dT%H:%M:%S" 2>/dev/null || echo "2000-01-01T00:00:00")
+
+    # Create a HOME directory whose path contains spaces
+    local space_home
+    space_home=$(mktemp -d)
+    local space_home_with_spaces="${space_home}/John Doe"
+    mkdir -p "$space_home_with_spaces"
+
+    local omt_dir="$space_home_with_spaces/.omt"
+    local proj_dir="$omt_dir/space-proj"
+    mkdir -p "$proj_dir"
+
+    local state_file="$proj_dir/goal-state-space-sess.json"
+    cat > "$state_file" << EOF
+{
+  "active": true,
+  "phase": "pursuing",
+  "last_touched_at": "${stale_ts}",
+  "outcome": "stale goal",
+  "iteration": 1
+}
+EOF
+
+    local out
+    out=$(HOME="$space_home_with_spaces" bash "$CLEANUP_SCRIPT" --dry-run 2>&1)
+
+    # Clean up our extra temp dir
+    rm -rf "$space_home"
+
+    # The full path (with spaces) must appear verbatim in DELETE output
+    if ! echo "$out" | grep "DELETE" | grep -q "goal-state-space-sess.json"; then
+        echo "ASSERTION FAILED: dry-run must list full state file path (spaces in HOME)"
+        echo "  Output: ${out}"
+        return 1
+    fi
+    return 0
+}
+
+# execute: the state file is deleted; no stray fragments left from word-split
+test_dead_state_space_in_home_execute_deletes_correct_file() {
+    local stale_ts
+    stale_ts=$(date -j -v-7H "+%Y-%m-%dT%H:%M:%S" 2>/dev/null || date -d "7 hours ago" "+%Y-%m-%dT%H:%M:%S" 2>/dev/null || echo "2000-01-01T00:00:00")
+
+    local space_home
+    space_home=$(mktemp -d)
+    local space_home_with_spaces="${space_home}/John Doe"
+    mkdir -p "$space_home_with_spaces"
+
+    local omt_dir="$space_home_with_spaces/.omt"
+    local proj_dir="$omt_dir/space-exec-proj"
+    mkdir -p "$proj_dir"
+
+    local state_file="$proj_dir/goal-state-space-exec-sess.json"
+    cat > "$state_file" << EOF
+{
+  "active": true,
+  "phase": "pursuing",
+  "last_touched_at": "${stale_ts}",
+  "outcome": "stale goal",
+  "iteration": 1
+}
+EOF
+
+    HOME="$space_home_with_spaces" bash "$CLEANUP_SCRIPT" --execute > /dev/null 2>&1
+
+    local result=0
+
+    # The state file must be gone (correctly deleted)
+    if [[ -f "$state_file" ]]; then
+        echo "ASSERTION FAILED: state file must be deleted by --execute"
+        result=1
+    fi
+
+    # Stray path fragments from word-split would be like "/tmp/tmpXXX/John" and "Doe/.omt/..."
+    # We detect this by checking no parent dirs or siblings were created erroneously.
+    # Specifically: the word before the space ("John") should not exist as a directory
+    # inside the fixture home (it'd be created by `rm -f /tmp/xxx/John` treating it as path).
+    # The real canary: proj_dir should be gone (rmdir cleaned it), but space_home itself intact.
+    if [[ -d "$space_home_with_spaces/.omt/space-exec-proj" ]]; then
+        # dir still exists — but only matters if state file was deleted; rmdir fails on non-empty
+        : # acceptable if something else is in there
+    fi
+
+    rm -rf "$space_home"
+    return $result
+}
+
 # Positive: a dir with a LIVE active goal-state (fresh heartbeat) IS preserved via liveness
 test_liveness_fresh_active_dir_preserved() {
     local fresh_ts
@@ -540,6 +637,10 @@ main() {
     run_test test_liveness_active_7h_idle_execute_keeps_plan
     run_test test_dead_state_dryrun_shows_state_file_path
     run_test test_liveness_fresh_active_dir_preserved
+
+    # (A) word-split regression — HOME path with spaces
+    run_test test_dead_state_space_in_home_dryrun_shows_full_path
+    run_test test_dead_state_space_in_home_execute_deletes_correct_file
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/scripts/omt-cleanup/omt-cleanup_test.sh
+++ b/scripts/omt-cleanup/omt-cleanup_test.sh
@@ -389,6 +389,72 @@ EOF
     return 0
 }
 
+# C4/omt-cleanup execute: dir with dead state + plans/plan.md keeps plan.md and the dir; state file is deleted
+test_liveness_active_7h_idle_execute_keeps_plan() {
+    local stale_ts
+    stale_ts=$(date -j -v-7H "+%Y-%m-%dT%H:%M:%S" 2>/dev/null || date -d "7 hours ago" "+%Y-%m-%dT%H:%M:%S" 2>/dev/null || echo "2000-01-01T00:00:00")
+
+    local stale_dir="$FIXTURE_HOME/.omt/stale-project-with-plans"
+    mkdir -p "$stale_dir/plans"
+    printf 'important plan content' > "$stale_dir/plans/plan.md"
+    cat > "$stale_dir/goal-state-stale-sess.json" << EOF
+{
+  "active": true,
+  "phase": "pursuing",
+  "last_touched_at": "${stale_ts}",
+  "outcome": "stale goal",
+  "iteration": 1
+}
+EOF
+
+    bash "$CLEANUP_SCRIPT" --execute > /dev/null
+
+    # State file must be gone
+    if [[ -f "$stale_dir/goal-state-stale-sess.json" ]]; then
+        echo "ASSERTION FAILED: dead state file must be deleted"
+        return 1
+    fi
+    # plan.md must survive
+    if [[ ! -f "$stale_dir/plans/plan.md" ]]; then
+        echo "ASSERTION FAILED: plans/plan.md must survive (only state files are reaped)"
+        return 1
+    fi
+    # directory must survive (non-empty after reap)
+    if [[ ! -d "$stale_dir" ]]; then
+        echo "ASSERTION FAILED: directory must survive when non-empty after state reap"
+        return 1
+    fi
+    return 0
+}
+
+# dry-run for dead-state dir lists state file path, not bare directory name
+test_dead_state_dryrun_shows_state_file_path() {
+    local stale_ts
+    stale_ts=$(date -j -v-7H "+%Y-%m-%dT%H:%M:%S" 2>/dev/null || date -d "7 hours ago" "+%Y-%m-%dT%H:%M:%S" 2>/dev/null || echo "2000-01-01T00:00:00")
+
+    local stale_dir="$FIXTURE_HOME/.omt/stale-dry-run-project"
+    mkdir -p "$stale_dir"
+    cat > "$stale_dir/goal-state-dry-sess.json" << EOF
+{
+  "active": true,
+  "phase": "pursuing",
+  "last_touched_at": "${stale_ts}",
+  "outcome": "stale goal",
+  "iteration": 1
+}
+EOF
+
+    local out
+    out=$(bash "$CLEANUP_SCRIPT" --dry-run 2>&1)
+    # Must list the state file path
+    if ! echo "$out" | grep "DELETE" | grep -q "goal-state-dry-sess.json"; then
+        echo "ASSERTION FAILED: dry-run must list state file path, not just dir name"
+        echo "  Output: ${out}"
+        return 1
+    fi
+    return 0
+}
+
 # Positive: a dir with a LIVE active goal-state (fresh heartbeat) IS preserved via liveness
 test_liveness_fresh_active_dir_preserved() {
     local fresh_ts
@@ -471,6 +537,8 @@ main() {
     # AC liveness unification (TODO 7)
     run_test test_liveness_all_dead_dir_not_preserved
     run_test test_liveness_active_7h_idle_dir_not_preserved
+    run_test test_liveness_active_7h_idle_execute_keeps_plan
+    run_test test_dead_state_dryrun_shows_state_file_path
     run_test test_liveness_fresh_active_dir_preserved
 
     echo "=========================================="

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -71,21 +71,21 @@ Inspired by the [Ouroboros project](https://github.com/Q00/ouroboros) which demo
 
 ```bash
 bun ${CLAUDE_SKILL_DIR}/scripts/deep-interview-state.ts init \
-  --initial-idea "$(cat <<'EOF'
+  --initial-idea "$(cat <<'OMT_DI_PAYLOAD_EOF'
 <prompt-safe initial-context summary or user input>
-EOF
+OMT_DI_PAYLOAD_EOF
 )" \
   --interview-id "<uuid>" \
   --type "greenfield|brownfield" \
   --current-phase "deep-interview" \
   --threshold <resolvedThreshold>
-  # brownfield only: append --codebase-context "$(cat <<'EOF'
+  # brownfield only: append --codebase-context "$(cat <<'OMT_DI_PAYLOAD_EOF'
   # <explore summary>
-  # EOF
+  # OMT_DI_PAYLOAD_EOF
   # )"
 ```
 
-Use `"$(cat <<'EOF' ... EOF)"` for `--initial-idea` and `--codebase-context` so apostrophes and `$`/backtick sequences in user text are passed verbatim without shell expansion.
+Use `"$(cat <<'OMT_DI_PAYLOAD_EOF' ... OMT_DI_PAYLOAD_EOF)"` for `--initial-idea` and `--codebase-context` so apostrophes and `$`/backtick sequences in user text are passed verbatim without shell expansion.
 
 The `init` subcommand performs a strict overlay of the rich state shape into the seed file that the PreToolUse hook already created. The full shape written to state is:
 
@@ -208,7 +208,7 @@ Brownfield: `ambiguity = 1 - (goal × 0.35 + constraints × 0.25 + criteria × 0
 
 **Calculate ontology stability:**
 
-**Round 1 special case:** For the first round, skip stability comparison. All entities are "new". Set stability_ratio = N/A. If any round produces zero entities, set stability_ratio = N/A (avoids division by zero).
+**Round 1 special case:** For the first round, skip stability comparison. All entities are "new". Set stability_ratio = null (JSON null — never the bare token N/A). If any round produces zero entities, set stability_ratio = null (avoids division by zero).
 
 For rounds 2+, compare with the previous round's entity list:
 - `stable_entities`: entities present in both rounds with the same name
@@ -225,12 +225,12 @@ Store the ontology snapshot (entities + stability_ratio + matching_reasoning) by
 
 ```bash
 bun ${CLAUDE_SKILL_DIR}/scripts/deep-interview-state.ts update \
-  --append-ontology-snapshot-stdin <<'EOF'
-{"entities":[...],"stability_ratio":<ratio>,"matching_reasoning":"<text>"}
-EOF
+  --append-ontology-snapshot-stdin <<'OMT_DI_PAYLOAD_EOF'
+{"entities":[...],"stability_ratio":<ratio or null>,"matching_reasoning":"<text>"}
+OMT_DI_PAYLOAD_EOF
 ```
 
-Use `--append-ontology-snapshot-stdin` with a quoted-delimiter heredoc (`<<'EOF'`) so entity names containing apostrophes or double quotes are not mangled by shell quoting.
+Use `--append-ontology-snapshot-stdin` with a quoted-delimiter heredoc (`<<'OMT_DI_PAYLOAD_EOF'`) to protect shell quoting (apostrophes, `$`, backticks in entity names are not expanded). This heredoc guards the shell layer only — all substituted string values must be JSON-encoded (`\"`, `\\`, newlines as `\n`) so the payload remains valid JSON.
 
 ### Step 2d: Report Progress
 
@@ -260,24 +260,24 @@ Update interview state with the new round and scores by invoking the CLI twice �
 
 ```bash
 bun ${CLAUDE_SKILL_DIR}/scripts/deep-interview-state.ts update \
-  --append-round-stdin <<'EOF'
+  --append-round-stdin <<'OMT_DI_PAYLOAD_EOF'
 {"n":<round_number>,"question":"<question>","answer":"<answer>","scores":{"goal":<g>,"constraints":<c>,"criteria":<cr>},"ambiguity":<ambiguity>}
-EOF
+OMT_DI_PAYLOAD_EOF
 
 bun ${CLAUDE_SKILL_DIR}/scripts/deep-interview-state.ts update \
   --current-phase "deep-interview" \
   --current-ambiguity <ambiguity>
 ```
 
-Use `--append-round-stdin` with a quoted-delimiter heredoc (`<<'EOF'`) so question and answer text containing apostrophes or double quotes is passed verbatim without shell-quoting hazards. The CLI reads stdin, validates JSON, and exits 1 loudly on invalid input.
+Use `--append-round-stdin` with a quoted-delimiter heredoc (`<<'OMT_DI_PAYLOAD_EOF'`) to protect shell quoting (apostrophes, `$`, backticks in question/answer text are not expanded). This heredoc guards the shell layer only — all substituted string values (`<question>`, `<answer>`) must be JSON-encoded (`\"`, `\\`, newlines as `\n`) so the payload remains valid JSON. The CLI reads stdin, validates JSON, and exits 1 loudly on invalid input.
 
 For brownfield interviews, include the `context` score in the `scores` object:
 
 ```bash
 bun ${CLAUDE_SKILL_DIR}/scripts/deep-interview-state.ts update \
-  --append-round-stdin <<'EOF'
+  --append-round-stdin <<'OMT_DI_PAYLOAD_EOF'
 {"n":<round_number>,"question":"<question>","answer":"<answer>","scores":{"goal":<g>,"constraints":<c>,"criteria":<cr>,"context":<ctx>},"ambiguity":<ambiguity>}
-EOF
+OMT_DI_PAYLOAD_EOF
 ```
 
 `context` carries 15% of the ambiguity formula for brownfield (`context × 0.15`) and is required for accurate resume after `adopt`.

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -71,13 +71,21 @@ Inspired by the [Ouroboros project](https://github.com/Q00/ouroboros) which demo
 
 ```bash
 bun ${CLAUDE_SKILL_DIR}/scripts/deep-interview-state.ts init \
-  --initial-idea "<prompt-safe initial-context summary or user input>" \
+  --initial-idea "$(cat <<'EOF'
+<prompt-safe initial-context summary or user input>
+EOF
+)" \
   --interview-id "<uuid>" \
   --type "greenfield|brownfield" \
   --current-phase "deep-interview" \
   --threshold <resolvedThreshold>
-  # brownfield only: append --codebase-context "<explore summary>"
+  # brownfield only: append --codebase-context "$(cat <<'EOF'
+  # <explore summary>
+  # EOF
+  # )"
 ```
+
+Use `"$(cat <<'EOF' ... EOF)"` for `--initial-idea` and `--codebase-context` so apostrophes and `$`/backtick sequences in user text are passed verbatim without shell expansion.
 
 The `init` subcommand performs a strict overlay of the rich state shape into the seed file that the PreToolUse hook already created. The full shape written to state is:
 
@@ -217,8 +225,12 @@ Store the ontology snapshot (entities + stability_ratio + matching_reasoning) by
 
 ```bash
 bun ${CLAUDE_SKILL_DIR}/scripts/deep-interview-state.ts update \
-  --append-ontology-snapshot '{"entities":[...],"stability_ratio":<ratio>,"matching_reasoning":"<text>"}'
+  --append-ontology-snapshot-stdin <<'EOF'
+{"entities":[...],"stability_ratio":<ratio>,"matching_reasoning":"<text>"}
+EOF
 ```
+
+Use `--append-ontology-snapshot-stdin` with a quoted-delimiter heredoc (`<<'EOF'`) so entity names containing apostrophes or double quotes are not mangled by shell quoting.
 
 ### Step 2d: Report Progress
 
@@ -248,12 +260,27 @@ Update interview state with the new round and scores by invoking the CLI twice â
 
 ```bash
 bun ${CLAUDE_SKILL_DIR}/scripts/deep-interview-state.ts update \
-  --append-round '{"n":<round_number>,"question":"<question>","answer":"<answer>","scores":{"goal":<g>,"constraints":<c>,"criteria":<cr>},"ambiguity":<ambiguity>}'
+  --append-round-stdin <<'EOF'
+{"n":<round_number>,"question":"<question>","answer":"<answer>","scores":{"goal":<g>,"constraints":<c>,"criteria":<cr>},"ambiguity":<ambiguity>}
+EOF
 
 bun ${CLAUDE_SKILL_DIR}/scripts/deep-interview-state.ts update \
   --current-phase "deep-interview" \
   --current-ambiguity <ambiguity>
 ```
+
+Use `--append-round-stdin` with a quoted-delimiter heredoc (`<<'EOF'`) so question and answer text containing apostrophes or double quotes is passed verbatim without shell-quoting hazards. The CLI reads stdin, validates JSON, and exits 1 loudly on invalid input.
+
+For brownfield interviews, include the `context` score in the `scores` object:
+
+```bash
+bun ${CLAUDE_SKILL_DIR}/scripts/deep-interview-state.ts update \
+  --append-round-stdin <<'EOF'
+{"n":<round_number>,"question":"<question>","answer":"<answer>","scores":{"goal":<g>,"constraints":<c>,"criteria":<cr>,"context":<ctx>},"ambiguity":<ambiguity>}
+EOF
+```
+
+`context` carries 15% of the ambiguity formula for brownfield (`context Ã— 0.15`) and is required for accurate resume after `adopt`.
 
 ### Step 2f: Check Soft Limits
 

--- a/skills/deep-interview/scripts/deep-interview-state.test.ts
+++ b/skills/deep-interview/scripts/deep-interview-state.test.ts
@@ -284,6 +284,100 @@ describe('deep-interview-state CLI main()', () => {
     initDeepInterviewState(SID, { initial_idea: 'q' });
     expect(() => run("update --append-ontology-snapshot '{bad}'")).toThrow();
   });
+
+  // ---------------------------------------------------------------------------
+  // stdin channel tests (Finding #7)
+  // ---------------------------------------------------------------------------
+
+  const runStdin = (cmd: string, stdinInput: string, env?: Record<string, string>): string =>
+    execSync(`bun ${script} ${cmd}`, {
+      encoding: 'utf8',
+      input: stdinInput,
+      env: { ...process.env, ...env },
+    });
+
+  // stdin --append-round-stdin: round with apostrophe and inner double quotes round-trips verbatim
+  test("stdin round-trip: apostrophe and inner double quotes in question/answer survive --append-round-stdin", () => {
+    writeSeed();
+    initDeepInterviewState(SID, { initial_idea: 'q' });
+    const payload = JSON.stringify({
+      n: 1,
+      question: "What's the user's role?",
+      answer: 'She said "admin" and "editor"',
+      scores: { goal: 0.8, constraints: 0.6, criteria: 0.7 },
+      ambiguity: 0.3,
+    });
+    runStdin('update --append-round-stdin', payload);
+    const state = rawState();
+    const rounds = (state['state'] as Record<string, unknown>)['rounds'] as unknown[];
+    expect(rounds).toHaveLength(1);
+    const r = rounds[0] as Record<string, unknown>;
+    expect(r['question']).toBe("What's the user's role?");
+    expect(r['answer']).toBe('She said "admin" and "editor"');
+  });
+
+  // stdin --append-round-stdin: invalid JSON → exit 1 loudly
+  test('stdin --append-round-stdin with invalid JSON exits non-zero', () => {
+    writeSeed();
+    initDeepInterviewState(SID, { initial_idea: 'q' });
+    expect(() => runStdin('update --append-round-stdin', 'not valid json')).toThrow();
+  });
+
+  // stdin --append-round-stdin back-compat: argv --append-round still works
+  test('argv --append-round still works alongside stdin flag (back-compat)', () => {
+    writeSeed();
+    initDeepInterviewState(SID, { initial_idea: 'q' });
+    run(`update --append-round '{"n":1,"scores":{"goal":0.5,"constraints":0.5,"criteria":0.5},"ambiguity":0.5}'`);
+    const state = rawState();
+    const rounds = (state['state'] as Record<string, unknown>)['rounds'] as unknown[];
+    expect(rounds).toHaveLength(1);
+    expect((rounds[0] as Record<string, unknown>)['n']).toBe(1);
+  });
+
+  // stdin --append-ontology-snapshot-stdin: round-trips verbatim
+  test('stdin round-trip: --append-ontology-snapshot-stdin persists snapshot verbatim', () => {
+    writeSeed();
+    initDeepInterviewState(SID, { initial_idea: 'q' });
+    const payload = JSON.stringify({
+      entities: [{ name: "User's \"account\"", type: 'entity', fields: [], relationships: [] }],
+      stability_ratio: 0.9,
+      matching_reasoning: "stable",
+    });
+    runStdin('update --append-ontology-snapshot-stdin', payload);
+    const state = rawState();
+    const snaps = (state['state'] as Record<string, unknown>)['ontology_snapshots'] as unknown[];
+    expect(snaps).toHaveLength(1);
+    const snap = snaps[0] as Record<string, unknown>;
+    expect((snap['entities'] as unknown[])).toHaveLength(1);
+    expect(((snap['entities'] as unknown[])[0] as Record<string, unknown>)['name']).toBe("User's \"account\"");
+  });
+
+  // stdin --append-ontology-snapshot-stdin: invalid JSON → exit 1
+  test('stdin --append-ontology-snapshot-stdin with invalid JSON exits non-zero', () => {
+    writeSeed();
+    initDeepInterviewState(SID, { initial_idea: 'q' });
+    expect(() => runStdin('update --append-ontology-snapshot-stdin', '{bad json}')).toThrow();
+  });
+
+  // brownfield context score: round with "context" key round-trips verbatim (Finding #6)
+  test('brownfield context score: round with context key round-trips verbatim via stdin', () => {
+    writeSeed();
+    initDeepInterviewState(SID, { initial_idea: 'q', type: 'brownfield' });
+    const payload = JSON.stringify({
+      n: 1,
+      question: 'Where is the auth layer?',
+      answer: 'In middleware',
+      scores: { goal: 0.7, constraints: 0.6, criteria: 0.6, context: 0.5 },
+      ambiguity: 0.42,
+    });
+    runStdin('update --append-round-stdin', payload);
+    const state = rawState();
+    const rounds = (state['state'] as Record<string, unknown>)['rounds'] as unknown[];
+    expect(rounds).toHaveLength(1);
+    const r = rounds[0] as Record<string, unknown>;
+    const scores = r['scores'] as Record<string, unknown>;
+    expect(scores['context']).toBe(0.5);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/skills/deep-interview/scripts/deep-interview-state.ts
+++ b/skills/deep-interview/scripts/deep-interview-state.ts
@@ -15,8 +15,12 @@
  *          Strict overlay of the rich shape into the EXISTING seed file.
  *   update [--current-phase <phase>] [--current-ambiguity <n>]
  *          [--append-round '<json>'] [--append-ontology-snapshot '<json>']
+ *          [--append-round-stdin] [--append-ontology-snapshot-stdin]
  *          [--challenge-mode <name>]
  *          Strict-overlay merge refreshing last_touched_at.
+ *          Stdin flags (--append-round-stdin / --append-ontology-snapshot-stdin) read
+ *          the JSON payload from stdin, avoiding shell-quoting hazards with free text
+ *          (apostrophes, double quotes). Use with a quoted-delimiter heredoc in SKILL.md.
  *   get    Print the state JSON.
  *
  * No sessionId field is ever written (ADR-7, RC3 root-cause fix: sid is
@@ -289,11 +293,33 @@ function main(): void {
     const ambiguity = str(args['current-ambiguity']);
     const appendRoundRaw = str(args['append-round']);
     const appendSnapshotRaw = str(args['append-ontology-snapshot']);
+    const appendRoundStdin = args['append-round-stdin'] === true;
+    const appendSnapshotStdin = args['append-ontology-snapshot-stdin'] === true;
     const challengeMode = str(args['challenge-mode']);
+
+    // Read stdin once if any stdin flag is present (avoids double-read)
+    let stdinText: string | undefined;
+    if (appendRoundStdin || appendSnapshotStdin) {
+      try {
+        stdinText = readFileSync(0, 'utf8').trim();
+      } catch (e) {
+        process.stderr.write(`deep-interview-state update: failed to read stdin: ${String(e)}\n`);
+        process.exit(1);
+      }
+    }
 
     // Validate JSON flags before any write
     let appendRound: unknown;
-    if (appendRoundRaw !== undefined) {
+    if (appendRoundStdin) {
+      try {
+        appendRound = JSON.parse(stdinText!);
+      } catch {
+        process.stderr.write(
+          `deep-interview-state update: --append-round-stdin: invalid JSON from stdin\n`
+        );
+        process.exit(1);
+      }
+    } else if (appendRoundRaw !== undefined) {
       try {
         appendRound = JSON.parse(appendRoundRaw);
       } catch {
@@ -304,7 +330,16 @@ function main(): void {
       }
     }
     let appendSnapshot: unknown;
-    if (appendSnapshotRaw !== undefined) {
+    if (appendSnapshotStdin) {
+      try {
+        appendSnapshot = JSON.parse(stdinText!);
+      } catch {
+        process.stderr.write(
+          `deep-interview-state update: --append-ontology-snapshot-stdin: invalid JSON from stdin\n`
+        );
+        process.exit(1);
+      }
+    } else if (appendSnapshotRaw !== undefined) {
       try {
         appendSnapshot = JSON.parse(appendSnapshotRaw);
       } catch {
@@ -357,6 +392,8 @@ function main(): void {
         '         [--current-phase <phase>] [--threshold <n>] [--codebase-context <text>]\n' +
         "  update [--current-phase <phase>] [--current-ambiguity <n>]\n" +
         "         [--append-round '<json>'] [--append-ontology-snapshot '<json>']\n" +
+        "         [--append-round-stdin]            (recommended for free-text: read JSON from stdin)\n" +
+        "         [--append-ontology-snapshot-stdin] (recommended for free-text: read JSON from stdin)\n" +
         '         [--challenge-mode <name>]\n' +
         '  get\n' +
         '  list-others\n' +

--- a/skills/goal/SKILL.md
+++ b/skills/goal/SKILL.md
@@ -53,7 +53,7 @@ bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts list-others
 
 If candidates exist, present them via AskUserQuestion with one option per candidate (labeled with the candidate's purpose and age — e.g. "ship X — started 2026-06-10, 3 hours idle"), plus a "start fresh" option. Proceed to the next step ONLY on an explicit user selection:
 
-- On candidate selection: run `bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts adopt --src <selected-sid>`, then resume normal flow on the adopted state.
+- On candidate selection: run `bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts adopt --src <selected-sid>`, then run `bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts get` to read what was adopted, and resume from the restored state — if `phase` is `planning`, resume planning from the stored `plan_path`/`resume_summary`; if `phase` is `pursuing`, continue pursuit at the adopted `iteration`. Do NOT re-seed via `set --phase planning` from the new invocation's text.
 - On "start fresh": proceed as a new goal.
 
 If no candidates exist, say so and proceed fresh. The branch never renames on its own — adoption requires an explicit user selection.


### PR DESCRIPTION
## 📌 Summary

PR #106(state lifecycle 하드닝 + ralph 은퇴) 머지 직후 수행한 2차 코드리뷰에서 확정된 finding들을 해소합니다. pristine-inert 원칙을 미적용 표면(deep-interview Stop·adoption 후보·prometheus 술어)까지 sweep하고, omt-cleanup의 디렉터리 단위 삭제를 파일 단위 reap으로 전환하며, deep-interview 페이로드 채널을 셸-안전한 stdin으로 교체합니다.

---

## 🔧 Changes

### state-core (상태 파일 공통 계약)

- adopt r5 재스탬프를 `writeFileSync` → `writeFileNoCreate`로 전환 — 모듈의 no-create 불변식을 마지막 raw 쓰기까지 완성
- `listOthers`가 pristine seed를 adopt 후보에서 제외, adopt에 r8(pristine source 거부) 신설
- `isPristine` prometheus 분기에 `resume_summary` 빈값 조건 추가 — S0 진행 중 상태가 빈 시드로 오분류되어 복원 경로가 막히던 결함 해소

**영향 범위**
상태 파일 3종(goal/prometheus/deep-interview)의 adoption 흐름 전체. 하위 호환: 기존 상태 파일 포맷 무변경, 판정 로직만 정밀화.

### deep-interview (Stop 보호 + 페이로드 채널)

- persistent-mode Stop 분기에 pristine-inert 게이트 추가 — 권한 거부/ESC로 고아가 된 seed가 세션 종료를 무한 차단하던 경로 차단 (goal 측 기존 fix의 미러)
- keyword-detector의 DI 키워드 프로즈를 "MODE ACTIVATED" 선언에서 `Skill(deep-interview)` 호출 지시로 교체 — 키워드 진입 시 상태 seed가 영영 생기지 않던 라우팅 결함 해소
- CLI에 stdin 페이로드 플래그(`--append-round-stdin` 등) 신설, SKILL.md 템플릿을 heredoc(고유 종결자 `OMT_DI_PAYLOAD_EOF`)→stdin으로 전환
- brownfield 라운드 페이로드에 `context` 점수 키 추가, stability_ratio 직렬화를 JSON null로 교정, JSON-encode 지시 명문화

**영향 범위**
deep-interview 인터뷰 영속·재개(adopt-resume) 전체와 키워드 진입 경로. CLI 기존 inline 플래그는 유지(stdin은 추가 채널).

### omt-cleanup (수동 정리 도구)

- dead-state 분기의 디렉터리 `rm -rf`를 파일 단위 reap + 빈 디렉터리 rmdir로 전환 — plans/ 등 영속 산출물 동반 삭제 차단
- DEAD_STATE_FILES를 개행 구분 + `while IFS= read -r` 소비로 교체(공백 포함 경로 word-split 해소), managed glob 3중 사본을 `list_state_files()` 단일 enumerator로 통합

**영향 범위**
`omt-cleanup --execute`의 삭제 동작이 보수적으로 변경(디렉터리→파일). dry-run 리포트에 DEAD-STATE 파일 경로가 명시됨.

### 회귀 가드 + goal

- ralph 은퇴 회귀 가드가 역사에 없던 완곡어 토큰을 grep하던 것을 실토큰(`ralph[-_]?state|ralph[-_]?active`) grep + GC glob exact-set 단언으로 교정 — 원본 코드를 되돌려도 green이던 가드 무력화 해소
- goal SKILL.md adopt 불릿에 post-adopt `get` 읽기·phase 분기 재개·재시드 금지 추가 (prometheus 측 기존 fix의 미러)

**영향 범위**
테스트·프로즈만. 런타임 행동 무변경.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. pristine-inert 원칙의 클래스 sweep — 그리고 술어 자체의 정밀도

**배경 및 문제 상황:**
PR #106이 "pristine seed(시드만 생성되고 진행 없는 상태 파일)는 소비자에게 inert"라는 원칙을 세웠지만 goal의 Stop/restore에만 적용했습니다. 같은 클래스의 결함이 deep-interview Stop 분기(seed가 세션 종료를 무한 차단)와 adoption 후보 노출(빈 껍데기가 adopt 후보로 표시)에 그대로 남아 있었습니다.

**해결 방안:**
원칙을 결함 인스턴스가 아니라 클래스 단위로 sweep — DI Stop 게이트, `listOthers` pristine 필터, adopt r8(source pristine 거부)을 한 번에 배선했습니다.

**구현 세부사항:**
sweep 후 자체 리뷰에서 sweep에 쓴 **술어 자체**의 갭이 발견됐습니다: prometheus는 실작업 마커(`plan_path`)가 파이프라인 후반(S2)에야 등장해, S0 요구사항 인터뷰 중 `resume_summary`를 기록한 상태가 pristine으로 오분류 — 문서화된 복원 경로("plan_path 부재 시 resume_summary에서 재시작")가 cross-session에서 도달 불가가 됩니다. goal의 outcome-sentinel 컨벤션과 동일한 형태로 `resume_summary` 빈값 조건을 추가해 닫았습니다.

**선택과 트레이드오프:**
DI pristine 판정은 rich `state` 객체 부재 기준이라, PR #106 이전 keyword-detector가 쓰던 레거시 마커(`{active, sessionId, started_at}`)도 inert로 처리됩니다. 트리거가 "구버전 배포본으로 인터뷰 시작 → 같은 세션 도중 sync → 6h TTL 내 Stop"이라는 1회성 전이 윈도우뿐이라, 죽은 포맷을 위한 영구 판별 분기를 추가하는 대신 수용했습니다(운영적으로 회피 가능).

### 2. omt-cleanup 삭제 입도 — 단죄 근거와 삭제 단위의 일치

**배경 및 문제 상황:**
dead-state 분기의 단죄 근거는 상태 파일의 죽음(파일 단위 증거)인데 삭제는 디렉터리 단위(`rm -rf`)였습니다. 모든 종료 세션의 상태는 수 시간 내 dead가 되므로, 이름 실드 밖 미래 프로젝트에서 `--execute` 한 번에 plans/ 연구 문서가 통째로 사라질 수 있었습니다 — 이 도구의 유일한 비가역 데이터 손실 경로.

**해결 방안:**
session-start GC의 기존 입도(상태 파일만 `rm -f`)를 미러: 죽은 상태 파일만 reap하고 디렉터리는 비었을 때만 rmdir.

**구현 세부사항:**
reap 목록(DEAD_STATE_FILES)이 풀 절대경로를 담게 되면서, 기존 리스트들(basename만 담아 안전)과 달리 HOME 프리픽스의 공백에 노출되는 word-split 결함이 함께 발견·해소됐습니다(개행 구분 + `while read`). managed glob 목록이 이 변경으로 스크립트 내 3중 복제가 되는 것을 `list_state_files()` enumerator로 통합했습니다.

**선택과 트레이드오프:**
enumerator 통합 범위를 이 스크립트 내부로 한정했습니다 — 같은 glob이 session-start.sh와 state-liveness.sh에도 있지만, hook 간 공유 라이브러리화는 배포 결합도를 높여 별도 작업으로 분리했습니다.

### 3. DI 페이로드 채널 — 셸 레이어와 JSON 레이어의 분리

**배경 및 문제 상황:**
SKILL.md 템플릿이 사용자 자유 답변을 single-quote 셸 JSON에 raw 치환하도록 지시했습니다. 아포스트로피(`don't`)는 셸을 분절시키고, double-quote 변형(`--initial-idea`)은 `$`/백틱을 조용히 확장합니다. 레포의 확립된 안전 관용구(heredoc→stdin)가 이 스킬에만 미적용 상태였습니다.

**해결 방안:**
CLI에 stdin 페이로드 플래그를 추가하고 템플릿을 heredoc→stdin으로 전환하되, 종결자를 고유 토큰(`OMT_DI_PAYLOAD_EOF`)으로 — 사용자 텍스트에 `EOF` 라인이 있으면 `"$(cat ...)"` 안에서 잔여 텍스트가 셸로 실행되는 구멍까지 닫았습니다.

**구현 세부사항:**
heredoc은 셸 레이어만 보호합니다. JSON 레이어(사용자 텍스트의 `"`)는 CLI가 자동 escape할 수 없습니다 — 페이로드가 도착했을 때 CLI는 어디까지가 사용자 텍스트인지 모르기 때문입니다. 대신 (a) 템플릿 프로즈에 JSON-encode 의무를 명문화하고 (b) CLI는 invalid JSON에 쓰기 전 loud-fail(stderr + exit 1)로 재시도를 유도합니다.

**선택과 트레이드오프:**
stdin 플래그 2종을 동시 지정하면 같은 페이로드가 두 배열에 기록되는 엣지가 남아 있습니다. 문서화된 호출은 항상 플래그 1개씩이고 의미상으로도 비결합이라 가드를 추가하지 않았습니다 — Simplicity First 우선, 실측 발생 시 2줄 가드로 닫을 수 있습니다.

### 4. 회귀 가드는 과거의 실제 코드에서 토큰을 가져와야 한다

**배경 및 문제 상황:**
ralph 은퇴를 보증하는 회귀 가드들이 `retired-loop-state|LOOP_ACTIVE` 같은 완곡어를 grep했는데, 제거된 실제 코드의 토큰은 `RALPH_STATE_FILE`/`RALPH_ACTIVE`였습니다 — 두 집합이 완전 disjoint라 원본 코드를 그대로 되돌려도 전 가드가 green. GC glob 테스트는 존재-only 단언 + 정규식 alternation 우선순위 버그로 사실상 공허했습니다.

**해결 방안:**
역사 실토큰(`ralph[-_]?state|ralph[-_]?active`) grep으로 교체하고, GC glob은 exact-set 단언(count + prefix별 1매치 + allowlist 외 부재)으로 전환했습니다.

**선택과 트레이드오프:**
테스트 본문에 "ralph"라는 단어를 다시 들이는 비용을 수용했습니다 — 회귀 가드의 목적은 어휘 청결이 아니라 재도입 검출이고, 검출 대상 토큰은 미래의 코드가 아니라 과거의 실제 코드에서 가져와야 합니다.

---

## ✅ Checklist

### state-core
- [ ] S0 + `resume_summary` 보유 상태가 non-pristine으로 판정되어 list-others 후보에 노출된다
  - `lib/state-core.test.ts`
- [ ] adopt r5 재스탬프가 사라진 파일을 재생성하지 않는다 (no-create)
  - `lib/state-core.test.ts`

### deep-interview
- [ ] seed-only(pristine) 상태 파일이 Stop을 차단하지 않고, 진행 중(rich state) 인터뷰는 계속 차단한다
  - `hooks/persistent-mode/decision.test.ts`
- [ ] stdin 페이로드가 invalid JSON일 때 쓰기 전에 exit 1로 실패한다
  - `skills/deep-interview/scripts/deep-interview-state.test.ts`
- [ ] SKILL.md에 bare `<<'EOF'` 종결자가 0건이다
  - `skills/deep-interview/SKILL.md`

### omt-cleanup
- [ ] dead-state 디렉터리에서 상태 파일만 삭제되고 plans/ 산출물은 보존된다
  - `scripts/omt-cleanup/omt-cleanup_test.sh`
- [ ] 공백 포함 HOME 경로에서 dry-run이 풀 경로를 표시하고 --execute가 정확한 파일을 삭제한다
  - `scripts/omt-cleanup/omt-cleanup_test.sh`

### 회귀 가드
- [ ] ralph 시절 실토큰(`ralph[-_]?state|ralph[-_]?active`)을 재도입하면 가드 테스트가 실패한다
  - `hooks/stop-notify_test.sh`, `hooks/session-start_test.sh`

### 전체
- [ ] `make validate` exit 0, `make test` 전건 통과 (shell 10/10, bun 2184+)
  - `Makefile`

---

## 📎 References
- [#106 state lifecycle 하드닝 + ralph 은퇴](https://github.com/toongri/oh-my-toong-playground/pull/106)