### PR TITLE
chore: PreCompact 핸드오프 생산자 훅 등록

### DIFF
--- a/claude.yaml
+++ b/claude.yaml
@@ -1,3 +1,8 @@
+hooks:
+  PreCompact:
+    - component: pre-compact.sh
+      timeout: 280
+
 config:
   language: "한국어"
   outputStyle: "Explanatory"


### PR DESCRIPTION
## 📌 Summary

컴팩션 핸드오프 파이프라인(#111)의 생산자 훅 `pre-compact.sh`는 머지됐지만, 훅 등록이 gitignored `claude.local.yaml`(머신-로컬 오버레이)에만 있어 비영속 상태로 유실됐고 글로벌 `settings.json`에서 사라져 있었다. 그 결과 소비자(SessionStart)만 살아있고 생산자가 발화하지 않는 **반쪽 파이프라인**이 됐다.

이 PR은 생산자 등록을 tracked 루트 `claude.yaml`로 끌어올려 버전관리·재현 가능하게 한다.

## 🔧 Changes

### PreCompact 훅을 루트 claude.yaml에 등록
- `claude.yaml`에 `hooks.PreCompact` 블록 추가 — `pre-compact.sh`를 `timeout: 280`으로 등록
- matcher 생략(기본 `*`) → manual·auto 컴팩션 양쪽에서 발화
- 루트 `sync.yaml`(path `~`)을 통해 글로벌 `~/.claude/settings.json`으로 배포됨

**영향 범위**: `claude.yaml`(글로벌 Claude 설정 배포 소스). 배포 결과물은 `~/.claude/settings.json`의 `hooks.PreCompact`. `claude.local.yaml`의 기존 훅들과 deep-merge라 무손실.

## 💬 Review Points

### 1. 등록 위치 — tracked claude.yaml vs gitignored claude.local.yaml

**배경 및 문제 상황**: 원래 #111 설계는 PreCompact 등록을 `claude.local.yaml`에 뒀다. 이 파일은 gitignored 머신-로컬 오버레이라 비영속 → 등록이 유실되고 글로벌 `settings.json`에서 사라져 생산자가 발화하지 않았다. 스크립트는 tracked인데 배선만 머신-로컬인 비대칭이 근본 원인.

**해결 방안**: 생산자 등록을 tracked 루트 `claude.yaml`로 이전.

**구현 세부사항**: 루트 `claude.yaml`과 `claude.local.yaml`은 둘 다 `sync.yaml` path `~`로 deep-merge되어 단일 글로벌 `settings.json`을 만든다. 따라서 claude.yaml에 PreCompact만 추가해도 claude.local.yaml의 기존 훅(SessionStart·Stop 등)은 보존된다(full-replace 아님, 머지).

**선택과 트레이드오프**: 의도적으로 생산자는 tracked, 소비자(`session-start.sh`)와 기타 OMT 훅 스택은 여전히 머신-로컬 `claude.local.yaml`에 둔다. 생산자는 파이프라인 기능이라 추적·공유 가치가 있고, 개인 훅 스택은 머신-로컬이 적절하다는 판단. 결과적으로 "생산자 tracked / 소비자 머신-로컬" 비대칭이 남지만 의도된 것이며, 글로벌에선 deep-merge로 한 곳에 합쳐져 짝이 맞는다.

### 2. timeout 280 근거

**배경 및 문제 상황**: PreCompact 훅은 요약기를 외부 호출(codex → sonnet 폴백)한다. Claude Code 기본 훅 timeout은 60s.

**해결 방안**: `timeout: 280`으로 등록.

**구현 세부사항**: `pre-compact.sh` 내부는 요약기당 `SUMMARIZER_TIMEOUT_SECS=120`(perl-alarm). codex 실패 시 sonnet 폴백이 순차로 도는 최악 경로 = 120 + 120 = 240s + 오버헤드 ≈ 250s 예산.

**선택과 트레이드오프**: 280은 250s 예산을 덮는 값. 기본 60s면 폴백 체인이 중간에 잘려 생산자가 핸드오프를 못 쓴다. timeout을 더 올리지 않은 건 TTFT-stall 교훈(무작정 상향 금지).

## ✅ Checklist

- [ ] `make validate-schema`·`make validate-components` 통과
  - `claude.yaml`
- [ ] 배포 시 글로벌 `~/.claude/settings.json`의 `hooks.PreCompact`가 `{matcher:"*", command:"$HOME/.claude/hooks/pre-compact.sh", timeout:280}`로 존재
  - `claude.yaml`
- [ ] 배포 후 기존 훅 이벤트(SessionStart·Stop·UserPromptSubmit 등) 전건 보존
  - `claude.yaml`

## 📎 References

- [#111 자동 컴팩션 핸드오프 파이프라인 추가](https://github.com/toongri/oh-my-toong-playground/pull/111) — 이 PR이 등록하는 생산자 훅 `pre-compact.sh`를 추가한 머지된 PR