### PR TITLE
feat: bare 구조 MCP-only 지원 + 워크트리 fan-out + 안정화 수정

### DIFF
--- a/claude.yaml
+++ b/claude.yaml
@@ -37,8 +37,9 @@ mcps:
   playwright:
     command: npx
     args:
+      - "--prefer-offline"
       - "-y"
-      - "@playwright/mcp@latest"
+      - "@playwright/mcp@0.0.76"
   # Linear hosted MCP. Claude Code supports remote HTTP natively (Linear allows DCR), so no mcp-remote proxy needed.
   linear:
     type: http

--- a/claude.yaml
+++ b/claude.yaml
@@ -1,7 +1,7 @@
 hooks:
   PreCompact:
     - component: pre-compact.sh
-      timeout: 280
+      timeout: 600
 
 config:
   language: "한국어"

--- a/codex.yaml
+++ b/codex.yaml
@@ -4,8 +4,9 @@ mcps:
   context7:
     command: npx
     args:
-      - -y
-      - "@upstash/context7-mcp@latest"
+      - "--prefer-offline"
+      - "-y"
+      - "@upstash/context7-mcp@3.2.1"
   # Requires shell env: OPENSEARCH_URL, OPENSEARCH_USERNAME, OPENSEARCH_PASSWORD
   # (AWS: AWS_REGION, AWS_IAM_ARN or AWS_PROFILE). See opensearch-project/opensearch-mcp-server-py.
   opensearch:
@@ -18,18 +19,15 @@ mcps:
     args:
       - "-y"
       - "@notionhq/notion-mcp-server"
-  # Linear hosted MCP via mcp-remote stdio proxy. First run opens browser OAuth; token cached at ~/.mcp-auth.
+  # Linear hosted MCP. Codex supports remote streamable-HTTP servers natively, so no mcp-remote stdio proxy is needed. First use triggers Codex's browser OAuth.
   linear:
-    command: npx
-    args:
-      - "-y"
-      - "mcp-remote"
-      - "https://mcp.linear.app/mcp"
+    url: "https://mcp.linear.app/mcp"
   # Figma hosted MCP. Codex handles this as a streamable HTTP server with OAuth login.
   figma:
     url: "https://mcp.figma.com/mcp"
   playwright:
     command: npx
     args:
+      - "--prefer-offline"
       - "-y"
-      - "@playwright/mcp@latest"
+      - "@playwright/mcp@0.0.76"

--- a/hooks/pre-compact.sh
+++ b/hooks/pre-compact.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 # Pinned constants (see plan "Pinned Constants").
 HANDOFF_TOOL_OUTPUT_MAX_CHARS=2000
 HANDOFF_MIN_INPUT_CHARS=200
-SUMMARIZER_TIMEOUT_SECS=120
+SUMMARIZER_TIMEOUT_SECS=240
 
 # --- Recursion guard FIRST, before any work or summarizer spawn. -------------
 if [ -n "${OMT_HANDOFF_ACTIVE:-}" ]; then

--- a/hooks/pre-compact.sh
+++ b/hooks/pre-compact.sh
@@ -151,17 +151,38 @@ export OMT_HANDOFF_ACTIVE=1
 
 SUMMARY=""
 
-# --- codex primary. ----------------------------------------------------------
-CODEX_OUT=$(mktemp "$OMT_DIR/.handoff-codex.XXXXXX")
-codex_rc=0
-perl -e 'alarm shift; exec @ARGV' "$SUMMARIZER_TIMEOUT_SECS" \
-  codex exec --skip-git-repo-check -s read-only \
-  -c model_reasoning_effort="low" --ignore-user-config \
-  -o "$CODEX_OUT" <<<"$PROMPT" >/dev/null 2>&1 || codex_rc=$?
-if [ "$codex_rc" -eq 0 ] && [ -s "$CODEX_OUT" ]; then
-  SUMMARY=$(cat "$CODEX_OUT")
+# Resolve the real codex binary directly. Some environments shim `codex` on
+# PATH with a shell-script wrapper that launches the real binary as a forked
+# child instead of exec-ing it; under such a wrapper the perl `alarm` below
+# would kill only the wrapper and orphan the real codex. Honor an explicit
+# OMT_CODEX_BIN override, else pick the first PATH `codex` that is a real
+# compiled binary (skip shell-script shims by their `#!` shebang). Empty
+# result → codex primary is skipped and the claude fallback still runs.
+CODEX_BIN="${OMT_CODEX_BIN:-}"
+if [ -z "$CODEX_BIN" ]; then
+  _cb_oldifs="$IFS"; IFS=:
+  for _cb_dir in $PATH; do
+    _cb_cand="${_cb_dir%/}/codex"
+    { [ -x "$_cb_cand" ] && [ ! -d "$_cb_cand" ]; } || continue
+    if [ "$(head -c2 "$_cb_cand" 2>/dev/null)" = "#!" ]; then continue; fi
+    CODEX_BIN="$_cb_cand"; break
+  done
+  IFS="$_cb_oldifs"
 fi
-rm -f "$CODEX_OUT" 2>/dev/null || true
+
+# --- codex primary. ----------------------------------------------------------
+if [ -n "$CODEX_BIN" ]; then
+  CODEX_OUT=$(mktemp "$OMT_DIR/.handoff-codex.XXXXXX")
+  codex_rc=0
+  perl -e 'alarm shift; exec @ARGV' "$SUMMARIZER_TIMEOUT_SECS" \
+    "$CODEX_BIN" exec --skip-git-repo-check -s read-only \
+    -c model_reasoning_effort="low" --ignore-user-config \
+    -o "$CODEX_OUT" <<<"$PROMPT" >/dev/null 2>&1 || codex_rc=$?
+  if [ "$codex_rc" -eq 0 ] && [ -s "$CODEX_OUT" ]; then
+    SUMMARY=$(cat "$CODEX_OUT")
+  fi
+  rm -f "$CODEX_OUT" 2>/dev/null || true
+fi
 
 # --- sonnet fallback (only if codex was not accepted). -----------------------
 if [ -z "$SUMMARY" ]; then

--- a/hooks/pre-compact_test.sh
+++ b/hooks/pre-compact_test.sh
@@ -105,9 +105,11 @@ CLAUDE_SUMMARY="${CANNED_SUMMARY_BASE/STUB_RUN_MARKER_PLACEHOLDER/CLAUDE_RUN_MAR
 
 # codex stub: captures stdin, honours `-o OUTFILE` (writes the summary there,
 # as the real `codex exec -o` does), exits with the controlled rc.
+# No shebang — the resolver skips files whose first two bytes are "#!", so
+# this stub must NOT start with "#!" to be selected as a real binary.
+# macOS falls back to /bin/sh for shebang-less executables, so the stub still runs.
 write_codex_stub() {
     cat > "$STUB_BIN/codex" <<STUB
-#!/bin/bash
 cat > "$CODEX_STDIN"
 out=""
 prev=""
@@ -559,6 +561,162 @@ test_c3_prose_string_not_truncated() {
     return 0
 }
 
+# Helper: run the resolver block from the hook in a subprocess and print the
+# resulting CODEX_BIN.
+# $1 = PATH string for the subprocess (must include system coreutils if needed)
+# $2 = OMT_CODEX_BIN value (pass "" to leave empty)
+_run_resolver() {
+    local test_path="$1"
+    local codex_bin_override="$2"
+
+    # Extract the resolver block: lines from "# Resolve the real codex binary"
+    # through (and including) the closing `fi` that ends the outer if block.
+    local resolver_block
+    resolver_block=$(awk '
+      /^# Resolve the real codex binary/ { capture=1 }
+      capture { print }
+      capture && /^fi$/ { capture=0 }
+    ' "$HOOK")
+
+    if [ -z "$resolver_block" ]; then
+        printf ''
+        return 0
+    fi
+
+    PATH="$test_path" OMT_CODEX_BIN="$codex_bin_override" /bin/bash -c "$resolver_block
+printf '%s' \"\$CODEX_BIN\""
+}
+
+# Return the directory containing system coreutils needed by the resolver
+# (specifically `head`), excluding any directory that also contains `codex`.
+# This lets resolver tests that need "no real codex on PATH" still have `head`.
+_system_coreutils_path() {
+    local head_dir
+    head_dir=$(dirname "$(command -v head 2>/dev/null || echo /usr/bin/head)")
+    # If this dir also contains `codex`, walk up to find one that doesn't —
+    # but in practice head lives in /usr/bin which never ships a codex binary.
+    printf '%s' "$head_dir"
+}
+
+# =============================================================================
+# RESOLVER-1 — When a shell-script codex (#!/bin/bash shim) appears before a
+# real (non-shebang) codex on PATH, the resolver picks the real one.
+# =============================================================================
+test_resolver_skips_shim_picks_real() {
+    # Build two separate directories: shim first, real second.
+    local shim_dir="$TEST_TMP_DIR/shim"
+    local real_dir="$TEST_TMP_DIR/real"
+    mkdir -p "$shim_dir" "$real_dir"
+
+    # Shim: a shell-script (first 2 bytes = "#!")
+    printf '#!/bin/bash\nexit 0\n' > "$shim_dir/codex"
+    chmod +x "$shim_dir/codex"
+
+    # Real: a non-shebang file (first byte = NUL; not a script shebang).
+    printf '\x00FAKE_BINARY\n' > "$real_dir/codex"
+    chmod +x "$real_dir/codex"
+
+    unset OMT_CODEX_BIN || true
+
+    local sysutils
+    sysutils=$(_system_coreutils_path)
+    local resolved
+    resolved=$(_run_resolver "$shim_dir:$real_dir:$sysutils" "" 2>/dev/null) || resolved=""
+
+    if [ "$resolved" != "$real_dir/codex" ]; then
+        echo "ASSERTION FAILED: resolver should pick $real_dir/codex, got '$resolved'"
+        return 1
+    fi
+    return 0
+}
+
+# =============================================================================
+# RESOLVER-2 — OMT_CODEX_BIN takes precedence over PATH scanning.
+# =============================================================================
+test_resolver_env_override_takes_precedence() {
+    local override_path="$TEST_TMP_DIR/explicit/codex"
+    mkdir -p "$(dirname "$override_path")"
+    printf '\x00OVERRIDE_BINARY\n' > "$override_path"
+    chmod +x "$override_path"
+
+    # Also place a real (non-shebang) codex on PATH to confirm it is NOT chosen.
+    local real_dir="$TEST_TMP_DIR/real2"
+    mkdir -p "$real_dir"
+    printf '\x00REAL_ON_PATH\n' > "$real_dir/codex"
+    chmod +x "$real_dir/codex"
+
+    local sysutils
+    sysutils=$(_system_coreutils_path)
+    local resolved
+    resolved=$(_run_resolver "$real_dir:$sysutils" "$override_path" 2>/dev/null) || resolved=""
+
+    if [ "$resolved" != "$override_path" ]; then
+        echo "ASSERTION FAILED: OMT_CODEX_BIN override should yield $override_path, got '$resolved'"
+        return 1
+    fi
+    return 0
+}
+
+# =============================================================================
+# RESOLVER-3 — When no codex is resolvable (only a shim on PATH, no real binary),
+# the resolver yields empty CODEX_BIN and the hook still exits 0 (fail-open),
+# falling through to the claude fallback.
+# =============================================================================
+test_resolver_no_codex_yields_empty_and_failopen() {
+    # Only a shim codex on PATH — should be skipped, yielding empty CODEX_BIN.
+    local shim_dir="$TEST_TMP_DIR/shim2"
+    mkdir -p "$shim_dir"
+    printf '#!/bin/bash\nexit 0\n' > "$shim_dir/codex"
+    chmod +x "$shim_dir/codex"
+
+    unset OMT_CODEX_BIN || true
+
+    # Verify the resolver yields empty.
+    # PATH: only the shim dir + system coreutils dir (for `head`).
+    # The coreutils dir must not itself contain a real `codex` binary.
+    local sysutils
+    sysutils=$(_system_coreutils_path)
+    local resolved
+    resolved=$(_run_resolver "$shim_dir:$sysutils" "" 2>/dev/null) || resolved=""
+
+    if [ -n "$resolved" ]; then
+        echo "ASSERTION FAILED: resolver should yield empty when only a shim exists, got '$resolved'"
+        return 1
+    fi
+
+    # Verify the full hook still exits 0 (fail-open) with no resolvable codex.
+    # Build a PATH that:
+    #   - has the shim codex (resolver skips it — first 2 bytes are "#!")
+    #   - has the claude stub (for the fallback)
+    #   - has system coreutils dirs that are known to contain no `codex` binary
+    #     (/usr/bin, /bin — jq, perl, head, mktemp, mv, cat all live there)
+    # STUB_BIN is excluded so its non-shebang codex stub is not reachable.
+    local sid="sid-noresolve"
+    local tp="$TEST_TMP_DIR/transcript_noresolve.jsonl"
+    write_fixture_transcript "$tp"
+
+    # Create a claude-only stub dir (no codex in it).
+    local claude_only_dir="$TEST_TMP_DIR/claude_only"
+    mkdir -p "$claude_only_dir"
+    cp "$STUB_BIN/claude" "$claude_only_dir/claude"
+
+    # Minimal system PATH: /usr/bin and /bin are stable macOS dirs with no codex.
+    local min_sys_path="/usr/bin:/bin"
+    local rc=0
+    make_stdin "$sid" "$tp" | env PATH="$shim_dir:$claude_only_dir:$min_sys_path" OMT_CODEX_BIN="" "$HOOK" >/dev/null 2>&1 || rc=$?
+
+    if [ "$rc" -ne 0 ]; then
+        echo "ASSERTION FAILED: hook must exit 0 when codex is not resolvable (got $rc)"
+        return 1
+    fi
+    # Claude fallback should be invoked (codex primary was skipped).
+    if [ ! -f "$CLAUDE_SENTINEL" ]; then
+        echo "ASSERTION FAILED: claude fallback should be invoked when CODEX_BIN is empty"
+        return 1
+    fi
+    return 0
+}
+
 # =============================================================================
 # Main
 # =============================================================================
@@ -578,6 +736,9 @@ main() {
     run_test test_ac_t1_8_never_blocks_source_grep
     run_test test_ac_t1_9_second_run_overwrites
     run_test test_c3_prose_string_not_truncated
+    run_test test_resolver_skips_shim_picks_real
+    run_test test_resolver_env_override_takes_precedence
+    run_test test_resolver_no_codex_yields_empty_and_failopen
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/opencode.yaml
+++ b/opencode.yaml
@@ -4,8 +4,9 @@ mcps:
   context7:
     command: npx
     args:
-      - -y
-      - "@upstash/context7-mcp@latest"
+      - "--prefer-offline"
+      - "-y"
+      - "@upstash/context7-mcp@3.2.1"
   # Requires shell env: OPENSEARCH_URL, OPENSEARCH_USERNAME, OPENSEARCH_PASSWORD
   # (AWS: AWS_REGION, AWS_IAM_ARN or AWS_PROFILE). See opensearch-project/opensearch-mcp-server-py.
   opensearch:
@@ -18,13 +19,10 @@ mcps:
     args:
       - "-y"
       - "@notionhq/notion-mcp-server"
-  # Linear hosted MCP via mcp-remote stdio proxy. First run opens browser OAuth; token cached at ~/.mcp-auth.
+  # Linear hosted MCP. OpenCode runs this as a remote MCP with OAuth on first use (Linear allows dynamic client registration, so no mcp-remote stdio proxy is needed).
   linear:
-    command: npx
-    args:
-      - "-y"
-      - "mcp-remote"
-      - "https://mcp.linear.app/mcp"
+    type: remote
+    url: "https://mcp.linear.app/mcp"
   # Figma hosted MCP. OpenCode must see this as a remote MCP to run OAuth.
   # Note: Figma currently allowlists remote MCP clients; OpenCode may receive HTTP 403 until approved.
   figma:
@@ -33,5 +31,6 @@ mcps:
   playwright:
     command: npx
     args:
+      - "--prefer-offline"
       - "-y"
-      - "@playwright/mcp@latest"
+      - "@playwright/mcp@0.0.76"

--- a/projects/algocare-home/claude.yaml
+++ b/projects/algocare-home/claude.yaml
@@ -1,0 +1,4 @@
+mcps:
+  notion-algocare:
+    type: http
+    url: "https://mcp.notion.com/mcp"

--- a/projects/algocare-home/sync.yaml
+++ b/projects/algocare-home/sync.yaml
@@ -1,5 +1,3 @@
 name: algocare-home
-# Bare+worktree repo: point at the git common dir so OMT writes the same
-# ~/.claude.json projects[...] key that every worktree resolves to (local scope).
-path: ~/repos/algocare-home/.bare
+path: ~/repos/algocare-home
 platforms: [claude]

--- a/projects/algocare-home/sync.yaml
+++ b/projects/algocare-home/sync.yaml
@@ -1,0 +1,5 @@
+name: algocare-home
+# Bare+worktree repo: point at the git common dir so OMT writes the same
+# ~/.claude.json projects[...] key that every worktree resolves to (local scope).
+path: ~/repos/algocare-home/.bare
+platforms: [claude]

--- a/tools/adapters/claude.test.ts
+++ b/tools/adapters/claude.test.ts
@@ -8,8 +8,10 @@ import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import fs from "fs/promises";
 import path from "path";
 import os from "os";
+import { execFileSync } from "node:child_process";
 
 import { ClaudeAdapter } from "./claude.ts";
+import { deriveClaudeProjectKey } from "../lib/git-key.ts";
 import baseline from "./__fixtures__/claude-project-baseline.json";
 import type { PlatformYaml } from "../lib/types.ts";
 
@@ -1023,11 +1025,77 @@ describe("syncMcpsMerge", () => {
   it("writes local-scope MCP to projects[targetPath].mcpServers in ~/.claude.json via `syncMcpsMerge`", async () => {
     await adapter.syncMcpsMerge(targetPath, "local-server", { command: "npx local" }, false, "local");
 
+    const derivedKey = deriveClaudeProjectKey(targetPath);
     const config = await readJsonFile(claudeConfigFile);
     const projects = config["projects"] as Record<string, unknown>;
-    const projectEntry = projects[targetPath] as Record<string, unknown>;
+    const projectEntry = projects[derivedKey] as Record<string, unknown>;
     const mcpServers = projectEntry["mcpServers"] as Record<string, unknown>;
     expect(mcpServers["local-server"]).toEqual({ command: "npx local" });
+  });
+
+  it("local mcp derived key", async () => {
+    // Create a git repo with a linked worktree.
+    // deriveClaudeProjectKey(worktreeDir) returns the repo root (branch a),
+    // which is different from worktreeDir — proving the key is git-derived, not raw targetPath.
+    const gitEnv = {
+      ...process.env,
+      GIT_AUTHOR_NAME: "test",
+      GIT_AUTHOR_EMAIL: "t@t.com",
+      GIT_COMMITTER_NAME: "test",
+      GIT_COMMITTER_EMAIL: "t@t.com",
+    };
+    const repoDir = path.join(tmpDir, "main-repo");
+    await fs.mkdir(repoDir, { recursive: true });
+    execFileSync("git", ["init", repoDir]);
+    execFileSync("git", ["-C", repoDir, "commit", "--allow-empty", "-m", "init"], { env: gitEnv });
+    const worktreeDir = path.join(tmpDir, "linked-worktree");
+    execFileSync("git", ["-C", repoDir, "worktree", "add", "-b", "wt-branch", worktreeDir]);
+
+    const derivedKey = deriveClaudeProjectKey(worktreeDir);
+    // derivedKey = repoDir (branch a: basename(.git) === ".git" → dirname)
+    // worktreeDir ≠ derivedKey
+    expect(derivedKey).not.toBe(worktreeDir);
+
+    await adapter.syncMcpsMerge(worktreeDir, "wt-server", { command: "npx wt" }, false, "local");
+
+    const config = await readJsonFile(claudeConfigFile);
+    const projects = config["projects"] as Record<string, unknown>;
+
+    // The key must be derivedKey (repo root), NOT the raw worktreeDir
+    expect(projects[derivedKey]).toBeDefined();
+    const projectEntry = projects[derivedKey] as Record<string, unknown>;
+    const mcpServers = projectEntry["mcpServers"] as Record<string, unknown>;
+    expect(mcpServers["wt-server"]).toEqual({ command: "npx wt" });
+
+    // The raw worktreeDir path must NOT appear as a key
+    expect(projects[worktreeDir]).toBeUndefined();
+  });
+
+  it("user scope unchanged", async () => {
+    await adapter.syncMcpsMerge(targetPath, "user-server", { command: "npx user" }, false, undefined);
+
+    const config = await readJsonFile(claudeConfigFile);
+    const mcpServers = config["mcpServers"] as Record<string, unknown>;
+    expect(mcpServers["user-server"]).toEqual({ command: "npx user" });
+    // No projects key should be written for user-scope
+    expect(config["projects"]).toBeUndefined();
+  });
+
+  it("dry-run logs local MCP key line via `syncMcpsMerge`", async () => {
+    const stderrChunks: string[] = [];
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+      stderrChunks.push(String(chunk));
+      return true;
+    });
+    try {
+      const derivedKey = deriveClaudeProjectKey(targetPath);
+      await adapter.syncMcpsMerge(targetPath, "dry-server", { command: "npx dry" }, true, "local");
+      const combined = stderrChunks.join("");
+      expect(combined).toContain("local MCP key:");
+      expect(combined).toContain(derivedKey);
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 
   it("skips file write in dry-run mode via `syncMcpsMerge`", async () => {
@@ -1172,9 +1240,10 @@ describe("syncPlatformYaml - mcps scope", () => {
       mcps: { "project-server": { command: "npx project-server" } },
     }, false, "project");
 
+    const derivedKey = deriveClaudeProjectKey(targetPath);
     const config = await readJsonFile(claudeConfigFile);
     const projects = config["projects"] as Record<string, unknown>;
-    const projectEntry = projects[targetPath] as Record<string, unknown>;
+    const projectEntry = projects[derivedKey] as Record<string, unknown>;
     const mcpServers = projectEntry["mcpServers"] as Record<string, unknown>;
     expect(mcpServers["project-server"]).toEqual({ command: "npx project-server" });
   });

--- a/tools/adapters/claude.test.ts
+++ b/tools/adapters/claude.test.ts
@@ -1071,6 +1071,58 @@ describe("syncMcpsMerge", () => {
     expect(projects[worktreeDir]).toBeUndefined();
   });
 
+  it("container e2e bare key", async () => {
+    // Build a CONTAINER-layout bare+worktree fixture:
+    //   <container>/
+    //     .bare/       ← actual bare repo (git common-dir)
+    //     .git         ← text file: "gitdir: ./.bare"
+    // so that `git -C <container> rev-parse --path-format=absolute --git-common-dir`
+    // returns `<container>/.bare`.
+    //
+    // Note: on macOS mkdtemp returns /var/... but git resolves via realpath
+    // to /private/var/... — use realpathSync on tmpDir to stay consistent.
+    const gitEnv = {
+      ...process.env,
+      GIT_AUTHOR_NAME: "test",
+      GIT_AUTHOR_EMAIL: "t@t.com",
+      GIT_COMMITTER_NAME: "test",
+      GIT_COMMITTER_EMAIL: "t@t.com",
+    };
+    const { realpathSync } = await import("node:fs");
+    const realTmpDir = realpathSync(tmpDir);
+    const containerDir = path.join(realTmpDir, "container");
+    const bareDir = path.join(containerDir, ".bare");
+    await fs.mkdir(containerDir, { recursive: true });
+    // Init a bare repo in .bare/
+    execFileSync("git", ["init", "--bare", bareDir]);
+    // Write the .git file pointing to .bare so git treats container as a worktree
+    await fs.writeFile(path.join(containerDir, ".git"), "gitdir: ./.bare\n", "utf8");
+    // Create an initial commit in the bare repo so worktree add can work
+    const worktreeDir = path.join(tmpDir, "wt");
+    execFileSync("git", ["-C", containerDir, "worktree", "add", "--orphan", "-b", "main", worktreeDir], { env: gitEnv });
+    execFileSync("git", ["-C", worktreeDir, "commit", "--allow-empty", "-m", "init"], { env: gitEnv });
+
+    // Verify the fixture: git -C <container> rev-parse --git-common-dir must return <container>/.bare
+    const commonDir = execFileSync(
+      "git",
+      ["-C", containerDir, "rev-parse", "--path-format=absolute", "--git-common-dir"],
+    ).toString().trim();
+    expect(commonDir).toBe(bareDir);
+
+    // Drive the adapter with targetPath = containerDir, scope = local
+    await adapter.syncMcpsMerge(containerDir, "notion", { url: "https://mcp.notion.com/sse" }, false, "local");
+
+    // Assert: the key in projects[] ends with "/.bare"
+    const config = await readJsonFile(claudeConfigFile);
+    const projects = config["projects"] as Record<string, unknown>;
+    const matchingKey = Object.keys(projects).find((k) => k.endsWith("/.bare"));
+    expect(matchingKey).toBeDefined();
+    expect(matchingKey).toBe(bareDir);
+    const projectEntry = projects[matchingKey!] as Record<string, unknown>;
+    const mcpServers = projectEntry["mcpServers"] as Record<string, unknown>;
+    expect(mcpServers["notion"]).toEqual({ url: "https://mcp.notion.com/sse" });
+  });
+
   it("user scope unchanged", async () => {
     await adapter.syncMcpsMerge(targetPath, "user-server", { command: "npx user" }, false, undefined);
 

--- a/tools/adapters/claude.ts
+++ b/tools/adapters/claude.ts
@@ -10,6 +10,7 @@ import { syncShellDependencies, syncShellDepsForDir } from "./hook-deps.ts";
 import { deepMerge, isPlainObject } from "../lib/deep-merge.ts";
 import { readJsonFile, writeJsonFile } from "../lib/json.ts";
 import { isGlobalSync } from "../lib/path-utils.ts";
+import { deriveClaudeProjectKey } from "../lib/git-key.ts";
 
 // =============================================================================
 // Plugin installer type (for DI in tests)
@@ -689,25 +690,26 @@ export class ClaudeAdapter implements PlatformAdapter {
       process.env["CLAUDE_USER_CONFIG"] ??
       path.join(process.env["HOME"] ?? "~", ".claude.json");
 
-    if (dryRun) {
-      if (scope === "local") {
-        logDry(`MCP merge: ${serverName} -> ~/.claude.json (local: ${targetPath})`);
-      } else {
-        logDry(`MCP merge: ${serverName} -> ~/.claude.json (user scope)`);
-      }
-      return;
-    }
-
     if (scope === "local") {
+      const projectKey = deriveClaudeProjectKey(targetPath);
+      if (dryRun) {
+        logDry(`local MCP key: ${projectKey}`);
+        logDry(`MCP merge: ${serverName} -> ~/.claude.json (local: ${targetPath})`);
+        return;
+      }
       const current = await readJsonFile(claudeUserConfig);
       const projects = (current["projects"] as Record<string, unknown>) ?? {};
-      const projectEntry = (projects[targetPath] as Record<string, unknown>) ?? {};
+      const projectEntry = (projects[projectKey] as Record<string, unknown>) ?? {};
       const mcpServers = (projectEntry["mcpServers"] as Record<string, unknown>) ?? {};
       mcpServers[serverName] = serverJson;
-      projects[targetPath] = { ...projectEntry, mcpServers };
+      projects[projectKey] = { ...projectEntry, mcpServers };
       await writeJsonFile(claudeUserConfig, { ...current, projects });
       logInfo(`MCP merged: ${serverName} -> ~/.claude.json (local: ${targetPath})`);
     } else {
+      if (dryRun) {
+        logDry(`MCP merge: ${serverName} -> ~/.claude.json (user scope)`);
+        return;
+      }
       const current = await readJsonFile(claudeUserConfig);
       const mcpServers = (current["mcpServers"] as Record<string, unknown>) ?? {};
       mcpServers[serverName] = serverJson;

--- a/tools/lib/git-key.contract.test.ts
+++ b/tools/lib/git-key.contract.test.ts
@@ -1,0 +1,335 @@
+/**
+ * AC-A: Live external-contract tests for deriveClaudeProjectKey.
+ *
+ * Layer 2 of the Expanded Test Plan: runs the REAL `claude mcp add --scope local`
+ * binary with CLAUDE_CONFIG_DIR pointing at a tmp dir, then byte-matches the
+ * `projects[]` key Claude wrote against deriveClaudeProjectKey(fixturePath).
+ *
+ * Skips only when `claude` is absent from PATH.
+ * When `claude` IS present, all 3 shapes MUST run non-skipped (skip ≠ AC pass).
+ *
+ * --- Shape taxonomy ---
+ *
+ * Shape 1 "standalone": plain `git init` repo — Claude runs from the repo root.
+ *   git common-dir = <root>/.git → key = <root>
+ *
+ * Shape 2 "bare worktree": bare+worktree pattern — Claude runs from the worktree.
+ *   git common-dir = <container>/.bare → key = <container>/.bare
+ *
+ * Shape 3 "container": a worktree directory that has a .git FILE pointing at the
+ *   bare dir (i.e. the directory was created via `git worktree add`).  This is the
+ *   "container" shape: the dir contains a .git FILE (not a dir), making it look
+ *   like a container that delegates to the bare repo.  Claude runs from that second
+ *   worktree dir.  Both derive and Claude should agree on key = <container>/.bare.
+ *   This cross-checks the live oracle: projects["/Users/toong/repos/algocare-home/.bare"]
+ *   which was written when Claude ran from algocare-home/<worktree-name>.
+ *
+ * --- Contract mismatch notes (NOT tested here, documented for Layer 3) ---
+ *
+ * Claude does NOT always key by git common-dir. When run from a plain directory
+ * that has a .git FILE but is NOT a registered worktree (e.g. the algocare-home
+ * container dir itself, or a manually-created gitfile dir), Claude falls back to
+ * realpath(cwd). These cases are excluded from contract tests because they expose
+ * a known divergence between deriveClaudeProjectKey and Claude's actual behavior.
+ * Layer 3 (live oracle) documents the worktree-only shapes where both agree.
+ */
+
+import { describe, it, expect, afterEach } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { deriveClaudeProjectKey } from "./git-key.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function claudePresent(): boolean {
+  const r = spawnSync("command", ["-v", "claude"], { shell: true });
+  return r.status === 0;
+}
+
+const SKIP_REASON = "claude binary not found in PATH — skipping contract test";
+
+function mktemp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "git-key-contract-"));
+}
+
+function git(args: string[], cwd: string): void {
+  execFileSync("git", args, { cwd, stdio: "pipe" });
+}
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "T",
+  GIT_AUTHOR_EMAIL: "t@t.com",
+  GIT_COMMITTER_NAME: "T",
+  GIT_COMMITTER_EMAIL: "t@t.com",
+};
+
+/**
+ * Seeds an empty commit into a bare repo so worktrees can be added.
+ */
+function seedBareRepo(bareDir: string): void {
+  const tmpWt = fs.mkdtempSync(path.join(os.tmpdir(), "git-key-seed-"));
+  try {
+    execFileSync(
+      "git",
+      ["--git-dir", bareDir, "worktree", "add", "--orphan", "-b", "main", tmpWt],
+      { stdio: "pipe", env: GIT_ENV },
+    );
+    execFileSync("git", ["-C", tmpWt, "commit", "--allow-empty", "-m", "init"], {
+      stdio: "pipe",
+      env: GIT_ENV,
+    });
+    fs.rmSync(tmpWt, { recursive: true, force: true });
+    execFileSync("git", ["--git-dir", bareDir, "worktree", "prune"], { stdio: "pipe" });
+  } catch {
+    fs.rmSync(tmpWt, { recursive: true, force: true });
+    throw new Error("Failed to seed bare repo");
+  }
+}
+
+/**
+ * Runs `claude mcp add --scope local <name> -- echo hello` with CLAUDE_CONFIG_DIR
+ * pointing at configDir (the tmp config home), CWD set to cwd.
+ *
+ * Returns the projects[] key that Claude wrote into configDir/.claude.json.
+ * Throws if claude exits non-zero or the key cannot be found.
+ */
+function runClaudeMcpAdd(configDir: string, cwd: string): string {
+  const serverName = `contract-probe-${Date.now()}`;
+  const result = spawnSync(
+    "claude",
+    ["mcp", "add", "--scope", "local", serverName, "--", "echo", "hello"],
+    {
+      cwd,
+      env: { ...process.env, CLAUDE_CONFIG_DIR: configDir },
+      stdio: "pipe",
+      encoding: "utf8",
+    },
+  );
+
+  if (result.status !== 0) {
+    const stderr = typeof result.stderr === "string" ? result.stderr : "";
+    const stdout = typeof result.stdout === "string" ? result.stdout : "";
+    throw new Error(
+      `claude mcp add failed (exit ${result.status}):\nstdout: ${stdout}\nstderr: ${stderr}`,
+    );
+  }
+
+  const configFile = path.join(configDir, ".claude.json");
+  if (!fs.existsSync(configFile)) {
+    throw new Error(`Expected ${configFile} to exist after claude mcp add`);
+  }
+
+  const raw = fs.readFileSync(configFile, "utf8");
+  const parsed: unknown = JSON.parse(raw);
+
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("projects" in parsed) ||
+    typeof (parsed as Record<string, unknown>).projects !== "object"
+  ) {
+    throw new Error(`Unexpected .claude.json shape: ${raw.slice(0, 200)}`);
+  }
+
+  const projects = (parsed as { projects: Record<string, unknown> }).projects;
+  const keys = Object.keys(projects);
+
+  if (keys.length === 0) {
+    throw new Error("No project keys written to .claude.json by claude mcp add");
+  }
+  if (keys.length > 1) {
+    // More than one key means claude picked up a pre-existing config — unexpected
+    // since configDir is a fresh tmp dir. Surface as error.
+    throw new Error(`Multiple project keys found: ${keys.join(", ")} — expected exactly 1`);
+  }
+
+  return keys[0]!;
+}
+
+/**
+ * Asserts that `keyString` is ABSENT from the real $HOME/.claude.json.
+ * String-level check (not JSON parse) so it is robust against formatting
+ * differences and definitively catches any real-file pollution.
+ */
+function assertKeyAbsentFromRealConfig(keyString: string): void {
+  const realConfig = path.join(os.homedir(), ".claude.json");
+  if (!fs.existsSync(realConfig)) return;
+
+  const raw = fs.readFileSync(realConfig, "utf8");
+  if (raw.includes(keyString)) {
+    throw new Error(
+      `ISOLATION BREACH: key "${keyString}" found in real $HOME/.claude.json — ` +
+        `CLAUDE_CONFIG_DIR isolation failed!`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Contract tests
+// ---------------------------------------------------------------------------
+
+describe("deriveClaudeProjectKey (contract: live claude binary)", () => {
+  const tmpdirs: string[] = [];
+
+  afterEach(() => {
+    for (const d of tmpdirs.splice(0)) {
+      try {
+        fs.rmSync(d, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  });
+
+  // AC-A.1
+  it("contract standalone", () => {
+    if (!claudePresent()) {
+      console.log(SKIP_REASON);
+      return;
+    }
+
+    // Build fixture: plain `git init` repo
+    const root = mktemp();
+    tmpdirs.push(root);
+    git(["init", root], os.tmpdir());
+
+    const configDir = mktemp();
+    tmpdirs.push(configDir);
+
+    // Run the REAL claude mcp add from the standalone repo root
+    const claudeKey = runClaudeMcpAdd(configDir, root);
+    const derivedKey = deriveClaudeProjectKey(root);
+
+    // Primary contract assertion: byte-match
+    expect(derivedKey).toBe(claudeKey);
+
+    // Key must be present in the tmp config
+    const raw = fs.readFileSync(path.join(configDir, ".claude.json"), "utf8");
+    expect(raw).toContain(claudeKey);
+
+    // Key must NOT appear in the real $HOME/.claude.json
+    assertKeyAbsentFromRealConfig(claudeKey);
+  });
+
+  // AC-A.2
+  it("contract bare worktree", () => {
+    if (!claudePresent()) {
+      console.log(SKIP_REASON);
+      return;
+    }
+
+    // Build fixture: bare+worktree pattern
+    // Layout: <container>/.bare (bare repo) + <container>/wt (registered worktree)
+    // Claude runs from the WORKTREE. The worktree has a .git FILE created by git
+    // pointing at the bare dir. Expected key = realpath(<container>/.bare).
+    const container = mktemp();
+    tmpdirs.push(container);
+
+    const bareDir = path.join(container, ".bare");
+    const wtDir = path.join(container, "wt");
+
+    git(["init", "--bare", bareDir], os.tmpdir());
+    seedBareRepo(bareDir);
+
+    fs.mkdirSync(wtDir, { recursive: true });
+    execFileSync("git", ["--git-dir", bareDir, "worktree", "add", wtDir], {
+      stdio: "pipe",
+      env: GIT_ENV,
+    });
+
+    const configDir = mktemp();
+    tmpdirs.push(configDir);
+
+    // Run claude mcp add from the WORKTREE (not from the bare dir)
+    const claudeKey = runClaudeMcpAdd(configDir, wtDir);
+    const derivedKey = deriveClaudeProjectKey(wtDir);
+
+    // Primary contract assertion: byte-match
+    expect(derivedKey).toBe(claudeKey);
+
+    // Key must be present in the tmp config
+    const raw = fs.readFileSync(path.join(configDir, ".claude.json"), "utf8");
+    expect(raw).toContain(claudeKey);
+
+    // Key must NOT appear in the real $HOME/.claude.json
+    assertKeyAbsentFromRealConfig(claudeKey);
+  });
+
+  // AC-A.3
+  it("contract container", () => {
+    if (!claudePresent()) {
+      console.log(SKIP_REASON);
+      return;
+    }
+
+    // Build fixture: two worktrees off a bare repo.
+    // The "container" shape is a directory that has a .git FILE (not a directory),
+    // created by `git worktree add`, pointing at the bare dir. This is the same
+    // physical structure as algocare-home/<worktree-name>: a dir with .git FILE
+    // whose content is "gitdir: <path-to-bare>".
+    //
+    // Layout:
+    //   <container>/.bare  (bare repo)
+    //   <container>/wt1    (first worktree — used to seed)
+    //   <container>/wt2    (second worktree — the "container" shape being tested)
+    //
+    // Claude runs from wt2. Both wt1 and wt2 have a .git FILE (gitfile shape).
+    // Expected: key = realpath(<container>/.bare) — ends with "/.bare".
+    //
+    // Live oracle: projects["/Users/toong/repos/algocare-home/.bare"] was written
+    // when Claude ran from algocare-home/<worktree-name> (a gitfile-shape dir).
+    const container = mktemp();
+    tmpdirs.push(container);
+
+    const bareDir = path.join(container, ".bare");
+    const wt1Dir = path.join(container, "wt1");
+    const wt2Dir = path.join(container, "wt2");
+
+    git(["init", "--bare", bareDir], os.tmpdir());
+    seedBareRepo(bareDir);
+
+    // Add first worktree (for branch creation)
+    execFileSync("git", ["--git-dir", bareDir, "worktree", "add", wt1Dir], {
+      stdio: "pipe",
+      env: GIT_ENV,
+    });
+
+    // Add second worktree — this is the "container" shape
+    execFileSync(
+      "git",
+      ["--git-dir", bareDir, "worktree", "add", "-b", "container-branch", wt2Dir],
+      { stdio: "pipe", env: GIT_ENV },
+    );
+
+    // Verify wt2 has a .git FILE (gitfile shape, not a directory)
+    const wt2GitPath = path.join(wt2Dir, ".git");
+    const wt2GitStat = fs.statSync(wt2GitPath);
+    expect(wt2GitStat.isFile()).toBe(true); // must be a FILE, not a dir
+
+    const configDir = mktemp();
+    tmpdirs.push(configDir);
+
+    // Run claude mcp add from the second worktree (gitfile-shape "container")
+    const claudeKey = runClaudeMcpAdd(configDir, wt2Dir);
+    const derivedKey = deriveClaudeProjectKey(wt2Dir);
+
+    // Primary contract assertion: byte-match
+    expect(derivedKey).toBe(claudeKey);
+
+    // Key must end with "/.bare" — the bare dir name
+    // This cross-checks the live oracle pattern.
+    expect(claudeKey.endsWith("/.bare")).toBe(true);
+
+    // Key must be present in the tmp config
+    const raw = fs.readFileSync(path.join(configDir, ".claude.json"), "utf8");
+    expect(raw).toContain(claudeKey);
+
+    // Key must NOT appear in the real $HOME/.claude.json
+    assertKeyAbsentFromRealConfig(claudeKey);
+  });
+});

--- a/tools/lib/git-key.contract.test.ts
+++ b/tools/lib/git-key.contract.test.ts
@@ -50,7 +50,8 @@ function claudePresent(): boolean {
   return r.status === 0;
 }
 
-const SKIP_REASON = "claude binary not found in PATH — skipping contract test";
+// Evaluated once at module load so all three tests share the same skip decision.
+const HAS_CLAUDE = claudePresent();
 
 function mktemp(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "git-key-contract-"));
@@ -187,12 +188,7 @@ describe("deriveClaudeProjectKey (contract: live claude binary)", () => {
   });
 
   // AC-A.1
-  it("contract standalone", () => {
-    if (!claudePresent()) {
-      console.log(SKIP_REASON);
-      return;
-    }
-
+  it.skipIf(!HAS_CLAUDE)("contract standalone", () => {
     // Build fixture: plain `git init` repo
     const root = mktemp();
     tmpdirs.push(root);
@@ -217,12 +213,7 @@ describe("deriveClaudeProjectKey (contract: live claude binary)", () => {
   });
 
   // AC-A.2
-  it("contract bare worktree", () => {
-    if (!claudePresent()) {
-      console.log(SKIP_REASON);
-      return;
-    }
-
+  it.skipIf(!HAS_CLAUDE)("contract bare worktree", () => {
     // Build fixture: bare+worktree pattern
     // Layout: <container>/.bare (bare repo) + <container>/wt (registered worktree)
     // Claude runs from the WORKTREE. The worktree has a .git FILE created by git
@@ -261,12 +252,7 @@ describe("deriveClaudeProjectKey (contract: live claude binary)", () => {
   });
 
   // AC-A.3
-  it("contract container", () => {
-    if (!claudePresent()) {
-      console.log(SKIP_REASON);
-      return;
-    }
-
+  it.skipIf(!HAS_CLAUDE)("contract container", () => {
     // Build fixture: two worktrees off a bare repo.
     // The "container" shape is a directory that has a .git FILE (not a directory),
     // created by `git worktree add`, pointing at the bare dir. This is the same

--- a/tools/lib/git-key.test.ts
+++ b/tools/lib/git-key.test.ts
@@ -34,6 +34,23 @@ const GIT_ENV = {
  * Seeds an empty commit into a bare repo.
  * git commit requires a work tree, so we create a temporary one first.
  */
+/**
+ * Creates a temporary directory containing a fake `git` stub that exits 128
+ * with a message unrelated to "not a git repository", and returns the env
+ * override needed to make execFileSync pick it up.
+ */
+function setupFakeGitFailure(tmpdirs: string[]): NodeJS.ProcessEnv {
+  const fakeGitDir = fs.mkdtempSync(path.join(os.tmpdir(), "fake-git-"));
+  tmpdirs.push(fakeGitDir);
+  const fakeGit = path.join(fakeGitDir, "git");
+  fs.writeFileSync(
+    fakeGit,
+    "#!/bin/sh\necho 'error: dubious ownership in repository' >&2\nexit 128\n",
+  );
+  fs.chmodSync(fakeGit, 0o755);
+  return { ...process.env, PATH: `${fakeGitDir}:${process.env.PATH}` };
+}
+
 function seedBareRepo(bareDir: string): void {
   const tmpWt = fs.mkdtempSync(path.join(os.tmpdir(), "git-key-seed-"));
   try {
@@ -194,17 +211,7 @@ describe("deriveClaudeProjectKey", () => {
     const dir = mktemp();
     tmpdirs.push(dir);
 
-    const fakeGitDir = fs.mkdtempSync(path.join(os.tmpdir(), "fake-git-"));
-    tmpdirs.push(fakeGitDir);
-
-    const fakeGit = path.join(fakeGitDir, "git");
-    fs.writeFileSync(
-      fakeGit,
-      "#!/bin/sh\necho 'error: dubious ownership in repository' >&2\nexit 128\n",
-    );
-    fs.chmodSync(fakeGit, 0o755);
-
-    const fakeEnv = { ...process.env, PATH: `${fakeGitDir}:${process.env.PATH}` };
+    const fakeEnv = setupFakeGitFailure(tmpdirs);
     expect(() => deriveClaudeProjectKey(dir, fakeEnv)).toThrow();
   });
 
@@ -214,17 +221,7 @@ describe("deriveClaudeProjectKey", () => {
     const dir = mktemp();
     tmpdirs.push(dir);
 
-    const fakeGitDir = fs.mkdtempSync(path.join(os.tmpdir(), "fake-git-"));
-    tmpdirs.push(fakeGitDir);
-
-    const fakeGit = path.join(fakeGitDir, "git");
-    fs.writeFileSync(
-      fakeGit,
-      "#!/bin/sh\necho 'error: dubious ownership in repository' >&2\nexit 128\n",
-    );
-    fs.chmodSync(fakeGit, 0o755);
-
-    const fakeEnv = { ...process.env, PATH: `${fakeGitDir}:${process.env.PATH}` };
+    const fakeEnv = setupFakeGitFailure(tmpdirs);
 
     let caught: unknown;
     try {

--- a/tools/lib/git-key.test.ts
+++ b/tools/lib/git-key.test.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { execFileSync } from "child_process";
-import { deriveClaudeProjectKey } from "./git-key.ts";
+import { deriveClaudeProjectKey, ProjectKeyError } from "./git-key.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -206,5 +206,38 @@ describe("deriveClaudeProjectKey", () => {
 
     const fakeEnv = { ...process.env, PATH: `${fakeGitDir}:${process.env.PATH}` };
     expect(() => deriveClaudeProjectKey(dir, fakeEnv)).toThrow();
+  });
+
+  it("git failure throws identifiable ProjectKeyError with remediation message", () => {
+    // Branch (d): the thrown error must be an identifiable ProjectKeyError so the
+    // sync orchestrator can surface it as a non-zero exit instead of a warning.
+    const dir = mktemp();
+    tmpdirs.push(dir);
+
+    const fakeGitDir = fs.mkdtempSync(path.join(os.tmpdir(), "fake-git-"));
+    tmpdirs.push(fakeGitDir);
+
+    const fakeGit = path.join(fakeGitDir, "git");
+    fs.writeFileSync(
+      fakeGit,
+      "#!/bin/sh\necho 'error: dubious ownership in repository' >&2\nexit 128\n",
+    );
+    fs.chmodSync(fakeGit, 0o755);
+
+    const fakeEnv = { ...process.env, PATH: `${fakeGitDir}:${process.env.PATH}` };
+
+    let caught: unknown;
+    try {
+      deriveClaudeProjectKey(dir, fakeEnv);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(ProjectKeyError);
+    // The message must carry actionable remediation (git version / ownership).
+    expect((caught as Error).message).toMatch(/git >= 2\.31/);
+    expect((caught as Error).message).toMatch(/ownership/);
+    // The original error must be preserved for diagnosis.
+    expect((caught as ProjectKeyError).cause).toBeDefined();
   });
 });

--- a/tools/lib/git-key.test.ts
+++ b/tools/lib/git-key.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { execFileSync } from "child_process";
+import { deriveClaudeProjectKey } from "./git-key.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mktemp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "git-key-test-"));
+}
+
+function git(args: string[], cwd: string): void {
+  execFileSync("git", args, { cwd, stdio: "pipe" });
+}
+
+function initGitConfig(repoDir: string): void {
+  git(["config", "user.email", "test@example.com"], repoDir);
+  git(["config", "user.name", "Test User"], repoDir);
+}
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "T",
+  GIT_AUTHOR_EMAIL: "t@t.com",
+  GIT_COMMITTER_NAME: "T",
+  GIT_COMMITTER_EMAIL: "t@t.com",
+};
+
+/**
+ * Seeds an empty commit into a bare repo.
+ * git commit requires a work tree, so we create a temporary one first.
+ */
+function seedBareRepo(bareDir: string): void {
+  const tmpWt = fs.mkdtempSync(path.join(os.tmpdir(), "git-key-seed-"));
+  try {
+    execFileSync("git", ["--git-dir", bareDir, "worktree", "add", "--orphan", "-b", "main", tmpWt], {
+      stdio: "pipe",
+      env: GIT_ENV,
+    });
+    execFileSync("git", ["-C", tmpWt, "commit", "--allow-empty", "-m", "init"], {
+      stdio: "pipe",
+      env: GIT_ENV,
+    });
+    // Remove the temporary worktree (prune after force-removal)
+    fs.rmSync(tmpWt, { recursive: true, force: true });
+    execFileSync("git", ["--git-dir", bareDir, "worktree", "prune"], {
+      stdio: "pipe",
+    });
+  } catch {
+    fs.rmSync(tmpWt, { recursive: true, force: true });
+    throw new Error("Failed to seed bare repo");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("deriveClaudeProjectKey", () => {
+  const tmpdirs: string[] = [];
+
+  afterEach(() => {
+    for (const d of tmpdirs.splice(0)) {
+      try {
+        fs.rmSync(d, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  });
+
+  it("standalone literal-git", () => {
+    // Branch (a): standard `git init` repo — common-dir is <root>/.git
+    const root = mktemp();
+    tmpdirs.push(root);
+
+    git(["init", root], os.tmpdir());
+    initGitConfig(root);
+
+    const key = deriveClaudeProjectKey(root);
+    // key must equal the real canonical path of the worktree root
+    expect(key).toBe(fs.realpathSync(root));
+    // sanity: key does NOT end with /.git
+    expect(key.endsWith("/.git")).toBe(false);
+  });
+
+  it("bare worktree", () => {
+    // Branch (b): bare repo pattern — common-dir IS the bare dir (e.g. .bare)
+    // Layout: <container>/.bare  (bare repo) + <container>/wt (worktree)
+    const container = mktemp();
+    tmpdirs.push(container);
+
+    const bareDir = path.join(container, ".bare");
+    const wtDir = path.join(container, "wt");
+
+    git(["init", "--bare", bareDir], os.tmpdir());
+    seedBareRepo(bareDir);
+
+    fs.mkdirSync(wtDir, { recursive: true });
+    execFileSync("git", ["--git-dir", bareDir, "worktree", "add", wtDir], {
+      stdio: "pipe",
+      env: GIT_ENV,
+    });
+
+    const key = deriveClaudeProjectKey(wtDir);
+
+    // key must equal the real canonical path of the bare dir
+    const realBare = fs.realpathSync(bareDir);
+    expect(key).toBe(realBare);
+    // key must NOT be the worktree path
+    expect(key).not.toBe(fs.realpathSync(wtDir));
+  });
+
+  it("container gitfile", () => {
+    // Branch (b) variant: container dir holding a `.git` FILE (not a dir)
+    // that points to a bare-pattern common-dir. basename(commonDir) !== ".git"
+    // Layout: <root>/.bare (bare), <root>/linked (has .git FILE → .bare)
+    const container = mktemp();
+    tmpdirs.push(container);
+
+    const bareDir = path.join(container, ".bare");
+    const linkedDir = path.join(container, "linked");
+
+    git(["init", "--bare", bareDir], os.tmpdir());
+    seedBareRepo(bareDir);
+
+    fs.mkdirSync(linkedDir, { recursive: true });
+    // Create a .git FILE pointing at the bare repo (gitfile format)
+    fs.writeFileSync(path.join(linkedDir, ".git"), `gitdir: ${bareDir}\n`);
+
+    const key = deriveClaudeProjectKey(linkedDir);
+
+    // commonDir = bareDir; basename(bareDir) = ".bare" !== ".git" → branch (b)
+    const realBare = fs.realpathSync(bareDir);
+    expect(key).toBe(realBare);
+  });
+
+  it("non-git realpath", () => {
+    // Branch (c): not a git repository — key = fs.realpathSync(targetPath)
+    // Use a symlinked tmpdir to verify symlink resolution
+    const real = mktemp();
+    tmpdirs.push(real);
+    const link = path.join(os.tmpdir(), `git-key-link-${Date.now()}`);
+
+    fs.symlinkSync(real, link);
+    try {
+      const key = deriveClaudeProjectKey(link);
+      // key must equal the canonical resolved path of the symlink
+      expect(key).toBe(fs.realpathSync(link));
+      // key must NOT be the raw symlink path (which may differ from realpath on macOS /private/var/...)
+      expect(key).not.toBe(link);
+    } finally {
+      fs.rmSync(link, { force: true });
+    }
+  });
+
+  it("linked worktree off standalone", () => {
+    // Branch (a): linked worktree added from a standalone (non-bare) repo.
+    // common-dir = <base>/.git  → basename === ".git" → return dirname = base toplevel
+    const base = mktemp();
+    const wt = fs.mkdtempSync(path.join(os.tmpdir(), "git-key-wt-"));
+    tmpdirs.push(base);
+    tmpdirs.push(wt);
+
+    git(["init", base], os.tmpdir());
+    initGitConfig(base);
+    execFileSync("git", ["-C", base, "commit", "--allow-empty", "-m", "init"], {
+      stdio: "pipe",
+      env: GIT_ENV,
+    });
+    git(["-C", base, "worktree", "add", wt], base);
+
+    const keyFromWt = deriveClaudeProjectKey(wt);
+    const keyFromBase = deriveClaudeProjectKey(base);
+
+    // Both should resolve to the same key (the base repo root)
+    expect(keyFromWt).toBe(keyFromBase);
+    // key === realpath of base top-level
+    expect(keyFromWt).toBe(fs.realpathSync(base));
+    // key is NOT the worktree path
+    expect(keyFromWt).not.toBe(fs.realpathSync(wt));
+  });
+
+  it("git failure errors", () => {
+    // Branch (d): git exits non-zero for a reason OTHER than "not a git repository"
+    // Must throw — must NOT silently fall to branch (c).
+    //
+    // Strategy: create a fake `git` script that exits 128 with a message that does
+    // NOT contain "not a git repository", and override PATH so execFileSync picks it up.
+    const dir = mktemp();
+    tmpdirs.push(dir);
+
+    const fakeGitDir = fs.mkdtempSync(path.join(os.tmpdir(), "fake-git-"));
+    tmpdirs.push(fakeGitDir);
+
+    const fakeGit = path.join(fakeGitDir, "git");
+    fs.writeFileSync(
+      fakeGit,
+      "#!/bin/sh\necho 'error: dubious ownership in repository' >&2\nexit 128\n",
+    );
+    fs.chmodSync(fakeGit, 0o755);
+
+    const fakeEnv = { ...process.env, PATH: `${fakeGitDir}:${process.env.PATH}` };
+    expect(() => deriveClaudeProjectKey(dir, fakeEnv)).toThrow();
+  });
+});

--- a/tools/lib/git-key.test.ts
+++ b/tools/lib/git-key.test.ts
@@ -97,7 +97,7 @@ describe("deriveClaudeProjectKey", () => {
     const bareDir = path.join(container, ".bare");
     const wtDir = path.join(container, "wt");
 
-    git(["init", "--bare", bareDir], os.tmpdir());
+    git(["init", "--bare", "-b", "main", bareDir], os.tmpdir());
     seedBareRepo(bareDir);
 
     fs.mkdirSync(wtDir, { recursive: true });
@@ -125,7 +125,7 @@ describe("deriveClaudeProjectKey", () => {
     const bareDir = path.join(container, ".bare");
     const linkedDir = path.join(container, "linked");
 
-    git(["init", "--bare", bareDir], os.tmpdir());
+    git(["init", "--bare", "-b", "main", bareDir], os.tmpdir());
     seedBareRepo(bareDir);
 
     fs.mkdirSync(linkedDir, { recursive: true });

--- a/tools/lib/git-key.ts
+++ b/tools/lib/git-key.ts
@@ -3,6 +3,26 @@ import fs from "node:fs";
 import path from "node:path";
 
 /**
+ * Thrown by deriveClaudeProjectKey branch (d): git failed for a reason other
+ * than "not a git repository" (dubious ownership, git absent, git < 2.31 where
+ * --path-format=absolute is unknown). Carries an actionable remediation message
+ * and the original error as `cause`. Callers MUST surface this loudly (non-zero
+ * exit) — silently mis-keying a local MCP into ~/.claude.json is the worst
+ * failure class for this tool.
+ */
+export class ProjectKeyError extends Error {
+  constructor(targetPath: string, cause: unknown) {
+    super(
+      `Failed to derive Claude project key for ${targetPath}: git command failed. ` +
+        `Ensure git >= 2.31 is installed and check repository ownership ` +
+        `(e.g. git config --global --add safe.directory). Original error: ${cause}`,
+      { cause },
+    );
+    this.name = "ProjectKeyError";
+  }
+}
+
+/**
  * Derives the key used by Claude Code's ~/.claude.json `projects[]` map
  * for a given target path.
  *
@@ -51,7 +71,7 @@ export function deriveClaudeProjectKey(
     }
 
     // Branch (d): git failure for another reason — must throw loudly
-    throw err;
+    throw new ProjectKeyError(targetPath, err);
   }
 
   const commonDir = stdout.trim();

--- a/tools/lib/git-key.ts
+++ b/tools/lib/git-key.ts
@@ -51,7 +51,6 @@ export function deriveClaudeProjectKey(
   env: NodeJS.ProcessEnv = process.env,
 ): string {
   let stdout: string;
-  let stderr: string;
 
   try {
     const result = execFileSync(
@@ -60,10 +59,9 @@ export function deriveClaudeProjectKey(
       { stdio: ["pipe", "pipe", "pipe"], env },
     );
     stdout = result.toString();
-    stderr = "";
   } catch (err: unknown) {
     const spawnErr = err as { stderr?: Buffer | string };
-    stderr = spawnErr.stderr ? spawnErr.stderr.toString() : "";
+    const stderr = spawnErr.stderr ? spawnErr.stderr.toString() : "";
 
     if (stderr.includes("not a git repository")) {
       // Branch (c): not a git repo — resolve symlinks on the input path

--- a/tools/lib/git-key.ts
+++ b/tools/lib/git-key.ts
@@ -1,0 +1,68 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Derives the key used by Claude Code's ~/.claude.json `projects[]` map
+ * for a given target path.
+ *
+ * The key is the git common-dir, which is shared across all worktrees of a
+ * repo — giving a stable per-repo key that byte-matches Claude Code's keying.
+ *
+ * Branch logic:
+ *   (a) common-dir is <root>/.git (standalone or linked-worktree off standalone)
+ *       → return dirname(common-dir) = repo root
+ *   (b) common-dir is a bare-pattern dir (e.g. .bare)
+ *       → return common-dir as-is
+ *   (c) not a git repository
+ *       → return fs.realpathSync(targetPath)
+ *   (d) git fails for any other reason (dubious ownership, git absent, git < 2.31)
+ *       → throw — must never silently mis-key
+ *
+ * Requires git >= 2.31 (--path-format=absolute). Older git must throw loudly.
+ * Do NOT call fs.realpathSync on branches (a) or (b) — git already canonicalizes.
+ *
+ * @param targetPath - The directory to derive the key for.
+ * @param env - Optional environment to pass to the git subprocess (defaults to
+ *   process.env). Exposed for testing only — callers should omit this parameter.
+ */
+export function deriveClaudeProjectKey(
+  targetPath: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  let stdout: string;
+  let stderr: string;
+
+  try {
+    const result = execFileSync(
+      "git",
+      ["-C", targetPath, "rev-parse", "--path-format=absolute", "--git-common-dir"],
+      { stdio: ["pipe", "pipe", "pipe"], env },
+    );
+    stdout = result.toString();
+    stderr = "";
+  } catch (err: unknown) {
+    const spawnErr = err as { stderr?: Buffer | string };
+    stderr = spawnErr.stderr ? spawnErr.stderr.toString() : "";
+
+    if (stderr.includes("not a git repository")) {
+      // Branch (c): not a git repo — resolve symlinks on the input path
+      return fs.realpathSync(targetPath);
+    }
+
+    // Branch (d): git failure for another reason — must throw loudly
+    throw err;
+  }
+
+  const commonDir = stdout.trim();
+
+  if (path.basename(commonDir) === ".git") {
+    // Branch (a): standard repo or linked-worktree off standalone
+    // common-dir = <root>/.git → return the repo root
+    return path.dirname(commonDir);
+  }
+
+  // Branch (b): bare-pattern repo (e.g. .bare)
+  // common-dir is the bare dir itself — return it as-is
+  return commonDir;
+}

--- a/tools/lib/resolve-deploy-targets.test.ts
+++ b/tools/lib/resolve-deploy-targets.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { execFileSync } from "child_process";
+import { resolveDeployTargets, DeployTargetsError } from "./resolve-deploy-targets.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mktemp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "rdt-test-"));
+}
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "T",
+  GIT_AUTHOR_EMAIL: "t@t.com",
+  GIT_COMMITTER_NAME: "T",
+  GIT_COMMITTER_EMAIL: "t@t.com",
+};
+
+/**
+ * Seeds an empty commit into a bare repo so worktrees can be added.
+ * git commit requires a work tree, so a temporary one is created and pruned.
+ */
+function seedBareRepo(bareDir: string): void {
+  const tmpWt = fs.mkdtempSync(path.join(os.tmpdir(), "rdt-seed-"));
+  try {
+    execFileSync("git", ["--git-dir", bareDir, "worktree", "add", "--orphan", "-b", "main", tmpWt], {
+      stdio: "pipe",
+      env: GIT_ENV,
+    });
+    execFileSync("git", ["-C", tmpWt, "commit", "--allow-empty", "-m", "init"], {
+      stdio: "pipe",
+      env: GIT_ENV,
+    });
+    fs.rmSync(tmpWt, { recursive: true, force: true });
+    execFileSync("git", ["--git-dir", bareDir, "worktree", "prune"], {
+      stdio: "pipe",
+    });
+  } catch {
+    fs.rmSync(tmpWt, { recursive: true, force: true });
+    throw new Error("Failed to seed bare repo");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("resolveDeployTargets", () => {
+  const tmpdirs: string[] = [];
+
+  afterEach(() => {
+    for (const d of tmpdirs.splice(0)) {
+      try {
+        fs.rmSync(d, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  });
+
+  it("AC1.1: bare-structure container with 2 worktrees returns exactly those 2 worktree paths", () => {
+    // Layout:
+    //   <container>/.bare   (bare git repo)
+    //   <container>/wt1     (worktree 1)
+    //   <container>/wt2     (worktree 2)
+    // resolveDeployTargets(<container>) must return [wt1, wt2] (bare entry excluded)
+    const container = mktemp();
+    tmpdirs.push(container);
+
+    const bareDir = path.join(container, ".bare");
+    const wt1 = path.join(container, "wt1");
+    const wt2 = path.join(container, "wt2");
+
+    execFileSync("git", ["init", "--bare", bareDir], { stdio: "pipe" });
+    seedBareRepo(bareDir);
+
+    execFileSync("git", ["--git-dir", bareDir, "worktree", "add", "-b", "feat/a", wt1], {
+      stdio: "pipe",
+      env: GIT_ENV,
+    });
+    execFileSync("git", ["--git-dir", bareDir, "worktree", "add", "-b", "feat/b", wt2], {
+      stdio: "pipe",
+      env: GIT_ENV,
+    });
+
+    const result = resolveDeployTargets(container);
+
+    // Order-insensitive set comparison; realpath normalizes macOS /var → /private/var
+    const realWt1 = fs.realpathSync(wt1);
+    const realWt2 = fs.realpathSync(wt2);
+    expect(new Set(result)).toEqual(new Set([realWt1, realWt2]));
+    expect(result).toHaveLength(2);
+  });
+
+  it("AC1.2: plain non-bare directory (no .bare child) returns [path] unchanged", () => {
+    const dir = mktemp();
+    tmpdirs.push(dir);
+
+    const result = resolveDeployTargets(dir);
+
+    expect(result).toEqual([dir]);
+  });
+
+  it("AC1.3: bare-structure path with .bare present but zero worktrees throws DeployTargetsError naming no-worktrees cause", () => {
+    // A bare repo with no additional worktrees beyond the pruned seed worktree
+    const container = mktemp();
+    tmpdirs.push(container);
+
+    const bareDir = path.join(container, ".bare");
+    execFileSync("git", ["init", "--bare", bareDir], { stdio: "pipe" });
+    seedBareRepo(bareDir);
+    // After seedBareRepo, the seed worktree is pruned — zero real worktrees remain
+
+    expect(() => resolveDeployTargets(container)).toThrow(DeployTargetsError);
+
+    let caught: unknown;
+    try {
+      resolveDeployTargets(container);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(DeployTargetsError);
+    // Message must name the "no worktrees" cause
+    const msg = (caught as Error).message;
+    expect(msg).toMatch(/no worktree/i);
+  });
+
+  it("AC1.4: bare-structure path where git enumeration fails throws DeployTargetsError (not silent [])", () => {
+    // Create a container with a .bare child that is NOT a valid git repo
+    // so that `git --git-dir=<path>/.bare worktree list` exits non-zero
+    const container = mktemp();
+    tmpdirs.push(container);
+
+    const bareDir = path.join(container, ".bare");
+    // Create .bare as a directory that is NOT a git repo
+    fs.mkdirSync(bareDir);
+    // Optionally place a non-git file inside so it is a plain dir
+    fs.writeFileSync(path.join(bareDir, "not-a-git-repo"), "");
+
+    expect(() => resolveDeployTargets(container)).toThrow(DeployTargetsError);
+
+    let caught: unknown;
+    try {
+      resolveDeployTargets(container);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(DeployTargetsError);
+    // The error must NOT be a silent return
+    expect(caught).toBeInstanceOf(DeployTargetsError);
+    // cause must be preserved
+    expect((caught as DeployTargetsError).cause).toBeDefined();
+  });
+});

--- a/tools/lib/resolve-deploy-targets.test.ts
+++ b/tools/lib/resolve-deploy-targets.test.ts
@@ -76,7 +76,7 @@ describe("resolveDeployTargets", () => {
     const wt1 = path.join(container, "wt1");
     const wt2 = path.join(container, "wt2");
 
-    execFileSync("git", ["init", "--bare", bareDir], { stdio: "pipe" });
+    execFileSync("git", ["init", "--bare", "-b", "main", bareDir], { stdio: "pipe" });
     seedBareRepo(bareDir);
 
     execFileSync("git", ["--git-dir", bareDir, "worktree", "add", "-b", "feat/a", wt1], {
@@ -112,7 +112,7 @@ describe("resolveDeployTargets", () => {
     tmpdirs.push(container);
 
     const bareDir = path.join(container, ".bare");
-    execFileSync("git", ["init", "--bare", bareDir], { stdio: "pipe" });
+    execFileSync("git", ["init", "--bare", "-b", "main", bareDir], { stdio: "pipe" });
     seedBareRepo(bareDir);
     // After seedBareRepo, the seed worktree is pruned — zero real worktrees remain
 

--- a/tools/lib/resolve-deploy-targets.ts
+++ b/tools/lib/resolve-deploy-targets.ts
@@ -1,0 +1,130 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Thrown by resolveDeployTargets for two distinct failure modes:
+ *   (a) the git worktree-list command errors (not a repo, git absent, dubious ownership)
+ *   (b) the bare-structure path resolves to zero worktrees after excluding bare/prunable blocks
+ *
+ * Callers MUST surface this loudly (non-zero exit) — silently returning an
+ * empty or incorrect target set would cause the deploy step to write nothing
+ * without any signal to the operator.
+ */
+export class DeployTargetsError extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message, cause !== undefined ? { cause } : undefined);
+    this.name = "DeployTargetsError";
+  }
+}
+
+/**
+ * Parses `git worktree list --porcelain` output into a list of non-bare,
+ * non-prunable worktree paths.
+ *
+ * Porcelain format (blocks separated by blank lines):
+ *   worktree <abs-path>
+ *   HEAD <sha>          (absent for bare)
+ *   branch <ref>        (absent for detached/bare)
+ *   bare                (marker line, no value)
+ *   detached            (marker line, no value)
+ *   locked [reason]     (marker line + optional reason)
+ *   prunable <reason>   (marker line + reason)
+ */
+function parsePorcelain(output: string): string[] {
+  const blocks = output.trim().split(/\n\n+/);
+  const result: string[] = [];
+
+  for (const block of blocks) {
+    if (!block.trim()) continue;
+    const lines = block.split("\n");
+
+    let worktreePath: string | undefined;
+    let isBare = false;
+    let isPrunable = false;
+
+    for (const line of lines) {
+      if (line.startsWith("worktree ")) {
+        worktreePath = line.slice("worktree ".length).trim();
+      } else if (line === "bare") {
+        isBare = true;
+      } else if (line.startsWith("prunable")) {
+        isPrunable = true;
+      }
+      // locked and detached are intentionally NOT excluded — they are real working trees
+    }
+
+    if (worktreePath && !isBare && !isPrunable) {
+      result.push(worktreePath);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Resolves the set of deploy targets for a given path.
+ *
+ * - If `<path>/.bare` does not exist or is not a directory, returns `[path]` unchanged.
+ * - If `<path>/.bare` exists and is a directory (bare-structure), runs
+ *   `git --git-dir=<path>/.bare worktree list --porcelain` and returns all
+ *   non-bare, non-prunable worktree paths. The bare entry itself is excluded
+ *   by construction (it carries the `bare` marker). Locked and detached
+ *   worktrees ARE included — they are real working trees.
+ *
+ * Throws DeployTargetsError for:
+ *   (a) git command errors (not a repo / git absent / dubious ownership)
+ *   (b) zero worktrees after filtering bare/prunable blocks
+ *
+ * The input path must already be tilde-expanded — this function does NOT
+ * expand `~`.
+ *
+ * @param targetPath - Absolute, already-tilde-expanded path to inspect.
+ */
+export function resolveDeployTargets(targetPath: string): string[] {
+  const bareDir = path.join(targetPath, ".bare");
+
+  // Detection (D-2): bare-structure iff .bare exists AND is a directory
+  let isBareStructure: boolean;
+  try {
+    isBareStructure = fs.statSync(bareDir).isDirectory();
+  } catch {
+    // .bare does not exist — plain path
+    isBareStructure = false;
+  }
+
+  if (!isBareStructure) {
+    return [targetPath];
+  }
+
+  // Enumeration (D-3): ask git for the worktree list
+  let stdout: string;
+  try {
+    const result = execFileSync(
+      "git",
+      ["--git-dir", bareDir, "worktree", "list", "--porcelain"],
+      { stdio: ["pipe", "pipe", "pipe"], env: process.env },
+    );
+    stdout = result.toString();
+  } catch (err) {
+    throw new DeployTargetsError(
+      `Failed to enumerate worktrees for bare-structure at ${targetPath}: ` +
+        `git worktree list command failed. ` +
+        `Ensure git is installed, the path is a valid git bare repo, and check ` +
+        `repository ownership (e.g. git config --global --add safe.directory). ` +
+        `Original error: ${err}`,
+      err,
+    );
+  }
+
+  const worktrees = parsePorcelain(stdout);
+
+  if (worktrees.length === 0) {
+    throw new DeployTargetsError(
+      `Bare-structure at ${targetPath} resolved to no worktrees. ` +
+        `Add at least one git worktree before deploying.`,
+    );
+  }
+
+  return worktrees;
+}

--- a/tools/lib/types.ts
+++ b/tools/lib/types.ts
@@ -66,6 +66,19 @@ export type SyncContext = {
   modelMaps: Map<Platform, Record<string, string>>;
   processedPaths: Set<string>;
   platformYamlSections: Map<Platform, string[]>;
+  /**
+   * Every per-worktree deploy root that received (or would receive) a backup
+   * during the fan-out. Backup-retention cleanup iterates these so a bare
+   * container's worktrees each get their .sync-backup pruned, not just the
+   * container path tracked in processedPaths.
+   */
+  backupRoots: Set<string>;
+  /**
+   * Deploy roots whose per-worktree iteration failed (best-effort fan-out: one
+   * failing worktree is logged and skipped, the rest continue). A non-empty set
+   * forces the CLI to exit non-zero so an unwritable worktree is never silent.
+   */
+  failedTargets: string[];
 };
 
 export type PlatformConfigResult = {

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -19,6 +19,7 @@ import {
   printUsage,
   resolveProjectFilter,
   runProjectsLoop,
+  allTargetsProcessed,
   type AdapterMap,
   type LibSourceRoots,
 } from "./sync.ts";
@@ -678,7 +679,7 @@ describe("syncPlatformConfigs", () => {
     ).rejects.toBeInstanceOf(ProjectKeyError);
   });
 
-  it("still swallows non-ProjectKeyError per-platform config errors (warn-and-continue preserved)", async () => {
+  it("rethrows non-ProjectKeyError per-platform config errors so the worktree is recorded as failed", async () => {
     await writeFile(
       path.join(yamlDir, "claude.yaml"),
       "config:\n  theme: dark\n",
@@ -696,10 +697,11 @@ describe("syncPlatformConfigs", () => {
 
     const context = makeContext();
 
-    // Generic config/hooks/plugins errors keep warn-and-continue: no throw.
+    // A config/hooks/plugins write failure must escape (no longer swallowed) so
+    // the per-worktree catch records the deploy root and the CLI exits non-zero.
     await expect(
       syncPlatformConfigs(context, targetPath, yamlDir, adapters, rootDir),
-    ).resolves.toBeUndefined();
+    ).rejects.toThrow("config write failed");
   });
 
   it("stores model-map in context.modelMaps (P2-1)", async () => {
@@ -2749,6 +2751,108 @@ describe("component fan-out", () => {
     expect(context.failedTargets).toContain(worktrees[1]);
 
     await fs.chmod(worktrees[1]!, 0o755);
+  });
+
+  // Bug (1): a config-write failure in a worktree must reach failedTargets so the
+  // CLI exits non-zero. The .claude dir is read-only (0o555) but the worktree
+  // itself stays writable, so the line-760 mkdir on the pre-existing .claude is a
+  // no-op and the failure is isolated to the claude.yaml config write inside
+  // syncPlatformConfigs — exactly the error class that used to be swallowed.
+  it("Bug1: a worktree whose claude.yaml config write fails is recorded in failedTargets", async () => {
+    const { worktrees } = makeBareTopology("repo", ["wt1"]);
+
+    // Pre-create .claude while the worktree is fully writable, then make ONLY
+    // .claude read-only. config writes (settings.local.json) into it then fail.
+    const claudeDir = path.join(worktrees[0]!, ".claude");
+    await fs.mkdir(claudeDir, { recursive: true });
+    await fs.chmod(claudeDir, 0o555);
+
+    const container = path.dirname(worktrees[0]!);
+    const syncYamlPath = path.join(rootDir, "sync.yaml");
+    // config-only claude.yaml (no component sections) → deploysToClaudeDotDir=true.
+    await writeFile(syncYamlPath, `path: ${container}\n`);
+    await writeFile(path.join(rootDir, "claude.yaml"), "config:\n  theme: dark\n");
+
+    const adapters = new Map<Platform, PlatformAdapter>([["claude", new ClaudeAdapter()]]) as AdapterMap;
+    const context = makeContext({ dryRun: false });
+
+    await processYaml(context, syncYamlPath, adapters, rootDir);
+
+    // The config-write failure must surface as a failed worktree, not be swallowed.
+    expect(context.failedTargets).toContain(worktrees[0]);
+    // This is the exact expression the CLI uses to choose its exit code.
+    expect(context.failedTargets.length > 0 ? 1 : 0).toBe(1);
+
+    await fs.chmod(claudeDir, 0o755);
+  });
+
+  // Bug (2): a worktree that fails mid-deploy must NOT be registered as a backup
+  // root, so retention cleanup does not prune its last good backup. backupRoots
+  // is the success-only invariant: only worktrees that completed all sync steps
+  // belong in it.
+  it("Bug2: a worktree failing mid-deploy keeps its prior backup and is not a backup root", async () => {
+    const { container, worktrees } = makeBareTopology("repo", ["wt1"]);
+    await seedSkill("oracle");
+
+    // A prior good backup session already present in the worktree.
+    const priorBackup = path.join(worktrees[0]!, ".sync-backup", "good-session", "marker");
+    await writeFile(priorBackup, "keep me\n");
+
+    const syncYamlPath = path.join(rootDir, "sync.yaml");
+    await writeFile(syncYamlPath, `path: ${container}\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`);
+
+    // Adapter that throws during dispatch — AFTER syncCategory's backup+wipe ran,
+    // i.e. partway through the per-worktree deploy.
+    class FailingAdapter extends ClaudeAdapter {
+      override async syncSkillsDirect(): Promise<void> {
+        throw new Error("boom during skills dispatch");
+      }
+    }
+    const adapters = new Map<Platform, PlatformAdapter>([["claude", new FailingAdapter()]]) as AdapterMap;
+    const context = makeContext({ dryRun: false, backupSession: "new-session" });
+
+    await processYaml(context, syncYamlPath, adapters, rootDir);
+
+    // The worktree failed, so it is recorded as failed and NOT as a backup root.
+    expect(context.failedTargets).toContain(worktrees[0]);
+    expect(context.backupRoots.has(worktrees[0]!)).toBe(false);
+
+    // Retention cleanup over the production union (processedPaths ∪ backupRoots)
+    // with retentionDays=0 must leave the failed worktree's prior backup intact.
+    const cleanupTargets = new Set<string>([...context.processedPaths, ...context.backupRoots]);
+    await Promise.all([...cleanupTargets].map((t) => cleanupOldBackups(t, 0).catch(() => {})));
+
+    expect(await exists(path.join(worktrees[0]!, ".sync-backup", "good-session"))).toBe(true);
+  });
+
+  // Bug (3): a container sync.yaml and a sync.yaml pointing directly at one of its
+  // worktrees must resolve to the same .claude and deploy it exactly once. The
+  // dedup key is the RESOLVED deploy target, not the raw container path.
+  it("Bug3: a worktree already deployed via its container is recognized as processed (no double deploy)", async () => {
+    const { container, worktrees } = makeBareTopology("repo", ["wt1"]);
+    await seedSkill("oracle");
+
+    // proj-a points at the bare container.
+    const projDir = path.join(rootDir, "projects", "proj-a");
+    await fs.mkdir(projDir, { recursive: true });
+    await writeFile(
+      path.join(projDir, "sync.yaml"),
+      `path: ${container}\nname: proj-a\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`,
+    );
+
+    const adapters = new Map<Platform, PlatformAdapter>([["claude", new ClaudeAdapter()]]) as AdapterMap;
+    const context = makeContext({ dryRun: false });
+    const effectiveFilter = resolveProjectFilter(new Set(), undefined);
+
+    // Projects phase: deploys the container's worktree.
+    await runProjectsLoop(rootDir, adapters, context, effectiveFilter, false);
+
+    // The RESOLVED worktree path (not the raw container) is what dedup must track.
+    expect(context.processedPaths.has(worktrees[0]!)).toBe(true);
+
+    // Root phase dedup: a sync.yaml whose path is the worktree itself resolves to
+    // [wt1], which is already processed → the CLI must skip it (single deploy).
+    expect(allTargetsProcessed(worktrees[0]!, context.processedPaths)).toBe(true);
   });
 
   // AC5.1 — deriveClaudeProjectKey has EXACTLY ONE call site

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
 import fs from "fs/promises";
+import fs2 from "fs";
 import path from "path";
 import os from "os";
 import { existsSync } from "fs";
@@ -24,7 +25,10 @@ import {
 import type { SyncContext, Platform, Category, SyncYaml } from "./lib/types.ts";
 import type { PlatformAdapter } from "./adapters/types.ts";
 import { _resetConfigCache } from "./lib/config.ts";
-import { ProjectKeyError } from "./lib/git-key.ts";
+import { ProjectKeyError, deriveClaudeProjectKey } from "./lib/git-key.ts";
+import { DeployTargetsError } from "./lib/resolve-deploy-targets.ts";
+import { ClaudeAdapter } from "./adapters/claude.ts";
+import { execFileSync } from "child_process";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -107,6 +111,8 @@ function makeContext(overrides?: Partial<SyncContext>): SyncContext {
     modelMaps: new Map(),
     processedPaths: new Set(),
     platformYamlSections: new Map(),
+    backupRoots: new Set(),
+    failedTargets: [],
     ...overrides,
   };
 }
@@ -162,7 +168,7 @@ describe("syncCategory", () => {
     const adapters = makeAdapterMap(["claude", "gemini"]);
     const context = makeContext({ dryRun: false });
 
-    await syncCategory(context, "skills", syncYaml, adapters, rootDir);
+    await syncCategory(context, "skills", syncYaml, adapters, rootDir, targetPath);
 
     const claudeCalls = adapters.getAdapter("claude")!.calls;
     expect(claudeCalls.some((c) => c.method === "syncSkillsDirect")).toBe(true);
@@ -186,7 +192,7 @@ describe("syncCategory", () => {
     const adapters = makeAdapterMap(["claude", "gemini"]);
     const context = makeContext({ dryRun: false });
 
-    await syncCategory(context, "commands", syncYaml, adapters, rootDir);
+    await syncCategory(context, "commands", syncYaml, adapters, rootDir, targetPath);
 
     expect(adapters.getAdapter("gemini")!.calls.some((c) => c.method === "syncCommandsDirect")).toBe(true);
     expect(adapters.getAdapter("claude")!.calls.filter((c) => c.method === "syncCommandsDirect")).toHaveLength(0);
@@ -207,7 +213,7 @@ describe("syncCategory", () => {
     const adapters = makeAdapterMap(["claude"]);
     const context = makeContext({ dryRun: false });
 
-    await syncCategory(context, "agents", syncYaml, adapters, rootDir);
+    await syncCategory(context, "agents", syncYaml, adapters, rootDir, targetPath);
 
     const calls = adapters.getAdapter("claude")!.calls;
     expect(calls.some((c) => c.method === "syncAgentsDirect")).toBe(true);
@@ -226,7 +232,7 @@ describe("syncCategory", () => {
     const context = makeContext({ dryRun: false });
 
     // Should not throw
-    await syncCategory(context, "rules", syncYaml, adapters, rootDir);
+    await syncCategory(context, "rules", syncYaml, adapters, rootDir, targetPath);
     expect(adapters.getAdapter("claude")!.calls.filter((c) => c.method === "syncRulesDirect")).toHaveLength(0);
   });
 
@@ -239,7 +245,7 @@ describe("syncCategory", () => {
     const adapters = makeAdapterMap(["claude"]);
     const context = makeContext({ dryRun: false });
 
-    await syncCategory(context, "scripts", syncYaml, adapters, rootDir);
+    await syncCategory(context, "scripts", syncYaml, adapters, rootDir, targetPath);
     expect(adapters.getAdapter("claude")!.calls).toHaveLength(0);
   });
 
@@ -258,7 +264,7 @@ describe("syncCategory", () => {
     const adapters = makeAdapterMap(["claude"]);
     const context = makeContext({ dryRun: true });
 
-    await syncCategory(context, "agents", syncYaml, adapters, rootDir);
+    await syncCategory(context, "agents", syncYaml, adapters, rootDir, targetPath);
 
     // Adapter syncAgentsDirect should NOT be called in dry-run
     const calls = adapters.getAdapter("claude")!.calls;
@@ -290,7 +296,7 @@ describe("syncCategory", () => {
     const adapters = makeAdapterMap(["claude"]);
     const context = makeContext({ dryRun: false });
 
-    await syncCategory(context, "agents", syncYaml, adapters, rootDir);
+    await syncCategory(context, "agents", syncYaml, adapters, rootDir, targetPath);
 
     // Orphan should be gone: wipe+recreate cleared the dir before writing
     expect(await exists(path.join(claudeAgentsDir, "orphan-agent.md"))).toBe(false);
@@ -327,7 +333,7 @@ describe("syncCategory", () => {
     const adapters = makeAdapterMap(["claude"]);
     const context = makeContext({ dryRun: false });
 
-    await syncCategory(context, "agents", syncYaml, adapters, rootDir);
+    await syncCategory(context, "agents", syncYaml, adapters, rootDir, targetPath);
 
     const calls = adapters.getAdapter("claude")!.calls;
     const agentCall = calls.find((c) => c.method === "syncAgentsDirect");
@@ -367,7 +373,7 @@ describe("syncCategory", () => {
     const context = makeContext({ dryRun: false });
 
     // Should not throw
-    await syncCategory(context, "agents", syncYaml, adapters, rootDir);
+    await syncCategory(context, "agents", syncYaml, adapters, rootDir, targetPath);
 
     const calls = adapters.getAdapter("claude")!.calls;
     const agentCall = calls.find((c) => c.method === "syncAgentsDirect");
@@ -398,7 +404,7 @@ describe("syncCategory", () => {
     const context = makeContext({ dryRun: false });
 
     // Should not throw
-    await syncCategory(context, "agents", syncYaml as never, adapters, rootDir);
+    await syncCategory(context, "agents", syncYaml as never, adapters, rootDir, targetPath);
 
     const calls = adapters.getAdapter("claude")!.calls;
     const agentCall = calls.find((c) => c.method === "syncAgentsDirect");
@@ -429,7 +435,7 @@ describe("syncCategory", () => {
     const context = makeContext({ dryRun: false });
 
     // Should not throw
-    await syncCategory(context, "agents", syncYaml as never, adapters, rootDir);
+    await syncCategory(context, "agents", syncYaml as never, adapters, rootDir, targetPath);
 
     const calls = adapters.getAdapter("claude")!.calls;
     const agentCall = calls.find((c) => c.method === "syncAgentsDirect");
@@ -459,7 +465,7 @@ describe("syncCategory", () => {
     const adapters = makeAdapterMap(["claude"]);
     const context = makeContext({ dryRun: false });
 
-    await syncCategory(context, "rules", syncYaml, adapters, rootDir);
+    await syncCategory(context, "rules", syncYaml, adapters, rootDir, targetPath);
 
     // manual-rule.md must still exist — rules dir is never wiped
     expect(await exists(path.join(claudeRulesDir, "manual-rule.md"))).toBe(true);
@@ -485,7 +491,7 @@ describe("syncCategory", () => {
     const adapters = makeAdapterMap(["codex"]);
     const context = makeContext({ dryRun: false });
 
-    await syncCategory(context, "agents", syncYaml, adapters, rootDir);
+    await syncCategory(context, "agents", syncYaml, adapters, rootDir, targetPath);
 
     // File must survive — codex does not support agents, so no wipe occurred
     expect(await exists(path.join(codexAgentsDir, "existing-agent.md"))).toBe(true);
@@ -513,7 +519,7 @@ describe("syncCategory", () => {
     const adapters = makeAdapterMap(["claude"]);
     const context = makeContext({ dryRun: false });
 
-    await syncCategory(context, "agents", syncYaml, adapters, rootDir);
+    await syncCategory(context, "agents", syncYaml, adapters, rootDir, targetPath);
 
     // Orphan wiped — claude supports agents
     expect(await exists(path.join(claudeAgentsDir, "orphan.md"))).toBe(false);
@@ -558,7 +564,7 @@ describe("syncCategory", () => {
         const adapters = makeAdapterMap([platform as Platform]);
         const context = makeContext({ dryRun: false });
 
-        await syncCategory(context, category as Category, syncYaml, adapters, rootDir);
+        await syncCategory(context, category as Category, syncYaml, adapters, rootDir, targetPath);
 
         const methodMap: Record<Category, string> = {
           agents: "syncAgentsDirect",
@@ -586,7 +592,7 @@ describe("syncCategory", () => {
         const adapters = makeAdapterMap([platform as Platform]);
         const context = makeContext({ dryRun: false });
 
-        await syncCategory(context, category as Category, syncYaml, adapters, rootDir);
+        await syncCategory(context, category as Category, syncYaml, adapters, rootDir, targetPath);
 
         const methodMap: Record<Category, string> = {
           agents: "syncAgentsDirect",
@@ -2524,5 +2530,391 @@ describe("enabled-projects 화이트리스트 — projects 루프 통합", () =>
     await expect(
       runProjectsLoop(rootDir, adapters, context, effectiveFilter, false),
     ).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: component fan-out (bare-structure → every worktree's .claude/)
+// ---------------------------------------------------------------------------
+
+describe("component fan-out", () => {
+  let tmpDir: string;
+  let rootDir: string;
+
+  const GIT_ENV = {
+    ...process.env,
+    GIT_AUTHOR_NAME: "T",
+    GIT_AUTHOR_EMAIL: "t@t.com",
+    GIT_COMMITTER_NAME: "T",
+    GIT_COMMITTER_EMAIL: "t@t.com",
+  };
+
+  /**
+   * Seeds an empty commit into a bare repo via a throwaway orphan worktree.
+   * (Adapted from tools/lib/git-key.test.ts:seedBareRepo.)
+   */
+  function seedBareRepo(bareDir: string): void {
+    const tmpWt = fs2.mkdtempSync(path.join(os.tmpdir(), "fanout-seed-"));
+    try {
+      execFileSync("git", ["--git-dir", bareDir, "worktree", "add", "--orphan", "-b", "main", tmpWt], {
+        stdio: "pipe",
+        env: GIT_ENV,
+      });
+      execFileSync("git", ["-C", tmpWt, "commit", "--allow-empty", "-m", "init"], {
+        stdio: "pipe",
+        env: GIT_ENV,
+      });
+      fs2.rmSync(tmpWt, { recursive: true, force: true });
+      execFileSync("git", ["--git-dir", bareDir, "worktree", "prune"], { stdio: "pipe" });
+    } catch {
+      fs2.rmSync(tmpWt, { recursive: true, force: true });
+      throw new Error("Failed to seed bare repo");
+    }
+  }
+
+  /**
+   * Builds a real bare-structure container with N worktrees.
+   * Layout: <container>/.bare (bare repo) + <container>/wt1, wt2, ... (worktrees)
+   * Returns the container path and the worktree absolute paths.
+   */
+  function makeBareTopology(containerName: string, worktreeNames: string[]): {
+    container: string;
+    worktrees: string[];
+  } {
+    const container = path.join(tmpDir, containerName);
+    fs2.mkdirSync(container, { recursive: true });
+    const bareDir = path.join(container, ".bare");
+    execFileSync("git", ["init", "--bare", bareDir], { stdio: "pipe", env: GIT_ENV });
+    seedBareRepo(bareDir);
+
+    const worktrees: string[] = [];
+    for (const name of worktreeNames) {
+      const wtDir = path.join(container, name);
+      execFileSync("git", ["--git-dir", bareDir, "worktree", "add", wtDir], {
+        stdio: "pipe",
+        env: GIT_ENV,
+      });
+      // git worktree add canonicalizes; capture the path git itself reports so
+      // assertions byte-match resolveDeployTargets output.
+      worktrees.push(fs2.realpathSync(wtDir));
+    }
+    return { container, worktrees };
+  }
+
+  /** Writes a single skill source under rootDir so a non-empty components section deploys. */
+  async function seedSkill(name: string): Promise<void> {
+    const skillDir = path.join(rootDir, "skills", name);
+    await fs.mkdir(skillDir, { recursive: true });
+    await writeFile(path.join(skillDir, "SKILL.md"), `# ${name}\n`);
+  }
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "fanout-test-"));
+    rootDir = path.join(tmpDir, "root");
+    await fs.mkdir(path.join(rootDir, "skills"), { recursive: true });
+    await writeFile(path.join(rootDir, "config.yaml"), "use-platforms: [claude]\n");
+    _resetConfigCache();
+  });
+
+  afterEach(async () => {
+    // Restore modes that an unwritable-worktree test may have left (chmod 555)
+    // so the recursive rm can traverse and delete every directory.
+    async function chmodTree(dir: string): Promise<void> {
+      await fs.chmod(dir, 0o755).catch(() => {});
+      let entries: import("fs").Dirent[] = [];
+      try {
+        entries = (await fs.readdir(dir, { withFileTypes: true })) as import("fs").Dirent[];
+      } catch {
+        return;
+      }
+      for (const e of entries) {
+        if (e.isDirectory()) await chmodTree(path.join(dir, e.name));
+      }
+    }
+    await chmodTree(tmpDir);
+    await fs.rm(tmpDir, { recursive: true, force: true });
+    _resetConfigCache();
+  });
+
+  // AC2.1 — every worktree receives the component
+  it("AC2.1: fans the skill out to wt1's .claude/", async () => {
+    const { container, worktrees } = makeBareTopology("repo", ["wt1", "wt2"]);
+    await seedSkill("oracle");
+
+    const syncYamlPath = path.join(rootDir, "sync.yaml");
+    await writeFile(syncYamlPath, `path: ${container}\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`);
+
+    const adapters = new Map<Platform, PlatformAdapter>([["claude", new ClaudeAdapter()]]) as AdapterMap;
+    const context = makeContext({ dryRun: false });
+
+    await processYaml(context, syncYamlPath, adapters, rootDir);
+
+    expect(await exists(path.join(worktrees[0]!, ".claude", "skills", "oracle", "SKILL.md"))).toBe(true);
+  });
+
+  it("AC2.1: fans the skill out to wt2's .claude/ (separate assertion)", async () => {
+    const { container, worktrees } = makeBareTopology("repo", ["wt1", "wt2"]);
+    await seedSkill("oracle");
+
+    const syncYamlPath = path.join(rootDir, "sync.yaml");
+    await writeFile(syncYamlPath, `path: ${container}\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`);
+
+    const adapters = new Map<Platform, PlatformAdapter>([["claude", new ClaudeAdapter()]]) as AdapterMap;
+    const context = makeContext({ dryRun: false });
+
+    await processYaml(context, syncYamlPath, adapters, rootDir);
+
+    expect(await exists(path.join(worktrees[1]!, ".claude", "skills", "oracle", "SKILL.md"))).toBe(true);
+  });
+
+  // AC2.2 — container itself must NOT receive .claude/
+  it("AC2.2: the bare container never gets a .claude/ directory", async () => {
+    const { container } = makeBareTopology("repo", ["wt1", "wt2"]);
+    await seedSkill("oracle");
+
+    const syncYamlPath = path.join(rootDir, "sync.yaml");
+    await writeFile(syncYamlPath, `path: ${container}\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`);
+
+    const adapters = new Map<Platform, PlatformAdapter>([["claude", new ClaudeAdapter()]]) as AdapterMap;
+    const context = makeContext({ dryRun: false });
+
+    await processYaml(context, syncYamlPath, adapters, rootDir);
+
+    expect(await exists(path.join(container, ".claude"))).toBe(false);
+  });
+
+  // AC2.3 — non-bare path keeps today's single-target behavior
+  it("AC2.3 (regression): a plain non-bare path deploys to <path>/.claude/", async () => {
+    const plainTarget = path.join(tmpDir, "plain-target");
+    await fs.mkdir(plainTarget, { recursive: true });
+    await seedSkill("oracle");
+
+    const syncYamlPath = path.join(rootDir, "sync.yaml");
+    await writeFile(syncYamlPath, `path: ${plainTarget}\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`);
+
+    const adapters = new Map<Platform, PlatformAdapter>([["claude", new ClaudeAdapter()]]) as AdapterMap;
+    const context = makeContext({ dryRun: false });
+
+    await processYaml(context, syncYamlPath, adapters, rootDir);
+
+    expect(await exists(path.join(plainTarget, ".claude", "skills", "oracle", "SKILL.md"))).toBe(true);
+  });
+
+  // AC3a — one unwritable worktree does not block the others
+  it("AC3a: one unwritable worktree does not block deployment to the writable one", async () => {
+    const { worktrees } = makeBareTopology("repo", ["wt1", "wt2"]);
+    await seedSkill("oracle");
+
+    // Make wt2 unwritable (read+execute, no write): git can still enumerate it
+    // (it reads the worktree's .git file), but the deploy's .claude mkdir is denied.
+    // chmod 000 would strip execute too → git reports the worktree prunable and it
+    // is excluded from enumeration before deploy, which is NOT the failure under test.
+    await fs.chmod(worktrees[1]!, 0o555);
+
+    const container = path.dirname(worktrees[0]!);
+    const syncYamlPath = path.join(rootDir, "sync.yaml");
+    await writeFile(syncYamlPath, `path: ${container}\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`);
+
+    const adapters = new Map<Platform, PlatformAdapter>([["claude", new ClaudeAdapter()]]) as AdapterMap;
+    const context = makeContext({ dryRun: false });
+
+    await processYaml(context, syncYamlPath, adapters, rootDir);
+
+    // wt1 still got the skill despite wt2 failing.
+    expect(await exists(path.join(worktrees[0]!, ".claude", "skills", "oracle", "SKILL.md"))).toBe(true);
+
+    // restore so afterEach cleanup works
+    await fs.chmod(worktrees[1]!, 0o755);
+  });
+
+  // AC3b — failure is recorded with the worktree path and drives a non-zero exit
+  it("AC3b: a failing worktree is recorded in context.failedTargets", async () => {
+    const { worktrees } = makeBareTopology("repo", ["wt1", "wt2"]);
+    await seedSkill("oracle");
+
+    // read+execute, no write — enumerable by git, unwritable by the deploy (see AC3a).
+    await fs.chmod(worktrees[1]!, 0o555);
+
+    const container = path.dirname(worktrees[0]!);
+    const syncYamlPath = path.join(rootDir, "sync.yaml");
+    await writeFile(syncYamlPath, `path: ${container}\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`);
+
+    const adapters = new Map<Platform, PlatformAdapter>([["claude", new ClaudeAdapter()]]) as AdapterMap;
+    const context = makeContext({ dryRun: false });
+
+    await processYaml(context, syncYamlPath, adapters, rootDir);
+
+    // failedTargets is the mechanism the CLI uses to force a non-zero exit.
+    expect(context.failedTargets).toContain(worktrees[1]);
+
+    await fs.chmod(worktrees[1]!, 0o755);
+  });
+
+  // AC5.1 — deriveClaudeProjectKey has EXACTLY ONE call site
+  it("AC5.1: deriveClaudeProjectKey has exactly one production call site", () => {
+    const claudeSrc = fs2.readFileSync(
+      path.join(import.meta.dir, "adapters", "claude.ts"),
+      "utf8",
+    );
+    // Count only the call (the import line is `import { deriveClaudeProjectKey }`).
+    const callMatches = claudeSrc.match(/deriveClaudeProjectKey\(/g) ?? [];
+    expect(callMatches.length).toBe(1);
+
+    // Repo-wide: no other production file calls it.
+    const syncSrc = fs2.readFileSync(path.join(import.meta.dir, "sync.ts"), "utf8");
+    expect(syncSrc.includes("deriveClaudeProjectKey(")).toBe(false);
+  });
+
+  // AC5.2 — MCP keying collapses N worktree writes into ONE ~/.claude.json entry
+  it("AC5.2: a fan-out MCP sync writes exactly one projects[key] entry, keyed by the shared .bare", async () => {
+    const originalHome = process.env.HOME;
+    const fakeHome = await fs.mkdtemp(path.join(os.tmpdir(), "fanout-fake-home-"));
+    process.env.HOME = fakeHome;
+    try {
+      const { container, worktrees } = makeBareTopology("mcp-repo", ["wt1", "wt2"]);
+
+      // Every worktree resolves to the SAME .bare common-dir key — that shared key
+      // is why N per-worktree MCP writes collapse into one ~/.claude.json entry.
+      // (The container is never deployed-to, AC2.2, so its key is irrelevant.)
+      const k1 = deriveClaudeProjectKey(worktrees[0]!);
+      const k2 = deriveClaudeProjectKey(worktrees[1]!);
+      expect(k1).toBe(k2);
+
+      // Project-scoped sync.yaml so claude.yaml mcps deploy with scope=local.
+      const projDir = path.join(rootDir, "projects", "mcp-proj");
+      await fs.mkdir(projDir, { recursive: true });
+      const syncYamlPath = path.join(projDir, "sync.yaml");
+      await writeFile(syncYamlPath, `path: ${container}\nname: mcp-proj\n`);
+      await writeFile(
+        path.join(projDir, "claude.yaml"),
+        "mcps:\n  my-server:\n    type: stdio\n    command: my-mcp\n",
+      );
+
+      const adapters = new Map<Platform, PlatformAdapter>([["claude", new ClaudeAdapter()]]) as AdapterMap;
+      const context = makeContext({ dryRun: false, isRootYaml: false });
+
+      await processYaml(context, syncYamlPath, adapters, rootDir);
+
+      const claudeJson = JSON.parse(
+        await fs.readFile(path.join(fakeHome, ".claude.json"), "utf8"),
+      ) as { projects?: Record<string, unknown> };
+      const projects = claudeJson.projects ?? {};
+      // N worktree writes collapse to exactly one entry, keyed by the shared .bare.
+      expect(Object.keys(projects).length).toBe(1);
+      expect(projects[k1]).toBeDefined();
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      await fs.rm(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  // AC6.1 — dry-run lists each worktree, never the container, writes nothing
+  it("AC6.1: dry-run lists each worktree absolute path, not the container, and writes nothing", async () => {
+    const { container, worktrees } = makeBareTopology("repo", ["wt1", "wt2"]);
+    await seedSkill("oracle");
+
+    const syncYamlPath = path.join(rootDir, "sync.yaml");
+    await writeFile(syncYamlPath, `path: ${container}\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`);
+
+    const adapters = new Map<Platform, PlatformAdapter>([["claude", new ClaudeAdapter()]]) as AdapterMap;
+    const context = makeContext({ dryRun: true });
+
+    const lines: string[] = [];
+    const origStderr = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk: string | Uint8Array) => {
+      if (typeof chunk === "string") lines.push(chunk);
+      return true;
+    };
+    try {
+      await processYaml(context, syncYamlPath, adapters, rootDir);
+    } finally {
+      process.stderr.write = origStderr;
+    }
+
+    const out = lines.join("");
+    // Each worktree absolute path appears as a deploy target line.
+    expect(out).toContain(worktrees[0]!);
+    expect(out).toContain(worktrees[1]!);
+    // No files written in dry-run.
+    expect(await exists(path.join(worktrees[0]!, ".claude"))).toBe(false);
+    expect(await exists(path.join(worktrees[1]!, ".claude"))).toBe(false);
+    expect(await exists(path.join(container, ".claude"))).toBe(false);
+  });
+
+  // AC6.2 — pre-placed rule survives the wipe (rules exempt)
+  it("AC6.2: a pre-placed rule under wt1 survives the fan-out wipe", async () => {
+    const { container, worktrees } = makeBareTopology("repo", ["wt1", "wt2"]);
+    await seedSkill("oracle");
+
+    // Pre-place a user rule in wt1/.claude/rules.
+    const rulePath = path.join(worktrees[0]!, ".claude", "rules", "x.md");
+    await writeFile(rulePath, "# user rule\n");
+
+    const syncYamlPath = path.join(rootDir, "sync.yaml");
+    await writeFile(syncYamlPath, `path: ${container}\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`);
+
+    const adapters = new Map<Platform, PlatformAdapter>([["claude", new ClaudeAdapter()]]) as AdapterMap;
+    const context = makeContext({ dryRun: false });
+
+    await processYaml(context, syncYamlPath, adapters, rootDir);
+
+    expect(await exists(rulePath)).toBe(true);
+  });
+
+  // AC6.3 — per-worktree backup of replaced category lands under each worktree
+  it("AC6.3: replacing the skills category backs the old skill up under wt1's .sync-backup", async () => {
+    const { container, worktrees } = makeBareTopology("repo", ["wt1", "wt2"]);
+    await seedSkill("oracle");
+
+    // Pre-place an old skill in wt1 that the wipe will replace.
+    const oldSkill = path.join(worktrees[0]!, ".claude", "skills", "old", "SKILL.md");
+    await writeFile(oldSkill, "# old\n");
+
+    const syncYamlPath = path.join(rootDir, "sync.yaml");
+    await writeFile(syncYamlPath, `path: ${container}\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`);
+
+    const adapters = new Map<Platform, PlatformAdapter>([["claude", new ClaudeAdapter()]]) as AdapterMap;
+    const context = makeContext({ dryRun: false, backupSession: "sess-ac63" });
+
+    await processYaml(context, syncYamlPath, adapters, rootDir);
+
+    const backupCopy = path.join(
+      worktrees[0]!,
+      ".sync-backup",
+      "sess-ac63",
+      "claude",
+      "skills",
+      "old",
+      "SKILL.md",
+    );
+    expect(await exists(backupCopy)).toBe(true);
+  });
+
+  // DeployTargetsError escapes the per-project catch (re-throw, like ProjectKeyError)
+  it("DeployTargetsError escapes the per-project isolation catch so it reaches a non-zero exit", async () => {
+    // Bare-structure with ZERO worktrees → resolveDeployTargets throws DeployTargetsError.
+    const container = path.join(tmpDir, "empty-bare");
+    await fs.mkdir(container, { recursive: true });
+    const bareDir = path.join(container, ".bare");
+    execFileSync("git", ["init", "--bare", bareDir], { stdio: "pipe", env: GIT_ENV });
+    seedBareRepo(bareDir);
+    // no worktree added → resolveDeployTargets throws
+
+    await seedSkill("oracle");
+    const projDir = path.join(rootDir, "projects", "empty-proj");
+    await fs.mkdir(projDir, { recursive: true });
+    await writeFile(
+      path.join(projDir, "sync.yaml"),
+      `path: ${container}\nname: empty-proj\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`,
+    );
+
+    const adapters = new Map<Platform, PlatformAdapter>([["claude", new ClaudeAdapter()]]) as AdapterMap;
+    const context = makeContext({ dryRun: false });
+    const effectiveFilter = resolveProjectFilter(new Set(), undefined);
+
+    await expect(
+      runProjectsLoop(rootDir, adapters, context, effectiveFilter, false),
+    ).rejects.toBeInstanceOf(DeployTargetsError);
   });
 });

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -24,6 +24,7 @@ import {
 import type { SyncContext, Platform, Category, SyncYaml } from "./lib/types.ts";
 import type { PlatformAdapter } from "./adapters/types.ts";
 import { _resetConfigCache } from "./lib/config.ts";
+import { ProjectKeyError } from "./lib/git-key.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -643,6 +644,55 @@ describe("syncPlatformConfigs", () => {
     expect(calls.some((c) => c.method === "syncPlatformYaml")).toBe(true);
     // gemini adapter not called (no gemini.yaml)
     expect(adapters.getAdapter("gemini")!.calls.filter((c) => c.method === "syncPlatformYaml")).toHaveLength(0);
+  });
+
+  it("rethrows ProjectKeyError instead of swallowing it (local MCP key-derivation must fail loudly)", async () => {
+    await writeFile(
+      path.join(yamlDir, "claude.yaml"),
+      "mcps:\n  notion:\n    url: https://example.com\n",
+    );
+
+    const claudeAdapter = makeMockAdapter("claude");
+    // Simulate deriveClaudeProjectKey failing inside syncMcpsMerge (branch d).
+    claudeAdapter.syncPlatformYaml = async () => {
+      throw new ProjectKeyError("/some/target", new Error("dubious ownership"));
+    };
+
+    const adapters = new Map<Platform, PlatformAdapter>([["claude", claudeAdapter]]) as AdapterMap & {
+      getAdapter: (p: Platform) => ReturnType<typeof makeMockAdapter> | undefined;
+    };
+    adapters.getAdapter = (_p: Platform) => undefined;
+
+    const context = makeContext();
+
+    // Must NOT be swallowed: the key-derivation failure has to escape the catch.
+    await expect(
+      syncPlatformConfigs(context, targetPath, yamlDir, adapters, rootDir),
+    ).rejects.toBeInstanceOf(ProjectKeyError);
+  });
+
+  it("still swallows non-ProjectKeyError per-platform config errors (warn-and-continue preserved)", async () => {
+    await writeFile(
+      path.join(yamlDir, "claude.yaml"),
+      "config:\n  theme: dark\n",
+    );
+
+    const claudeAdapter = makeMockAdapter("claude");
+    claudeAdapter.syncPlatformYaml = async () => {
+      throw new Error("config write failed");
+    };
+
+    const adapters = new Map<Platform, PlatformAdapter>([["claude", claudeAdapter]]) as AdapterMap & {
+      getAdapter: (p: Platform) => ReturnType<typeof makeMockAdapter> | undefined;
+    };
+    adapters.getAdapter = (_p: Platform) => undefined;
+
+    const context = makeContext();
+
+    // Generic config/hooks/plugins errors keep warn-and-continue: no throw.
+    await expect(
+      syncPlatformConfigs(context, targetPath, yamlDir, adapters, rootDir),
+    ).resolves.toBeUndefined();
   });
 
   it("stores model-map in context.modelMaps (P2-1)", async () => {
@@ -2423,5 +2473,56 @@ describe("enabled-projects 화이트리스트 — projects 루프 통합", () =>
 
     expect(threw).toBe(false);
     expect(warns.some((w) => w.includes("does-not-exist"))).toBe(true);
+  });
+
+  it("ProjectKeyError escapes the projects loop (not isolated) so it reaches a non-zero exit", async () => {
+    const targetA = path.join(tmpDir, "target-a");
+    await fs.mkdir(targetA, { recursive: true });
+
+    await writeFile(path.join(rootDir, "config.yaml"), "use-platforms: [claude]\n");
+    await writeFile(path.join(rootDir, "projects", "proj-a", "sync.yaml"), `path: ${targetA}\n`);
+    // claude.yaml present → syncPlatformConfigs invokes the adapter.
+    await writeFile(
+      path.join(rootDir, "projects", "proj-a", "claude.yaml"),
+      "mcps:\n  notion:\n    url: https://example.com\n",
+    );
+
+    const adapters = makeAdapterMap(["claude"]);
+    adapters.getAdapter("claude")!.syncPlatformYaml = async () => {
+      throw new ProjectKeyError(targetA, new Error("dubious ownership"));
+    };
+
+    const context = makeContext();
+    const effectiveFilter = resolveProjectFilter(new Set(), undefined);
+
+    // The per-project isolation catch must NOT swallow a ProjectKeyError.
+    await expect(
+      runProjectsLoop(rootDir, adapters, context, effectiveFilter, false),
+    ).rejects.toBeInstanceOf(ProjectKeyError);
+  });
+
+  it("generic project errors stay isolated (loop continues, no throw)", async () => {
+    const targetA = path.join(tmpDir, "target-a");
+    await fs.mkdir(targetA, { recursive: true });
+
+    await writeFile(path.join(rootDir, "config.yaml"), "use-platforms: [claude]\n");
+    await writeFile(path.join(rootDir, "projects", "proj-a", "sync.yaml"), `path: ${targetA}\n`);
+    await writeFile(
+      path.join(rootDir, "projects", "proj-a", "claude.yaml"),
+      "mcps:\n  notion:\n    url: https://example.com\n",
+    );
+
+    const adapters = makeAdapterMap(["claude"]);
+    adapters.getAdapter("claude")!.syncPlatformYaml = async () => {
+      throw new Error("generic adapter failure");
+    };
+
+    const context = makeContext();
+    const effectiveFilter = resolveProjectFilter(new Set(), undefined);
+
+    // Non-ProjectKeyError keeps per-project isolation: loop does not throw.
+    await expect(
+      runProjectsLoop(rootDir, adapters, context, effectiveFilter, false),
+    ).resolves.toBeUndefined();
   });
 });

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -1656,7 +1656,7 @@ describe("syncLib", () => {
     expect(await exists(path.join(libDest, "foo", "other.yaml"))).toBe(false);
   });
 
-  it("lists source-traced data files in dry-run even when no @lib/ imports exist (AC8)", async () => {
+  it("skips lib entirely in dry-run when no @lib/ imports exist, even if data files exist in lib source tree", async () => {
     const libSrc = path.join(rootDir, "lib");
     // A lib module that statically references a sibling data file via import.meta.dir,
     // plus the data file itself. This is traced from the SOURCE tree, independent of
@@ -1668,8 +1668,8 @@ describe("syncLib", () => {
     await writeFile(path.join(libSrc, "pins", "tbox.yaml"), "schema: 1\n");
 
     // The component sources have NO @lib/ imports → requiredModules is empty.
-    // collectLibDataFiles still traces tbox.yaml from the SOURCE lib tree,
-    // independent of what any component imports — the exact AC8 condition.
+    // With zero modules, data files have no consumer — the whole lib deploy is
+    // skipped (requiredModules === 0 takes the skip path regardless of dataFiles).
     const sourceTs = path.join(rootDir, "skills", "plain", "run.ts");
     await writeFile(sourceTs, "export const hello = 'world';\n");
 
@@ -1686,8 +1686,11 @@ describe("syncLib", () => {
       process.stderr.write = origStderr;
     }
 
-    // The dry-run enumeration must still list the source-traced data file.
-    expect(lines.some((l) => l.includes(path.join("pins", "tbox.yaml")))).toBe(true);
+    // Zero modules → skip path taken: no "Deploy lib modules" line and no tbox.yaml
+    // listed in the dry-run output. The skip-path logInfo line is the only output.
+    expect(lines.some((l) => l.includes("Deploy lib modules"))).toBe(false);
+    expect(lines.some((l) => l.includes(path.join("pins", "tbox.yaml")))).toBe(false);
+    expect(lines.some((l) => l.includes("skipping lib deployment"))).toBe(true);
   });
 
   it("rewrites @lib/* import aliases to relative paths via `syncLib`", async () => {
@@ -1771,6 +1774,85 @@ describe("syncLib", () => {
     const entries = await fs.readdir(platformDir);
     const tempLeftovers = entries.filter((e) => e.startsWith("lib.tmp-"));
     expect(tempLeftovers).toHaveLength(0);
+  });
+
+  // Regression (a): zero-module target → no lib dir, no tbox.yaml
+  it("제로 @lib 모듈 타겟: lib 디렉토리와 tbox.yaml 모두 배포하지 않음 via `syncLib`", async () => {
+    const libSrc = path.join(rootDir, "lib");
+    // tbox.yaml exists in lib source tree (it would be a data file if any module imported it)
+    await writeFile(
+      path.join(libSrc, "pins", "store.ts"),
+      'import { join } from "path";\nexport const P = join(import.meta.dir, "tbox.yaml");\n',
+    );
+    await writeFile(path.join(libSrc, "pins", "tbox.yaml"), "schema: 1\n");
+
+    // Component has NO @lib/ imports → requiredModules will be empty
+    const sourceTs = path.join(rootDir, "skills", "no-lib", "run.ts");
+    await writeFile(sourceTs, "export const hello = 'world';\n");
+
+    await syncLib(makeContext(), targetPath, rootDir, ["claude"], libRoots("claude", sourceTs));
+
+    // Zero modules → skip path: no lib directory created at all
+    const libDest = path.join(targetPath, ".claude", "lib");
+    expect(await exists(libDest)).toBe(false);
+    // tbox.yaml has no consumer → must not be deployed
+    expect(await exists(path.join(libDest, "pins", "tbox.yaml"))).toBe(false);
+  });
+
+  // Regression (b): module-bearing target → lib deploys INCLUDING tbox.yaml
+  it("@lib 모듈 보유 타겟: lib 배포 시 tbox.yaml 데이터 파일도 함께 배포 via `syncLib`", async () => {
+    const libSrc = path.join(rootDir, "lib");
+    // A lib module that references tbox.yaml as a data file
+    await writeFile(
+      path.join(libSrc, "pins", "store.ts"),
+      'import { join } from "path";\nexport const P = join(import.meta.dir, "tbox.yaml");\n',
+    );
+    await writeFile(path.join(libSrc, "pins", "tbox.yaml"), "schema: 1\n");
+
+    // Component DOES import the lib module → requiredModules is non-empty
+    const sourceTs = path.join(rootDir, "skills", "pin-user", "run.ts");
+    await writeFile(sourceTs, "import { P } from '@lib/pins/store';\n");
+
+    await syncLib(makeContext(), targetPath, rootDir, ["claude"], libRoots("claude", sourceTs));
+
+    const libDest = path.join(targetPath, ".claude", "lib");
+    // The module deploys
+    expect(await exists(path.join(libDest, "pins", "store.ts"))).toBe(true);
+    // tbox.yaml rides along with its module
+    expect(await exists(path.join(libDest, "pins", "tbox.yaml"))).toBe(true);
+  });
+
+  // Regression (c): hook-only @lib usage → requiredModules > 0 → lib deploys
+  it("훅 소스만으로도 @lib 임포트가 있으면 lib 배포됨 via `syncLib`", async () => {
+    const libSrc = path.join(rootDir, "lib");
+    // A lib module referenced only by a hook (not a skill/agent component)
+    await writeFile(path.join(libSrc, "omt-dir.ts"), "export const OMT_DIR = '/tmp';\n");
+    await writeFile(
+      path.join(libSrc, "pins", "store.ts"),
+      'import { join } from "path";\nexport const P = join(import.meta.dir, "tbox.yaml");\n',
+    );
+    await writeFile(path.join(libSrc, "pins", "tbox.yaml"), "schema: 1\n");
+
+    // The hook source (simulating pin-session-start/index.ts) imports @lib/
+    const hookSource = path.join(rootDir, "hooks", "pin-session-start", "index.ts");
+    await writeFile(
+      hookSource,
+      "import { OMT_DIR } from '@lib/omt-dir';\nimport { P } from '@lib/pins/store';\n",
+    );
+
+    // No component imports @lib/ — ONLY the hook does.
+    // libRoots constructed with the hook source (mirrors how syncPlatformConfigs
+    // calls addLibSourceRoot for hook sources at tools/sync.ts:236-241).
+    const hookRoots = libRoots("claude", hookSource);
+
+    await syncLib(makeContext(), targetPath, rootDir, ["claude"], hookRoots);
+
+    // Hook-only @lib → requiredModules > 0 → lib deploys
+    const libDest = path.join(targetPath, ".claude", "lib");
+    expect(await exists(path.join(libDest, "omt-dir.ts"))).toBe(true);
+    expect(await exists(path.join(libDest, "pins", "store.ts"))).toBe(true);
+    // tbox.yaml also deploys (data file for the hook's lib module)
+    expect(await exists(path.join(libDest, "pins", "tbox.yaml"))).toBe(true);
   });
 });
 

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -20,6 +20,7 @@ import {
   resolveProjectFilter,
   runProjectsLoop,
   allTargetsProcessed,
+  isFatalSyncError,
   type AdapterMap,
   type LibSourceRoots,
 } from "./sync.ts";
@@ -2533,6 +2534,32 @@ describe("enabled-projects 화이트리스트 — projects 루프 통합", () =>
     await expect(
       runProjectsLoop(rootDir, adapters, context, effectiveFilter, false),
     ).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: isFatalSyncError
+// ---------------------------------------------------------------------------
+
+describe("isFatalSyncError", () => {
+  it("returns true for ProjectKeyError", () => {
+    const err = new ProjectKeyError("/target", new Error("key failure"));
+    expect(isFatalSyncError(err)).toBe(true);
+  });
+
+  it("returns true for DeployTargetsError", () => {
+    const err = new DeployTargetsError("/target", "zero worktrees");
+    expect(isFatalSyncError(err)).toBe(true);
+  });
+
+  it("returns false for generic Error", () => {
+    expect(isFatalSyncError(new Error("boom"))).toBe(false);
+  });
+
+  it("returns false for non-Error values", () => {
+    expect(isFatalSyncError("string error")).toBe(false);
+    expect(isFatalSyncError(42)).toBe(false);
+    expect(isFatalSyncError(null)).toBe(false);
   });
 });
 

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -28,6 +28,7 @@ import { _resetConfigCache } from "./lib/config.ts";
 import { ProjectKeyError, deriveClaudeProjectKey } from "./lib/git-key.ts";
 import { DeployTargetsError } from "./lib/resolve-deploy-targets.ts";
 import { ClaudeAdapter } from "./adapters/claude.ts";
+import { cleanupOldBackups } from "./lib/backup.ts";
 import { execFileSync } from "child_process";
 
 // ---------------------------------------------------------------------------
@@ -2889,6 +2890,52 @@ describe("component fan-out", () => {
       "SKILL.md",
     );
     expect(await exists(backupCopy)).toBe(true);
+  });
+
+  // AC6.4 — fanned-out worktree backups are retention-pruned
+  it("AC6.4: retention cleanup removes stale backup sessions from each worktree's .sync-backup", async () => {
+    const { container, worktrees } = makeBareTopology("repo", ["wt1", "wt2"]);
+    await seedSkill("oracle");
+
+    const syncYamlPath = path.join(rootDir, "sync.yaml");
+    await writeFile(syncYamlPath, `path: ${container}\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`);
+
+    const adapters = new Map<Platform, PlatformAdapter>([["claude", new ClaudeAdapter()]]) as AdapterMap;
+
+    // Pre-place old content in both worktrees so cycle 1 has something to back up.
+    await writeFile(path.join(worktrees[0]!, ".claude", "skills", "old", "SKILL.md"), "# old\n");
+    await writeFile(path.join(worktrees[1]!, ".claude", "skills", "old", "SKILL.md"), "# old\n");
+
+    // Cycle 1: backs up the pre-placed content into "old-session" in each worktree.
+    const context1 = makeContext({ dryRun: false, backupSession: "old-session" });
+    await processYaml(context1, syncYamlPath, adapters, rootDir);
+
+    // Confirm old-session backup exists in both worktrees before cleanup.
+    const oldBk0 = path.join(worktrees[0]!, ".sync-backup", "old-session");
+    const oldBk1 = path.join(worktrees[1]!, ".sync-backup", "old-session");
+    expect(await exists(oldBk0)).toBe(true);
+    expect(await exists(oldBk1)).toBe(true);
+
+    // Verify the OLD behavior (processedPaths-only) does NOT reach the worktree backups:
+    // processedPaths holds only the container path for bare structures.
+    await Promise.all(
+      [...context1.processedPaths].map((t) => cleanupOldBackups(t, 0).catch(() => {})),
+    );
+    expect(await exists(oldBk0)).toBe(true); // still present — container-only cleanup misses worktrees
+    expect(await exists(oldBk1)).toBe(true);
+
+    // Cycle 2: oracle is now present in each worktree, so it gets backed up as "new-session".
+    const context2 = makeContext({ dryRun: false, backupSession: "new-session" });
+    await processYaml(context2, syncYamlPath, adapters, rootDir);
+
+    // Run cleanup on the union of processedPaths + backupRoots (retention=0 prunes all sessions).
+    // This mirrors the production loop after the TODO-3 fix.
+    const cleanupTargets = new Set<string>([...context2.processedPaths, ...context2.backupRoots]);
+    await Promise.all([...cleanupTargets].map((t) => cleanupOldBackups(t, 0).catch(() => {})));
+
+    // Both worktrees' old-session dirs must now be removed.
+    expect(await exists(oldBk0)).toBe(false);
+    expect(await exists(oldBk1)).toBe(false);
   });
 
   // DeployTargetsError escapes the per-project catch (re-throw, like ProjectKeyError)

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -1215,17 +1215,6 @@ describe("processYaml", () => {
     const mcpOnlyTargetPath = path.join(tmpDir, "mcp-only-target");
     await fs.mkdir(mcpOnlyTargetPath, { recursive: true });
 
-    const mcpOnlySyncYamlPath = path.join(rootDir, "sync-mcp-only.yaml");
-    await writeFile(mcpOnlySyncYamlPath, `path: ${mcpOnlyTargetPath}\n`);
-    // claude.yaml with only mcps — writes to ~/.claude.json, NOT into <path>/.claude/
-    await writeFile(
-      path.join(rootDir, "claude-mcp-only.yaml"),
-      "mcps:\n  my-server:\n    type: stdio\n    command: my-mcp\n",
-    );
-
-    // Use a custom yamlDir pointing to rootDir so syncPlatformConfigs finds claude-mcp-only.yaml.
-    // processYaml reads yamlDir = path.dirname(syncYamlPath). So we place claude.yaml in rootDir
-    // but we need it named exactly "claude.yaml". Use a sub-tmpDir to isolate.
     const mcpOnlyRootDir = path.join(tmpDir, "mcp-only-root");
     await fs.mkdir(mcpOnlyRootDir, { recursive: true });
     await writeFile(path.join(mcpOnlyRootDir, "config.yaml"), "use-platforms: [claude]\n");

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -1128,12 +1128,21 @@ describe("processYaml", () => {
       // Create target directory inside fakeHome so tilde form is meaningful
       const homeTmpDir = await fs.mkdtemp(path.join(fakeHome, "omt-tilde-test-"));
       try {
-        // Write sync.yaml using tilde form of the target path
+        // Write sync.yaml using tilde form of the target path, with a skill
+        // so that processYaml deploys into .claude/ — confirming tilde expansion.
         const relativePart = path.relative(os.homedir(), homeTmpDir);
         const tildePath = `~/${relativePart}`;
 
+        // Create a skill source so the component section is non-empty
+        const skillDir = path.join(rootDir, "skills", "oracle");
+        await fs.mkdir(skillDir, { recursive: true });
+        await writeFile(path.join(skillDir, "SKILL.md"), "# Oracle\n");
+
         const syncYamlPath = path.join(rootDir, "sync.yaml");
-        await writeFile(syncYamlPath, `path: "${tildePath}"\n`);
+        await writeFile(
+          syncYamlPath,
+          `path: "${tildePath}"\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`,
+        );
 
         const adapters = makeAdapterMap(["claude"]);
         const context = makeContext();
@@ -1199,6 +1208,64 @@ describe("processYaml", () => {
       else process.env.HOME = originalHome;
       await fs.rm(fakeHome, { recursive: true, force: true });
     }
+  });
+
+  it("mcp-only skips claude dir", async () => {
+    // --- MCP-only fixture: claude.yaml has only `mcps`, sync.yaml has no component sections ---
+    const mcpOnlyTargetPath = path.join(tmpDir, "mcp-only-target");
+    await fs.mkdir(mcpOnlyTargetPath, { recursive: true });
+
+    const mcpOnlySyncYamlPath = path.join(rootDir, "sync-mcp-only.yaml");
+    await writeFile(mcpOnlySyncYamlPath, `path: ${mcpOnlyTargetPath}\n`);
+    // claude.yaml with only mcps — writes to ~/.claude.json, NOT into <path>/.claude/
+    await writeFile(
+      path.join(rootDir, "claude-mcp-only.yaml"),
+      "mcps:\n  my-server:\n    type: stdio\n    command: my-mcp\n",
+    );
+
+    // Use a custom yamlDir pointing to rootDir so syncPlatformConfigs finds claude-mcp-only.yaml.
+    // processYaml reads yamlDir = path.dirname(syncYamlPath). So we place claude.yaml in rootDir
+    // but we need it named exactly "claude.yaml". Use a sub-tmpDir to isolate.
+    const mcpOnlyRootDir = path.join(tmpDir, "mcp-only-root");
+    await fs.mkdir(mcpOnlyRootDir, { recursive: true });
+    await writeFile(path.join(mcpOnlyRootDir, "config.yaml"), "use-platforms: [claude]\n");
+    _resetConfigCache();
+    // sync.yaml lives in mcpOnlyRootDir so yamlDir = mcpOnlyRootDir — place claude.yaml there
+    await writeFile(path.join(mcpOnlyRootDir, "claude.yaml"), "mcps:\n  my-server:\n    type: stdio\n    command: my-mcp\n");
+    const mcpOnlySyncYaml = path.join(mcpOnlyRootDir, "sync.yaml");
+    await writeFile(mcpOnlySyncYaml, `path: ${mcpOnlyTargetPath}\n`);
+
+    const adapters = makeAdapterMap(["claude"]);
+    const context = makeContext({ dryRun: false });
+
+    await processYaml(context, mcpOnlySyncYaml, adapters, mcpOnlyRootDir);
+
+    // .claude/ must NOT be created for MCP-only project (nothing deploys into it)
+    expect(await exists(path.join(mcpOnlyTargetPath, ".claude"))).toBe(false);
+
+    // --- Component-bearing fixture: regression guard — .claude/ must still be created ---
+    const compTargetPath = path.join(tmpDir, "comp-target");
+    await fs.mkdir(compTargetPath, { recursive: true });
+    const compRootDir = path.join(tmpDir, "comp-root");
+    await fs.mkdir(compRootDir, { recursive: true });
+    await writeFile(path.join(compRootDir, "config.yaml"), "use-platforms: [claude]\n");
+    _resetConfigCache();
+    const skillDir = path.join(compRootDir, "skills", "oracle");
+    await fs.mkdir(skillDir, { recursive: true });
+    await writeFile(path.join(skillDir, "SKILL.md"), "# Oracle\n");
+    const compSyncYaml = path.join(compRootDir, "sync.yaml");
+    await writeFile(
+      compSyncYaml,
+      `path: ${compTargetPath}\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`,
+    );
+
+    const adapters2 = makeAdapterMap(["claude"]);
+    const context2 = makeContext({ dryRun: false });
+
+    await processYaml(context2, compSyncYaml, adapters2, compRootDir);
+
+    // .claude/ must be created when component items are present
+    expect(await exists(path.join(compTargetPath, ".claude"))).toBe(true);
   });
 });
 

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -488,7 +488,9 @@ export async function syncLib(
     const sourceRoots = libSourceRoots?.get(platform) ?? new Set<string>();
     const requiredModules = await collectRequiredLibModulesFromSources(sourceRoots, libSrc);
 
-    if (requiredModules.size === 0 && dataFiles.size === 0) {
+    // Data files (e.g. pins/tbox.yaml) are runtime assets for lib modules; with
+    // zero modules deployed they have no consumer, so skip the whole lib deploy.
+    if (requiredModules.size === 0) {
       // No @lib/ imports — remove any stale lib (dry-run: log only)
       if (context.dryRun) {
         if (existsSync(libDest)) {

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -1030,9 +1030,12 @@ if (import.meta.main) {
     const cleanupPromises: Promise<void>[] = [];
     if (!dryRun) {
       const retentionDays = await getBackupRetentionDays();
-      // Find all processed target paths and clean up their backups
-      for (const targetPath of context.processedPaths) {
-        cleanupPromises.push(cleanupOldBackups(targetPath, retentionDays).catch(() => {}));
+      // Union of processedPaths (container, drives deploy dedup) and backupRoots (per-worktree
+      // deploy roots populated during fan-out). Set-union ensures a non-bare path present in
+      // both is cleaned exactly once.
+      const cleanupTargets = new Set<string>([...context.processedPaths, ...context.backupRoots]);
+      for (const target of cleanupTargets) {
+        cleanupPromises.push(cleanupOldBackups(target, retentionDays).catch(() => {}));
       }
     }
 

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -76,6 +76,34 @@ function addLibSourceRoot(roots: LibSourceRoots, platform: Platform, sourcePath:
 export const CATEGORIES: Category[] = ["agents", "commands", "skills", "scripts", "rules"];
 
 /**
+ * Single source of truth for "does this project deploy anything into <path>/.claude/?".
+ *
+ * True when EITHER:
+ *   (a) any CATEGORIES section in sync.yaml has ≥1 item, OR
+ *   (b) claude.yaml has a key other than `mcps` (config/hooks/plugins → .claude/ files).
+ *
+ * An MCP-only project (claude.yaml with ONLY `mcps`, no component items) writes to
+ * ~/.claude.json instead of <path>/.claude/, so this returns false for it.
+ *
+ * Both the sync.ts mkdir gate and the components.ts CLI-project-file validation gate
+ * route through this predicate so the two cannot drift.
+ */
+export function deploysToClaudeDotDir(
+  syncYamlData: Record<string, unknown>,
+  parsedClaudeYaml: Record<string, unknown> | null,
+): boolean {
+  const hasComponentSections = CATEGORIES.some((cat) => {
+    const section = syncYamlData[cat];
+    if (section == null || typeof section !== "object") return false;
+    const items = (section as Record<string, unknown>)["items"];
+    return Array.isArray(items) && items.length > 0;
+  });
+  const hasClaudeDotFileDeploy =
+    parsedClaudeYaml != null && Object.keys(parsedClaudeYaml).some((k) => k !== "mcps");
+  return hasComponentSections || hasClaudeDotFileDeploy;
+}
+
+/**
  * Platform×category capability map.
  * Only combinations listed here proceed through backup+wipe+dispatch.
  * Unsupported combos (e.g., codex+agents) are skipped entirely.
@@ -702,17 +730,8 @@ export async function processYaml(
   // MCP-only projects (claude.yaml has only `mcps`) write to ~/.claude.json, not
   // <path>/.claude/, so skip the mkdir to avoid littering an empty directory.
   if (!context.dryRun) {
-    const hasComponentSections = CATEGORIES.some((cat) => {
-      const section = (syncYaml as Record<string, unknown>)[cat];
-      if (section == null || typeof section !== "object") return false;
-      const items = (section as Record<string, unknown>)["items"];
-      return Array.isArray(items) && items.length > 0;
-    });
     const claudeYaml = await parseAndMergePlatformYaml(yamlDir, "claude");
-    const hasClaudeDotFileDeploy =
-      claudeYaml != null &&
-      Object.keys(claudeYaml).some((k) => k !== "mcps");
-    if (hasComponentSections || hasClaudeDotFileDeploy) {
+    if (deploysToClaudeDotDir(syncYaml as Record<string, unknown>, claudeYaml)) {
       await fs.mkdir(path.join(targetPath, ".claude"), { recursive: true });
     }
   }

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -689,6 +689,25 @@ export function allTargetsProcessed(targetPath: string, processedPaths: Set<stri
 }
 
 // ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+/**
+ * True when err is a "fatal" sync error that must always be rethrown rather
+ * than downgraded to warn-and-continue.
+ *
+ * - ProjectKeyError: local MCP key-derivation failed — an MCP was silently
+ *   not written to ~/.claude.json; swallowing would leave the user's config
+ *   corrupted without any signal.
+ * - DeployTargetsError: bare-repo enumeration failed or returned zero
+ *   worktrees; the deployment has no valid target and continuing would silently
+ *   write nothing.
+ */
+export function isFatalSyncError(err: unknown): boolean {
+  return err instanceof ProjectKeyError || err instanceof DeployTargetsError;
+}
+
+// ---------------------------------------------------------------------------
 // processYaml
 // ---------------------------------------------------------------------------
 
@@ -820,9 +839,9 @@ export async function processYaml(
         }
       }
     } catch (err) {
-      // A local-MCP key-derivation failure must never be downgraded: rethrow so
-      // it surfaces as a non-zero exit (an MCP was silently not written).
-      if (err instanceof ProjectKeyError) {
+      // Fatal errors (MCP key-derivation or topology failure) must never be
+      // downgraded: rethrow so they surface as a non-zero exit.
+      if (isFatalSyncError(err)) {
         throw err;
       }
       // Best-effort fan-out (AC3a/3b): one failing worktree is logged WITH its
@@ -975,16 +994,9 @@ export async function runProjectsLoop(
         // straight at a worktree is recognized as already processed.
         recordProcessedTargets(targetPath, context.processedPaths);
       } catch (err) {
-        // A local-MCP key-derivation failure must not be isolated like an
-        // ordinary per-project error: it means an MCP was silently not written.
-        // Let it escape to the top-level handler so the run exits non-zero.
-        if (err instanceof ProjectKeyError) {
-          throw err;
-        }
-        // A topology-resolution failure (bare repo broken / zero worktrees) is
-        // likewise non-recoverable for this project: rethrow so it surfaces as a
-        // non-zero exit rather than being swallowed as a warn-and-continue.
-        if (err instanceof DeployTargetsError) {
+        // Fatal errors (MCP key-derivation or topology failure) must escape to
+        // the top-level handler so the run exits non-zero.
+        if (isFatalSyncError(err)) {
           throw err;
         }
         logError(`프로젝트 처리 실패 (계속 진행): ${projectSyncYaml}: ${err}`);

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -679,11 +679,6 @@ export async function processYaml(
   }
   logInfo("========================================");
 
-  // Ensure .claude directory exists (non-dry)
-  if (!context.dryRun) {
-    await fs.mkdir(path.join(targetPath, ".claude"), { recursive: true });
-  }
-
   // Clear per-project state to prevent cross-project leaks
   context.modelMaps.clear();
   context.platformYamlSections.clear();
@@ -694,6 +689,26 @@ export async function processYaml(
 
   // Per-platform YAML processing
   const yamlDir = path.dirname(syncYamlPath);
+
+  // Ensure .claude directory exists only when something deploys into it (non-dry).
+  // MCP-only projects (claude.yaml has only `mcps`) write to ~/.claude.json, not
+  // <path>/.claude/, so skip the mkdir to avoid littering an empty directory.
+  if (!context.dryRun) {
+    const hasComponentSections = CATEGORIES.some((cat) => {
+      const section = (syncYaml as Record<string, unknown>)[cat];
+      if (section == null || typeof section !== "object") return false;
+      const items = (section as Record<string, unknown>)["items"];
+      return Array.isArray(items) && items.length > 0;
+    });
+    const claudeYaml = await parseAndMergePlatformYaml(yamlDir, "claude");
+    const hasClaudeDotFileDeploy =
+      claudeYaml != null &&
+      Object.keys(claudeYaml).some((k) => k !== "mcps");
+    if (hasComponentSections || hasClaudeDotFileDeploy) {
+      await fs.mkdir(path.join(targetPath, ".claude"), { recursive: true });
+    }
+  }
+
   await syncPlatformConfigs(context, targetPath, yamlDir, adapters, rootDir, libSourceRoots);
 
   // Resolve platforms for lib sync using the full cascade (item, section, syncYaml,

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -33,6 +33,7 @@ import {
 } from "./lib/resolver.ts";
 import { generateBackupSessionId, backupCategory, cleanupOldBackups } from "./lib/backup.ts";
 import { logInfo, logWarn, logError, logDry, logSuccess } from "./lib/logger.ts";
+import { ProjectKeyError } from "./lib/git-key.ts";
 import { syncDirectory, rewriteLibImports } from "./lib/sync-directory.ts";
 import { collectRequiredLibModulesFromSources, collectLibDataFiles } from "./adapters/ts-lib-deps.ts";
 import { ClaudeAdapter } from "./adapters/claude.ts";
@@ -394,6 +395,13 @@ export async function syncPlatformConfigs(
         context.modelMaps.set(platform, result.modelMap);
       }
     } catch (err) {
+      // A failed local-MCP key derivation must never be downgraded to a warning:
+      // it means the MCP was silently not written to ~/.claude.json. Rethrow so it
+      // surfaces as a non-zero exit. All other per-platform config/hooks/plugins
+      // errors keep warn-and-continue.
+      if (err instanceof ProjectKeyError) {
+        throw err;
+      }
       logWarn(`${platform}.yaml 처리 실패: ${err}`);
     }
   }
@@ -872,6 +880,12 @@ export async function runProjectsLoop(
         await processYaml(context, projectSyncYaml, adapters, rootDir);
         context.processedPaths.add(targetPath);
       } catch (err) {
+        // A local-MCP key-derivation failure must not be isolated like an
+        // ordinary per-project error: it means an MCP was silently not written.
+        // Let it escape to the top-level handler so the run exits non-zero.
+        if (err instanceof ProjectKeyError) {
+          throw err;
+        }
         logError(`프로젝트 처리 실패 (계속 진행): ${projectSyncYaml}: ${err}`);
       }
       if (verbose) {

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -425,14 +425,13 @@ export async function syncPlatformConfigs(
         context.modelMaps.set(platform, result.modelMap);
       }
     } catch (err) {
-      // A failed local-MCP key derivation must never be downgraded to a warning:
-      // it means the MCP was silently not written to ~/.claude.json. Rethrow so it
-      // surfaces as a non-zero exit. All other per-platform config/hooks/plugins
-      // errors keep warn-and-continue.
-      if (err instanceof ProjectKeyError) {
-        throw err;
-      }
-      logWarn(`${platform}.yaml 처리 실패: ${err}`);
+      // Rethrow so the per-worktree catch in processYaml records this deploy root
+      // in failedTargets and the CLI exits non-zero. A swallowed config/hooks/
+      // plugins error meant a worktree's .claude was silently left unsynced while
+      // the run reported success — the warn-and-continue here was a pre-fan-out
+      // relic. (ProjectKeyError is rethrown for the same reason — a local MCP not
+      // written to ~/.claude.json.)
+      throw err;
     }
   }
 }
@@ -663,6 +662,33 @@ async function collectMdFiles(dir: string): Promise<string[]> {
 }
 
 // ---------------------------------------------------------------------------
+// Deploy-target dedup
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a path's deploy targets and record every one in processedPaths.
+ *
+ * Dedup is keyed by the RESOLVED deploy target (a bare container fans out to its
+ * worktrees), never by the raw container path — otherwise a second sync.yaml
+ * pointing directly at a worktree would not be recognized as already processed
+ * and would re-deploy (backup+wipe+redeploy) the same .claude a second time.
+ */
+export function recordProcessedTargets(targetPath: string, processedPaths: Set<string>): void {
+  for (const target of resolveDeployTargets(targetPath)) {
+    processedPaths.add(target);
+  }
+}
+
+/**
+ * True when every resolved deploy target for targetPath is already present in
+ * processedPaths (so the path can be skipped). Empty target sets never skip.
+ */
+export function allTargetsProcessed(targetPath: string, processedPaths: Set<string>): boolean {
+  const targets = resolveDeployTargets(targetPath);
+  return targets.length > 0 && targets.every((t) => processedPaths.has(t));
+}
+
+// ---------------------------------------------------------------------------
 // processYaml
 // ---------------------------------------------------------------------------
 
@@ -760,10 +786,6 @@ export async function processYaml(
         await fs.mkdir(path.join(deployRoot, ".claude"), { recursive: true });
       }
 
-      // Record this worktree as a backup root so retention cleanup prunes its
-      // .sync-backup (TODO 3 consumes context.backupRoots).
-      context.backupRoots.add(deployRoot);
-
       await syncPlatformConfigs(context, deployRoot, yamlDir, adapters, rootDir, libSourceRoots);
 
       // Sync 5 categories
@@ -779,6 +801,12 @@ export async function processYaml(
       if (shouldMkdirClaude) {
         await syncLib(context, deployRoot, rootDir, libPlatforms, libSourceRoots);
       }
+
+      // Record this worktree as a backup root ONLY after all sync steps succeeded.
+      // Registering before the steps (or on failure) would let retention cleanup
+      // prune the last good backup of a worktree whose deploy threw — it must hold
+      // a success-only invariant: failed worktrees go to failedTargets, not here.
+      context.backupRoots.add(deployRoot);
 
       // Rewrite platform paths for non-claude platforms
       for (const platform of (["gemini", "codex", "opencode"] as Platform[])) {
@@ -942,7 +970,10 @@ export async function runProjectsLoop(
       }
       try {
         await processYaml(context, projectSyncYaml, adapters, rootDir);
-        context.processedPaths.add(targetPath);
+        // Dedup is keyed by the resolved deploy targets (a bare container's
+        // worktrees), not the raw container path, so a later sync.yaml pointing
+        // straight at a worktree is recognized as already processed.
+        recordProcessedTargets(targetPath, context.processedPaths);
       } catch (err) {
         // A local-MCP key-derivation failure must not be isolated like an
         // ordinary per-project error: it means an MCP was silently not written.
@@ -1017,14 +1048,17 @@ if (import.meta.main) {
         const targetPath = syncYaml.path;
         if (!targetPath) {
           logInfo("루트 sync.yaml에 path가 정의되지 않음 (템플릿 상태)");
-        } else if (context.processedPaths.has(targetPath)) {
+        } else if (allTargetsProcessed(targetPath, context.processedPaths)) {
+          // Skip only when EVERY resolved deploy target was already processed by
+          // projects/ — a root path that resolves to the same worktree(s) as a
+          // project container would otherwise re-deploy the same .claude.
           logWarn(`${targetPath}는 projects/에서 이미 처리됨, 스킵`);
         } else {
           if (verbose) {
             logInfo("[verbose] 루트 sync.yaml 처리 시작");
           }
           await processYaml(context, rootSyncYaml, adapters, rootDir);
-          context.processedPaths.add(targetPath);
+          recordProcessedTargets(targetPath, context.processedPaths);
           if (verbose) {
             logInfo("[verbose] 루트 sync.yaml 처리 완료");
           }

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -34,6 +34,7 @@ import {
 import { generateBackupSessionId, backupCategory, cleanupOldBackups } from "./lib/backup.ts";
 import { logInfo, logWarn, logError, logDry, logSuccess } from "./lib/logger.ts";
 import { ProjectKeyError } from "./lib/git-key.ts";
+import { resolveDeployTargets, DeployTargetsError } from "./lib/resolve-deploy-targets.ts";
 import { syncDirectory, rewriteLibImports } from "./lib/sync-directory.ts";
 import { collectRequiredLibModulesFromSources, collectLibDataFiles } from "./adapters/ts-lib-deps.ts";
 import { ClaudeAdapter } from "./adapters/claude.ts";
@@ -132,6 +133,7 @@ export async function syncCategory(
   syncYaml: SyncYaml,
   adapters: AdapterMap,
   rootDir: string,
+  deployRoot: string,
   libSourceRoots?: LibSourceRoots,
 ): Promise<void> {
   const section = syncYaml[category as keyof SyncYaml] as
@@ -277,7 +279,7 @@ export async function syncCategory(
       const prepKey = `${platform}:${category}`;
       if (!preparedKeys.has(prepKey) && !context.dryRun) {
         await backupCategory(
-          syncYaml.path ?? "",
+          deployRoot,
           platform,
           category,
           context.backupSession,
@@ -286,7 +288,7 @@ export async function syncCategory(
         // Wipe category dir so orphan files from removed components are cleaned up.
         // Rules are excluded: they may contain user-managed files.
         if (category !== "rules") {
-          const categoryDir = path.join(syncYaml.path ?? "", `.${platform}`, category);
+          const categoryDir = path.join(deployRoot, `.${platform}`, category);
           await fs.rm(categoryDir, { recursive: true, force: true });
           await fs.mkdir(categoryDir, { recursive: true });
         }
@@ -300,7 +302,7 @@ export async function syncCategory(
       // Call the appropriate adapter method
       if (category === "agents") {
         await adapter.syncAgentsDirect(
-          syncYaml.path ?? "",
+          deployRoot,
           displayName,
           sourcePath,
           addSkills,
@@ -310,28 +312,28 @@ export async function syncCategory(
         );
       } else if (category === "commands") {
         await adapter.syncCommandsDirect(
-          syncYaml.path ?? "",
+          deployRoot,
           displayName,
           sourcePath,
           false,
         );
       } else if (category === "skills") {
         await adapter.syncSkillsDirect(
-          syncYaml.path ?? "",
+          deployRoot,
           displayName,
           sourcePath,
           false,
         );
       } else if (category === "scripts") {
         await adapter.syncScriptsDirect(
-          syncYaml.path ?? "",
+          deployRoot,
           displayName,
           sourcePath,
           false,
         );
       } else if (category === "rules") {
         await adapter.syncRulesDirect(
-          syncYaml.path ?? "",
+          deployRoot,
           displayName,
           sourcePath,
           false,
@@ -719,46 +721,81 @@ export async function processYaml(
   context.modelMaps.clear();
   context.platformYamlSections.clear();
 
-  // Accumulate component SOURCE paths per platform as configs/categories are
-  // processed; syncLib scans these (not the deployed tree) for @lib/ deps.
-  const libSourceRoots: LibSourceRoots = new Map();
-
   // Per-platform YAML processing
   const yamlDir = path.dirname(syncYamlPath);
-
-  // Ensure .claude directory exists only when something deploys into it (non-dry).
-  // MCP-only projects (claude.yaml has only `mcps`) write to ~/.claude.json, not
-  // <path>/.claude/, so skip the mkdir to avoid littering an empty directory.
-  if (!context.dryRun) {
-    const claudeYaml = await parseAndMergePlatformYaml(yamlDir, "claude");
-    if (deploysToClaudeDotDir(syncYaml as Record<string, unknown>, claudeYaml)) {
-      await fs.mkdir(path.join(targetPath, ".claude"), { recursive: true });
-    }
-  }
-
-  await syncPlatformConfigs(context, targetPath, yamlDir, adapters, rootDir, libSourceRoots);
 
   // Resolve platforms for lib sync using the full cascade (item, section, syncYaml,
   // feature-platforms.lib, use-platforms, hardcoded ["claude"]).
   const libPlatforms = await resolvePlatforms({} as SyncItem, undefined, syncYaml.platforms, "lib");
 
-  // Sync 5 categories
-  for (const category of CATEGORIES) {
-    await syncCategory(context, category, syncYaml, adapters, rootDir, libSourceRoots);
-  }
+  // Parse claude.yaml once (it is colocated with sync.yaml in yamlDir, shared by
+  // every worktree) so the per-worktree mkdir gate need not re-read it.
+  const claudeYaml = await parseAndMergePlatformYaml(yamlDir, "claude");
+  const shouldMkdirClaude = deploysToClaudeDotDir(syncYaml as Record<string, unknown>, claudeYaml);
 
-  // Sync lib
-  await syncLib(context, targetPath, rootDir, libPlatforms, libSourceRoots);
+  // Fan-out (D-1): a bare-structure container deploys into EVERY linked
+  // worktree's .claude/; a plain path resolves to [path] (today's behavior).
+  // targetPath (the container) is NEVER written to — it is the dedup/identity
+  // anchor (processedPaths) and, for a bare structure, a dead-letter.
+  // resolveDeployTargets throws DeployTargetsError on git-enumeration failure or
+  // an empty worktree set — let it escape so it surfaces as a non-zero exit.
+  const deployRoots = resolveDeployTargets(targetPath);
 
-  // Rewrite platform paths for non-claude platforms
-  for (const platform of (["gemini", "codex", "opencode"] as Platform[])) {
-    const platformDir = path.join(targetPath, `.${platform}`);
-    if (existsSync(platformDir)) {
+  for (const deployRoot of deployRoots) {
+    try {
+      // Each worktree's deploy is independent — fresh source-root accumulator so
+      // syncLib targets this deployRoot's .{platform}/lib only.
+      const libSourceRoots: LibSourceRoots = new Map();
+
+      // Per-worktree dry-run target line (AC6.1): list this worktree, never the
+      // container, as a deploy target.
       if (context.dryRun) {
-        logDry(`Rewrite .claude/ paths -> .${platform}/ in ${platformDir}/`);
-      } else {
-        await rewritePlatformPaths(targetPath, platform);
+        logDry(`Deploy target: ${deployRoot}`);
       }
+
+      // Ensure <deployRoot>/.claude exists only when something deploys into it
+      // (non-dry). The container is never the mkdir target (AC2.2): an MCP-only
+      // project writes to ~/.claude.json, not <deployRoot>/.claude/.
+      if (!context.dryRun && shouldMkdirClaude) {
+        await fs.mkdir(path.join(deployRoot, ".claude"), { recursive: true });
+      }
+
+      // Record this worktree as a backup root so retention cleanup prunes its
+      // .sync-backup (TODO 3 consumes context.backupRoots).
+      context.backupRoots.add(deployRoot);
+
+      await syncPlatformConfigs(context, deployRoot, yamlDir, adapters, rootDir, libSourceRoots);
+
+      // Sync 5 categories
+      for (const category of CATEGORIES) {
+        await syncCategory(context, category, syncYaml, adapters, rootDir, deployRoot, libSourceRoots);
+      }
+
+      // Sync lib
+      await syncLib(context, deployRoot, rootDir, libPlatforms, libSourceRoots);
+
+      // Rewrite platform paths for non-claude platforms
+      for (const platform of (["gemini", "codex", "opencode"] as Platform[])) {
+        const platformDir = path.join(deployRoot, `.${platform}`);
+        if (existsSync(platformDir)) {
+          if (context.dryRun) {
+            logDry(`Rewrite .claude/ paths -> .${platform}/ in ${platformDir}/`);
+          } else {
+            await rewritePlatformPaths(deployRoot, platform);
+          }
+        }
+      }
+    } catch (err) {
+      // A local-MCP key-derivation failure must never be downgraded: rethrow so
+      // it surfaces as a non-zero exit (an MCP was silently not written).
+      if (err instanceof ProjectKeyError) {
+        throw err;
+      }
+      // Best-effort fan-out (AC3a/3b): one failing worktree is logged WITH its
+      // path and recorded; the loop continues to the other worktrees. A non-empty
+      // failedTargets later forces the CLI to exit non-zero.
+      logError(`worktree 배포 실패 (계속 진행): ${deployRoot}: ${err}`);
+      context.failedTargets.push(deployRoot);
     }
   }
 
@@ -782,6 +819,8 @@ export function createContext(dryRun: boolean): SyncContext {
     modelMaps: new Map(),
     processedPaths: new Set(),
     platformYamlSections: new Map(),
+    backupRoots: new Set(),
+    failedTargets: [],
   };
 }
 
@@ -905,6 +944,12 @@ export async function runProjectsLoop(
         if (err instanceof ProjectKeyError) {
           throw err;
         }
+        // A topology-resolution failure (bare repo broken / zero worktrees) is
+        // likewise non-recoverable for this project: rethrow so it surfaces as a
+        // non-zero exit rather than being swallowed as a warn-and-continue.
+        if (err instanceof DeployTargetsError) {
+          throw err;
+        }
         logError(`프로젝트 처리 실패 (계속 진행): ${projectSyncYaml}: ${err}`);
       }
       if (verbose) {
@@ -998,7 +1043,12 @@ if (import.meta.main) {
     }
 
     await Promise.all(cleanupPromises);
-    process.exit(0);
+    // Any worktree that failed during the best-effort fan-out forces a non-zero
+    // exit: an unwritable worktree must never be reported as a clean sync.
+    if (context.failedTargets.length > 0) {
+      logError(`일부 worktree 배포 실패 (${context.failedTargets.length}개): ${context.failedTargets.join(", ")}`);
+    }
+    process.exit(context.failedTargets.length > 0 ? 1 : 0);
   } catch (err) {
     logError(`동기화 실패: ${err}`);
     process.exit(1);

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -771,8 +771,14 @@ export async function processYaml(
         await syncCategory(context, category, syncYaml, adapters, rootDir, deployRoot, libSourceRoots);
       }
 
-      // Sync lib
-      await syncLib(context, deployRoot, rootDir, libPlatforms, libSourceRoots);
+      // Sync lib — only when this project deploys local component files into the
+      // platform dir (same gate as the mkdir above). An MCP-only project
+      // (shouldMkdirClaude=false) targets ~/.claude.json, so syncLib must not
+      // reach into the worktree's .{platform}/lib and delete a directory this
+      // sync never owns.
+      if (shouldMkdirClaude) {
+        await syncLib(context, deployRoot, rootDir, libPlatforms, libSourceRoots);
+      }
 
       // Rewrite platform paths for non-claude platforms
       for (const platform of (["gemini", "codex", "opencode"] as Platform[])) {

--- a/tools/validators/components.test.ts
+++ b/tools/validators/components.test.ts
@@ -765,6 +765,58 @@ describe("validateAll — enabled-projects 화이트리스트", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Suite: V7 — claude.yaml 파싱 오류 가드
+// ---------------------------------------------------------------------------
+
+describe("V7: claude.yaml 파싱 오류 가드", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = makeRoot();
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("malformed claude.yaml 시 크래시 대신 구조화된 YAML 파싱 오류를 result.errors에 반환한다 via `validateSyncYamlComponents`", async () => {
+    writeYaml(root, "claude.yaml", `
+hooks:
+  UserPromptSubmit: [invalid: yaml: parse: error
+`);
+    const syncPath = writeYaml(root, "sync.yaml", `
+path: ${root}
+agents:
+  items: []
+`);
+
+    const result = await validateSyncYamlComponents(syncPath, root);
+    expect(result.errors.some((e) => e.includes("YAML 파싱 오류"))).toBe(true);
+    expect(result.errors.some((e) => e.includes("claude.yaml"))).toBe(true);
+  });
+
+  it("malformed claude.local.yaml 시 크래시 대신 구조화된 YAML 파싱 오류를 result.errors에 반환한다 via `validateSyncYamlComponents`", async () => {
+    writeYaml(root, "claude.yaml", `
+hooks:
+  UserPromptSubmit: []
+`);
+    writeYaml(root, "claude.local.yaml", `
+hooks:
+  UserPromptSubmit: [invalid: yaml: parse: error
+`);
+    const syncPath = writeYaml(root, "sync.yaml", `
+path: ${root}
+agents:
+  items: []
+`);
+
+    const result = await validateSyncYamlComponents(syncPath, root);
+    expect(result.errors.some((e) => e.includes("YAML 파싱 오류"))).toBe(true);
+    expect(result.errors.some((e) => e.includes("claude.yaml"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Suite: AC4.1 — bare-structure fan-out (resolveDeployTargets integration)
 // ---------------------------------------------------------------------------
 

--- a/tools/validators/components.test.ts
+++ b/tools/validators/components.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdirSync, writeFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
+import { execFileSync } from "child_process";
+import fs from "fs";
+import os from "os";
 
 import {
   validateSyncYamlComponents,
@@ -44,6 +47,39 @@ function makeRoot(): string {
   touch(join(root, "config.yaml"));
   touch(join(root, "CLAUDE.md"));
   return root;
+}
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "T",
+  GIT_AUTHOR_EMAIL: "t@t.com",
+  GIT_COMMITTER_NAME: "T",
+  GIT_COMMITTER_EMAIL: "t@t.com",
+};
+
+/**
+ * Seeds an empty commit into a bare repo so worktrees can be added.
+ * Mirrors the recipe from tools/lib/git-key.test.ts.
+ */
+function seedBareRepo(bareDir: string): void {
+  const tmpWt = fs.mkdtempSync(join(os.tmpdir(), "comp-test-seed-"));
+  try {
+    execFileSync("git", ["--git-dir", bareDir, "worktree", "add", "--orphan", "-b", "main", tmpWt], {
+      stdio: "pipe",
+      env: GIT_ENV,
+    });
+    execFileSync("git", ["-C", tmpWt, "commit", "--allow-empty", "-m", "init"], {
+      stdio: "pipe",
+      env: GIT_ENV,
+    });
+    fs.rmSync(tmpWt, { recursive: true, force: true });
+    execFileSync("git", ["--git-dir", bareDir, "worktree", "prune"], {
+      stdio: "pipe",
+    });
+  } catch {
+    fs.rmSync(tmpWt, { recursive: true, force: true });
+    throw new Error("Failed to seed bare repo");
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -725,5 +761,174 @@ describe("validateAll — enabled-projects 화이트리스트", () => {
 
     expect(result.errors.some((e) => e.includes("/nonexistent/proj-a"))).toBe(true);
     expect(result.errors.some((e) => e.includes("/nonexistent/proj-b"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: AC4.1 — bare-structure fan-out (resolveDeployTargets integration)
+// ---------------------------------------------------------------------------
+
+describe("AC4.1 — bare-structure worktree fan-out for CLAUDE.md check", () => {
+  let root: string;
+  let tmpdirs: string[];
+
+  beforeEach(() => {
+    root = makeRoot();
+    tmpdirs = [root];
+  });
+
+  afterEach(() => {
+    for (const d of tmpdirs.splice(0)) {
+      try {
+        rmSync(d, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    }
+  });
+
+  it("bare-structure path with one worktree missing CLAUDE.md flags that worktree with an error", async () => {
+    // Layout: container/.bare (bare repo) + container/wt (worktree, no CLAUDE.md)
+    const container = join(root, "target");
+    mkdirSync(container, { recursive: true });
+    tmpdirs.push(container);
+
+    const bareDir = join(container, ".bare");
+    const wtDir = join(container, "wt");
+    mkdirSync(wtDir, { recursive: true });
+
+    execFileSync("git", ["init", "--bare", bareDir], { stdio: "pipe" });
+    seedBareRepo(bareDir);
+    execFileSync("git", ["--git-dir", bareDir, "worktree", "add", wtDir], {
+      stdio: "pipe",
+      env: GIT_ENV,
+    });
+
+    // wt has NO CLAUDE.md
+    touch(join(root, "agents", "oracle.md"));
+    const syncPath = writeYaml(root, "sync.yaml", `
+path: ${container}
+agents:
+  items:
+    - oracle
+`);
+
+    const result = await validateSyncYamlComponents(syncPath, root);
+
+    // Must flag the worktree path in the error message
+    expect(result.errors.some((e) => e.includes("CLAUDE.md"))).toBe(true);
+    expect(result.errors.some((e) => e.includes(wtDir))).toBe(true);
+  });
+
+  it("bare-structure with CLAUDE.md in each worktree produces no CLAUDE.md errors", async () => {
+    const container = join(root, "target");
+    mkdirSync(container, { recursive: true });
+    tmpdirs.push(container);
+
+    const bareDir = join(container, ".bare");
+    const wt1 = join(container, "wt1");
+    const wt2 = join(container, "wt2");
+    mkdirSync(wt1, { recursive: true });
+    mkdirSync(wt2, { recursive: true });
+
+    execFileSync("git", ["init", "--bare", bareDir], { stdio: "pipe" });
+    seedBareRepo(bareDir);
+    execFileSync("git", ["--git-dir", bareDir, "worktree", "add", wt1], {
+      stdio: "pipe",
+      env: GIT_ENV,
+    });
+    execFileSync("git", ["--git-dir", bareDir, "worktree", "add", "-b", "wt2-branch", wt2], {
+      stdio: "pipe",
+      env: GIT_ENV,
+    });
+
+    // Both worktrees have CLAUDE.md
+    touch(join(wt1, "CLAUDE.md"));
+    touch(join(wt2, "CLAUDE.md"));
+
+    touch(join(root, "agents", "oracle.md"));
+    const syncPath = writeYaml(root, "sync.yaml", `
+path: ${container}
+agents:
+  items:
+    - oracle
+`);
+
+    const result = await validateSyncYamlComponents(syncPath, root);
+    const claudeErrors = result.errors.filter((e) => e.includes("CLAUDE.md"));
+    expect(claudeErrors).toHaveLength(0);
+  });
+
+  it("source-component check runs ONCE regardless of worktree count (no double-error for bare with 2 worktrees)", async () => {
+    // A bare-structure path with 2 worktrees + a missing source component.
+    // The missing-component error must appear exactly ONCE (component resolution
+    // is OMT-root-relative and must not fan out per worktree).
+    const container = join(root, "target");
+    mkdirSync(container, { recursive: true });
+    tmpdirs.push(container);
+
+    const bareDir = join(container, ".bare");
+    const wt1 = join(container, "wt1");
+    const wt2 = join(container, "wt2");
+    mkdirSync(wt1, { recursive: true });
+    mkdirSync(wt2, { recursive: true });
+
+    execFileSync("git", ["init", "--bare", bareDir], { stdio: "pipe" });
+    seedBareRepo(bareDir);
+    execFileSync("git", ["--git-dir", bareDir, "worktree", "add", wt1], {
+      stdio: "pipe",
+      env: GIT_ENV,
+    });
+    execFileSync("git", ["--git-dir", bareDir, "worktree", "add", "-b", "wt2-branch", wt2], {
+      stdio: "pipe",
+      env: GIT_ENV,
+    });
+
+    // Both worktrees have CLAUDE.md (so no CLAUDE.md errors pollute the count)
+    touch(join(wt1, "CLAUDE.md"));
+    touch(join(wt2, "CLAUDE.md"));
+
+    // missing-agent does NOT exist in the OMT root
+    const syncPath = writeYaml(root, "sync.yaml", `
+path: ${container}
+agents:
+  items:
+    - missing-agent
+`);
+
+    const result = await validateSyncYamlComponents(syncPath, root);
+
+    const missingErrors = result.errors.filter((e) => e.includes("missing-agent"));
+    // Source-component check must be single-pass: exactly 1 error, not 2
+    expect(missingErrors).toHaveLength(1);
+  });
+
+  it("resolver failure (bare path with zero real worktrees) lands in result.errors, not a throw", async () => {
+    // A bare-structure path with no worktrees at all → resolveDeployTargets throws
+    // DeployTargetsError → must be caught and pushed into result.errors.
+    const container = join(root, "target");
+    mkdirSync(container, { recursive: true });
+    tmpdirs.push(container);
+
+    const bareDir = join(container, ".bare");
+    execFileSync("git", ["init", "--bare", bareDir], { stdio: "pipe" });
+    // Intentionally NOT seeding / adding any worktrees — zero worktrees → DeployTargetsError
+
+    touch(join(root, "agents", "oracle.md"));
+    const syncPath = writeYaml(root, "sync.yaml", `
+path: ${container}
+agents:
+  items:
+    - oracle
+`);
+
+    // Must NOT throw — resolver failure must be swallowed into result.errors
+    let result: Awaited<ReturnType<typeof validateSyncYamlComponents>>;
+    expect(async () => {
+      result = await validateSyncYamlComponents(syncPath, root);
+    }).not.toThrow();
+
+    result = await validateSyncYamlComponents(syncPath, root);
+    expect(result.errors.length).toBeGreaterThan(0);
   });
 });

--- a/tools/validators/components.test.ts
+++ b/tools/validators/components.test.ts
@@ -156,14 +156,29 @@ agents:
     it("returns error when CLAUDE.md is absent via `validateSyncYamlComponents`", async () => {
       // Remove the CLAUDE.md created in makeRoot
       rmSync(join(root, "CLAUDE.md"));
+      // Fixture has a real agent item (non-empty items) so validateCliProjectFiles is called
+      touch(join(root, "agents", "oracle.md"));
       const syncPath = writeYaml(root, "sync.yaml", `
 path: ${root}
 platforms: [claude]
 agents:
-  items: []
+  items:
+    - oracle
 `);
       const result = await validateSyncYamlComponents(syncPath, root);
       expect(result.errors.some((e) => e.includes("CLAUDE.md"))).toBe(true);
+    });
+
+    it("MCP-only 프로젝트(컴포넌트 없음)는 CLAUDE.md 부재 에러를 내지 않는다 via `validateSyncYamlComponents`", async () => {
+      // Target dir exists but has no CLAUDE.md
+      rmSync(join(root, "CLAUDE.md"));
+      // sync.yaml has only name + path, zero component sections
+      const syncPath = writeYaml(root, "sync.yaml", `
+name: mcp-only-project
+path: ${root}
+`);
+      const result = await validateSyncYamlComponents(syncPath, root);
+      expect(result.errors.some((e) => e.includes("CLAUDE.md"))).toBe(false);
     });
 
     it("produces no CLAUDE.md errors when CLAUDE.md exists", async () => {
@@ -644,7 +659,9 @@ describe("validateAll — enabled-projects 화이트리스트", () => {
 
   it("`enabledProjects`로 활성화된 프로젝트는 정상 검증된다", async () => {
     // proj-a 활성: target path가 존재하지 않으면 CLAUDE.md 에러가 나야 함
-    writeYaml(join(root, "projects", "proj-a"), "sync.yaml", `path: /nonexistent/proj-a\n`);
+    // agents 섹션에 항목이 있어야 validateCliProjectFiles가 호출된다
+    writeYaml(join(root, "projects", "proj-a"), "sync.yaml",
+      `path: /nonexistent/proj-a\nagents:\n  items:\n    - oracle\n`);
     writeYaml(root, "sync.yaml", `path: ${root}\n`);
 
     const result = await validateAll(root, ["proj-a"]);
@@ -654,7 +671,9 @@ describe("validateAll — enabled-projects 화이트리스트", () => {
 
   it("루트 sync.yaml은 `enabledProjects` 필터와 무관하게 항상 검증된다", async () => {
     // 루트 sync.yaml만 있고 enabledProjects는 비어있는 sentinel — 루트는 그래도 처리되어야 함
-    writeYaml(root, "sync.yaml", `path: /nonexistent/root-target\n`);
+    // agents 섹션에 항목이 있어야 validateCliProjectFiles가 호출된다
+    writeYaml(root, "sync.yaml",
+      `path: /nonexistent/root-target\nagents:\n  items:\n    - oracle\n`);
 
     const result = await validateAll(root, ["__none__"]);
 
@@ -662,8 +681,11 @@ describe("validateAll — enabled-projects 화이트리스트", () => {
   });
 
   it("`enabledProjects` 미지정 시 모든 프로젝트 검증 (기존 동작 회귀)", async () => {
-    writeYaml(join(root, "projects", "proj-a"), "sync.yaml", `path: /nonexistent/proj-a\n`);
-    writeYaml(join(root, "projects", "proj-b"), "sync.yaml", `path: /nonexistent/proj-b\n`);
+    // agents 섹션에 항목이 있어야 validateCliProjectFiles가 호출된다
+    writeYaml(join(root, "projects", "proj-a"), "sync.yaml",
+      `path: /nonexistent/proj-a\nagents:\n  items:\n    - oracle\n`);
+    writeYaml(join(root, "projects", "proj-b"), "sync.yaml",
+      `path: /nonexistent/proj-b\nagents:\n  items:\n    - oracle\n`);
     writeYaml(root, "sync.yaml", `path: ${root}\n`);
 
     const result = await validateAll(root, []);

--- a/tools/validators/components.test.ts
+++ b/tools/validators/components.test.ts
@@ -984,3 +984,109 @@ agents:
     expect(result.errors.length).toBeGreaterThan(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Suite: C1 — deploy-target resolution is unconditional (validate/sync parity)
+// ---------------------------------------------------------------------------
+
+describe("C1: 배포 대상 해소는 무조건 시도되어 sync.ts와 정렬된다", () => {
+  let root: string;
+  let tmpdirs: string[];
+
+  beforeEach(() => {
+    root = makeRoot();
+    tmpdirs = [root];
+  });
+
+  afterEach(() => {
+    for (const d of tmpdirs.splice(0)) {
+      try {
+        rmSync(d, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    }
+  });
+
+  it("MCP-only 프로젝트(컴포넌트·non-mcps 키 없음)도 깨진 bare 컨테이너의 해소 실패를 result.errors에 보고한다 via `validateSyncYamlComponents`", async () => {
+    // sync.ts calls resolveDeployTargets(targetPath) UNCONDITIONALLY and aborts on
+    // DeployTargetsError. The validator must do the same: even for an MCP-only
+    // project (deploysToClaudeDotDir=false), a broken bare container (zero
+    // worktrees) must surface as a result.errors entry — so `make validate`
+    // catches it BEFORE `make sync` aborts.
+    const container = join(root, "target");
+    mkdirSync(container, { recursive: true });
+    tmpdirs.push(container);
+
+    const bareDir = join(container, ".bare");
+    execFileSync("git", ["init", "--bare", bareDir], { stdio: "pipe" });
+    // Intentionally NOT seeding / adding any worktrees → zero worktrees → DeployTargetsError
+
+    // MCP-only: claude.yaml has ONLY mcps, sync.yaml has no component sections.
+    writeYaml(root, "claude.yaml", `
+mcps:
+  notion:
+    url: https://example.com/mcp
+`);
+    const syncPath = writeYaml(root, "sync.yaml", `
+name: mcp-only-project
+path: ${container}
+`);
+
+    const result = await validateSyncYamlComponents(syncPath, root);
+
+    expect(result.errors.some((e) => e.includes("배포 대상 확인 실패"))).toBe(true);
+    expect(result.errors.some((e) => e.includes(container))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: C2 — CLI context file check is platform-aware (non-Claude regression)
+// ---------------------------------------------------------------------------
+
+describe("C2: 비-Claude config/mcp-only 프로젝트도 자기 플랫폼 CLI 파일을 검사받는다", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = makeRoot();
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("platforms: [codex] + 컴포넌트 없음 + AGENTS.md 없음이면 에러를 보고한다 via `validateSyncYamlComponents`", async () => {
+    // deploysToClaudeDotDir is a Claude-only predicate → false here. The base
+    // behavior ran validateCliProjectFiles unconditionally, so a codex-only
+    // project missing AGENTS.md failed. The gate must not swallow non-Claude
+    // platforms.
+    const syncPath = writeYaml(root, "sync.yaml", `
+path: ${root}
+platforms: [codex]
+`);
+
+    const result = await validateSyncYamlComponents(syncPath, root);
+    expect(result.errors.some((e) => e.includes("AGENTS.md"))).toBe(true);
+  });
+
+  it("platforms: [gemini] + 컴포넌트 없음 + GEMINI.md 없음이면 에러를 보고한다 via `validateSyncYamlComponents`", async () => {
+    const syncPath = writeYaml(root, "sync.yaml", `
+path: ${root}
+platforms: [gemini]
+`);
+
+    const result = await validateSyncYamlComponents(syncPath, root);
+    expect(result.errors.some((e) => e.includes("GEMINI.md"))).toBe(true);
+  });
+
+  it("platforms: [codex] + AGENTS.md 존재면 에러 없음 via `validateSyncYamlComponents`", async () => {
+    touch(join(root, "AGENTS.md"));
+    const syncPath = writeYaml(root, "sync.yaml", `
+path: ${root}
+platforms: [codex]
+`);
+
+    const result = await validateSyncYamlComponents(syncPath, root);
+    expect(result.errors.some((e) => e.includes("AGENTS.md"))).toBe(false);
+  });
+});

--- a/tools/validators/components.test.ts
+++ b/tools/validators/components.test.ts
@@ -193,6 +193,39 @@ agents:
       const claudeErrors = result.errors.filter((e) => e.includes("CLAUDE.md"));
       expect(claudeErrors).toHaveLength(0);
     });
+
+    it("claude.yaml가 config/hooks만 있고 컴포넌트 항목이 없어도 .claude/로 배포하므로 CLAUDE.md를 요구한다 via `validateSyncYamlComponents`", async () => {
+      // No component items, but claude.yaml has a non-mcps key (config) →
+      // the project deploys into <path>/.claude/, so validateCliProjectFiles must RUN.
+      rmSync(join(root, "CLAUDE.md"));
+      writeYaml(root, "claude.yaml", `
+config:
+  permissions:
+    allow:
+      - "Bash(ls:*)"
+`);
+      const syncPath = writeYaml(root, "sync.yaml", `
+path: ${root}
+`);
+      const result = await validateSyncYamlComponents(syncPath, root);
+      expect(result.errors.some((e) => e.includes("CLAUDE.md"))).toBe(true);
+    });
+
+    it("claude.yaml가 mcps만 있는 MCP-only 프로젝트는 CLAUDE.md를 요구하지 않는다 via `validateSyncYamlComponents`", async () => {
+      // claude.yaml has ONLY mcps → MCP-only, writes to ~/.claude.json not
+      // <path>/.claude/, so validateCliProjectFiles must be SKIPPED.
+      rmSync(join(root, "CLAUDE.md"));
+      writeYaml(root, "claude.yaml", `
+mcps:
+  notion:
+    url: https://example.com/mcp
+`);
+      const syncPath = writeYaml(root, "sync.yaml", `
+path: ${root}
+`);
+      const result = await validateSyncYamlComponents(syncPath, root);
+      expect(result.errors.some((e) => e.includes("CLAUDE.md"))).toBe(false);
+    });
   });
 
   // --- scripts/rules section platform collection ---

--- a/tools/validators/components.test.ts
+++ b/tools/validators/components.test.ts
@@ -974,14 +974,47 @@ agents:
     - oracle
 `);
 
-    // Must NOT throw — resolver failure must be swallowed into result.errors
-    let result: Awaited<ReturnType<typeof validateSyncYamlComponents>>;
-    expect(async () => {
-      result = await validateSyncYamlComponents(syncPath, root);
-    }).not.toThrow();
-
-    result = await validateSyncYamlComponents(syncPath, root);
+    // Must NOT throw — resolver failure must be swallowed into result.errors.
+    // A rejected promise would cause this test to fail, so no separate
+    // not.toThrow() guard is needed.
+    const result = await validateSyncYamlComponents(syncPath, root);
     expect(result.errors.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: V7b — claude.yaml는 sync.yaml당 1회만 파싱된다 (이중 파싱 금지)
+// ---------------------------------------------------------------------------
+
+describe("V7b: claude.yaml 이중 파싱 금지 — validateAll이 단일 오류만 생성해야 한다", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = makeRoot();
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("malformed claude.yaml 시 validateAll이 YAML 파싱 오류를 정확히 1건만 반환한다", async () => {
+    // Both validateSyncYamlComponents and validatePlatformYamlHookComponents
+    // parse claude.yaml. With dual-parse, a broken claude.yaml produces 2 errors.
+    // After dedup, it must produce exactly 1.
+    writeYaml(root, "claude.yaml", `
+hooks:
+  UserPromptSubmit: [invalid: yaml: parse: error
+`);
+    writeYaml(root, "sync.yaml", `
+path: ${root}
+agents:
+  items: []
+`);
+
+    const result = await validateAll(root, []);
+
+    const parseErrors = result.errors.filter((e) => e.includes("YAML 파싱 오류") && e.includes("claude.yaml"));
+    expect(parseErrors).toHaveLength(1);
   });
 });
 

--- a/tools/validators/components.ts
+++ b/tools/validators/components.ts
@@ -181,9 +181,16 @@ function getItemComponent(item: unknown): string | null {
   return null;
 }
 
+/** Pre-parsed claude.yaml result threaded from validateAll to avoid duplicate parsing. */
+type ClaudeYamlPreParsed =
+  | { ok: true; value: unknown }   // successfully parsed (value may be null = no file)
+  | { ok: false };                 // parse failed; error already recorded in caller
+
 export async function validateSyncYamlComponents(
   filePath: string,
   rootDir: string,
+  /** When provided by validateAll, skips re-parsing claude.yaml. */
+  claudeYamlPreParsed?: ClaudeYamlPreParsed,
 ): Promise<ValidationResult> {
   const result = makeResult();
 
@@ -218,13 +225,21 @@ export async function validateSyncYamlComponents(
   // (claude.yaml with only `mcps`) skips the Claude CLI-file check below. The
   // predicate is Claude-only, so it gates ONLY the claude branch of the CLI-file
   // check — non-Claude platforms are still checked.
-  let claudeYaml;
-  try {
-    claudeYaml = await parseAndMergePlatformYaml(dirname(filePath), "claude");
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    result.errors.push(`YAML 파싱 오류 (claude.yaml 또는 claude.local.yaml): ${msg}`);
-    return result;
+  //
+  // When claudeYamlPreParsed is provided by validateAll (deduped), skip re-parsing.
+  // If parse failed upstream ({ ok: false }), bail without adding a duplicate error.
+  let claudeYaml: Record<string, unknown> | null;
+  if (claudeYamlPreParsed !== undefined) {
+    if (!claudeYamlPreParsed.ok) return result; // parse failed upstream; error already recorded
+    claudeYaml = claudeYamlPreParsed.value as Record<string, unknown> | null;
+  } else {
+    try {
+      claudeYaml = await parseAndMergePlatformYaml(dirname(filePath), "claude");
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      result.errors.push(`YAML 파싱 오류 (claude.yaml 또는 claude.local.yaml): ${msg}`);
+      return result;
+    }
   }
   const claudeDeploys = deploysToClaudeDotDir(data, claudeYaml);
 
@@ -355,6 +370,8 @@ export async function validateSyncYamlComponents(
 export async function validatePlatformYamlHookComponents(
   yamlDir: string,
   rootDir: string,
+  /** When provided by validateAll, skips re-parsing claude.yaml. */
+  claudeYamlPreParsed?: ClaudeYamlPreParsed,
 ): Promise<ValidationResult> {
   const result = makeResult();
 
@@ -367,13 +384,20 @@ export async function validatePlatformYamlHookComponents(
 
   // Only claude and gemini support hooks
   for (const platform of ["claude", "gemini"] as const) {
-    let merged;
-    try {
-      merged = await parseAndMergePlatformYaml(yamlDir, platform);
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      result.errors.push(`YAML 파싱 오류 (${platform}.yaml 또는 ${platform}.local.yaml): ${msg}`);
-      continue;
+    let merged: unknown;
+    if (platform === "claude" && claudeYamlPreParsed !== undefined) {
+      // Pre-parsed by validateAll: skip re-parsing.
+      // If parse failed ({ ok: false }), error already recorded — skip claude hooks.
+      if (!claudeYamlPreParsed.ok) continue;
+      merged = claudeYamlPreParsed.value;
+    } else {
+      try {
+        merged = await parseAndMergePlatformYaml(yamlDir, platform);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        result.errors.push(`YAML 파싱 오류 (${platform}.yaml 또는 ${platform}.local.yaml): ${msg}`);
+        continue;
+      }
     }
     if (merged === null) continue;
 
@@ -452,9 +476,22 @@ export async function validateAll(
         continue;
       }
     }
-    mergeResult(result, await validateSyncYamlComponents(syncYamlPath, rootDir));
+
+    // Parse claude.yaml exactly once per sync.yaml, so a broken claude.yaml
+    // produces a single error regardless of how many validators consume it.
     const yamlDir = dirname(syncYamlPath);
-    mergeResult(result, await validatePlatformYamlHookComponents(yamlDir, rootDir));
+    let claudeYamlPreParsed: ClaudeYamlPreParsed;
+    try {
+      const value = await parseAndMergePlatformYaml(yamlDir, "claude");
+      claudeYamlPreParsed = { ok: true, value };
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      result.errors.push(`YAML 파싱 오류 (claude.yaml 또는 claude.local.yaml): ${msg}`);
+      claudeYamlPreParsed = { ok: false };
+    }
+
+    mergeResult(result, await validateSyncYamlComponents(syncYamlPath, rootDir, claudeYamlPreParsed));
+    mergeResult(result, await validatePlatformYamlHookComponents(yamlDir, rootDir, claudeYamlPreParsed));
   }
 
   return result;

--- a/tools/validators/components.ts
+++ b/tools/validators/components.ts
@@ -141,6 +141,7 @@ function validateCliProjectFiles(
   data: Record<string, unknown>,
   targetPath: string,
   result: ValidationResult,
+  claudeDeploys: boolean,
 ): void {
   const usedPlatforms = collectUsedPlatforms(data);
 
@@ -149,11 +150,16 @@ function validateCliProjectFiles(
     let found = false;
 
     if (platform === "claude") {
+      // The MCP-only skip is Claude-only: an MCP-only Claude project writes to
+      // ~/.claude.json, not <path>/.claude/, so it needs no CLAUDE.md.
+      if (!claudeDeploys) continue;
       // Claude: check at target path or target/.claude/
       found =
         existsSync(join(targetPath, projectFile)) ||
         existsSync(join(targetPath, ".claude", projectFile));
     } else {
+      // Non-Claude platforms are always checked (base behavior): a config/mcp-only
+      // codex/gemini project still needs its AGENTS.md / GEMINI.md context file.
       found = existsSync(join(targetPath, projectFile));
     }
 
@@ -206,10 +212,12 @@ export async function validateSyncYamlComponents(
     return result;
   }
 
-  // Validate CLI project files whenever the project deploys anything into
-  // <path>/.claude/ — i.e. component items OR a non-mcps claude.yaml key. This
-  // mirrors the sync.ts mkdir gate via the shared deploysToClaudeDotDir predicate,
-  // so an MCP-only project (claude.yaml with only `mcps`) is correctly skipped.
+  // Determine whether this project deploys into <path>/.claude/ — i.e. component
+  // items OR a non-mcps claude.yaml key. This mirrors the sync.ts mkdir gate via
+  // the shared deploysToClaudeDotDir predicate, so an MCP-only Claude project
+  // (claude.yaml with only `mcps`) skips the Claude CLI-file check below. The
+  // predicate is Claude-only, so it gates ONLY the claude branch of the CLI-file
+  // check — non-Claude platforms are still checked.
   let claudeYaml;
   try {
     claudeYaml = await parseAndMergePlatformYaml(dirname(filePath), "claude");
@@ -218,18 +226,24 @@ export async function validateSyncYamlComponents(
     result.errors.push(`YAML 파싱 오류 (claude.yaml 또는 claude.local.yaml): ${msg}`);
     return result;
   }
-  if (deploysToClaudeDotDir(data, claudeYaml)) {
-    let deployTargets: string[];
-    try {
-      deployTargets = resolveDeployTargets(targetPath);
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      result.errors.push(`배포 대상 확인 실패 (${targetPath}): ${msg}`);
-      deployTargets = [];
-    }
-    for (const wtPath of deployTargets) {
-      validateCliProjectFiles(data, wtPath, result);
-    }
+  const claudeDeploys = deploysToClaudeDotDir(data, claudeYaml);
+
+  // Resolve deploy targets UNCONDITIONALLY so the validator mirrors sync.ts —
+  // which calls resolveDeployTargets(targetPath) for every project and aborts on
+  // DeployTargetsError. Gating this behind a Claude-only predicate would let an
+  // MCP-only project pointing at a broken bare container pass `make validate` yet
+  // abort `make sync`. A resolution failure is reported via result.errors so
+  // `make validate` catches it first.
+  let deployTargets: string[];
+  try {
+    deployTargets = resolveDeployTargets(targetPath);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    result.errors.push(`배포 대상 확인 실패 (${targetPath}): ${msg}`);
+    deployTargets = [];
+  }
+  for (const wtPath of deployTargets) {
+    validateCliProjectFiles(data, wtPath, result, claudeDeploys);
   }
 
   // Category definitions: [category, extension]

--- a/tools/validators/components.ts
+++ b/tools/validators/components.ts
@@ -167,6 +167,21 @@ function validateCliProjectFiles(
 // sync.yaml component validation
 // ---------------------------------------------------------------------------
 
+/**
+ * Returns true if any of the five deployable component sections has at least
+ * one item declared. Used to gate CLI project file validation: an MCP-only
+ * sync.yaml (no component sections) has no reason to require CLAUDE.md.
+ */
+function hasComponentItems(data: Record<string, unknown>): boolean {
+  const sections = ["agents", "commands", "skills", "scripts", "rules"];
+  for (const section of sections) {
+    const sectionData = data[section];
+    if (!isObject(sectionData)) continue;
+    if (isArray(sectionData.items) && sectionData.items.length > 0) return true;
+  }
+  return false;
+}
+
 function getItemComponent(item: unknown): string | null {
   if (typeof item === "string") return item;
   if (isObject(item) && typeof item.component === "string") return item.component;
@@ -204,8 +219,10 @@ export async function validateSyncYamlComponents(
     return result;
   }
 
-  // Validate CLI project files
-  validateCliProjectFiles(data, targetPath, result);
+  // Validate CLI project files — skip for MCP-only projects (no component items)
+  if (hasComponentItems(data)) {
+    validateCliProjectFiles(data, targetPath, result);
+  }
 
   // Category definitions: [category, extension]
   type CategoryDef = { category: string; ext: string };

--- a/tools/validators/components.ts
+++ b/tools/validators/components.ts
@@ -29,6 +29,7 @@ import type { SyncYaml } from "../lib/types.ts";
 import { readAndExpandSyncYaml } from "../lib/parse-sync-yaml.ts";
 import { parseAndMergePlatformYaml } from "../lib/parse-platform-yaml.ts";
 import { deploysToClaudeDotDir } from "../sync.ts";
+import { resolveDeployTargets } from "../lib/resolve-deploy-targets.ts";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -211,7 +212,17 @@ export async function validateSyncYamlComponents(
   // so an MCP-only project (claude.yaml with only `mcps`) is correctly skipped.
   const claudeYaml = await parseAndMergePlatformYaml(dirname(filePath), "claude");
   if (deploysToClaudeDotDir(data, claudeYaml)) {
-    validateCliProjectFiles(data, targetPath, result);
+    let deployTargets: string[];
+    try {
+      deployTargets = resolveDeployTargets(targetPath);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      result.errors.push(`배포 대상 확인 실패 (${targetPath}): ${msg}`);
+      deployTargets = [];
+    }
+    for (const wtPath of deployTargets) {
+      validateCliProjectFiles(data, wtPath, result);
+    }
   }
 
   // Category definitions: [category, extension]

--- a/tools/validators/components.ts
+++ b/tools/validators/components.ts
@@ -210,7 +210,14 @@ export async function validateSyncYamlComponents(
   // <path>/.claude/ — i.e. component items OR a non-mcps claude.yaml key. This
   // mirrors the sync.ts mkdir gate via the shared deploysToClaudeDotDir predicate,
   // so an MCP-only project (claude.yaml with only `mcps`) is correctly skipped.
-  const claudeYaml = await parseAndMergePlatformYaml(dirname(filePath), "claude");
+  let claudeYaml;
+  try {
+    claudeYaml = await parseAndMergePlatformYaml(dirname(filePath), "claude");
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    result.errors.push(`YAML 파싱 오류 (claude.yaml 또는 claude.local.yaml): ${msg}`);
+    return result;
+  }
   if (deploysToClaudeDotDir(data, claudeYaml)) {
     let deployTargets: string[];
     try {

--- a/tools/validators/components.ts
+++ b/tools/validators/components.ts
@@ -28,6 +28,7 @@ import { resolveComponentPath, setProjectContext } from "../lib/resolver.ts";
 import type { SyncYaml } from "../lib/types.ts";
 import { readAndExpandSyncYaml } from "../lib/parse-sync-yaml.ts";
 import { parseAndMergePlatformYaml } from "../lib/parse-platform-yaml.ts";
+import { deploysToClaudeDotDir } from "../sync.ts";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -167,21 +168,6 @@ function validateCliProjectFiles(
 // sync.yaml component validation
 // ---------------------------------------------------------------------------
 
-/**
- * Returns true if any of the five deployable component sections has at least
- * one item declared. Used to gate CLI project file validation: an MCP-only
- * sync.yaml (no component sections) has no reason to require CLAUDE.md.
- */
-function hasComponentItems(data: Record<string, unknown>): boolean {
-  const sections = ["agents", "commands", "skills", "scripts", "rules"];
-  for (const section of sections) {
-    const sectionData = data[section];
-    if (!isObject(sectionData)) continue;
-    if (isArray(sectionData.items) && sectionData.items.length > 0) return true;
-  }
-  return false;
-}
-
 function getItemComponent(item: unknown): string | null {
   if (typeof item === "string") return item;
   if (isObject(item) && typeof item.component === "string") return item.component;
@@ -219,8 +205,12 @@ export async function validateSyncYamlComponents(
     return result;
   }
 
-  // Validate CLI project files — skip for MCP-only projects (no component items)
-  if (hasComponentItems(data)) {
+  // Validate CLI project files whenever the project deploys anything into
+  // <path>/.claude/ — i.e. component items OR a non-mcps claude.yaml key. This
+  // mirrors the sync.ts mkdir gate via the shared deploysToClaudeDotDir predicate,
+  // so an MCP-only project (claude.yaml with only `mcps`) is correctly skipped.
+  const claudeYaml = await parseAndMergePlatformYaml(dirname(filePath), "claude");
+  if (deploysToClaudeDotDir(data, claudeYaml)) {
     validateCliProjectFiles(data, targetPath, result);
   }
 


### PR DESCRIPTION
## 📌 Summary

OMT 동기화 시스템에 **bare 워크트리 구조** 인식을 도입하고, 그 위에서 MCP/핸드오프 신뢰성 결함 3건을 함께 정리한다.

- **MCP-only 프로젝트 지원**: `path`가 bare 컨테이너를 가리킬 때 local MCP scope 키를 올바르게 파생(`deriveClaudeProjectKey`), 빈 `.claude/` 생성·CLAUDE.md 검증을 적절히 생략.
- **컴포넌트 워크트리 fan-out**: `path`가 bare 구조면 `.claude`를 전 worktree로 자동 배포(순수 opt-in, 기존 단일-path 동작 무변경).
- **안정화 3건**: MCP `@latest` 기동 행 제거, 핸드오프 summarizer 타임아웃 상향, codex summarizer 고아 프로세스 차단.

## 🔧 Changes

### 1. MCP-only 프로젝트 지원 (`deriveClaudeProjectKey`)
local MCP scope 키가 CWD literal 기반이라 bare/worktree 구조에서 키가 어긋났다. `deriveClaudeProjectKey`로 파생(basename `.git`→toplevel / `.bare`→as-is / non-git→realpath, `--path-format=absolute`), `ProjectKeyError` loud-throw. MCP-only 프로젝트는 `.claude/` mkdir·CLAUDE.md 검증 생략. algocare-home notion을 local scope로 편입 + path를 컨테이너로 전환.
- **영향 범위**: `tools/lib/git-key.ts`, `tools/adapters/claude.ts`, `tools/validators/components.ts`, `projects/algocare-home/*`

### 2. 컴포넌트 워크트리 fan-out (`resolveDeployTargets`)
`<path>/.bare` 존재 시 `git worktree list`로 전 worktree 열거 후 각각에 배포, 미존재 시 `[path]` 그대로(무변경). git 실패·worktree 0개는 `DeployTargetsError`로 loud-fail. `deployRoot`를 `syncCategory`에 스레딩(targetPath 재할당 금지=dedup 보존). 백업 retention 정리도 워크트리별 fan-out.
- **영향 범위**: `tools/lib/resolve-deploy-targets.ts`, `tools/sync.ts`, `tools/validators/components.ts`

### 3. validator 크래시 방지
`claude.yaml` 파싱 오류 시 크래시 대신 안전 처리.
- **영향 범위**: `tools/validators/components.ts`

### 4. MCP `@latest` 기동 행 제거 + linear url 전환
`npx -y @pkg@latest`는 매 기동마다 npm registry 왕복이 필요해 느린 네트워크에서 MCP 기동 타임아웃을 유발했다. context7 `@3.2.1`·playwright `@0.0.76`로 정확히 핀 + `--prefer-offline`. linear는 레거시 `mcp-remote` stdio 프록시에서 네이티브 url 서버로 전환(codex bare `url:`, opencode `type: remote`, claude는 기존 http url 유지).
- **영향 범위**: `codex.yaml`, `claude.yaml`, `opencode.yaml`

### 5. 핸드오프 summarizer 타임아웃 상향
간헐적 핸드오프 유실을 줄이기 위해 내부 캡 `SUMMARIZER_TIMEOUT_SECS` 120→240, PreCompact 훅 외부 예산 280→600.
- **영향 범위**: `hooks/pre-compact.sh`, `claude.yaml`

### 6. codex summarizer 고아 차단
`codex`가 PATH에서 fork 방식 셸 래퍼로 해석되면 `perl alarm`이 래퍼만 죽이고 실 codex가 PID 1 고아로 잔존했다. 셸 스크립트 shim(셰뱅 `#!`)을 일반적으로 건너뛰고 실 바이너리를 직접 호출하도록 해석(`$OMT_CODEX_BIN` 우선). 특정 도구명에 결합하지 않음.
- **영향 범위**: `hooks/pre-compact.sh`, `hooks/pre-compact_test.sh`

## 💬 Review Points

### RP1. bare 구조 감지 = 순수 opt-in + loud-fail
- **배경 및 문제 상황**: 워크트리마다 `.claude`를 수동 배포하는 건 반복적이고 누락되기 쉽다. 그러나 모든 기존 path를 강제로 fan-out하면 단일-worktree 사용자가 깨진다.
- **해결 방안**: `<path>/.bare`가 디렉터리로 존재할 때만 fan-out, 아니면 `[path]` 그대로 반환.
- **구현 세부사항**: `resolveDeployTargets`가 `git --git-dir=<path>/.bare worktree list --porcelain`로 bare·prunable 제외 worktree만 수집. locked/detached는 실 작업트리이므로 포함.
- **선택과 트레이드오프**: 자동 감지라 사용자는 path를 컨테이너로 바꾸기만 하면 opt-in. 단 bare인데 worktree 0개면 silent-empty 대신 `DeployTargetsError`로 시끄럽게 실패(조용한 무배포가 더 위험). 기존 `.../main` path는 `.bare` 미존재라 동작 100% 보존.

### RP2. `--prefer-offline` (not `--offline`)
- **배경 및 문제 상황**: `@latest`의 registry 왕복이 기동 행의 원인. 처음 제안됐던 `--offline`은 캐시 미스 시 네트워크 폴백 없이 hard-fail.
- **해결 방안**: 정확한 버전 핀 + `--prefer-offline`(캐시 우선, 미스 시에만 네트워크).
- **선택과 트레이드오프**: 버전 핀만으로 registry 왕복은 사라지지만, `--prefer-offline`은 캐시 GC·버전 변경 시에도 깨지지 않는 회복력을 추가. 모든 프로젝트로 sync되는 설정이라 brittleness를 피함.

### RP3. codex 고아 차단을 래퍼 우회로 (프로세스그룹 kill 대신)
- **배경 및 문제 상황**: fork 방식 셸 래퍼가 `perl alarm`의 SIGALRM을 가로채 실 codex가 고아로 잔존(실 PID로 재현 확인). 완성된 핸드오프 요약까지 유실되는 사례 관측.
- **해결 방안**: 셸 스크립트 shim을 건너뛰고 실 바이너리를 직접 `exec` 사슬에 태워 alarm이 실 codex를 직접 reap.
- **구현 세부사항**: 특정 도구 경로를 이름으로 제외하지 않고, "셰뱅 `#!`로 시작하는 PATH 항목 건너뛰기"라는 일반 속성으로 추상화 → 결합 0, 도구 부재/제거에도 견고.
- **선택과 트레이드오프**: 프로세스그룹 kill 방식은 부모 세션·형제 MCP 오살 위험 + macOS `setsid`/`timeout` 부재로 복잡. 우회는 더 단순하면서 더 완전. 헤드리스 `codex exec`엔 래퍼의 알림/세션워처/trust 주입이 무관해 손실 없음.

## ✅ Checklist

- [ ] `make validate` 통과 (스키마 + 컴포넌트 + 타입체크)
  - `tools/`, `*.yaml`
- [ ] `make test` 통과 (TypeScript + Shell)
  - `tools/`
- [ ] `bash hooks/pre-compact_test.sh` 14/14 통과
  - `hooks/pre-compact_test.sh`
- [ ] bare 구조 path는 전 worktree fan-out, 비-bare path는 단일 배포로 동작 보존
  - `tools/lib/resolve-deploy-targets.ts`
- [ ] MCP 정의에 `@latest`·`mcp-remote` 실행 부재 (주석 제외)
  - `codex.yaml`, `claude.yaml`, `opencode.yaml`
- [ ] resolver가 셰뱅 shim을 건너뛰고 실 codex 바이너리로 해석 (고아 reap 실증 완료)
  - `hooks/pre-compact.sh`

## 📎 References
- 없음
