### PR TITLE
feat: least-code ladder 룰 도입 및 단순성 룰 통합

### DIFF
--- a/projects/loopers-kotlin-spring-template/sync.yaml
+++ b/projects/loopers-kotlin-spring-template/sync.yaml
@@ -45,3 +45,4 @@ rules:
     - tool-usage-policy
     - work-principles
     - coding-discipline
+    - least-code

--- a/projects/oh-my-resume/sync.yaml
+++ b/projects/oh-my-resume/sync.yaml
@@ -35,4 +35,5 @@ rules:
     - tool-usage-policy
     - work-principles
     - coding-discipline
+    - least-code
     - resume-workflow

--- a/projects/oh-my-toong/sync.yaml
+++ b/projects/oh-my-toong/sync.yaml
@@ -53,5 +53,6 @@ rules:
     - tool-usage-policy
     - work-principles
     - coding-discipline
+    - least-code
     - private-component-management
     - documentation-currency

--- a/projects/resume-manage/sync.yaml
+++ b/projects/resume-manage/sync.yaml
@@ -51,4 +51,5 @@ rules:
     - tool-usage-policy
     - work-principles
     - coding-discipline
+    - least-code
     - resume-workflow

--- a/projects/toong-java-spring-template/sync.yaml
+++ b/projects/toong-java-spring-template/sync.yaml
@@ -45,3 +45,4 @@ rules:
     - tool-usage-policy
     - work-principles
     - coding-discipline
+    - least-code

--- a/rules/coding-discipline.md
+++ b/rules/coding-discipline.md
@@ -14,19 +14,7 @@ Before implementing:
 - If a simpler approach exists, say so. Push back when warranted.
 - If something is unclear, stop. Name what's confusing. Ask.
 
-## 2. Simplicity First
-
-**Minimum code that solves the problem. Nothing speculative.**
-
-- No features beyond what was asked.
-- No abstractions for single-use code.
-- No "flexibility" or "configurability" that wasn't requested.
-- No error handling for impossible scenarios.
-- If you write 200 lines and it could be 50, rewrite it.
-
-Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
-
-## 3. Surgical Changes
+## 2. Surgical Changes
 
 **Touch only what you must. Clean up only your own mess.**
 
@@ -42,7 +30,7 @@ When your changes create orphans:
 
 The test: Every changed line should trace directly to the user's request.
 
-## 4. Goal-Driven Execution
+## 3. Goal-Driven Execution
 
 **Define success criteria. Loop until verified.**
 
@@ -60,7 +48,7 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
-## 5. Deep Modules
+## 4. Deep Modules
 
 **Prefer deep modules — a small interface hiding substantial implementation. Don't scatter logic across many shallow files.**
 

--- a/rules/least-code.md
+++ b/rules/least-code.md
@@ -4,7 +4,7 @@ The best code is the code you never write. Lazy means efficient, not careless: a
 
 ## The ladder
 
-Before writing code, climb this ladder and stop at the first rung that holds:
+This ladder is a default. An explicit user instruction, a co-loaded project skill, or a project's CLAUDE.md that mandates a specific pattern outranks it on that point — the project's contract is a standing "asked for". Absent that, climb this ladder before writing code and stop at the first rung that holds:
 
 1. **Does this need to exist at all?** Speculative need — skip it, say so in one line. (YAGNI)
 2. **Already in this codebase?** A helper, util, type, or pattern that already lives here — reuse it. Re-implementing what sits a few files over is the most common slop; look before you write.

--- a/rules/least-code.md
+++ b/rules/least-code.md
@@ -1,0 +1,40 @@
+# Least-Code Ladder
+
+The best code is the code you never write. Lazy means efficient, not careless: aim for the shortest solution that actually works, and only that. You have seen over-engineered systems and been paged for them at 3am — the clever layer nobody needed is the one that wakes you.
+
+## The ladder
+
+Before writing code, climb this ladder and stop at the first rung that holds:
+
+1. **Does this need to exist at all?** Speculative need — skip it, say so in one line. (YAGNI)
+2. **Already in this codebase?** A helper, util, type, or pattern that already lives here — reuse it. Re-implementing what sits a few files over is the most common slop; look before you write.
+3. **Standard library does it?** Use it.
+4. **Native platform feature covers it?** Prefer the platform builtin over a dependency — a DB constraint over app code, a framework primitive over a hand-rolled one, a language or runtime feature over a library.
+5. **Already-installed dependency solves it?** Use it. Never add a new dependency for what a few lines do.
+6. **Can it be one line?** Make it one line.
+7. **Only then:** write the minimum code that works.
+
+Two rungs hold? Take the higher one and move on. The ladder is a reflex, not a research project.
+
+## Understand before you climb
+
+The ladder shortens the solution, never the reading. It runs *after* you understand the problem, not instead of it: read the task and the code it touches, trace the real flow end to end, then climb. A small diff in the wrong place isn't lazy — it's a second bug. Laziness that skips comprehension to ship a small diff is the dangerous kind: it dresses up as efficiency and ships a confident wrong fix.
+
+**Bug fix = root cause, not symptom.** A report names a symptom. Before editing, find every caller of the function you are about to touch and fix the shared function once — one guard there is a smaller diff than one guard per caller, and patching only the path the ticket names leaves sibling callers broken.
+
+## What "simple" rules out
+
+- No abstractions that weren't asked for: no interface with one implementation, no factory for one product, no config for a value that never changes.
+- No flexibility or configurability for unproven scenarios. Speculative defensiveness — fallbacks, layers, options for cases that don't exist yet — is forbidden unless tied to a concrete current trigger.
+- No error handling for impossible states.
+- No boilerplate or scaffolding "for later" — later can scaffold for itself.
+- Deletion over addition. When uncertain between adding defensive logic and removing it, remove: default to deleting speculative additions, not code with verified callers.
+- The simpler form wins: between two approaches with the same outcome, take the one with fewer lines, fewer abstractions, fewer code paths. If you wrote 200 lines and it could be 50, rewrite it. Ask: "Would a senior engineer call this overcomplicated?" If yes, simplify.
+
+## What is never simplified away
+
+These are not bloat — keep them even as the rest shrinks: input validation at trust boundaries, error handling that prevents data loss, security, accessibility, and anything the user explicitly asked for. Between two same-size options, pick the one correct on edge cases — lazy means writing less code, not picking the flimsier algorithm. Non-trivial logic (a branch, a loop, a parser, a money or security path) leaves ONE runnable check behind: the smallest thing that fails if the logic breaks — an assert-based self-check or one small test. No frameworks, no fixtures unless asked. Trivial one-liners need no test.
+
+## Output and traceability
+
+Code first, then at most a few lines: what you skipped, when to add it (`skipped: X, add when Y`). If the explanation runs longer than the code, delete the explanation — a paragraph defending a simplification is complexity smuggled back in as prose. Explanation the user explicitly asked for (a report, a walkthrough) is not debt; give it in full. Mark a deliberate shortcut with a `lazy:` comment that names its ceiling and the upgrade path — `// lazy: global lock; per-account locks if throughput matters`. A shortcut with no named trigger silently rots.

--- a/rules/least-code.md
+++ b/rules/least-code.md
@@ -33,7 +33,7 @@ The ladder shortens the solution, never the reading. It runs *after* you underst
 
 ## What is never simplified away
 
-These are not bloat — keep them even as the rest shrinks: input validation at trust boundaries, error handling that prevents data loss, security, accessibility, and anything the user explicitly asked for. Between two same-size options, pick the one correct on edge cases — lazy means writing less code, not picking the flimsier algorithm. Non-trivial logic (a branch, a loop, a parser, a money or security path) leaves ONE runnable check behind: the smallest thing that fails if the logic breaks — an assert-based self-check or one small test. No frameworks, no fixtures unless asked. Trivial one-liners need no test.
+These are not bloat — keep them even as the rest shrinks: input validation at trust boundaries, error handling that prevents data loss, security, accessibility, and anything the user explicitly asked for. Between two same-size options, pick the one correct on edge cases — lazy means writing less code, not picking the flimsier algorithm. Non-trivial logic (a branch, a loop, a parser, a money or security path) leaves ONE runnable check behind: the smallest thing that fails if the logic breaks — an assert-based self-check or one small test. No frameworks, no fixtures unless asked. A bug fix always leaves this check, however small. Only a one-liner that changes no logic — a rename, a config value, a passthrough — skips it.
 
 ## Output and traceability
 

--- a/rules/work-principles.md
+++ b/rules/work-principles.md
@@ -15,12 +15,6 @@ Before any tool call, file edit, or delegation:
 - Plan in steps, then execute one step at a time — never act on impulse.
 - Brief or terse instructions ("진행해", "just do it") suppress narration, not the thinking itself.
 
-## MANDATORY: Simplicity First
-
-- The simpler form wins, always. When two approaches achieve the same outcome, take the one with fewer lines, fewer abstractions, fewer code paths.
-- Speculative defensiveness — fallbacks, abstractions, configurability for unproven scenarios — is forbidden unless tied to a concrete current trigger.
-- When uncertain between adding *defensive* logic and removing it: remove. Default to deletion of speculative additions, not of code with verified callers.
-
 ## Analytical Stance
 
 - Lead with objective facts and critical analysis, not emotional validation.


### PR DESCRIPTION
## 📌 Summary

AI 코딩 에이전트가 "단순하고 요청에 맞춘 코드"를 쓰도록 강제하는 least-code ladder 룰을 OMT에 도입하고, `coding-discipline`·`work-principles`에 흩어져 있던 Simplicity First 가이드를 이 단일 룰로 통합한다.

---

## 🔧 Changes

### rules/least-code.md (신규)

- 코드 작성 전 올라갈 7단계 의사결정 ladder: YAGNI → 기존 코드 재사용 → 표준 라이브러리 → 플랫폼 빌트인 → 설치된 의존성 → 한 줄 → 최소 코드
- 보조 섹션: 이해 우선·root-cause 수정(`Understand before you climb`), 단순화가 배제하는 것(`What 'simple' rules out`), 절대 단순화하지 않는 것(`What is never simplified away` — 입력 검증/데이터 손실 방지/보안/접근성/요청된 것), 산출·추적성(`lazy:` 주석으로 의도적 단축 표시)

ponytail 프롬프트 리서치 결론 — 가치는 슬로건이 아니라 **순서 있는 의사결정 사다리**이고, "절차(constraint) 프레이밍"이 "지시(instruction) 프레이밍"보다 강하게 작동 — 을 OMT 룰로 옮긴 것이다. frontmatter 없이 두어 always-load(경로 무관 상시 주입)로 동작한다.

**영향 범위**
배선된 모든 프로젝트 + 전역 overlay의 에이전트 컨텍스트에 상시 주입. 실행 코드 영향 없음(룰 prose). 실제 배포는 merge 후 `make sync` 별도 필요.

### rules/coding-discipline.md, rules/work-principles.md (중복 제거)

- `coding-discipline.md`의 Simplicity First 섹션 제거(이하 재번호), `work-principles.md`의 MANDATORY Simplicity First 제거
- 제거된 specifics는 `least-code.md`가 흡수(내용 손실 없음)

**영향 범위**
두 룰의 나머지 디렉티브(Think Before Coding, Surgical Changes, Goal-Driven Execution, Deep Modules 등)는 그대로 유지.

### 배선 (5개 프로젝트 sync.yaml + sync.local.yaml)

- `oh-my-toong`, `oh-my-resume`, `resume-manage`, `toong-java-spring-template`, `loopers-kotlin-spring-template`의 `rules`에 `least-code` 추가
- 전역 overlay `sync.local.yaml`(gitignored)에도 추가

**영향 범위**
`algocare-home`은 OMT 메타-룰을 쓰지 않으므로 제외(누락 아님). `make validate`의 컴포넌트 검증으로 참조 무결성 확인됨.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.

### 1. 테스트 면제 규칙을 "버그 = 재현 테스트" 명령과 정합

**배경 및 문제 상황:**
`least-code`의 "한 줄짜리(trivial one-liner)는 테스트 불필요"가 같은 always-load 셋에 있는 `coding-discipline`의 "버그 픽스 = 재현 테스트 작성 후 통과"와 충돌. 게다가 한 줄짜리 경계 수정(off-by-one)은 "trivial one-liner"(크기 기준)와 "non-trivial logic"(성질 기준) 두 절에 동시 해당해 룰 내부에서도 모호했다.

**해결 방안:**
면제 대상을 "로직을 건드리지 않는 한 줄(rename·config 값·passthrough)"로 한정하고, 버그/로직 한 줄은 체크를 남기도록 명시.

**선택과 트레이드오프:**
두 룰이 동급(peer)이라 우선순위 선언으로는 풀리지 않고 모순 문장 자체를 수정해야 했다. 면제 조항을 통째로 삭제하는 안은 진짜 사소한 한 줄(문자열 오타 등)까지 over-test하게 만들어 least-code 철학에 역행하므로, 범위를 좁히는 쪽을 택했다.

### 2. 전역 룰이 프로젝트 강제 패턴에 양보하도록 우선순위 명시

**배경 및 문제 상황:**
`least-code`가 always-load 전역 룰이 되면서, Spring 템플릿 프로젝트의 `implementation`/`testing` 스킬이 강제하는 패턴과 충돌. 예: ladder의 "framework primitive 선호"가 `@Cacheable`을 가리키지만 스킬은 수동 Cache-Aside를 강제; "단일 구현 인터페이스 금지"가 필수 `ApiSpec`/Repository 인터페이스와 충돌; "프레임워크/픽스처 자제"가 Testcontainers/WireMock 강제와 충돌.

**해결 방안:**
ladder 도입부에 "이 사다리는 기본값이며, co-load된 프로젝트 스킬이나 CLAUDE.md가 특정 패턴을 강제하는 지점에서는 그 강제가 우선한다"는 범위한정 우선순위 한 문장 추가.

**선택과 트레이드오프:**
충돌 지점마다 개별 carve-out을 다는 안(brittle, 미래 충돌마다 패치 필요) 대신 단일 우선순위 선언으로 현재 3개 + 미래 충돌까지 커버. 핵심어 `on that point`(지점 한정 → 과잉 양보 차단)와 `Absent that`(기본값 복귀)로 99%의 비충돌 경우엔 ladder가 평소대로 작동하게 했다. 하네스의 기존 우선순위 모델(사용자 지시 > 스킬 > 기본 동작)과 일치.

---

## ✅ Checklist

### least-code 룰
- [ ] `make validate` 통과 (SCHEMA / COMPONENT / LIB-IMPORT)
  - `rules/least-code.md`, `projects/*/sync.yaml`
- [ ] `make test` 통과 (Bun 2460 pass / Shell 11)
- [ ] `least-code`가 `coding-discipline`/`work-principles` 배선된 모든 프로젝트 + 전역 overlay에 일관 추가됨
  - `sync.local.yaml`, `projects/{oh-my-toong,oh-my-resume,resume-manage,toong-java-spring-template,loopers-kotlin-spring-template}/sync.yaml`
- [ ] 제거된 Simplicity First 내용이 `least-code.md`에 손실 없이 흡수됨
  - `rules/coding-discipline.md`, `rules/work-principles.md`, `rules/least-code.md`
- [ ] 테스트 면제 규칙이 "버그 = 재현 테스트" 명령과 모순 없음
  - `rules/least-code.md`
- [ ] ladder가 프로젝트 강제 패턴에 양보함이 명시됨
  - `rules/least-code.md`

---

## 📎 References
- [ponytail (포팅 원천 리서치)](https://github.com/DietrichGebert/ponytail)
