### PR TITLE
fix(ultraresearch): 세션 디렉토리를 $OMT_DIR 기준으로 교정

### DIFF
--- a/skills/ultraresearch/SKILL.md
+++ b/skills/ultraresearch/SKILL.md
@@ -82,7 +82,7 @@ A worker with nothing to expand writes `## EXPAND` then `none — <one-line reas
 
 ## Phase 0 — Decompose and intent-route
 
-Decompose the query into 3+ orthogonal axes, classify the posture and tier (see the Postures section), and open the session directory `.omt/ultraresearch/<timestamp>/` as `$SESSION_DIR`. You own the journal: you write every file in it; workers never do.
+Decompose the query into 3+ orthogonal axes, classify the posture and tier (see the Postures section), and open the session directory `$OMT_DIR/ultraresearch/<slug>-<timestamp>/` as `$SESSION_DIR` (`<slug>` is a short kebab-case label derived from the query so the run is identifiable; the `<timestamp>` suffix keeps concurrent or repeated runs from colliding). You own the journal: you write every file in it; workers never do.
 
 ## Phase 1 — Saturation wave
 


### PR DESCRIPTION
## 📌 Summary

ultraresearch가 연구 저널을 레포 작업트리(`.omt/`)에 쓰던 것을 다른 state 스킬과 동일하게 `$OMT_DIR` 아래로 옮기고, 격리 세그먼트를 충돌에 안전한 `<slug>-<timestamp>` 조합으로 변경합니다.

---

## 🔧 Changes

### ultraresearch SKILL.md (Phase 0)

- 세션 디렉토리 정의(`$SESSION_DIR`)를 `.omt/ultraresearch/<timestamp>/`에서 `$OMT_DIR/ultraresearch/<slug>-<timestamp>/`로 변경

`$OMT_DIR`은 session-start hook이 export하는 홈 앵커(`~/.omt/<repo-name>`) state 베이스로, deep-interview/prometheus/goal 등 저장을 하는 거의 모든 스킬이 이 위에 쓴다. ultraresearch만 이를 쓰지 않고 CWD 상대 리터럴이라 저널(claim-ledger, SYNTHESIS, wave 로그)이 레포 작업트리 안으로 떨어졌다. 정작 같은 파일의 pre-work handoff(`:175`)는 이미 `$OMT_DIR`을 쓰고 있어, 한 스킬 안에 두 베이스가 공존하던 상태였다.

**영향 범위**
prose 한 줄 변경. `$SESSION_DIR`은 변수로 한 번 정의되고 저널 기록부(`:221`)가 이를 참조만 하므로 자동 전파된다. handoff(`:175`)와 journal 참조(`:221`)는 byte-unchanged. 배포본(`~/.claude/...`) 반영은 `make sync`가 필요하며 이 PR에는 포함하지 않는다.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 격리 세그먼트를 단일 키가 아닌 slug-timestamp 조합으로

**배경 및 문제 상황:**
디렉토리를 격리할 키 후보가 셋 있었고 각각 약점이 있었다. timestamp는 초 단위라 같은 초에 두 run이 시작하면 디렉토리가 충돌한다. session id는 타 스킬 컨벤션과 일치하지만, 같은 세션에서 두 번 돌리면 동일 sid라 똑같이 충돌하고, prose가 sid를 주입받는 배선이 없으며, 불투명해서 나중에 디렉토리를 봐도 어떤 연구였는지 알 수 없다. slug 단독은 가독성이 최고지만 비슷한 두 연구가 같은 slug를 낼 수 있다.

**해결 방안:**
사람이 식별할 부분(slug)과 충돌을 막는 부분(timestamp suffix)을 합친 `<slug>-<timestamp>`를 채택했다.

**구현 세부사항:**
slug는 Phase 0에서 query로부터 만드는 짧은 kebab-case 라벨이며, 채움 기준을 prose에 명시했다. timestamp는 기존과 동일하게 모델이 런타임에 생성한다(별도 생성 코드 없음, prose placeholder).

**선택과 트레이드오프:**
session id가 "타 스킬과의 컨벤션 일치" 면에선 우위지만, 배선 부재 + 불투명성 + 같은 세션 반복 충돌이라는 세 가지 이유로 기각했다. slug-timestamp는 추가 배선 없이 가독성과 충돌 안전성을 동시에 얻는다. 다만 완전히 동일한 query를 같은 초에 두 번 시작하는 극단 케이스는 여전히 충돌 가능하나, 현실성이 낮아 수용했다.

---

## ✅ Checklist

### ultraresearch 세션 디렉토리
- [ ] 세션 디렉토리 정의가 `$OMT_DIR/ultraresearch/<slug>-<timestamp>/` 형태다 (CWD 상대 `.omt/` 리터럴 제거)
  - `skills/ultraresearch/SKILL.md`
- [ ] pre-work handoff(`:175`)와 journal 참조(`:221`)는 변경되지 않았다
  - `skills/ultraresearch/SKILL.md`
- [ ] `make validate` 통과 (스키마·컴포넌트·타입체크 무회귀)