### PR TITLE
feat(rules): 코딩 규칙에 Deep Modules 원칙 추가

### DIFF
--- a/rules/coding-discipline.md
+++ b/rules/coding-discipline.md
@@ -59,3 +59,14 @@ For multi-step tasks, state a brief plan:
 ```
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+## 5. Deep Modules
+
+**Prefer deep modules — a small interface hiding substantial implementation. Don't scatter logic across many shallow files.**
+
+A *shallow* module's interface is nearly as complex as what it hides; splitting code into many tiny files turns understanding one concept into bouncing across dozens of them. Fewer, deeper modules beat many shallow ones.
+
+- Don't extract a function or file unless it earns its interface. One caller + thin body → inline it.
+- Hide complexity behind the interface; don't spread it across siblings. Locality over fragmentation.
+
+The test: imagine deleting the module. If complexity vanishes, it was a pass-through — inline it. If it reappears across multiple callers, it earned its keep.


### PR DESCRIPTION
## 📌 Summary

coding-discipline 규칙에 §5 "Deep Modules"를 추가한다. AI가 코드를 작은 shallow 파일 수십 개로 쪼개 길을 잃는 실패 모드를 줄이기 위해, Ousterhout의 deep-vs-shallow module 원칙(작은 인터페이스 뒤에 복잡성을 숨김)을 행동 규칙으로 명문화한다.

---

## 🔧 Changes

### rules/coding-discipline.md

- 기존 §1–§4 뒤에 §5 "Deep Modules" 섹션 신설(+11줄): deep module 선호 / shallow 파일 난립 금지 / deletion test 휴리스틱.

deep module = 작은 인터페이스 + 두꺼운 구현, shallow module = 구현만큼 복잡한 thin pass-through. 한 개념을 이해하려고 수십 파일을 오가게 만드는 게 LLM 코딩의 흔한 실패 모드라, "LLM 코딩 실수 감소"를 목적으로 하는 이 파일에 명시한다. §3의 "The test:" 컨벤션을 §5의 deletion test가 그대로 따른다.

**영향 범위**
- 문서 전용 변경. 코드 경로/런타임 영향 없음.
- coding-discipline은 5개 프로젝트 sync.yaml의 `rules.items`에 이미 등록되어 있어, 다음 `make sync` 시 별도 wiring 없이 전 프로젝트 + global 사본(`~/.claude/rules/`)에 전파된다.
- §1–§4는 byte-unchanged.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.

### 1. 새 rule 파일이 아니라 기존 coding-discipline에 흡수

**배경 및 문제 상황:**
deep-module 원칙을 별도 파일(`rules/deep-modules.md`)로 둘지, 기존 파일에 섹션으로 더할지 선택이 있었다. 새 파일은 5개 프로젝트 sync.yaml에 일일이 등록해야 전파되고, 무엇보다 "작은 단일목적 파일로 쪼개지 마라"는 원칙 자체와 모순된다 — 원칙을 추가하려고 또 하나의 shallow 파일을 만드는 셈.

**해결 방안:**
기존 deep 모듈인 `coding-discipline.md`에 §5로 흡수. §2 Simplicity First에 한 줄로 섞는 방안도 검토했으나, Simplicity(코드 *양*)와 Deep modules(*구조*)는 다른 축이라 별도 named section으로 분리.

**구현 세부사항:**
coding-discipline은 모든 프로젝트 `rules.items`에 이미 있으므로 sync.yaml 변경 0으로 전파된다. §3의 "The test:" 마무리 컨벤션을 deletion test로 재사용해 파일 내 형식 일관성을 유지.

**선택과 트레이드오프:**
규칙의 *구조*가 규칙의 *내용*을 따르게 했다(self-consistency). 트레이드오프: 한 파일이 조금 길어지지만, 파일 수·sync wiring 증가보다 navigation·locality 이득이 크다.

---

## ✅ Checklist

### Deep Modules rule
- [ ] `coding-discipline.md`에 `## 5. Deep Modules` 섹션이 존재한다
  - `rules/coding-discipline.md`
- [ ] `^## ` 헤더 수가 5개다 (§1–§4 무변경, 재번호 없음)
  - `rules/coding-discipline.md`
- [ ] 영어 산문·이모지 없음, §3의 "The test:" 컨벤션을 따른다
  - `rules/coding-discipline.md`