### PR TITLE
feat: code-review 리포트를 브라우저 HTML로 렌더

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -570,6 +570,8 @@ Use `data-verdict="PLAUSIBLE"` for plausible findings.
 
 **Injection guard — card-body code must stay fenced**: The render sink is `container.innerHTML = marked.parse(md)` with no DOM sanitizer. Only the card chrome (the `<div data-verdict>`, title, verdict badge) is raw HTML. Every reviewed-code snippet inside a card (Current Code / Fix) MUST be a fenced ` ```{lang} ` block so marked.js HTML-escapes it. Fencing — not a DOM sanitizer — is what neutralizes hostile reviewed code (e.g. `<img src=x onerror=BOOM>`, `</script>`): the fenced path goes through marked's escape pipeline while raw HTML inside marked.parse is treated as live HTML and passed through to innerHTML unchanged. NEVER author reviewed code snippets as raw HTML inside a card body. If the reviewed snippet itself contains a line that is a code fence (` ``` ` or `~~~`), the card's Current Code / Fix fence MUST use a fence the inner fence cannot terminate — a strictly longer fence of the same character (e.g. 4+ backticks) or the other fence type (`~~~`). CommonMark closes a fence only with the same character and an equal-or-greater run length, so a `~~~`-delimited card body is immune to inner backtick fences and vice-versa.
 
+**Injection guard — prose fields too**: The same `innerHTML = marked.parse(md)` sink treats raw HTML in *prose* as live, not only in card bodies. The card's prose fields — the finding title, `What's wrong`, and `Failure scenario` — are not fenced, so a reviewed-code fragment quoted bare there (e.g. `<img src=x onerror=BOOM>`, `</script>`) reaches innerHTML as live HTML exactly as an unfenced card body would. Every code-derived fragment echoed in a prose field MUST be wrapped in an inline-code span (backticks) so marked.js escapes it as code — or HTML-escaped if an inline-code span does not fit. If the fragment itself contains a backtick, delimit the span with a longer backtick run (CommonMark matches an inline-code span on an equal-length backtick run). NEVER quote a reviewed-code fragment bare in prose.
+
 **Unverified entries — plain markdown, no card**: `Unverified (verifier unavailable)` entries have no verdict by design (they are coverage gaps, not findings). Do NOT wrap them in `<div class="finding" data-verdict>`. Leave them as plain markdown list items.
 
 **Mermaid validity**: The Architecture and Sequence diagrams derive from the reviewed change. mermaid treats `;` as a statement separator — a raw `;` inside sequence-message text (common in code, e.g. `mkdir -p; rm`) silently splits the line and the whole diagram renders as an error SVG. mermaid source MUST be syntactically valid: keep sequence-message text free of raw `;` (rephrase to `then`, a comma, or omit the problematic fragment), and avoid unescaped mermaid control tokens throughout all mermaid fences.
@@ -613,6 +615,14 @@ Substitute into the template placeholders:
 | `{{REVIEW_FILE_PATH}}` | Absolute path to the written HTML file |
 | `{{REVIEW_MARKDOWN_JSON}}` | close-tag-escaped JSON string of the assembled review markdown |
 | `{{FOOTER_NOTE}}` | Session language note, e.g. `This review reports; it does not gate.` |
+
+**Active-HTML placeholders MUST be HTML-escaped.** Every placeholder above EXCEPT `{{REVIEW_MARKDOWN_JSON}}` lands in a live HTML position (`<title>`, `<h1>`, `<span>`). An HTML-significant character flowing in from a repo/branch name, file path, or count — Git permits branch names such as `x<svg/onload=alert(1)>` — would otherwise inject live markup. Escape each value before substitution:
+
+```js
+const esc = (s) => String(s).replace(/[&<>"']/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c]));
+```
+
+`{{REVIEW_MARKDOWN_JSON}}` is exempt — it sits in the inert `<script type="application/json">` container and already carries the close-tag escape above. `{{LANG_CODE}}` must be a plain BCP-47 tag (e.g. `ko`, `en`), not free text.
 
 Then write the substituted HTML:
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -568,7 +568,7 @@ If nothing survived verification: "No findings survived verification."]
 
 Use `data-verdict="PLAUSIBLE"` for plausible findings.
 
-**Injection guard — card-body code must stay fenced**: The render sink is `container.innerHTML = marked.parse(md)` with no DOM sanitizer. Only the card chrome (the `<div data-verdict>`, title, verdict badge) is raw HTML. Every reviewed-code snippet inside a card (Current Code / Fix) MUST be a fenced ` ```{lang} ` block so marked.js HTML-escapes it. Fencing — not a DOM sanitizer — is what neutralizes hostile reviewed code (e.g. `<img src=x onerror=BOOM>`, `</script>`): the fenced path goes through marked's escape pipeline while raw HTML inside marked.parse is treated as live HTML and passed through to innerHTML unchanged. NEVER author reviewed code snippets as raw HTML inside a card body.
+**Injection guard — card-body code must stay fenced**: The render sink is `container.innerHTML = marked.parse(md)` with no DOM sanitizer. Only the card chrome (the `<div data-verdict>`, title, verdict badge) is raw HTML. Every reviewed-code snippet inside a card (Current Code / Fix) MUST be a fenced ` ```{lang} ` block so marked.js HTML-escapes it. Fencing — not a DOM sanitizer — is what neutralizes hostile reviewed code (e.g. `<img src=x onerror=BOOM>`, `</script>`): the fenced path goes through marked's escape pipeline while raw HTML inside marked.parse is treated as live HTML and passed through to innerHTML unchanged. NEVER author reviewed code snippets as raw HTML inside a card body. If the reviewed snippet itself contains a line that is a code fence (` ``` ` or `~~~`), the card's Current Code / Fix fence MUST use a fence the inner fence cannot terminate — a strictly longer fence of the same character (e.g. 4+ backticks) or the other fence type (`~~~`). CommonMark closes a fence only with the same character and an equal-or-greater run length, so a `~~~`-delimited card body is immune to inner backtick fences and vice-versa.
 
 **Unverified entries — plain markdown, no card**: `Unverified (verifier unavailable)` entries have no verdict by design (they are coverage gaps, not findings). Do NOT wrap them in `<div class="finding" data-verdict>`. Leave them as plain markdown list items.
 
@@ -597,7 +597,7 @@ where `{repo-basename}` = `basename -s .git $(git remote get-url origin)`, or `b
 Count correctness and cleanup findings (CONFIRMED + PLAUSIBLE each). Apply the close-tag escape to the assembled markdown:
 
 ```js
-JSON.stringify(reviewMarkdown).replace(/<\/script>/g, '<\\/script>')
+JSON.stringify(reviewMarkdown).replace(/<\/(script)([\s/>])/gi, '<\\/$1$2')
 ```
 
 Substitute into the template placeholders:

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -594,7 +594,7 @@ where `{repo-basename}` = `basename -s .git $(git remote get-url origin)`, or `b
 
 #### Step R4: Substitute Placeholders and Write
 
-Count correctness and cleanup findings (CONFIRMED + PLAUSIBLE each). Apply Rule 6b to the assembled markdown:
+Count correctness and cleanup findings (CONFIRMED + PLAUSIBLE each). Apply the close-tag escape to the assembled markdown:
 
 ```js
 JSON.stringify(reviewMarkdown).replace(/<\/script>/g, '<\\/script>')
@@ -611,7 +611,7 @@ Substitute into the template placeholders:
 | `{{CORRECTNESS_COUNT}}` | e.g. `3 correctness` |
 | `{{CLEANUP_COUNT}}` | e.g. `2 cleanup` |
 | `{{REVIEW_FILE_PATH}}` | Absolute path to the written HTML file |
-| `{{REVIEW_MARKDOWN_JSON}}` | Rule 6b-escaped JSON string of the assembled review markdown |
+| `{{REVIEW_MARKDOWN_JSON}}` | close-tag-escaped JSON string of the assembled review markdown |
 | `{{FOOTER_NOTE}}` | Session language note, e.g. `This review reports; it does not gate.` |
 
 Then write the substituted HTML:

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -495,67 +495,151 @@ This is a **report**. You surface verified findings, ranked by what matters most
 | Zero findings after verification | Skip enrichment. Report a clean review (Walkthrough + "No findings survived verification."). |
 | 50+ candidates requiring verification | Dispatch verifiers in batches per Phase 2 (≤25), correctness candidates first. |
 
-### Final Output Format (report-only)
+### HTML Render + Terminal Pointer
+
+This is a **report**. It does not gate. There is no Assessment / "Ready to merge" section.
+
+After Phase 2 verification is complete, assemble the render-time markdown, render it into `$OMT_DIR/reviews/{slug}.html`, and print a short terminal pointer. The full report lives only in the HTML — the terminal receives counts and a path, not the report body.
+
+#### Step R1: Assemble the Render-Time Markdown
+
+Assemble the report markdown with these top-level sections (omit optional sections when empty per the rules below):
 
 ```
 ## Walkthrough
 
 ### Change Summary
-[Generated in Phase 1]
+[Phase 1 prose — 1-2 paragraphs]
 
 ### Core Logic Analysis
-[Generated in Phase 1]
+[Phase 1 prose — module narrative, data flow, design decisions]
 
 ### Architecture Diagram
-[Generated in Phase 1 — Mermaid or "No structural changes — existing architecture preserved"]
+[Phase 1 — ```mermaid class/component diagram, or "No structural changes — existing architecture preserved"]
 
 ### Sequence Diagram
-[Generated in Phase 1 — Mermaid or "No call flow changes"]
+[Phase 1 — ```mermaid sequence diagram, or "No call flow changes"]
 
 ---
 
 ## Findings
 [Ranked: correctness CONFIRMED → correctness PLAUSIBLE → cleanup CONFIRMED → cleanup PLAUSIBLE.
-If nothing survived verification: "No findings survived verification." and stop here.]
+If nothing survived verification: "No findings survived verification."]
 
 ### Correctness
-[Findings where the change behaves wrong. Omit the section if none.]
+[Omit if none.]
 
 ### Cleanup
-[Findings where behavior is correct but quality is low. Omit the section if none.]
+[Omit if none.]
 
-Per-finding format (enriched during Phase 2 verification):
-**[{CONFIRMED|PLAUSIBLE}] {finding title}**
-- **Location**: `{file}:{line}` — {section/function name}
+## Out of Scope (Pre-existing)
+[Findings on unchanged context lines — verdict-labeled cards. Do not gate on these.]
+
+## Unverified (verifier unavailable)
+[Only when one or more verifiers errored or timed out — plain markdown, NO data-verdict, explicit count. Omit entirely when every candidate was verified.]
+
+## Recommendations
+[Optional — from the Findings section only (not Out of Scope or Unverified); omit if none.]
+```
+
+**Verdict-bearing findings as literal card HTML** (Findings + Out of Scope Pre-existing): every finding that carries a verdict is authored in the render-time markdown as a literal `<div class="finding" data-verdict="CONFIRMED">…</div>` (or `data-verdict="PLAUSIBLE"`). The literal `[CONFIRMED]` or `[PLAUSIBLE]` token also appears in the card text. Card format:
+
+```
+<div class="finding" data-verdict="CONFIRMED">
+
+**[CONFIRMED] {finding title}**
+<span class="loc">`{file}:{line}` — {section/function name}</span>
+
+- **What's wrong**: {problem, grounded in the quoted line}
+- **Failure scenario**: {concrete inputs/state → wrong output, crash, or lost effect; for cleanup, the concrete cost}
 - **Current Code**:
   ```{lang}
   [5-15 lines centered on the issue]
   ```
-- **What's wrong**: {problem, grounded in the quoted line}
-- **Failure scenario**: {concrete inputs/state → wrong output, crash, or lost effect; for cleanup, the concrete cost — what is duplicated, wasted, or harder to maintain}
 - **Fix**:
   ```diff
   [concrete diff or, if structural, a design direction]
   ```
-- **Blast Radius**: {grep/reference evidence — what else references this, or "This location only"}
-- **Found by**: {angle(s) — note when multiple angles corroborated the same finding}
+- **Blast Radius**: {grep/reference evidence, or "This location only"}
+- **Found by**: {angle(s)}
 
-Fallback (verifier failed): If a verifier subagent errored or timed out for a candidate, do NOT assign a verdict — an unverified candidate is not a finding. List it under the `## Unverified (verifier unavailable)` section using the finder's text, and state how many candidates went unverified. These are coverage gaps the reader must check manually, not confirmed or plausible findings.
-
-## Out of Scope (Pre-existing)
-[Findings on unchanged context lines, verdict-labeled. These do not gate anything — they are noted, not blocking.]
-
-## Unverified (verifier unavailable)
-[Only if one or more verifiers errored or timed out. Candidates listed with the finder's text and a count, explicitly NOT verdict-labeled — coverage gaps, not findings. Omit the section entirely when every candidate was verified.]
-
-## Recommendations
-[Optional. From the `## Findings` section above only (not Out of Scope or
-Unverified), the ones worth resolving — where resolving carries real
-benefit: it preserves a requirement, removes a bug, or improves
-maintainability. Recommend those; omit if none.]
+</div>
 ```
 
-There is no Assessment / "Ready to merge" section. This review reports; it does not gate.
+Use `data-verdict="PLAUSIBLE"` for plausible findings.
+
+**Injection guard — card-body code must stay fenced**: The render sink is `container.innerHTML = marked.parse(md)` with no DOM sanitizer. Only the card chrome (the `<div data-verdict>`, title, verdict badge) is raw HTML. Every reviewed-code snippet inside a card (Current Code / Fix) MUST be a fenced ` ```{lang} ` block so marked.js HTML-escapes it. Fencing — not a DOM sanitizer — is what neutralizes hostile reviewed code (e.g. `<img src=x onerror=BOOM>`, `</script>`): the fenced path goes through marked's escape pipeline while raw HTML inside marked.parse is treated as live HTML and passed through to innerHTML unchanged. NEVER author reviewed code snippets as raw HTML inside a card body.
+
+**Unverified entries — plain markdown, no card**: `Unverified (verifier unavailable)` entries have no verdict by design (they are coverage gaps, not findings). Do NOT wrap them in `<div class="finding" data-verdict>`. Leave them as plain markdown list items.
+
+**Mermaid validity**: The Architecture and Sequence diagrams derive from the reviewed change. mermaid treats `;` as a statement separator — a raw `;` inside sequence-message text (common in code, e.g. `mkdir -p; rm`) silently splits the line and the whole diagram renders as an error SVG. mermaid source MUST be syntactically valid: keep sequence-message text free of raw `;` (rephrase to `then`, a comma, or omit the problematic fragment), and avoid unescaped mermaid control tokens throughout all mermaid fences.
+
+**Translation**: Translate all render-time prose to the detected session language. NEVER translate: code blocks, file paths, CLI tokens, verdict tokens (`CONFIRMED`/`PLAUSIBLE`), the literal `data-verdict="CONFIRMED"` and `data-verdict="PLAUSIBLE"` attribute values (translating these would break the CSS `[data-verdict]` selector), `file:line` references, and finding identifiers. If language detection is ambiguous, fall back to the original language.
+
+**Fallback (verifier failed)**: If a verifier errored or timed out for a candidate, do NOT assign a verdict — list the candidate under `## Unverified (verifier unavailable)` as plain markdown with a count. Do not card it.
+
+#### Step R2: Read the Template
+
+Read the HTML template from `${CLAUDE_SKILL_DIR}/templates/review-presentation.html`. Do NOT construct the path relative to the current working directory — during a review, the skill's bash CWD is the review target repo, not the skill directory, so a CWD-relative read would miss the deployed copy.
+
+#### Step R3: Derive the Slug
+
+Derive `{slug}` from the review target — stable per target so that re-reviewing the same target **overwrites** the prior file (no timestamp suffix):
+
+- PR review: `{repo-basename}-pr{N}` (e.g. `algocare-home-pr123`)
+- Branch comparison: `{repo-basename}-{sanitized-branch}` (branch sanitized to `[a-z0-9-]`)
+- Fallback (no PR, no branch): `{repo-basename}-{short-diff-range-hash}`
+
+where `{repo-basename}` = `basename -s .git $(git remote get-url origin)`, or `basename $(git rev-parse --show-toplevel)` if no remote.
+
+#### Step R4: Substitute Placeholders and Write
+
+Count correctness and cleanup findings (CONFIRMED + PLAUSIBLE each). Apply Rule 6b to the assembled markdown:
+
+```js
+JSON.stringify(reviewMarkdown).replace(/<\/script>/g, '<\\/script>')
+```
+
+Substitute into the template placeholders:
+
+| Placeholder | Value |
+|-------------|-------|
+| `{{LANG_CODE}}` | BCP-47 language tag of the session language (e.g. `ko`, `en`) |
+| `{{HTML_TITLE}}` | Human-readable review title, e.g. `{repo} PR #{N} Code Review` |
+| `{{REVIEW_TITLE}}` | Short kicker, e.g. `Code Review` |
+| `{{TOC_TITLE}}` | TOC nav label in session language, e.g. `목차` / `Contents` |
+| `{{CORRECTNESS_COUNT}}` | e.g. `3 correctness` |
+| `{{CLEANUP_COUNT}}` | e.g. `2 cleanup` |
+| `{{REVIEW_FILE_PATH}}` | Absolute path to the written HTML file |
+| `{{REVIEW_MARKDOWN_JSON}}` | Rule 6b-escaped JSON string of the assembled review markdown |
+| `{{FOOTER_NOTE}}` | Session language note, e.g. `This review reports; it does not gate.` |
+
+Then write the substituted HTML:
+
+```bash
+mkdir -p $OMT_DIR/reviews
+# write to: $OMT_DIR/reviews/{slug}.html
+```
+
+#### Step R5: Open and Print Terminal Pointer
+
+Attempt to open the HTML file in the browser (best-effort, non-blocking — never error on failure):
+
+```bash
+open "$OMT_DIR/reviews/{slug}.html" 2>/dev/null || \
+  xdg-open "$OMT_DIR/reviews/{slug}.html" 2>/dev/null || \
+  true
+```
+
+On headless/CI environments where neither `open` nor `xdg-open` succeeds, print the file path so the user can open it manually — do not raise an error.
+
+Print the terminal pointer (finding counts by verdict/category + the html path — NOT the full report body):
+
+```
+Review written: $OMT_DIR/reviews/{slug}.html
+Correctness: {N confirmed} CONFIRMED, {N plausible} PLAUSIBLE
+Cleanup:     {N confirmed} CONFIRMED, {N plausible} PLAUSIBLE
+```
 
 ### Example Final Output
 

--- a/skills/code-review/templates/review-presentation.html
+++ b/skills/code-review/templates/review-presentation.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="{{LANG_CODE}}">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{HTML_TITLE}}</title>
+<script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js" integrity="sha384-/TQbtLCAerC3jgaim+N78RZSDYV7ryeoBCVqTuzRrFec2akfBkHS7ACQ3PQhvMVi" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js" integrity="sha384-rbtjAdnIQE/aQJGEgXrVUlMibdfTSa4PQju4HDhN3sR2PmaKFzhEafuePsl9H/9I" crossorigin="anonymous"></script>
+<style>
+:root {
+  --bg: #fafafa;
+  --panel: #ffffff;
+  --text: #1a1a1a;
+  --muted: #6b7280;
+  --border: #e5e7eb;
+  --accent: #2563eb;
+  --accent-bg: #eff6ff;
+  --code-bg: #f3f4f6;
+  --ok: #059669;
+  --warn: #d97706;
+  --info: #7c3aed;
+  --danger: #dc2626;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f1115;
+    --panel: #161921;
+    --text: #e5e7eb;
+    --muted: #9ca3af;
+    --border: #2a2f3a;
+    --accent: #60a5fa;
+    --accent-bg: #1e293b;
+    --code-bg: #1a1f2b;
+    --ok: #34d399;
+    --warn: #fbbf24;
+    --info: #a78bfa;
+    --danger: #f87171;
+  }
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans KR", "Apple SD Gothic Neo", sans-serif;
+  font-size: 15px;
+  line-height: 1.65;
+}
+.layout { display: grid; grid-template-columns: 260px minmax(0, 1fr); min-height: 100vh; }
+nav.toc {
+  position: sticky; top: 0;
+  height: 100vh; overflow-y: auto;
+  border-right: 1px solid var(--border);
+  background: var(--panel);
+  padding: 20px 16px;
+  font-size: 13px;
+}
+nav.toc .title { font-weight: 700; color: var(--muted); text-transform: uppercase; font-size: 11px; letter-spacing: 1px; margin-bottom: 12px; }
+nav.toc ul { list-style: none; padding: 0; margin: 0; }
+nav.toc li { margin: 4px 0; }
+nav.toc a { color: var(--muted); text-decoration: none; display: block; padding: 3px 6px; border-radius: 4px; }
+nav.toc a:hover { background: var(--accent-bg); color: var(--accent); }
+nav.toc .lvl-2 { padding-left: 0; }
+nav.toc .lvl-3 { padding-left: 14px; font-size: 12px; }
+nav.toc .lvl-4 { padding-left: 28px; font-size: 11.5px; color: var(--muted); }
+main { padding: 32px 48px 80px; max-width: 960px; }
+header.hero { border-bottom: 1px solid var(--border); margin-bottom: 24px; padding-bottom: 20px; }
+header.hero .kicker { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 1px; }
+header.hero h1 { font-size: 28px; margin: 4px 0 4px; }
+header.hero .meta { color: var(--muted); font-size: 13px; display: flex; gap: 16px; flex-wrap: wrap; margin-top: 8px; }
+header.hero .meta .pill { background: var(--accent-bg); color: var(--accent); padding: 2px 10px; border-radius: 12px; font-weight: 600; }
+header.hero .meta .pill.danger { background: #fef2f2; color: var(--danger); }
+header.hero .meta .pill.warn { background: #fffbeb; color: var(--warn); }
+@media (prefers-color-scheme: dark) {
+  header.hero .meta .pill.danger { background: #2d1515; color: var(--danger); }
+  header.hero .meta .pill.warn { background: #2d2010; color: var(--warn); }
+}
+.section-box { background: var(--panel); border: 1px solid var(--border); border-left: 4px solid var(--accent); border-radius: 6px; padding: 16px 20px; margin: 20px 0; }
+.section-box.ok { border-left-color: var(--ok); }
+.section-box.warn { border-left-color: var(--warn); }
+.section-box.info { border-left-color: var(--info); }
+.section-box.danger { border-left-color: var(--danger); }
+.section-box h3 { margin-top: 0; font-size: 15px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--muted); }
+.section-box h3 .tag { display: inline-block; background: var(--ok); color: white; padding: 1px 8px; border-radius: 10px; font-size: 11px; letter-spacing: 0.5px; margin-left: 8px; vertical-align: middle; }
+.section-box.warn h3 .tag { background: var(--warn); }
+.section-box.info h3 .tag { background: var(--info); }
+.findings-grid { display: grid; gap: 10px; margin-top: 10px; }
+.finding { background: var(--bg); border: 1px solid var(--border); border-radius: 4px; padding: 10px 14px; font-size: 13.5px; }
+.finding .loc { color: var(--muted); font-size: 12px; font-family: ui-monospace, SF Mono, Menlo, monospace; }
+.finding .sev { display: inline-block; padding: 1px 7px; border-radius: 10px; font-size: 11px; font-weight: 600; margin-right: 8px; background: var(--accent-bg); color: var(--accent); }
+.finding[data-verdict="CONFIRMED"] { border-left: 4px solid var(--danger); background: #fef2f2; }
+.finding[data-verdict="CONFIRMED"] .sev { background: #fef2f2; color: var(--danger); border: 1px solid var(--danger); }
+.finding[data-verdict="PLAUSIBLE"] { border-left: 4px solid var(--warn); background: #fffbeb; }
+.finding[data-verdict="PLAUSIBLE"] .sev { background: #fffbeb; color: var(--warn); border: 1px solid var(--warn); }
+@media (prefers-color-scheme: dark) {
+  .finding[data-verdict="CONFIRMED"] { background: #1f1010; }
+  .finding[data-verdict="CONFIRMED"] .sev { background: #2d1515; }
+  .finding[data-verdict="PLAUSIBLE"] { background: #1f1a08; }
+  .finding[data-verdict="PLAUSIBLE"] .sev { background: #2d2010; }
+}
+article#review-content { padding-top: 8px; }
+article h1 { display: none; }
+article h2 { font-size: 22px; margin-top: 40px; padding-bottom: 6px; border-bottom: 1px solid var(--border); }
+article h3 { font-size: 17px; margin-top: 28px; }
+article h4 { font-size: 14.5px; margin-top: 20px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; }
+article code { background: var(--code-bg); padding: 1px 5px; border-radius: 3px; font-size: 0.9em; font-family: ui-monospace, SF Mono, Menlo, monospace; }
+article pre { background: var(--code-bg); border: 1px solid var(--border); border-radius: 4px; padding: 12px 14px; overflow-x: auto; font-size: 12.5px; line-height: 1.5; }
+article pre code { background: transparent; padding: 0; }
+article table { border-collapse: collapse; width: 100%; margin: 16px 0; font-size: 13.5px; }
+article th, article td { border: 1px solid var(--border); padding: 7px 10px; text-align: left; vertical-align: top; }
+article th { background: var(--code-bg); font-weight: 600; }
+article blockquote { border-left: 3px solid var(--accent); background: var(--accent-bg); margin: 14px 0; padding: 10px 14px; color: var(--text); }
+article hr { border: none; border-top: 1px solid var(--border); margin: 28px 0; }
+article ul, article ol { padding-left: 22px; }
+article li { margin: 3px 0; }
+article li input[type="checkbox"] { margin-right: 6px; }
+article a { color: var(--accent); }
+article .mermaid { display: block; margin: 22px 0; text-align: center; }
+article .mermaid svg { max-width: 100%; height: auto; }
+.footer-note { margin-top: 60px; padding-top: 20px; border-top: 1px solid var(--border); color: var(--muted); font-size: 12px; }
+@media (max-width: 900px) {
+  .layout { grid-template-columns: 1fr; }
+  nav.toc { position: relative; height: auto; max-height: 300px; }
+  main { padding: 20px; }
+}
+</style>
+</head>
+<body>
+<div class="layout">
+<nav class="toc"><div class="title">{{TOC_TITLE}}</div><ul id="toc"></ul></nav>
+<main>
+<header class="hero">
+  <div class="kicker">{{REVIEW_TITLE}}</div>
+  <h1>{{HTML_TITLE}}</h1>
+  <div class="meta">
+    <span class="pill danger">{{CORRECTNESS_COUNT}}</span>
+    <span class="pill warn">{{CLEANUP_COUNT}}</span>
+    <span>{{REVIEW_FILE_PATH}}</span>
+  </div>
+</header>
+
+<article id="review-content"></article>
+
+<div class="footer-note">{{FOOTER_NOTE}}</div>
+
+</main>
+</div>
+
+<script type="application/json" id="review-md">{{REVIEW_MARKDOWN_JSON}}</script>
+<script>
+(function() {
+  const md = JSON.parse(document.getElementById('review-md').textContent);
+  marked.setOptions({ gfm: true, breaks: false });
+  const container = document.getElementById('review-content');
+  container.innerHTML = marked.parse(md);
+  // Diagram enrichment: marked renders a ```mermaid fence as <pre><code class="language-mermaid">.
+  // Convert each into a <div class="mermaid"> that the Mermaid runtime renders into SVG.
+  container.querySelectorAll('pre > code.language-mermaid').forEach(code => {
+    const div = document.createElement('div');
+    div.className = 'mermaid';
+    div.textContent = code.textContent;
+    code.parentElement.replaceWith(div);
+  });
+  if (window.mermaid) {
+    const dark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    mermaid.initialize({ startOnLoad: false, theme: dark ? 'dark' : 'default', securityLevel: 'strict' });
+    mermaid.run({ querySelector: '.mermaid' });
+  }
+  const toc = document.getElementById('toc');
+  const headings = container.querySelectorAll('h2, h3, h4');
+  const slugify = (t) => t.toLowerCase().trim().replace(/[^\p{L}\p{N}\s-]/gu, '').replace(/\s+/g, '-') || 'sec';
+  const used = new Set();
+  headings.forEach(h => {
+    let id = h.id || slugify(h.textContent);
+    let base = id, i = 2;
+    while (used.has(id)) { id = base + '-' + i; i++; }
+    used.add(id);
+    h.id = id;
+    const lvl = parseInt(h.tagName.substring(1));
+    const li = document.createElement('li');
+    li.className = 'lvl-' + lvl;
+    const a = document.createElement('a');
+    a.href = '#' + id;
+    a.textContent = h.textContent;
+    li.appendChild(a);
+    toc.appendChild(li);
+  });
+})();
+</script>
+</body>
+</html>

--- a/skills/prometheus/review-pipeline.md
+++ b/skills/prometheus/review-pipeline.md
@@ -166,7 +166,7 @@ Six invariants govern substitution and injection during Stage A rendering.
 
 - **(6b) Content-side close-tag escape**: The injection pipeline MUST escape the container's close-tag sequence so plan prose cannot terminate the container prematurely. Canonical pattern:
   ```js
-  const payload = JSON.stringify(planMarkdown).replace(/<\/script>/g, '<\\/script>');
+  const payload = JSON.stringify(planMarkdown).replace(/<\/(script)([\s/>])/gi, '<\\/$1$2');
   // consumer: JSON.parse(container.textContent)
   ```
 

--- a/skills/prometheus/review-pipeline.md
+++ b/skills/prometheus/review-pipeline.md
@@ -146,7 +146,7 @@ Rationale: `plan.md` is the artifact the pipeline reviewed — Momus reviewed th
 
 ### Rendering Methodology
 
-Six invariants govern substitution and injection during Stage A rendering.
+Seven invariants govern substitution and injection during Stage A rendering.
 
 **Rule 1 — Active-element-only substitution**: `{{…}}` placeholders are substituted only at their active template elements. For `{{PLAN_MARKDOWN_JSON}}`, the active container is the `script type="application/json" id="plan-md"` element; substitution occurs only at that active element line. Literal occurrences inside the top-comment documentation block are NOT substituted. Replacement patterns must be anchored to the specific enclosing element by its opening-tag signature, not to the raw placeholder token alone.
 
@@ -158,7 +158,7 @@ Six invariants govern substitution and injection during Stage A rendering.
 
 **Rule 4 — Error recovery / fallback**: If any placeholder is not found in the template, the rendering engine retains the original element untouched — no silent HTML destruction. If translation detection fails per the Translation Rule, fallback to original language.
 
-**Rule 5 — Tool-agnostic**: Substitution engine is the implementer's choice (awk, sed, Node, Python, Bun script, etc.). Rendering Methodology declares invariants, not implementation. Any tool satisfying the six rules is acceptable.
+**Rule 5 — Tool-agnostic**: Substitution engine is the implementer's choice (awk, sed, Node, Python, Bun script, etc.). Rendering Methodology declares invariants, not implementation. Any tool satisfying the seven rules is acceptable.
 
 **Rule 6 — Parser-resilient container embedding**: The HTML element holding plan markdown content (`{{PLAN_MARKDOWN_JSON}}` container) MUST satisfy:
 
@@ -173,6 +173,8 @@ Six invariants govern substitution and injection during Stage A rendering.
 `script type="text/markdown"` MUST NOT be used — unencoded markdown without close-tag escape fails (6b).
 
 Both (6a) and (6b) MUST be present regardless of container choice; alternative inert containers MUST supply their own paired close-tag escape.
+
+**Rule 7 — Active-placeholder HTML escape**: Every `{{…}}` placeholder substituted into an active HTML position — `{{HTML_TITLE}}`, `{{STAGE_KICKER}}`, `{{PLAN_TITLE}}`, `{{TODO_COUNT}}`, `{{AC_COUNT}}`, `{{WAVE_COUNT_LABEL}}`, `{{PLAN_FILE_LABEL}}`, `{{PLAN_FILE_PATH}}`, `{{TOC_TITLE}}`, `{{FOOTER_NOTE}}` — MUST be HTML-escaped (`&`, `<`, `>`, `"`, `'`) before substitution. A plan title, label, or path carrying an HTML-significant character would otherwise inject live markup into `<title>`, `<h1>`, etc. `{{PLAN_MARKDOWN_JSON}}` is exempt — it lives in the inert JSON container and is governed by Rule 6 (the 6b close-tag escape) instead. `{{LANG_CODE}}` must be a plain BCP-47 tag (e.g. `ko`, `en`), not free text.
 
 ---
 


### PR DESCRIPTION
## 📌 Summary

code-review 스킬이 리뷰 리포트를 터미널 마크다운 덤프 대신 **브라우저로 열리는 자체완결 HTML 파일**로 렌더하고, 터미널에는 finding 카운트와 파일 경로 포인터만 출력합니다. prometheus의 "Stage A" 렌더 패턴을 차용했으며, 렌더는 런타임 코드가 아닌 **LLM이 수행하는 템플릿 치환**입니다.

---

## 🔧 Changes

### code-review 스킬 — HTML 렌더 파이프라인

- 신규 템플릿 `review-presentation.html` 추가 (prometheus `plan-presentation.html`에서 파생): 좌측 sticky TOC + 2열 레이아웃, 다크모드, marked@12.0.2 + mermaid@11.4.1 CDN(SRI), inert `<script type="application/json">` 컨테이너 + `marked.parse`/mermaid 렌더 소비자, 그리고 **verdict 색상 카드 CSS**(`.finding[data-verdict="CONFIRMED"]` 빨강 / `PLAUSIBLE` 호박색)
- `SKILL.md` Phase 3 재작성: 기존 "Final Output Format"(터미널 full-report 출력)을 **"HTML Render + Terminal Pointer"(R1~R5)** 로 교체 — render-time 마크다운 조립 → `${CLAUDE_SKILL_DIR}` 기준 템플릿 read → slug 도출 → `</script>` escape + placeholder 치환 → `$OMT_DIR/reviews/{slug}.html` 기록 → best-effort open → 터미널 포인터 출력
- 한글 mojibake 방지를 위해 `<meta charset>`를 문서 첫 1024바이트 안에 배치(prometheus 템플릿의 선두 주석은 의도적으로 미반영), AI 작화 mermaid의 statement-separator(`;`) 깨짐 방지 지시 포함

**영향 범위**
code-review 스킬의 **출력 단계(Phase 3)만** 변경 — single-pass·chunk 모드가 공유하는 단일 렌더 포인트. 런타임 모듈 추가 없음(LLM 수행 치환). Step 0~5(입력 파싱·청킹·dispatch·검증)와 prometheus 템플릿은 무수정. 출력 surface가 "터미널 전체 → HTML + 포인터"로 바뀌는 비하위호환 동작 변화(의도된 교체).

### prometheus — `</script>` escape parity

- `review-pipeline.md` Rule 6b의 close-tag escape 정규식을 code-review와 동일하게 확장(1줄). 두 스킬이 byte-identical 정규식을 공유하므로 한쪽만 고치면 parity가 깨짐

**영향 범위**
prometheus Rule 6b escape 1줄만. base case `</script>` 출력 불변(backward-compatible)이라 기존 plan 렌더 동작에 영향 없음.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. sanitizer 없이 닫는 두 개의 injection 표면

**배경 및 문제 상황:**
finding을 verdict 색상 카드로 보여주는 게 가독성의 핵심인데, marked.js는 단일 마크다운 페이로드를 클라이언트에서 HTML로 렌더하므로 일반 마크다운(`###`, `-`)으로는 카드 구조 + verdict별 색을 표현할 수 없습니다. 동시에 code-review는 **임의의 리뷰 대상 코드**(HTML·JS·마크다운 포함)를 카드에 인용하는데, 렌더 싱크가 `container.innerHTML = marked.parse(md)`(DOM sanitizer 없음)라 인용된 hostile 마크업(`<img onerror>`, `</script>`, `</div>`)이 그대로 실행되거나 리포트를 깨뜨릴 수 있습니다.

**해결 방안:**
카드 *chrome*(`<div class="finding" data-verdict>`, 제목, 배지)만 리터럴 HTML로 author해 marked가 mermaid 펜스처럼 통과시키고, 카드 *본문*의 인용 코드는 반드시 fenced 블록에 둬서 marked가 escape하게 합니다(chrome=raw, 코드 본문=fenced). 별도로 JSON 컨테이너 경계는 `</script>` escape로 보호합니다. DOMPurify/CSP 같은 sanitizer는 **로컬·단일사용자·자체생성 아티팩트**에는 과설계라 채택하지 않았습니다.

**구현 세부사항:**
두 표면을 각각 닫습니다 — (a) **JSON 컨테이너 경계**: escape 정규식이 HTML5 종료 규칙(대소문자 무관 + 공백/슬래시 변형)까지 덮도록 확장. (b) **innerHTML 라이브 경로**: 인용 스니펫이 자체 코드 펜스를 포함하면 카드 펜스는 inner 펜스가 조기 종료시키지 못하도록 더 긴 같은-종류(4-backtick+) 또는 다른-종류(`~~~`) 펜스를 쓰게 함(CommonMark 펜스 길이·문자 precedence).

**관련 코드:**
```js
// Before: 소문자 정확매치만 — </SCRIPT>, </script > 변형이 컨테이너를 조기 종료시켜 blank 리포트
JSON.stringify(reviewMarkdown).replace(/<\/script>/g, '<\\/script>')

// After: HTML5 종료 변형(대소문자·공백·슬래시)까지 escape, base </script> 출력은 불변
JSON.stringify(reviewMarkdown).replace(/<\/(script)([\s/>])/gi, '<\\/$1$2')
```

**선택과 트레이드오프:**
대안으로 (B) 마크다운을 순수하게 유지하고 marked 이후 DOM transform으로 카드를 래핑하는 방식을 검토했으나, fragile한 heading 탐지 JS가 필요하고 prometheus 패턴에서 멀어지며 검증이 어려워 거부했습니다. 선택지 A는 템플릿 JS를 0줄 추가하면서 grep으로 검증 가능합니다. 트레이드오프: render-time 마크다운에 HTML-in-마크다운이 섞여 author(LLM)가 카드 계약(chrome=raw, 코드=fenced)을 정확히 지켜야 합니다. **이 견고성은 병합 전 self-/code-review로 검증되어, escape 변형 누락·펜스 우선순위 2건을 발견·보강했습니다**(이 PR의 fix 커밋 + prometheus parity).

### 2. 터미널 full-report를 포인터로 "대체"

**배경 및 문제 상황:**
기존 Phase 3는 전체 리포트를 터미널에 마크다운으로 덤프했습니다. 요구는 "터미널 말고 HTML로 보고 싶다"였고, 가독성 관점에서 HTML과 터미널 덤프가 중복되면 노이즈만 늘어납니다.

**해결 방안:**
터미널은 finding 카운트(verdict/카테고리별)와 HTML 경로만 출력하고, full report는 HTML에만 존재하게 했습니다(augment가 아니라 replace). 파일은 항상 기록하되 브라우저 open은 best-effort입니다.

**구현 세부사항:**
open은 `open`(macOS) → `xdg-open`(linux) → 실패/headless 시 경로 출력 순으로 degrade하며 **절대 에러를 던지지 않습니다**(CI 안전). slug는 타겟별 안정(`{repo}-pr{N}` / sanitized 브랜치 / range 해시)이라 같은 타겟 재리뷰 시 timestamp 없이 overwrite됩니다.

**선택과 트레이드오프:**
대안 augment(터미널 full + HTML 동시)는 의도("터미널 말고")와 충돌하고 중복이라 거부했습니다. 트레이드오프: 터미널 출력을 grep하던 워크플로는 사라집니다(부분 완화: HTML에 리포트 마크다운이 JSON으로 임베드돼 verdict-token grep은 가능하나, 멀티라인 코드 스니펫 grep은 JSON-escape된 텍스트로 나와 ergonomic 회귀가 있음 — 사용자 명시적 선택으로 수용).

### 3. 런타임 렌더 스크립트 없음 — LLM 수행 치환 (테스트가 없는 이유)

**배경 및 문제 상황:**
~300줄 변경에 새 테스트가 없어 reviewer가 의아할 수 있습니다.

**해결 방안:**
렌더는 새 런타임 모듈이 아니라 **LLM이 리뷰 시점에 수행하는 템플릿 치환**입니다. 템플릿의 클라이언트 JS(`marked.parse`, `mermaid.run`, TOC 빌더)는 prometheus에서 byte-identical로 가져온 정적 셸이라 테스트 대상 코드가 추가되지 않습니다. prometheus의 Stage A 렌더도 동일하게 자동 렌더 테스트가 없습니다.

**선택과 트레이드오프:**
런타임 렌더 스크립트를 도입하면 TDD를 강제해야 하는데, 단일 자체생성 아티팩트엔 과설계라 거부했습니다. 검증은 구조적 assertion(SRI byte-identity, charset<1024, 템플릿 landmark, escape 변형 동작)과 fixture 치환 round-trip smoke test로 대체했고, `make validate`는 green입니다.

---

## ✅ Checklist

### HTML 템플릿
- [ ] marked@12.0.2 + mermaid@11.4.1 CDN 태그가 SRI와 함께 존재하고, SRI 해시가 prometheus 템플릿과 byte-identical
  - `skills/code-review/templates/review-presentation.html`
  - `skills/prometheus/templates/plan-presentation.html`
- [ ] `<meta charset="UTF-8">`가 문서 첫 1024바이트 안에 위치
  - `skills/code-review/templates/review-presentation.html`
- [ ] verdict 색상 카드 CSS(`.finding[data-verdict="CONFIRMED"]` / `PLAUSIBLE`)와 inert `application/json` 컨테이너가 존재
  - `skills/code-review/templates/review-presentation.html`

### Phase 3 렌더 + 포인터
- [ ] Phase 3가 `$OMT_DIR/reviews/{slug}.html`로 렌더하고 터미널엔 카운트+경로 포인터만 출력하며, opt-in 플래그 게이팅이 없음
  - `skills/code-review/SKILL.md`
- [ ] 템플릿을 `${CLAUDE_SKILL_DIR}` 기준으로 읽음(CWD-상대 아님)
  - `skills/code-review/SKILL.md`
- [ ] 카드 본문 인용 코드가 fenced 블록에 머물도록(inner 펜스보다 긴/다른 종류 펜스) injection 가드 규칙이 명시됨
  - `skills/code-review/SKILL.md`

### escape parity
- [ ] `</script>` escape 정규식이 `</SCRIPT>`·`</script >`·`</script/>` 변형까지 escape하고 base `</script>` 출력은 불변
  - `skills/code-review/SKILL.md`
  - `skills/prometheus/review-pipeline.md`

### 빌드
- [ ] `make validate` exit 0