### PR TITLE
feat: prometheus verify-lane intent-split·explore 그라운딩

### DIFF
--- a/agents/explore.md
+++ b/agents/explore.md
@@ -106,12 +106,14 @@ Route by query type first, not by tool brand. Pick the entry that matches what y
 1. **Filename / location known** → file/glob discovery (`Glob`).
 2. **Text / string / config / log / comment** → text pattern search (`Grep`).
 3. **Code-structure shape** (a syntactic form: a call shape, a decorator, a function signature) → structural search (`ast-grep`).
-4. **Symbol / reference work** (definitions, callers, usages) → approximate with `ast-grep` + `Grep`, **with the capability loss stated openly** (see below). There is no semantic find-references tool in this repo.
+4. **Symbol / reference work** (definitions, callers, usages) → **prefer `codegraph_*` when present** (`codegraph_callers`/`codegraph_callees`/`codegraph_impact`/`codegraph_search`) — it is the semantic symbol-graph tool and resolves which definition each usage binds to. When `codegraph_*` is absent, approximate with `ast-grep` + `Grep`, **with the capability loss stated openly** (see below).
 5. **History / evolution** → `git` (only when freshness or how-it-changed is actually required by the request).
 
-### Symbol / Reference Capability Loss (read before doing reference work)
+### Symbol / Reference: code-graph first, else approximate (read before doing reference work)
 
-This repo has no semantic symbol-graph tool (no LSP / language server). Symbol and reference work is therefore an **approximation**, and you MUST treat it as one:
+**Code-graph first when present.** When `codegraph_*` tools exist (check `codegraph_status`), prefer them for symbol, reference, structure, and dependency work — `codegraph_explore`/`codegraph_search` for symbol/file inventory, `codegraph_callers`/`codegraph_callees`/`codegraph_impact` for reference centrality and blast radius — and ground every load-bearing claim in that graph data instead of inferring from convention. Code-graph is the semantic symbol-graph tool this repo otherwise lacks: it resolves which definition each usage actually binds to.
+
+When `codegraph_*` is absent, inactive, or uninitialized, this repo has no semantic symbol-graph tool (no LSP / language server), so symbol and reference work degrades to a textual/syntactic **approximation**, and you MUST treat it as one:
 
 - `Grep` find-references is **textual**. It matches a name as a string, so expect name-collision false positives across methods, variables, comments, and strings. It resolves no scope, no type, and no imports — it cannot tell a real caller from an unrelated identical name.
 - `ast-grep` find-references is **syntactic**. It matches a code shape within a single language and has no cross-file semantic binding — it does not follow imports or resolve which definition a usage actually refers to.

--- a/agents/explore.md
+++ b/agents/explore.md
@@ -106,7 +106,7 @@ Route by query type first, not by tool brand. Pick the entry that matches what y
 1. **Filename / location known** → file/glob discovery (`Glob`).
 2. **Text / string / config / log / comment** → text pattern search (`Grep`).
 3. **Code-structure shape** (a syntactic form: a call shape, a decorator, a function signature) → structural search (`ast-grep`).
-4. **Symbol / reference work** (definitions, callers, usages) → **prefer `codegraph_*` when present** (`codegraph_callers`/`codegraph_callees`/`codegraph_impact`/`codegraph_search`) — it is the semantic symbol-graph tool and resolves which definition each usage binds to. When `codegraph_*` is absent, approximate with `ast-grep` + `Grep`, **with the capability loss stated openly** (see below).
+4. **Symbol / reference work** (definitions, callers, usages) → **prefer `codegraph_*` when present** (see the Symbol / Reference section below); when absent, approximate with `ast-grep` + `Grep`, **with the capability loss stated openly**.
 5. **History / evolution** → `git` (only when freshness or how-it-changed is actually required by the request).
 
 ### Symbol / Reference: code-graph first, else approximate (read before doing reference work)

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -341,7 +341,7 @@ Phase 1 ritual (context loading + explore + librarian) is invisible by default �
 - Context files loaded: <list each Read path, or "missing — skipped per Graceful skip rule">
 - explore dispatched THIS session: <Agent invocation reference, or "N/A — intent is Trivial/Scoped without explore need">
 - librarian dispatched THIS session: <Agent invocation reference, or "N/A — Architecture, or Complex with design surface, not present; intent is Trivial/Scoped, or a purely mechanical refactor">
-- verify lane: dispatched / N lanes / M excluded <or "no-op / 0 lanes / 0 excluded" when all collect lanes are empty (Complex/Architecture with no findings) | "N/A — intent is Trivial/Scoped (verify lane is Complex/Architecture only)">
+- verify lane: <inline (Complex) | dispatched (Architecture)> / N lanes / M excluded <or "no-op / 0 lanes / 0 excluded" when all collect lanes are empty | "N/A — intent is Trivial/Scoped (verify lane is Complex/Architecture only)">
 - Results received and assimilated: <Y/N — Y requires both summary read and key findings noted>
 ```
 
@@ -371,9 +371,12 @@ collect lane scoped to its aspect. The aspect set is closed: you do not add, dro
 When the librarian default lane is present (per `### Subagent Use During Interview`), it runs in the
 same parallel response as a sixth, external collect lane alongside the 5 aspect lanes.
 
-#### Collect→verify contract (falsifying verifier)
+#### Collect→verify contract (intent-split: Complex inline, Architecture delegated)
 
-After collect, every non-empty **collect lane** is handed to its own **falsifying verifier** — one
+After collect, every non-empty **collect lane** is falsified before its findings reach grounding. How
+the falsification runs splits by intent:
+
+**On Architecture intent**, each non-empty lane is handed to its own **falsifying verifier** — one
 verifier per non-empty lane (the 5 explore aspect lanes + the librarian external lane when present),
 dispatched in **ONE parallel response**. The dispatch mechanics mirror the per-candidate verifier of
 the Review Pipeline's finder-verifier pattern: each verifier is interpolated with its own lane's
@@ -381,6 +384,15 @@ findings, dispatched in a single parallel response, and **scoped to its matched 
 request only — NEVER the full aggregate**. Per-lane isolation is deliberate: it keeps each judgment
 free of the other lanes' framing (no cross-lane anchoring) and makes the verifier structurally
 adversarial — its job is to falsify the lane's claims, not confirm them.
+
+**On Complex intent**, the planner runs that same falsification **inline** — no verifier subagent:
+treat each finding as a claim to disprove, re-read or re-grep the cited evidence yourself, then apply
+the per-finding schema + Exclusion rule directly. Zero spawns. (Inline suits Complex's smaller finding
+count; Architecture keeps the delegated verifier because its independent re-read is what catches a
+collector that misread or cited a `nonexistent_path`.)
+
+The verdict schema, Exclusion rule, no-op path, and 4-key checklist below apply to both paths — only
+the actor (planner inline vs delegated verifier) differs.
 
 Each verifier inspects **every finding** in its lane and returns a **per-finding** verdict against
 this schema (a deliberate divergence from the Review Pipeline's `CONFIRMED/PLAUSIBLE/REFUTED` ladder
@@ -406,11 +418,13 @@ not a verifier's.
 nothing to falsify, the `verify lane:` Evidence line records `no-op / 0 lanes / 0 excluded`, and
 grounding proceeds.
 
-The `verify lane: dispatched / N lanes / M excluded` line in the Phase-1 Evidence block makes this
+The `verify lane: <mode> / N lanes / M excluded` line in the Phase-1 Evidence block makes this
 stage **visible-or-violation** — the verify stage must be reported there exactly as the
 `explore dispatched THIS session` line is, so a skipped verify lane surfaces as a missing Evidence
-line, not a silent omission. Note the unit difference: **N counts lanes** (one per non-empty collect
-lane dispatched to a verifier), **M counts individual findings** excluded across all lanes (the two
+line, not a silent omission. `<mode>` is **`inline`** for Complex (planner self-QA) or **`dispatched`**
+for Architecture (delegated verifiers); all collect lanes empty records `no-op`. Note the unit
+difference: **N counts lanes** (one per non-empty collect lane — falsified inline at Complex, dispatched
+to a verifier at Architecture), **M counts individual findings** excluded across all lanes (the two
 units are independent and will often differ).
 
 #### Adversarial evidence keys (#13 vocabulary)

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -149,9 +149,9 @@ The Co-Design Daedalus advisory pass is on the mandatory path but is purely advi
 | Clearance checklist evaluation | Yes | - |
 | AC drafting & user confirmation | Yes | - |
 | Plan file writing ($OMT_DIR/plans/) | Yes | - |
-| Codebase fact gathering | NEVER (exception: re-reading already-collected cited evidence inside the Complex inline verify lane per `#### Collect→verify contract`) | explore |
+| Codebase fact gathering | NEVER (exception: re-reading already-collected cited evidence inside the Complex inline verify lane **for the codebase (explore aspect) lanes** per `#### Collect→verify contract` — the external lane is NOT excepted; it is verified by a delegated subagent even at Complex) | explore |
 | Architecture feasibility check | NEVER | oracle |
-| External tech research | NEVER | librarian |
+| External tech research | NEVER (this includes external-lane falsification — even at Complex intent, the librarian external lane is verified by the delegated verifier, never re-read inline by the planner; see `#### Collect→verify contract`) | librarian |
 | Pre-plan gap analysis | NEVER | metis |
 | In-phase design review (Co-Design, advisory) | NEVER | daedalus (MANDATORY — advisory only, never gates) |
 | Post-plan codebase verification | NEVER | momus (MANDATORY) |
@@ -262,7 +262,7 @@ Anti-Patterns describe *what* goes wrong. This table targets the *reasoning* you
 | Thought | Reality |
 |---|---|
 | "explore was already done in a prior turn / prior session traces are visible" | Verify the result is in YOUR session as a tool message. If absent, re-dispatch. Trust-without-verify is a violation. |
-| "I'll just grep / Read directly — it's faster" | `Do vs Delegate Decision Matrix` is absolute: codebase fact gathering = **NEVER you, ALWAYS explore**. Efficiency does not override mandate. Exception: re-reading or re-grepping an already-collected finding's cited evidence inside the Complex inline verify lane (per `#### Collect→verify contract`) is the mandated falsification action, not new fact gathering. |
+| "I'll just grep / Read directly — it's faster" | `Do vs Delegate Decision Matrix` is absolute: codebase fact gathering = **NEVER you, ALWAYS explore**. Efficiency does not override mandate. Exception: re-reading or re-grepping an already-collected finding's cited evidence inside the Complex inline verify lane **for the codebase (explore aspect) lanes** (per `#### Collect→verify contract`) is the mandated falsification action, not new fact gathering. The external lane is NOT covered by this exception — it is always verified by a delegated subagent. |
 | "Clearance items all look OK" | Implicit judgment is forbidden. Per `## Clearance Checklist` ("Run after EVERY interview turn") + Red Flags STOP signal, you must output each of the 6 items YES/NO in the agent's visible reasoning every turn. This is the agent owning its own decision, not asking the user — line 204 forbids the latter, not the former. |
 | "Decomposition Formalism feels like ritual" | For Architecture/Complex intent, missing MECE/Atomicity/Anti-pattern evaluation IS the direct cause of silent regression. Skip = contract violation. |
 | "Write the plan first, create tasks later" | "From the moment intent is classified" — the timing is non-negotiable. Late TaskCreate = invisible incomplete work. |
@@ -279,7 +279,7 @@ Anti-Patterns describe *what* goes wrong. This table targets the *reasoning* you
 If any of these signals are present in YOUR own behavior, halt and reset:
 
 - STOP — Proceeding to Phase 2 without `explore` (and `librarian` for Architecture) dispatched **in this session** with results assimilated
-- STOP — About to type `grep` / `find` / Bash search yourself for codebase facts not covered by loaded `context/` files **or by the Complex inline verify lane (per `#### Collect→verify contract`), where re-reading or re-grepping an already-collected finding's cited evidence to falsify it is the mandated action — not forbidden ad-hoc gathering**
+- STOP — About to type `grep` / `find` / Bash search yourself for codebase facts not covered by loaded `context/` files **or by the Complex inline verify lane for the codebase (explore aspect) lanes (per `#### Collect→verify contract`), where re-reading or re-grepping an already-collected finding's cited evidence to falsify it is the mandated action — not forbidden ad-hoc gathering. The external lane is NOT covered here — it is always verified by a delegated subagent.**
 - STOP — Clearance Checklist 6 items not written out one-by-one with YES/NO this turn
 - STOP — About to write plan without `Decomposition Self-Check` output (MECE / Atomicity 3-conditions / Anti-pattern) for Complex/Architecture intent
 - STOP — No `TaskCreate` calls visible in this session despite intent already classified
@@ -341,7 +341,7 @@ Phase 1 ritual (context loading + explore + librarian) is invisible by default �
 - Context files loaded: <list each Read path, or "missing — skipped per Graceful skip rule">
 - explore dispatched THIS session: <Agent invocation reference, or "N/A — intent is Trivial/Scoped without explore need">
 - librarian dispatched THIS session: <Agent invocation reference, or "N/A — Architecture, or Complex with design surface, not present; intent is Trivial/Scoped, or a purely mechanical refactor">
-- verify lane: <inline (Complex) | dispatched (Architecture)> / N lanes / M excluded <or "no-op / 0 lanes / 0 excluded" when all collect lanes are empty | "N/A — intent is Trivial/Scoped (verify lane is Complex/Architecture only)">
+- verify lane: <inline (codebase) + dispatched (external) (Complex with external lane) | inline (Complex, no external lane) | dispatched (Architecture)> / N lanes / M excluded <or "no-op / 0 lanes / 0 excluded" when all collect lanes are empty | "N/A — intent is Trivial/Scoped (verify lane is Complex/Architecture only)">
 - Results received and assimilated: <Y/N — Y requires both summary read and key findings noted>
 ```
 
@@ -371,7 +371,7 @@ collect lane scoped to its aspect. The aspect set is closed: you do not add, dro
 When the librarian default lane is present (per `### Subagent Use During Interview`), it runs in the
 same parallel response as a sixth, external collect lane alongside the 5 aspect lanes.
 
-#### Collect→verify contract (intent-split: Complex inline, Architecture delegated)
+#### Collect→verify contract (intent-split: Complex codebase-inline + external-delegated, Architecture all-delegated)
 
 After collect, every non-empty **collect lane** is falsified before its findings reach grounding. How
 the falsification runs splits by intent:
@@ -385,9 +385,13 @@ request only — NEVER the full aggregate**. Per-lane isolation is deliberate: i
 free of the other lanes' framing (no cross-lane anchoring) and makes the verifier structurally
 adversarial — its job is to falsify the lane's claims, not confirm them.
 
-**On Complex intent**, the planner runs that same falsification **inline** — no verifier subagent:
-treat each finding as a claim to disprove, re-read or re-grep the cited evidence yourself, then apply
-the per-finding schema + Exclusion rule directly. Zero spawns.
+**On Complex intent**, the planner runs that same falsification **inline for the codebase (explore
+aspect) lanes** — no verifier subagent for those lanes: treat each finding as a claim to disprove,
+re-read or re-grep the cited evidence yourself, then apply the per-finding schema + Exclusion rule
+directly. Zero spawns for the codebase lanes. The **librarian external lane, when present, keeps its
+delegated falsifying-verifier subagent (Complex and Architecture alike)** — untrusted external text
+must not enter the planner context directly, so the isolation logic that protects Architecture
+applies at Complex too.
 
 The schema, Exclusion rule, no-op path, and 4-key checklist below are one shared procedure both paths
 run — only the actor differs (delegated verifier vs inline planner). The actor inspects **every
@@ -418,7 +422,7 @@ grounding proceeds.
 The `verify lane: <mode> / N lanes / M excluded` line in the Phase-1 Evidence block makes this
 stage **visible-or-violation** — the verify stage must be reported there exactly as the
 `explore dispatched THIS session` line is, so a skipped verify lane surfaces as a missing Evidence
-line, not a silent omission. `<mode>` is the actor that ran (`inline` / `dispatched` / `no-op`). Note
+line, not a silent omission. `<mode>` is the actor that ran (`inline (codebase) + dispatched (external)` for Complex with an external lane / `inline` for Complex without an external lane / `dispatched` for Architecture / `no-op`). Note
 the unit difference: **N counts lanes** (one per non-empty collect lane), **M counts individual
 findings** excluded across all lanes (the two units are independent and will often differ).
 

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -149,7 +149,7 @@ The Co-Design Daedalus advisory pass is on the mandatory path but is purely advi
 | Clearance checklist evaluation | Yes | - |
 | AC drafting & user confirmation | Yes | - |
 | Plan file writing ($OMT_DIR/plans/) | Yes | - |
-| Codebase fact gathering | NEVER | explore |
+| Codebase fact gathering | NEVER (exception: re-reading already-collected cited evidence inside the Complex inline verify lane per `#### Collect→verify contract`) | explore |
 | Architecture feasibility check | NEVER | oracle |
 | External tech research | NEVER | librarian |
 | Pre-plan gap analysis | NEVER | metis |
@@ -262,7 +262,7 @@ Anti-Patterns describe *what* goes wrong. This table targets the *reasoning* you
 | Thought | Reality |
 |---|---|
 | "explore was already done in a prior turn / prior session traces are visible" | Verify the result is in YOUR session as a tool message. If absent, re-dispatch. Trust-without-verify is a violation. |
-| "I'll just grep / Read directly — it's faster" | `Do vs Delegate Decision Matrix` is absolute: codebase fact gathering = **NEVER you, ALWAYS explore**. Efficiency does not override mandate. |
+| "I'll just grep / Read directly — it's faster" | `Do vs Delegate Decision Matrix` is absolute: codebase fact gathering = **NEVER you, ALWAYS explore**. Efficiency does not override mandate. Exception: re-reading or re-grepping an already-collected finding's cited evidence inside the Complex inline verify lane (per `#### Collect→verify contract`) is the mandated falsification action, not new fact gathering. |
 | "Clearance items all look OK" | Implicit judgment is forbidden. Per `## Clearance Checklist` ("Run after EVERY interview turn") + Red Flags STOP signal, you must output each of the 6 items YES/NO in the agent's visible reasoning every turn. This is the agent owning its own decision, not asking the user — line 204 forbids the latter, not the former. |
 | "Decomposition Formalism feels like ritual" | For Architecture/Complex intent, missing MECE/Atomicity/Anti-pattern evaluation IS the direct cause of silent regression. Skip = contract violation. |
 | "Write the plan first, create tasks later" | "From the moment intent is classified" — the timing is non-negotiable. Late TaskCreate = invisible incomplete work. |
@@ -279,7 +279,7 @@ Anti-Patterns describe *what* goes wrong. This table targets the *reasoning* you
 If any of these signals are present in YOUR own behavior, halt and reset:
 
 - STOP — Proceeding to Phase 2 without `explore` (and `librarian` for Architecture) dispatched **in this session** with results assimilated
-- STOP — About to type `grep` / `find` / Bash search yourself for codebase facts not covered by loaded `context/` files
+- STOP — About to type `grep` / `find` / Bash search yourself for codebase facts not covered by loaded `context/` files **or by the Complex inline verify lane (per `#### Collect→verify contract`), where re-reading or re-grepping an already-collected finding's cited evidence to falsify it is the mandated action — not forbidden ad-hoc gathering**
 - STOP — Clearance Checklist 6 items not written out one-by-one with YES/NO this turn
 - STOP — About to write plan without `Decomposition Self-Check` output (MECE / Atomicity 3-conditions / Anti-pattern) for Complex/Architecture intent
 - STOP — No `TaskCreate` calls visible in this session despite intent already classified

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -387,17 +387,14 @@ adversarial — its job is to falsify the lane's claims, not confirm them.
 
 **On Complex intent**, the planner runs that same falsification **inline** — no verifier subagent:
 treat each finding as a claim to disprove, re-read or re-grep the cited evidence yourself, then apply
-the per-finding schema + Exclusion rule directly. Zero spawns. (Inline suits Complex's smaller finding
-count; Architecture keeps the delegated verifier because its independent re-read is what catches a
-collector that misread or cited a `nonexistent_path`.)
+the per-finding schema + Exclusion rule directly. Zero spawns.
 
-The verdict schema, Exclusion rule, no-op path, and 4-key checklist below apply to both paths — only
-the actor (planner inline vs delegated verifier) differs.
-
-Each verifier inspects **every finding** in its lane and returns a **per-finding** verdict against
-this schema (a deliberate divergence from the Review Pipeline's `CONFIRMED/PLAUSIBLE/REFUTED` ladder
-— only the dispatch mechanics are reused, NOT the verdict vocabulary). A lane may contain one or
-several findings; the verifier emits one schema record per finding, not a single lane-level summary:
+The schema, Exclusion rule, no-op path, and 4-key checklist below are one shared procedure both paths
+run — only the actor differs (delegated verifier vs inline planner). The actor inspects **every
+finding** in its lane and returns a **per-finding** verdict against this schema (a deliberate divergence
+from the Review Pipeline's `CONFIRMED/PLAUSIBLE/REFUTED` ladder — only the dispatch mechanics are
+reused, NOT the verdict vocabulary). A lane may contain one or several findings; the actor emits one
+schema record per finding, not a single lane-level summary:
 
 ```
 { verdict, evidence, confidence ∈ {high, medium, low} }
@@ -421,11 +418,9 @@ grounding proceeds.
 The `verify lane: <mode> / N lanes / M excluded` line in the Phase-1 Evidence block makes this
 stage **visible-or-violation** — the verify stage must be reported there exactly as the
 `explore dispatched THIS session` line is, so a skipped verify lane surfaces as a missing Evidence
-line, not a silent omission. `<mode>` is **`inline`** for Complex (planner self-QA) or **`dispatched`**
-for Architecture (delegated verifiers); all collect lanes empty records `no-op`. Note the unit
-difference: **N counts lanes** (one per non-empty collect lane — falsified inline at Complex, dispatched
-to a verifier at Architecture), **M counts individual findings** excluded across all lanes (the two
-units are independent and will often differ).
+line, not a silent omission. `<mode>` is the actor that ran (`inline` / `dispatched` / `no-op`). Note
+the unit difference: **N counts lanes** (one per non-empty collect lane), **M counts individual
+findings** excluded across all lanes (the two units are independent and will often differ).
 
 #### Adversarial evidence keys (#13 vocabulary)
 

--- a/skills/prometheus/interview.md
+++ b/skills/prometheus/interview.md
@@ -124,18 +124,14 @@ Collect the five results as five named lanes before moving to the verify step.
 
 How the collect lanes are falsified splits by intent (see SKILL.md `#### Collect→verify contract`).
 
-**On Architecture intent**, dispatch one **falsifying verifier** subagent per non-empty lane. Mirrors
-the code-review per-candidate isolation model: each verifier reads the actual files and returns a
-**per-finding** verdict against the SKILL.md schema — `corroborated` (finding stands) or `refuted`
-(does not hold). Only the dispatch mechanics are reused, NOT the Review Pipeline's
-CONFIRMED/PLAUSIBLE/REFUTED verdict vocabulary. Verifiers are foreground and parallel; dispatch all
-non-empty lanes in ONE response.
+**On Architecture intent**, dispatch one **falsifying verifier** subagent per non-empty lane —
+foreground, parallel, all non-empty lanes in ONE response — using the template below. Each verifier
+returns the per-finding verdict schema (`confidence` included); verdict semantics and the
+vocabulary-divergence rule live in SKILL.md.
 
-**On Complex intent**, do NOT dispatch verifiers — the planner falsifies each lane inline: treat each
-finding as a claim to disprove, **re-read or re-grep the cited `file:line` evidence yourself**, apply
-the 4-key checklist, and emit the same per-finding record (`verdict`, `evidence`, `confidence`, `keys`)
-directly. Then apply the Exclusion rule below. Zero spawns; use the dispatch template below only as
-your inline rubric.
+**On Complex intent**, do NOT dispatch verifiers — the planner falsifies each lane inline, using the
+template below as its rubric: **re-read or re-grep the cited `file:line` evidence yourself**, emit the
+same per-finding record directly, then apply the Exclusion rule. Zero spawns.
 
 For each lane (Architecture path), interpolate the placeholders before dispatching:
 

--- a/skills/prometheus/interview.md
+++ b/skills/prometheus/interview.md
@@ -120,7 +120,7 @@ Collect the five results as five named lanes before moving to the verify step.
 
 ---
 
-### Phase-1 verify lane (intent-split: Complex inline, Architecture delegated)
+### Phase-1 verify lane (intent-split: Complex codebase-inline + external-delegated, Architecture all-delegated)
 
 How the collect lanes are falsified splits by intent (see SKILL.md `#### Collect→verify contract`).
 
@@ -129,9 +129,12 @@ foreground, parallel, all non-empty lanes in ONE response — using the template
 returns the per-finding verdict schema (`confidence` included); verdict semantics and the
 vocabulary-divergence rule live in SKILL.md.
 
-**On Complex intent**, do NOT dispatch verifiers — the planner falsifies each lane inline, using the
-template below as its rubric: **re-read or re-grep the cited `file:line` evidence yourself**, emit the
-same per-finding record directly, then apply the Exclusion rule. Zero spawns.
+**On Complex intent**, do NOT dispatch verifiers for the codebase (explore aspect) lanes — the
+planner falsifies those lanes inline, using the template below as its rubric: **re-read or re-grep
+the cited `file:line` evidence yourself**, emit the same per-finding record directly, then apply the
+Exclusion rule. Zero spawns for the codebase lanes. The librarian external lane is the exception:
+dispatch its delegated verifier even at Complex (same as Architecture) — untrusted external text
+must not enter the planner context directly.
 
 For each lane (Architecture path), interpolate the placeholders before dispatching:
 
@@ -187,7 +190,7 @@ Agent(subagent_type="librarian", prompt="I am planning {REQUEST_SUMMARY}. Extern
 ```
 
 Dispatch this in the same parallel response as the Phase-1 multi-aspect fan-out explore (above).
-Its results form the EXTERNAL collect lane, which is falsified by the same verify lane (inline at Complex, delegated at Architecture).
+Its results form the EXTERNAL collect lane, which is **always falsified by a delegated verifier subagent (Complex and Architecture alike)** — untrusted external text must not enter the planner context directly (see `#### Collect→verify contract` in SKILL.md).
 
 ---
 

--- a/skills/prometheus/interview.md
+++ b/skills/prometheus/interview.md
@@ -120,17 +120,24 @@ Collect the five results as five named lanes before moving to the verify step.
 
 ---
 
-### Phase-1 verify-lane falsifying verifier (per lane)
+### Phase-1 verify lane (intent-split: Complex inline, Architecture delegated)
 
-After collecting all lanes, dispatch one **falsifying verifier** subagent per non-empty lane.
-Mirrors the code-review per-candidate isolation model: each verifier reads the actual files and
-returns a **per-finding** verdict against the SKILL.md schema — each finding in the lane gets one
-record whose verdict is `corroborated` (finding stands) or `refuted` (finding does not hold).
-This is a deliberate divergence from the Review Pipeline's
-CONFIRMED/PLAUSIBLE/REFUTED ladder: only the dispatch mechanics are reused, NOT the verdict
-vocabulary. Verifiers are foreground and parallel; dispatch all non-empty lanes in ONE response.
+How the collect lanes are falsified splits by intent (see SKILL.md `#### Collect→verify contract`).
 
-For each lane, interpolate the placeholders before dispatching:
+**On Architecture intent**, dispatch one **falsifying verifier** subagent per non-empty lane. Mirrors
+the code-review per-candidate isolation model: each verifier reads the actual files and returns a
+**per-finding** verdict against the SKILL.md schema — `corroborated` (finding stands) or `refuted`
+(does not hold). Only the dispatch mechanics are reused, NOT the Review Pipeline's
+CONFIRMED/PLAUSIBLE/REFUTED verdict vocabulary. Verifiers are foreground and parallel; dispatch all
+non-empty lanes in ONE response.
+
+**On Complex intent**, do NOT dispatch verifiers — the planner falsifies each lane inline: treat each
+finding as a claim to disprove, **re-read or re-grep the cited `file:line` evidence yourself**, apply
+the 4-key checklist, and emit the same per-finding record (`verdict`, `evidence`, `confidence`, `keys`)
+directly. Then apply the Exclusion rule below. Zero spawns; use the dispatch template below only as
+your inline rubric.
+
+For each lane (Architecture path), interpolate the placeholders before dispatching:
 
 ```
 Agent(subagent_type="general-purpose", prompt="You are an adversarial falsifying verifier for a single Phase-1 collect lane. Your job is to read the actual codebase evidence and try to falsify each lane finding — assume every finding is wrong until the cited code forces you to corroborate it.
@@ -184,7 +191,7 @@ Agent(subagent_type="librarian", prompt="I am planning {REQUEST_SUMMARY}. Extern
 ```
 
 Dispatch this in the same parallel response as the Phase-1 multi-aspect fan-out explore (above).
-Its results form the EXTERNAL collect lane, which is subject to the same falsifying verifier step.
+Its results form the EXTERNAL collect lane, which is falsified by the same verify lane (inline at Complex, delegated at Architecture).
 
 ---
 

--- a/skills/prometheus/scripts/verify-lane-contract.test.ts
+++ b/skills/prometheus/scripts/verify-lane-contract.test.ts
@@ -42,9 +42,11 @@ describe('SKILL.md presence — verify-lane tokens', () => {
     expect(skillContent).toContain('falsifying verifier');
   });
 
-  it('P3: verify lane: Evidence-block list-marker line (intent-split mode placeholder)', () => {
+  it('P3: verify lane: Evidence-block list-marker line (mixed Complex mode placeholder)', () => {
+    // The template now expresses the mixed Complex case: codebase lanes inline
+    // + external lane dispatched when present. Old single-mode form is gone.
     expect(skillContent).toContain(
-      '- verify lane: <inline (Complex) | dispatched (Architecture)> / N lanes / M excluded',
+      '- verify lane: <inline (codebase) + dispatched (external) (Complex with external lane) | inline (Complex, no external lane) | dispatched (Architecture)> / N lanes / M excluded',
     );
   });
 
@@ -321,6 +323,63 @@ describe('interview.md P2-B — per-finding schema and {LANE_FINDINGS} guard', (
     // Guards the Complex half of the intent-split alongside the Architecture half above (P2-B-I4).
     // Deleting the Complex inline-falsification prose from interview.md turns this RED.
     expect(interviewContent).toContain('do NOT dispatch verifiers');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Option A invariant: external lane is ALWAYS delegated (Complex and
+// Architecture alike). The planner never inline-reads external evidence.
+//
+// Presence tests: distinctive new clauses that must appear after the fix.
+// Absence tests: old "inline at Complex" phrasing for the external lane must
+// be gone — if someone reverts to external-inline, the absence half goes RED.
+// ---------------------------------------------------------------------------
+
+describe('Option A — external lane always delegated (SKILL.md + interview.md)', () => {
+  it('OA-P1: SKILL.md — external lane keeps delegated verifier at Complex (new clause)', () => {
+    // Guards the core Option A invariant in SKILL.md: the external lane is
+    // delegated even on Complex intent. Reverting to all-inline-at-Complex
+    // removes this phrase and turns this RED.
+    // Anchors on the single-line portion of the new clause (line 392 of SKILL.md):
+    // the full clause spans two lines, so we pin the distinctive single-line tail.
+    expect(skillContent).toContain(
+      'delegated falsifying-verifier subagent (Complex and Architecture alike)',
+    );
+  });
+
+  it('OA-P2: interview.md — external lane always delegated verifier subagent (new clause)', () => {
+    // Guards the Option A invariant in interview.md: the EXTERNAL collect lane
+    // is always falsified by a delegated verifier, not inline at Complex.
+    // Reverting to "(inline at Complex, delegated at Architecture)" removes this
+    // phrase and turns this RED.
+    expect(interviewContent).toContain(
+      'always falsified by a delegated verifier subagent (Complex and Architecture alike)',
+    );
+  });
+
+  it('OA-A1: interview.md — old "inline at Complex" external-lane phrasing is gone', () => {
+    // The stale phrase that made the external lane inline at Complex.
+    // Must be absent after the fix; if it survives, Option A is incomplete.
+    expect(interviewContent).not.toContain(
+      'inline at Complex, delegated at Architecture',
+    );
+  });
+
+  it('OA-A2: SKILL.md — codebase inline rule is now explicitly scoped (not unqualified "inline — no verifier subagent")', () => {
+    // The old unqualified phrase applied to ALL lanes. After the fix the rule
+    // is scoped to codebase lanes only. The unqualified form must be gone.
+    expect(skillContent).not.toContain(
+      'planner runs that same falsification inline — no verifier subagent',
+    );
+  });
+
+  it('OA-A3: SKILL.md — old Evidence-block template single-mode form is gone', () => {
+    // The old template used <inline (Complex) | dispatched (Architecture)> — a
+    // single-actor form that could not represent the mixed Complex case.
+    // After the fix it must be gone; the new mixed-mode form replaces it.
+    expect(skillContent).not.toContain(
+      '<inline (Complex) | dispatched (Architecture)>',
+    );
   });
 });
 

--- a/skills/prometheus/scripts/verify-lane-contract.test.ts
+++ b/skills/prometheus/scripts/verify-lane-contract.test.ts
@@ -42,8 +42,14 @@ describe('SKILL.md presence — verify-lane tokens', () => {
     expect(skillContent).toContain('falsifying verifier');
   });
 
-  it('P3: verify lane: Evidence-block list-marker line (replaces success-output checklist)', () => {
-    expect(skillContent).toContain('- verify lane: dispatched / N lanes / M excluded');
+  it('P3: verify lane: Evidence-block list-marker line (intent-split mode placeholder)', () => {
+    expect(skillContent).toContain(
+      '- verify lane: <inline (Complex) | dispatched (Architecture)> / N lanes / M excluded',
+    );
+  });
+
+  it('P3-A: old mode-less verify lane line is gone (intent-split replaces it)', () => {
+    expect(skillContent).not.toContain('- verify lane: dispatched / N lanes / M excluded');
   });
 
   it('P4: stale_state key (additive)', () => {

--- a/skills/prometheus/scripts/verify-lane-contract.test.ts
+++ b/skills/prometheus/scripts/verify-lane-contract.test.ts
@@ -278,6 +278,19 @@ describe('SKILL.md P2-B — per-finding verdict vocabulary', () => {
     // Distinctive phrase that confirms per-finding scope of the Exclusion rule.
     expect(skillContent).toContain('Exclusion is applied **per finding**');
   });
+
+  it('P2-B-P4: Complex intent inline branch — "no verifier subagent" present (SKILL.md :388)', () => {
+    // Guards the Complex zero-spawn half of the intent-split (collect→verify contract).
+    // Paired with P2-B-I4 (Architecture dispatch invariant) — both halves must survive.
+    // Deleting the Complex branch from SKILL.md turns this RED.
+    expect(skillContent).toContain('no verifier subagent');
+  });
+
+  it('P2-B-P5: Complex intent inline branch — "Zero spawns" present (SKILL.md :390)', () => {
+    // Second anchor on the Complex zero-spawn contract. Two distinct literals means
+    // paraphrasing one literal still trips the other.
+    expect(skillContent).toContain('Zero spawns');
+  });
 });
 
 describe('interview.md P2-B — per-finding schema and {LANE_FINDINGS} guard', () => {
@@ -303,6 +316,12 @@ describe('interview.md P2-B — per-finding schema and {LANE_FINDINGS} guard', (
       'dispatch one **falsifying verifier** subagent per non-empty lane',
     );
   });
+
+  it('P2-B-I5: Complex zero-spawn invariant — "do NOT dispatch verifiers" present (interview.md :132)', () => {
+    // Guards the Complex half of the intent-split alongside the Architecture half above (P2-B-I4).
+    // Deleting the Complex inline-falsification prose from interview.md turns this RED.
+    expect(interviewContent).toContain('do NOT dispatch verifiers');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -313,20 +332,20 @@ describe('interview.md P2-B — per-finding schema and {LANE_FINDINGS} guard', (
 // ---------------------------------------------------------------------------
 
 describe('scenarios P2-C — P-25 axis reframe (old absent, new present)', () => {
-  it('P2-C-A1: old framing "OUTSIDE the verify lane" is gone', () => {
-    expect(scenariosContent).not.toContain('OUTSIDE the verify lane');
+  it('P2-C-A1: old framing "outside the verify lane" is gone (case-insensitive)', () => {
+    expect(scenariosContent.toLowerCase()).not.toContain('outside the verify lane');
   });
 
-  it('P2-C-A2: old framing "not confined to the verify stage" is gone', () => {
-    expect(scenariosContent).not.toContain('not confined to the verify stage');
+  it('P2-C-A2: old framing "not confined to the verify stage" is gone (case-insensitive)', () => {
+    expect(scenariosContent.toLowerCase()).not.toContain('not confined to the verify stage');
   });
 
-  it('P2-C-A3: old framing "NOT produced inside the verify lane itself" is gone', () => {
-    expect(scenariosContent).not.toContain('NOT produced inside the verify lane itself');
+  it('P2-C-A3: old framing "not produced inside the verify lane itself" is gone (case-insensitive)', () => {
+    expect(scenariosContent.toLowerCase()).not.toContain('not produced inside the verify lane itself');
   });
 
-  it('P2-C-A4: old framing "out-of-verify-lane" is gone', () => {
-    expect(scenariosContent).not.toContain('out-of-verify-lane');
+  it('P2-C-A4: old framing "out-of-verify-lane" is gone (case-insensitive)', () => {
+    expect(scenariosContent.toLowerCase()).not.toContain('out-of-verify-lane');
   });
 
   it('P2-C-P1: new axis "applies uniformly across all lane types" is present', () => {

--- a/skills/prometheus/tests/application-scenarios.md
+++ b/skills/prometheus/tests/application-scenarios.md
@@ -40,7 +40,7 @@ These scenarios test whether the prometheus skill's **core techniques** are corr
 | BH-5 | ADR Log Emission and Structural Enumeration Timing | Decision log with structural enumeration at Complex/Architecture; full-item log without structural items at Scoped; no ADR log at Trivial | ADR Log + Structural Enumeration |
 | P-27 | Per-Step State Persistence + Resume | Per-Step State Persistence (State Lifecycle) | AC Recording at S1 |
 | P-28 | Trigger-Based Diagram Lenses (Stage A) | Diagram Lens Taxonomy (trigger-based REQUIRED) | Stage A Fidelity + Grouped Placement |
-| P-29 | Complex Inline Verify-Lane | Verify Lane: Complex inline falsification — planner re-reads cited paths, excludes nonexistent_path finding, zero verifier spawns | Phase-1 Grounding + Collect→Verify Contract (intent-split) |
+| P-29 | Complex Mixed Verify-Lane | Verify Lane: Complex mixed mode — codebase lanes inline-falsified by planner, librarian external lane delegated to one verifier subagent, nonexistent_path finding in codebase lane excluded, Evidence line records `inline (codebase) + dispatched (external)` | Phase-1 Grounding + Collect→Verify Contract (intent-split) |
 
 ---
 
@@ -1144,25 +1144,28 @@ Render the Stage A HTML presentation.
 
 ---
 
-## Scenario P-29: Complex Inline Verify-Lane
+## Scenario P-29: Complex Mixed Verify-Lane
 
-**Primary Technique:** Verify Lane — Complex inline falsification: the planner re-reads/re-greps each cited path inline (zero verifier subagent spawns), excludes findings whose cited paths do not exist, and records `verify lane: inline` in the Phase-1 Evidence block.
+**Primary Technique:** Verify Lane — Complex mixed mode: the planner inline-falsifies the codebase (explore aspect) lanes (zero verifier subagents for those lanes), while the librarian external lane is delegated to exactly one falsifying verifier subagent. The nonexistent-path finding sits in a codebase lane and is refuted by the planner's own inline re-read. The Phase-1 Evidence block records `verify lane: inline (codebase) + dispatched (external)`.
 
 **Setup:**
-Complex intent (the inline falsification path — on Architecture intent these lanes are handed to dispatched falsifying verifiers). Phase-1 grounding completes the collect step: 3 of the 5 explore aspect lanes are non-empty (pattern, convention, naming/registration). The librarian external lane is also non-empty. The remaining 2 aspect lanes (similar implementation, test infrastructure) are empty.
+Complex intent. Phase-1 grounding completes the collect step: 3 of the 5 explore aspect lanes are non-empty (pattern, convention, naming/registration). The librarian external lane is also non-empty. The remaining 2 aspect lanes (similar implementation, test infrastructure) are empty.
 
-The naming/registration lane returns one finding that cites `src/handlers/user_profile_handler.go:42`. The planner inline-verifies each finding by re-reading or re-grepping the cited path. On re-read, `src/handlers/user_profile_handler.go` does not exist in the repository.
+The naming/registration lane (a codebase aspect lane) returns one finding that cites `src/handlers/user_profile_handler.go:42`. For the 3 non-empty codebase aspect lanes, the planner inline-verifies each finding by re-reading or re-grepping the cited path directly — zero verifier subagent spawns for these lanes. On re-read, `src/handlers/user_profile_handler.go` does not exist in the repository, so that finding is tagged `nonexistent_path`, `verdict: refuted`, and excluded.
 
-The other 3 non-empty lanes each return one finding citing paths that exist and corroborate on re-read.
+The librarian external lane keeps its delegated falsifying-verifier subagent (untrusted external text must not enter the planner context directly; the isolation logic applies at Complex just as at Architecture). Exactly one verifier subagent is dispatched for this lane, returns a corroborated finding, and the finding passes through.
+
+The pattern and convention codebase lanes each return one finding citing paths that exist and corroborate on inline re-read.
 
 **Verification Points:**
 
 | # | Check | Expected Behavior |
 |---|-------|-------------------|
-| V1 | Zero verifier subagents spawned | The planner does NOT dispatch any falsifying verifier subagent. Zero Agent tool calls are issued for the verify step — the planner itself re-reads or re-greps each cited path inline (this is the mandated inline actor for Complex intent) |
-| V2 | Nonexistent-path finding refuted and excluded | The naming/registration finding citing `src/handlers/user_profile_handler.go:42` is refuted by the planner's own inline re-read (path does not exist → tagged `nonexistent_path`, `verdict: refuted`). It is excluded from the filtered findings that reach the interview, AC, and plan — it does NOT appear in plan grounding material |
-| V3 | Evidence line records `inline` mode | The Phase-1 Evidence block records a `verify lane: inline / 4 lanes / 1 excluded` line — the mode token is `inline`, NOT `dispatched`; the lane count is 4 (the 3 corroborated aspect lanes + the corroborated librarian lane); the excluded count is 1 |
+| V1 | Zero verifier subagents for codebase lanes | For the 3 non-empty codebase aspect lanes (pattern, convention, naming/registration) the planner does NOT dispatch any falsifying verifier subagent. Zero Agent tool calls are issued for those lanes — the planner itself re-reads or re-greps each cited path inline |
+| V2 | Nonexistent-path codebase finding refuted and excluded | The naming/registration finding citing `src/handlers/user_profile_handler.go:42` is refuted by the planner's own inline re-read (path does not exist → tagged `nonexistent_path`, `verdict: refuted`). It is excluded from the filtered findings that reach the interview, AC, and plan — it does NOT appear in plan grounding material |
+| V3 | Evidence line records mixed mode | The Phase-1 Evidence block records a `verify lane: inline (codebase) + dispatched (external) / 4 lanes / 1 excluded` line — the mode token is `inline (codebase) + dispatched (external)`, NOT `inline` alone or `dispatched` alone; the lane count is 4 (the 3 non-empty codebase aspect lanes + the librarian lane); the excluded count is 1 |
 | V4 | Corroborated findings pass through unchanged | The 3 corroborated findings from the pattern, convention, and librarian lanes reach the interview/AC/plan grounding step unchanged — exclusion applies only to the refuted naming/registration finding |
+| V5 | Exactly one verifier subagent dispatched for librarian lane | Exactly one Agent tool call is issued for the librarian external lane. That verifier is scoped to its own lane's findings only — it is NOT given the codebase lanes' findings. The verifier returns a corroborated result that passes the Exclusion rule |
 
 ---
 
@@ -1203,4 +1206,4 @@ The other 3 non-empty lanes each return one finding citing paths that exist and 
 | P-26 | All-Collect-Lanes-Empty No-Op | | | New empty-lanes no-op scenario (valid no-op when all collect lanes empty). Needs testing |
 | P-27 | Per-Step State Persistence + Resume | | | Needs testing |
 | P-28 | Trigger-Based Diagram Lenses (Stage A) | | | Needs testing |
-| P-29 | Complex Inline Verify-Lane | | | New Complex inline verify-lane scenario (planner falsifies inline, zero verifier spawns, nonexistent_path finding excluded, Evidence line records `inline` mode). Needs testing |
+| P-29 | Complex Mixed Verify-Lane | | | New Complex mixed verify-lane scenario (codebase lanes inline-falsified by planner, librarian external lane delegated to one verifier subagent, nonexistent_path codebase finding excluded, Evidence line records `inline (codebase) + dispatched (external)` mode). Needs testing |

--- a/skills/prometheus/tests/application-scenarios.md
+++ b/skills/prometheus/tests/application-scenarios.md
@@ -781,7 +781,7 @@ Add a new POST /api/orders endpoint that creates an order and returns the create
 **Primary Technique:** Verify Lane — collect → falsifying verifier per non-empty lane → refuted finding excluded from plan grounding
 
 **Setup:**
-Complex/Architecture intent. Phase-1 grounding completes the collect step: 3 of the 5 explore aspect lanes are non-empty (pattern, convention, naming/registration). The librarian external lane is also non-empty. The remaining 2 aspect lanes (similar implementation, test infrastructure) are empty.
+Architecture intent (the delegated verify path — on Complex these lanes are falsified inline by the planner with no verifier dispatch). Phase-1 grounding completes the collect step: 3 of the 5 explore aspect lanes are non-empty (pattern, convention, naming/registration). The librarian external lane is also non-empty. The remaining 2 aspect lanes (similar implementation, test infrastructure) are empty.
 
 4 falsifying verifiers are dispatched in ONE parallel response — one per non-empty lane. The verifier for the naming/registration lane returns:
 
@@ -809,7 +809,7 @@ The remaining 3 verifiers return `verdict: corroborated` with `confidence: high`
 **Primary Technique:** Adversarial Evidence-Key Vocabulary — a #13 key-tag surfaces on a librarian external finding (not one of the 5 explore aspect lanes), proving the 4-key vocabulary applies uniformly across all lane types, not just the explore aspect lanes
 
 **Setup:**
-Complex/Architecture intent. Phase-1 collect dispatches a librarian agent to retrieve an external API specification for a third-party service. The librarian returns a finding about the API's authentication flow.
+Architecture intent (delegated verify path; on Complex the same 4-key tagging happens inline). Phase-1 collect dispatches a librarian agent to retrieve an external API specification for a third-party service. The librarian returns a finding about the API's authentication flow.
 
 The librarian finding is passed to the external-lane falsifying verifier (D-1 verify). While applying the D-5 adversarial 4-key checklist to the finding, the verifier tags it:
 

--- a/skills/prometheus/tests/application-scenarios.md
+++ b/skills/prometheus/tests/application-scenarios.md
@@ -29,7 +29,7 @@ These scenarios test whether the prometheus skill's **core techniques** are corr
 | P-19 | QA Scenarios in TODO | QA Scenarios | Plan Template Structure |
 | P-23 | Scenario Verification Principle | Scenario Verification Principle Declaration | - |
 | P-24 | Verify-Lane Round | Verify Lane: collect → falsifying verify → refuted exclusion | Phase-1 Grounding |
-| P-25 | Cross-Lane #13 Witness | Adversarial Evidence-Key: key-tag outside the verify lane | D-5 Key Vocabulary |
+| P-25 | Cross-Lane #13 Witness | Adversarial Evidence-Key: key-tag produced INSIDE the external verify lane (cross-lane uniformity across all lane types) | D-5 Key Vocabulary |
 | P-26 | All-Collect-Lanes-Empty No-Op | Verify Lane: valid no-op when every collect lane is empty | Phase-1 Grounding |
 | UC-P1 | End-to-End: Full Planning Pipeline | Full workflow integration | Classification + Interview + Clearance + AC + Metis + Co-Design (Daedalus advisory + human design gate) + Plan + Momus + Execution |
 | UC-P2 | End-to-End: Review Pipeline Rejection and Recovery | Review pipeline feedback loops | Momus REQUEST_CHANGES + defect-type loop-back + revision + re-Momus + User rejection + pipeline re-run |
@@ -40,6 +40,7 @@ These scenarios test whether the prometheus skill's **core techniques** are corr
 | BH-5 | ADR Log Emission and Structural Enumeration Timing | Decision log with structural enumeration at Complex/Architecture; full-item log without structural items at Scoped; no ADR log at Trivial | ADR Log + Structural Enumeration |
 | P-27 | Per-Step State Persistence + Resume | Per-Step State Persistence (State Lifecycle) | AC Recording at S1 |
 | P-28 | Trigger-Based Diagram Lenses (Stage A) | Diagram Lens Taxonomy (trigger-based REQUIRED) | Stage A Fidelity + Grouped Placement |
+| P-29 | Complex Inline Verify-Lane | Verify Lane: Complex inline falsification — planner re-reads cited paths, excludes nonexistent_path finding, zero verifier spawns | Phase-1 Grounding + Collect→Verify Contract (intent-split) |
 
 ---
 
@@ -1143,6 +1144,28 @@ Render the Stage A HTML presentation.
 
 ---
 
+## Scenario P-29: Complex Inline Verify-Lane
+
+**Primary Technique:** Verify Lane — Complex inline falsification: the planner re-reads/re-greps each cited path inline (zero verifier subagent spawns), excludes findings whose cited paths do not exist, and records `verify lane: inline` in the Phase-1 Evidence block.
+
+**Setup:**
+Complex intent (the inline falsification path — on Architecture intent these lanes are handed to dispatched falsifying verifiers). Phase-1 grounding completes the collect step: 3 of the 5 explore aspect lanes are non-empty (pattern, convention, naming/registration). The librarian external lane is also non-empty. The remaining 2 aspect lanes (similar implementation, test infrastructure) are empty.
+
+The naming/registration lane returns one finding that cites `src/handlers/user_profile_handler.go:42`. The planner inline-verifies each finding by re-reading or re-grepping the cited path. On re-read, `src/handlers/user_profile_handler.go` does not exist in the repository.
+
+The other 3 non-empty lanes each return one finding citing paths that exist and corroborate on re-read.
+
+**Verification Points:**
+
+| # | Check | Expected Behavior |
+|---|-------|-------------------|
+| V1 | Zero verifier subagents spawned | The planner does NOT dispatch any falsifying verifier subagent. Zero Agent tool calls are issued for the verify step — the planner itself re-reads or re-greps each cited path inline (this is the mandated inline actor for Complex intent) |
+| V2 | Nonexistent-path finding refuted and excluded | The naming/registration finding citing `src/handlers/user_profile_handler.go:42` is refuted by the planner's own inline re-read (path does not exist → tagged `nonexistent_path`, `verdict: refuted`). It is excluded from the filtered findings that reach the interview, AC, and plan — it does NOT appear in plan grounding material |
+| V3 | Evidence line records `inline` mode | The Phase-1 Evidence block records a `verify lane: inline / 4 lanes / 1 excluded` line — the mode token is `inline`, NOT `dispatched`; the lane count is 4 (the 3 corroborated aspect lanes + the corroborated librarian lane); the excluded count is 1 |
+| V4 | Corroborated findings pass through unchanged | The 3 corroborated findings from the pattern, convention, and librarian lanes reach the interview/AC/plan grounding step unchanged — exclusion applies only to the refuted naming/registration finding |
+
+---
+
 ## Test Results
 
 | # | Scenario | Result | Date | Notes |
@@ -1176,7 +1199,8 @@ Render the Stage A HTML presentation.
 | BH-4 | `[DECISION NEEDED]` Absence | | | New behavior scenario (in-phase co-design resolution, no placeholder). Needs testing |
 | BH-5 | ADR Log Emission and Structural Enumeration Timing | | | New behavior scenario (decision log with structural D-N items before human design gate at Complex/Architecture; full-item log without structural items at Scoped; no ADR log at Trivial — the two gates are distinct). Needs testing |
 | P-24 | Verify-Lane Round | | | New verify-lane scenario (collect → falsifying verify → refuted exclusion). Needs testing |
-| P-25 | Cross-Lane #13 Witness | | | New cross-lane witness scenario (prompt_injection key on librarian finding, outside verify lane). Needs testing |
+| P-25 | Cross-Lane #13 Witness | | | New cross-lane witness scenario (prompt_injection key on librarian finding, produced inside the external verify lane — cross-lane uniformity). Needs testing |
 | P-26 | All-Collect-Lanes-Empty No-Op | | | New empty-lanes no-op scenario (valid no-op when all collect lanes empty). Needs testing |
 | P-27 | Per-Step State Persistence + Resume | | | Needs testing |
 | P-28 | Trigger-Based Diagram Lenses (Stage A) | | | Needs testing |
+| P-29 | Complex Inline Verify-Lane | | | New Complex inline verify-lane scenario (planner falsifies inline, zero verifier spawns, nonexistent_path finding excluded, Evidence line records `inline` mode). Needs testing |


### PR DESCRIPTION
## 📌 Summary

prometheus와 explore가 추측이나 맹목적 위임 대신 실제 증거에 그라운딩해 검증하도록 두 에이전트의 지침을 강화한다. prometheus의 Phase-1 검증 레인을 intent별로 분기(Complex는 planner가 인용 증거를 직접 재독, Architecture는 위임 검증자 유지)하고, explore는 Symbol/Reference 탐색을 codegraph에 우선 그라운딩한다. 같은 브랜치에서 자체 코드리뷰로 발견한 5건(지침 모순·검증 커버리지 갭)을 함께 수정해 변경을 완결한다.

---

## 🔧 Changes

### prometheus — verify-lane intent-split

- Phase-1 collect→verify 레인을 intent type별로 분기: **Complex**는 planner가 인용된 `file:line` 증거를 직접 inline 재독해 반증(verifier subagent 0개), **Architecture**는 비어있지 않은 레인마다 위임 falsifying-verifier를 유지
- 두 에이전트에 중복되던 검증 rationale 산문을 슬림화 (WHAT은 스킬 본문에, WHY는 외부 spec/메모로)
- (리뷰 수정) Complex inline 재독을 always-loaded "planner는 사실 수집 금지" Red Flag에서 명시적으로 carve-out
- (리뷰 수정) intent-split 양쪽 절반을 contract test로 고정 + Complex inline 경로를 행사하는 시나리오(P-29) 추가 + stale 검증-레인 액자(framing) 정정

**영향 범위**
- prometheus 스킬 한정. 런타임 코드 변경 없음(에이전트 지침 산문 + 계약 테스트). 하위호환: 기존 Architecture 위임 동작은 그대로 보존되고, Complex 경로의 검증만 inline로 회수됨. `make validate` + `make test` 전부 green(Bun 2736 pass).

### explore — codegraph-first 그라운딩

- Symbol/Reference 질의를 codegraph MCP에 우선 그라운딩하고, codegraph 부재 시 기존 ast-grep/grep 근사(candidate set to verify)로 fallback

**영향 범위**
- explore 에이전트 공유 정의(8줄). codegraph가 없는 환경에서는 기존 탐색 동작이 그대로 유지되어 무해. additive 변경.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다. diff를 보지 않아도 핵심 결정을 이해할 수 있도록 작성했습니다.

### 1. 왜 Complex만 inline로 회수하고 Architecture는 위임을 유지하나

**배경 및 문제 상황:**
원래 목표는 "탐색 결과 검증을 위임에서 직접 검증으로" 일괄 전환하는 것이었다(all-inline). 즉 planner가 모든 finding을 스스로 재독해 반증하고, 별도 검증 subagent를 두지 않는 방향.

**해결 방안:**
all-inline 대신 intent type별로 분기했다. Complex = inline 직접 재독(verifier 0), Architecture = 위임 falsifying-verifier 유지.

**구현 세부사항:**
위임 verifier에게 넘어가는 것은 collector(explore/librarian)의 산출물이 아니라, verifier가 인용된 원본 소스를 **다시 읽어** 주장을 반증하는 절차다. 두 경로는 같은 schema와 Exclusion rule을 공유하고 actor(위임 verifier vs inline planner)만 다르다.

**선택과 트레이드오프:**
all-inline은 oracle 독립검토가 반증했다. 위임 verifier의 '원본 재독'은 토큰 낭비가 아니라 falsification의 본체다. 메인 컨텍스트에 routed된 요약만으로는 `nonexistent_path` 같은 가짜 인용을 못 잡기 때문이다. 그래서 finding이 많고 고위험인 Architecture는 독립 검증자를 유지하고, 소수·저위험인 Complex만 inline로 회수했다. **남은 트레이드오프:** inline self-QA는 메인이 자기 finding을 스스로 판정하므로 confirmation bias가 잔존한다(적대적 자세 + executed re-check로 완화했으나, 완전한 독립성은 별도 미해결 항목으로 파킹).

### 2. intent-split이 도입한 규칙 충돌과 carve-out

**배경 및 문제 상황:**
prometheus에는 "planner는 코드베이스 사실을 절대 직접 수집하지 않는다(explore에 위임)"는 always-loaded Red Flag/Do-vs-Delegate 절대 규칙이 있다. intent-split이 추가한 "Complex는 인용 증거를 직접 재독"이 이 규칙과 carve-out 없이 충돌했다. 그대로 두면 흔한 Complex 경로에서 에이전트가 STOP 규칙을 위반하거나 검증을 수행하지 못하는 양자택일에 빠진다.

**해결 방안:**
SOURCE 기준 carve-out을 추가했다. 이미 수집된 finding의 인용 증거를 재독하는 것(검증)은 허용하고, planner가 아직 수집되지 않은 사실을 새로 originating하는 것은 여전히 금지한다.

**선택과 트레이드오프:**
기존에 같은 파일이 쓰던 context-file 면제 패턴을 mirror했고, append-only로 추가해 contract test가 검사하는 기존 literal을 보존했다(검증 게이트를 깨지 않음).

### 3. 지침-산문 변경을 회귀로부터 보호하는 방법

**배경 및 문제 상황:**
verify-lane은 자연어 지침이라 build/test로는 모순이나 커버리지 갭이 잡히지 않는다. 실제로 자체 리뷰가 "계약 테스트가 intent-split의 Complex 절반을 전혀 고정하지 않는다"를 경험적으로 적발했다. SKILL.md에서 Complex 분기 prose를 통째로 지워도 테스트가 green이었다(false-green).

**해결 방안:**
both-halves presence assertion을 추가했다. Architecture 위임 불변식 바로 옆에 Complex zero-spawn 불변식(`no verifier subagent` / `Zero spawns` / `do NOT dispatch verifiers`)을 고정해, 한쪽이라도 삭제되면 RED가 되게 했다. stale-framing 부재 가드는 대소문자 무시로 강화해 소문자 잔재를 못 잡던 맹점을 제거했다.

**선택과 트레이드오프:**
산문을 string assertion으로 핀하는 방식은 brittle하다(표현을 바꾸면 테스트도 함께 고쳐야 함). 그러나 지침 회귀를 막는 유일한 자동 게이트라 수용했다. brittleness 비용 < 의도-분기 한쪽이 조용히 사라지는 false-green의 비용.

---

## ✅ Checklist

### prometheus verify-lane
- [ ] Complex intent에서 verifier subagent가 0개 spawn되고 planner가 인용 증거를 inline 재독한다
  - `skills/prometheus/SKILL.md`
- [ ] Architecture intent에서 비어있지 않은 레인마다 falsifying-verifier가 위임된다
  - `skills/prometheus/SKILL.md`
- [ ] Complex inline 재독이 Red Flag/Do-vs-Delegate carve-out으로 허용되어 규칙 충돌이 없다
  - `skills/prometheus/SKILL.md`
- [ ] contract test가 intent-split 양쪽 절반(Complex zero-spawn + Architecture 위임)을 모두 고정한다
  - `skills/prometheus/scripts/verify-lane-contract.test.ts`
- [ ] Complex inline 경로를 비어있지 않은 레인으로 행사하는 시나리오(P-29)가 존재한다
  - `skills/prometheus/tests/application-scenarios.md`
- [ ] coverage map과 시나리오 본문의 검증-레인 축이 일치한다(stale "outside the verify lane" 잔재 없음)
  - `skills/prometheus/tests/application-scenarios.md`

### explore 그라운딩
- [ ] Symbol/Reference 질의가 codegraph 우선, 부재 시 ast-grep/grep로 fallback한다
  - `agents/explore.md`

### 검증
- [ ] `make validate` 통과(schema/components/lib-imports/typecheck)
- [ ] `make test` 통과(Shell 10/10 + Bun 2736 pass)

---

## 📎 References
- 없음 (내부 하네스 변경, 연결 이슈 없음)