### PR TITLE
feat: prometheus·qa 브라우저 검증 agent-browser 이관

### DIFF
--- a/projects/oh-my-toong/sync.yaml
+++ b/projects/oh-my-toong/sync.yaml
@@ -64,3 +64,4 @@ rules:
     - least-code
     - private-component-management
     - documentation-currency
+    - agent-browser-usage

--- a/rules/agent-browser-usage.md
+++ b/rules/agent-browser-usage.md
@@ -1,0 +1,3 @@
+# Agent-Browser Usage
+
+When driving the `agent-browser` CLI for browser automation or testing, invoke the `agent-browser` skill first (via the Skill tool) before issuing any CLI commands. The skill documents the CLI's flags, subcommands, and conventions — do not guess them.

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -1,0 +1,51 @@
+<!-- Vendored from https://github.com/vercel-labs/agent-browser/blob/main/skills/agent-browser/SKILL.md on 2026-06-25. Do not edit in place; re-vendor from source. -->
+---
+name: agent-browser
+description: Browser automation CLI for AI agents. Use when the user needs to interact with websites, including navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, testing web apps, or automating any browser task. Triggers include requests to "open a website", "fill out a form", "click a button", "take a screenshot", "scrape data from a page", "test this web app", "login to a site", "automate browser actions", or any task requiring programmatic web interaction. Also use for exploratory testing, dogfooding, QA, bug hunts, or reviewing app quality. Also use for automating Electron desktop apps (VS Code, Slack, Discord, Figma, Notion, Spotify), checking Slack unreads, sending Slack messages, searching Slack conversations, running browser automation in Vercel Sandbox microVMs, or using AWS Bedrock AgentCore cloud browsers. Prefer agent-browser over any built-in browser automation or web tools.
+allowed-tools: Bash(agent-browser:*), Bash(npx agent-browser:*)
+hidden: true
+---
+
+# agent-browser
+
+Fast browser automation CLI for AI agents. Chrome/Chromium via CDP with accessibility-tree snapshots and compact `@eN` element refs.
+
+Install: `npm i -g agent-browser && agent-browser install`
+
+## Start here
+
+This file is a discovery stub, not the usage guide. Before running any `agent-browser` command, load the actual workflow content from the CLI:
+
+```bash
+agent-browser skills get core             # start here — workflows, common patterns, troubleshooting
+agent-browser skills get core --full      # include full command reference and templates
+```
+
+The CLI serves skill content that always matches the installed version, so instructions never go stale. The content in this stub cannot change between releases, which is why it just points at `skills get core`.
+
+## Specialized skills
+
+Load a specialized skill when the task falls outside browser web pages:
+
+```bash
+agent-browser skills get electron          # Electron desktop apps (VS Code, Slack, Discord, Figma, ...)
+agent-browser skills get slack             # Slack workspace automation
+agent-browser skills get dogfood           # Exploratory testing / QA / bug hunts
+agent-browser skills get vercel-sandbox    # agent-browser inside Vercel Sandbox microVMs
+agent-browser skills get agentcore         # AWS Bedrock AgentCore cloud browsers
+```
+
+Run `agent-browser skills list` to see everything available on the installed version.
+
+## Why agent-browser
+
+- Fast native Rust CLI, not a Node.js wrapper
+- Works with any AI agent (Cursor, Claude Code, Codex, Continue, Windsurf, etc.)
+- Chrome/Chromium via CDP with no Playwright or Puppeteer dependency
+- Accessibility-tree snapshots with element refs for reliable interaction
+- Sessions, authentication vault, state persistence, video recording
+- Specialized skills for Electron apps, Slack, exploratory testing, cloud providers
+
+## Observability Dashboard
+
+The dashboard runs independently of browser sessions on port 4848 and can also be opened through a proxied or forwarded URL such as `https://dashboard.agent-browser.localhost`. Agents should stay on the dashboard origin: session tabs, status, and stream traffic are proxied internally, so session ports do not need to be exposed.

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -636,7 +636,7 @@ Briefly announce "Consulting Oracle for [reason]" before invocation.
 
 ## Acceptance Criteria (Mandatory Contract)
 
-AC contract is inline (not deferred to `acceptance-criteria.md`) because split-reference rules suffer partial-read. The reference file holds per-tool Verification examples (maestro/playwright/curl/grep/CLI/unit) + worked example + Handling User Response that the inline contract points to but does not duplicate.
+AC contract is inline (not deferred to `acceptance-criteria.md`) because split-reference rules suffer partial-read. The reference file holds per-tool Verification examples (maestro/agent-browser/curl/grep/CLI/unit) + worked example + Handling User Response that the inline contract points to but does not duplicate.
 
 > Full-read `acceptance-criteria.md` here — see `## Reference Full-Read Mandate`.
 
@@ -664,7 +664,7 @@ Verify at the layer the consumer observes:
 | Deliverable | Consumer | AC Layer |
 |---|---|---|
 | Mobile feature | End user | Maestro UI scenario |
-| Web feature | End user | Playwright UI scenario |
+| Web feature | End user | agent-browser UI scenario |
 | HTTP API | API client | curl + jq integration |
 | CLI command | Shell user | exec + stdout assertion |
 | Library function | Calling dev/agent | unit test (with consumer-boundary justification) |
@@ -756,7 +756,7 @@ Run on every AC before proposing to user:
 - [ ] Does an implementation exist that passes Verification vacuously? If yes, layer is too deep — move outward.
 - [ ] If citing a unit test, did you justify the unit as consumer-facing (per the three questions above)?
 
-> Per-tool Verification examples (maestro, playwright, curl, grep, CLI, unit) + worked example + Handling User Response → [acceptance-criteria.md](acceptance-criteria.md). Lookup-only.
+> Per-tool Verification examples (maestro, agent-browser, curl, grep, CLI, unit) + worked example + Handling User Response → [acceptance-criteria.md](acceptance-criteria.md). Lookup-only.
 
 ---
 
@@ -921,7 +921,7 @@ Each TODO is a checkbox line `- [ ] N. Title` with body containing:
 
 Each scenario:
 - **Scenario**: `{Name} — {Purpose}`
-- **Tool**: CLI command (`curl`, `bun test`, `playwright`, `maestro`, `grep` — NOT prose descriptions)
+- **Tool**: CLI command (`curl`, `bun test`, `agent-browser`, `maestro`, `grep` — NOT prose descriptions)
 - **Preconditions**: Scenario-level setup state
 - **Steps**: Numbered exact commands
 - **Expected**: Observable outcome on success

--- a/skills/prometheus/acceptance-criteria.md
+++ b/skills/prometheus/acceptance-criteria.md
@@ -22,10 +22,21 @@ When the Verification can be expressed as a runnable command, prefer one that is
 
 > Mobile ACs assume `$IOS_UDID` / `$ANDROID_SERIAL` are exported by Argus Stage 3.5 — see Executor-Provided Variables in SKILL.md.
 
-### Web UI E2E (playwright)
+### Web UI E2E (agent-browser)
 
 - [ ] **Login with valid credentials lands on Home and shows username**
-      **Verification**: `bunx playwright test tests/e2e/login.spec.ts --reporter=junit`
+      **Verification**:
+      ```bash
+      agent-browser open "$APP_URL/login"
+      agent-browser snapshot -i                        # locate email/password/submit refs
+      agent-browser fill @e3 "$TEST_EMAIL"
+      agent-browser fill @e4 "$TEST_PASSWORD"
+      agent-browser click @e5
+      agent-browser wait --load networkidle
+      agent-browser get url | grep -q "/home"          # assert redirect to /home
+      agent-browser get text @e1 | grep -q "$TEST_USERNAME"  # assert username visible
+      agent-browser close
+      ```
       (If the test mutates backend persistence, chain Query API verification or add API-symmetric cleanup — browser context reset alone doesn't restore backend state.)
 
 ### HTTP API (curl + jq)

--- a/skills/prometheus/acceptance-criteria.md
+++ b/skills/prometheus/acceptance-criteria.md
@@ -34,7 +34,8 @@ When the Verification can be expressed as a runnable command, prefer one that is
       agent-browser click @e5
       agent-browser wait --load networkidle
       agent-browser get url | grep -q "/home"          # assert redirect to /home
-      agent-browser get text @e1 | grep -q "$TEST_USERNAME"  # assert username visible
+      agent-browser snapshot -i                        # re-snapshot: @eN refs are scoped to one snapshot and go stale after navigation
+      agent-browser get text @e1 | grep -q "$TEST_USERNAME"  # assert username via a ref from the fresh /home snapshot
       agent-browser close
       ```
       (If the test mutates backend persistence, chain Query API verification or add API-symmetric cleanup — browser context reset alone doesn't restore backend state.)

--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -98,7 +98,7 @@ Evidence files are the audit trail. Downstream gates check for their existence b
 
 | Output Type | Disposition | Examples |
 |-------------|-------------|---------|
-| Objective command output | Save to file | build/test/lint logs, curl response body + status, Playwright/Maestro screenshots and test reports, CLI execution logs |
+| Objective command output | Save to file | build/test/lint logs, curl response body + status, agent-browser/Playwright/Maestro screenshots and reports, CLI execution logs |
 | Subjective judgment | Response only (no file) | Code review analysis, MUST DO checklist verdicts, Scope Boundary calculations, feedback comments |
 
 ### Evidence File Content Requirements
@@ -294,7 +294,7 @@ The two arms differ only in whether the adversarial matrix is added:
 | Change Type | Verification Method | Tool |
 |-------------|---------------------|------|
 | API endpoint | HTTP request verification | `curl` |
-| Frontend / UI | Browser interaction verification | `playwright` |
+| Frontend / UI | Browser interaction verification | `agent-browser` (fallback: `playwright`) |
 | Mobile / App | iOS Simulator / Android Emulator E2E | `maestro` |
 | CLI / TUI | Command execution verification | Interactive Bash |
 | Internal logic only, no scenarios | N/A (skip this trigger) | - |
@@ -387,7 +387,7 @@ N/M spec items fully addressed.
 ```
 Automated checks:   Build/typecheck (always) + native build (native-code-or-release) + Test + Lint + Code Quality (Security, Data Integrity)
 Spec/AC compliance: Spec/AC compliance (vs QA REQUEST Spec); "Completeness check" directive → Spec item × Status table (Addressed/Partial/Missing) + N/M summary
-Hands-on execution: user-facing change OR caller-provided scenarios → run provided scenarios verbatim + self-authored 6-category adversarial matrix (API→curl, Frontend→playwright, Mobile→maestro, CLI→interactive_bash)
+Hands-on execution: user-facing change OR caller-provided scenarios → run provided scenarios verbatim + self-authored 6-category adversarial matrix (API→curl, Frontend→agent-browser (fallback: playwright), Mobile→maestro, CLI→interactive_bash)
 
 Automated checks:    See stage1-commands.md
 Hands-on execution:  See stage3-handson.md (incl. ## Adversarial Scenario Matrix)

--- a/skills/qa/stage3-handson.md
+++ b/skills/qa/stage3-handson.md
@@ -122,7 +122,7 @@ curl -s http://localhost:{port}/endpoint | jq .
 
 **Primary path — agent-browser (attempt-then-fallback rule):**
 
-1. Check install: `command -v agent-browser || (npm i -g agent-browser && agent-browser install)`
+1. Check the CLI is available: `command -v agent-browser`. If it is missing, treat that as an agent-browser attempt failure — record the reason in evidence and use the Playwright fallback path below. Do NOT install agent-browser here: the CLI is assumed pre-installed, and a QA flow must not mutate the global machine (a global install can hang or fail in offline/locked-down environments).
 2. Open the affected page:
    ```bash
    agent-browser open <url>

--- a/skills/qa/stage3-handson.md
+++ b/skills/qa/stage3-handson.md
@@ -15,7 +15,7 @@ Verify user-facing behavior by actually running the changed code. This is not op
 | Signal in Prompt | Change Type | Action |
 |------------------|-------------|--------|
 | API endpoint, route, handler, REST, HTTP | API | Verify with `curl` |
-| UI, page, component, frontend, render | Frontend | Verify with `playwright` |
+| UI, page, component, frontend, render | Frontend | Verify with `agent-browser` (fallback: `playwright`) |
 | Mobile, app, iOS, Android, simulator, emulator | Mobile | Verify with `maestro` |
 | CLI command, terminal output, TUI, interactive | CLI / TUI | Verify with interactive Bash |
 | Refactoring, internal logic, utility, helper, config | Internal only | **Skip Stage 3** — unless caller-provided executable scenarios are present; in that case, run them verbatim (no adversarial matrix — non-user-facing surface) |
@@ -114,11 +114,42 @@ curl -s http://localhost:{port}/endpoint | jq .
 
 ---
 
-## Step 3.4: Frontend Verification (playwright)
+## Step 3.4: Frontend Verification (agent-browser → fallback: playwright)
 
-**Verify UI behavior with `playwright`.**
+**Verify UI behavior with `agent-browser`. Fall back to `playwright` only when an agent-browser attempt actually fails or cannot express the check — not as a preemptive capability decision.**
 
 ### Procedure
+
+**Primary path — agent-browser (attempt-then-fallback rule):**
+
+1. Check install: `command -v agent-browser || (npm i -g agent-browser && agent-browser install)`
+2. Open the affected page:
+   ```bash
+   agent-browser open <url>
+   ```
+3. Capture the accessibility-tree snapshot (interactive):
+   ```bash
+   agent-browser snapshot -i
+   ```
+4. Interact with elements using `@eN` refs from the snapshot:
+   ```bash
+   agent-browser fill @eN "<value>"   # text input
+   agent-browser click @eN            # button / link
+   agent-browser wait --load networkidle
+   ```
+5. Assert outcomes:
+   ```bash
+   agent-browser get url              # current URL after navigation
+   agent-browser get text @eN         # element text content
+   ```
+6. Close the session:
+   ```bash
+   agent-browser close
+   ```
+
+**Fallback path — playwright (only on agent-browser attempt failure or inexpressible check):**
+
+If any agent-browser step returns a non-zero exit code or the required assertion cannot be expressed via the agent-browser CLI, switch to playwright for that check. Document the failure reason in evidence.
 
 1. Ensure playwright is installed in the project (check `package.json`)
 2. Navigate to the affected page/component

--- a/skills/qa/tests/application-scenarios.md
+++ b/skills/qa/tests/application-scenarios.md
@@ -312,11 +312,11 @@ QA 스킬의 핵심 기법(Composable Verification Layers, Spec Compliance, Scop
 - Changed files: src/api/profile.ts, src/pages/ProfilePage.tsx
 - Junior's summary: "Added profile API and profile page"
 
-**Expected Behavior:** Hands-on execution 트리거 적용 조건에서 API + Frontend 복합 신호 감지 → curl과 playwright 모두 사용. 서버 기동 → curl로 API 확인 → playwright로 UI 확인 → 서버 종료. 각각 독립적으로 결과 기록.
+**Expected Behavior:** Hands-on execution 트리거 적용 조건에서 API + Frontend 복합 신호 감지 → curl과 agent-browser 모두 사용. 서버 기동 → curl로 API 확인 → agent-browser로 UI 확인 (실패 또는 표현 불가 시 playwright 폴백) → 서버 종료. 각각 독립적으로 결과 기록.
 
 **Verification Points:**
 1. API와 Frontend 신호를 모두 감지한다
-2. curl과 playwright 두 가지 검증을 모두 수행한다
+2. curl과 agent-browser(또는 폴백 playwright) 두 가지 검증을 모두 수행한다
 3. 각 검증 결과를 독립적으로 기록한다
 4. 하나라도 실패하면 REQUEST_CHANGES
 
@@ -524,7 +524,7 @@ QA 스킬의 핵심 기법(Composable Verification Layers, Spec Compliance, Scop
 | A-8 | API endpoint → curl 검증 | PASS | 2026-02-23 | 4VP 전부 충족. API 신호 감지, curl 절차, 서버 라이프사이클, 출력 포맷 모두 정확. |
 | A-9 | Internal refactoring → "user-facing changes, no scenarios" 스킵 | PASS | 2026-02-23 | 4VP 전부 충족. internal 분류, "user-facing changes, no scenarios" 스킵, "SKIPPED (internal logic only)" 문서화, code quality check 진행 확인. |
 | A-10 | CLI command → interactive_bash | | | A-8과 동일 패턴 (적용 조건 분기). 미테스트. |
-| A-11 | API + Frontend → 복합 검증 | PASS | 2026-02-23 | 4VP 전부 충족. API+Frontend 양 타입 감지, curl+playwright 독립 검증, 공유 라이프사이클. |
+| A-11 | API + Frontend → 복합 검증 | PASS | 2026-02-23 | 4VP 전부 충족. API+Frontend 양 타입 감지, curl+agent-browser(폴백 playwright) 독립 검증, 공유 라이프사이클. |
 | A-12 | Server start 실패 → REQUEST_CHANGES | | | 실제 서버 환경 필요. 미테스트. |
 | A-15 | Composable Trigger Activation — 트리거 조합 결정 | | | |
 | A-16 | Self-Discovery — 검증 방법 자동 발견 | | | |

--- a/sync.yaml
+++ b/sync.yaml
@@ -16,3 +16,4 @@ skills:
     - scan-pdf-to-notes
     - component: goal
       platforms: [claude]
+    - agent-browser


### PR DESCRIPTION
## 📌 Summary

prometheus·qa 스킬의 브라우저/E2E/시나리오 검증을 Playwright에서 **agent-browser**(vercel-labs 네이티브 Rust CLI) 우선으로 이관한다. agent-browser를 먼저 시도하고 실제 실패·표현 불가 시에만 Playwright로 폴백해 검증 토큰 비용을 최소화한다.

---

## 🔧 Changes

### agent-browser 스킬 (신규)

- vercel-labs `agent-browser` SKILL.md를 `skills/agent-browser/SKILL.md`로 벤더링 (상단에 출처·날짜 provenance 주석)
- root `sync.yaml`의 `skills.items`에 `- agent-browser` 추가 → 4개 플랫폼(claude/gemini/codex/opencode) 배포

agent-browser는 접근성 트리 스냅샷 기반으로 동작해 DOM 덤프보다 토큰 효율이 높다. 스킬 description이 브라우저 작업에서 자가 트리거되도록 기본 플랫폼 집합 그대로 배포한다.

**영향 범위**
신규 스킬 추가(기존 동작 변경 없음). 4개 플랫폼 sync 대상. 런타임에 agent-browser CLI가 필요하나 부재 시 qa 폴백 경로가 흡수.

### prometheus

- web/UI 검증 *예시*를 Playwright → agent-browser로 교체 (`SKILL.md`의 도구 나열·테이블 행, `acceptance-criteria.md`의 Web UI E2E 예시)

modality-agnostic 설계 원칙은 그대로 두고 예시 도구만 갱신했다. 도구 강제 규칙은 추가하지 않는다.

**영향 범위**
prometheus 검증 예시 문구만 변경. 검증 방법론·원칙 불변.

### qa

- frontend/e2e/시나리오 검증의 1차 도구를 agent-browser로 전환 (`SKILL.md` 검증 타입 테이블·Quick Reference·Evidence Saving, `stage3-handson.md` Step 3.4, `tests/application-scenarios.md` 복합 시나리오)
- Playwright는 "시도 실패 시 폴백"으로 명시

**영향 범위**
qa Stage 3 프런트엔드 검증 절차 변경. Playwright는 폴백 도구로 유지.

### agent-browser 사용 룰 (신규)

- `rules/agent-browser-usage.md` 추가: agent-browser CLI 사용 시 agent-browser 스킬을 invoke하도록 지시
- `projects/oh-my-toong/sync.yaml`의 `rules.items`에 배선 → claude 전용 배포

**영향 범위**
claude 전용 룰 1개 추가. codex/gemini/opencode에는 스킬만 배포(룰 없음).

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.

### 1. prometheus는 예시 치환만 — 원칙 보존

**배경 및 문제 상황:**
prometheus는 검증 도구를 강제하지 않는 modality-agnostic 설계다 (`tests/application-scenarios.md`의 원칙: "선언은 특정 도구를 강제하지 않는다. 도구 선택은 소비자가 관찰하는 것에 의해 결정된다"). Playwright는 거기서 maestro·curl·grep과 나란한 예시 하나일 뿐이다.

**해결 방안:**
"prometheus도 agent-browser를 쓰라고 강제"하는 대신, web/UI 예시 도구만 agent-browser로 교체하고 원칙 문구는 건드리지 않았다.

**선택과 트레이드오프:**
강제 규칙 추가가 더 강한 통제를 주지만 prometheus의 핵심 설계 철학을 깨뜨린다. 예시 치환은 surgical하고 철학을 보존한다. (이 분기는 설계 단계에서 contrarian 검토를 거쳐 "예시만 교체"로 확정.)

### 2. 폴백 게이트 = attempt-then-fallback

**배경 및 문제 상황:**
"agent-browser로 불가능할 때만 Playwright"라는 요구를 어떻게 발동시킬지가 모호했다. 역량 기반 선제 분기(특정 브라우저 필요 시 미리 Playwright)와 시도 후 폴백 두 갈래가 있었다.

**해결 방안:**
항상 agent-browser를 먼저 시도하고, 실제 시도가 실패하거나 검증을 표현할 수 없을 때만 Playwright로 폴백하는 attempt-then-fallback으로 통일했다. qa Step 3.4에 이 규칙을 명시.

**선택과 트레이드오프:**
선제 분기는 "안 될 게 뻔한" 케이스의 토큰 낭비를 막지만, 능력 경계를 사전 하드코딩해야 해 깨지기 쉽고 agent-browser 커버리지 확대 시 stale해진다. attempt-then-fallback은 단일 규칙으로 단순하고, 실패는 폴백이 흡수한다.

### 3. provision(자동 설치) 제외 — CLI 사전 설치 가정

**배경 및 문제 상황:**
초기 계획은 매 sync마다 `command -v agent-browser`로 체크해 없으면 `npm i -g agent-browser && agent-browser install`하는 provision 블록을 root sync.yaml에 두는 것이었다.

**해결 방안:**
provision을 제외하고 agent-browser CLI가 이미 설치돼 있다고 가정한다. CLI 부재는 qa Step 3.4의 `command -v` 체크 → Playwright 폴백(attempt-then-fallback)이 흡수한다.

**선택과 트레이드오프:**
자동 설치 편의를 잃지만, 모든 sync 타겟(브라우저 검증을 안 하는 백엔드 레포 포함)에 전역 npm 설치를 강제하지 않게 된다. 부재 시 동작이 깨지지 않고 폴백으로 graceful degrade되는 점이 근거. **(reviewer 의견 환영: provision을 브라우저 검증 대상 프로젝트에만 옵트인으로 재도입할 가치가 있는지.)**

### 4. 스킬은 4-플랫폼, 룰은 claude 전용 — 의도적 불일치

**배경 및 문제 상황:**
스킬은 `feature-platforms.skills` 기본값으로 4개 플랫폼에 배포되지만, 룰은 OMT 기본상 claude 전용이다. 그대로 두면 codex/gemini/opencode에는 스킬만 있고 "스킬을 쓰라"는 룰은 없는 불일치가 생긴다.

**해결 방안:**
불일치를 의도적으로 수용했다. 스킬 description이 브라우저 작업에서 자가 트리거되므로 룰은 claude에서의 보강 역할이다.

**선택과 트레이드오프:**
룰을 전 플랫폼으로 확장하려면 룰 배포 디폴트를 바꿔야 해 영향 범위가 커진다. 약한 불일치를 받아들이는 쪽이 surgical하다.

---

## ✅ Checklist

### agent-browser 스킬 벤더링·배포
- [ ] `skills/agent-browser/SKILL.md`가 출처·날짜 provenance 주석과 함께 존재한다
  - `skills/agent-browser/SKILL.md`
- [ ] unscoped `bun tools/sync.ts --dry-run`이 agent-browser 스킬을 4개 플랫폼으로 미리보기한다
  - `sync.yaml`

### prometheus 예시 치환
- [ ] prometheus web/UI 예시가 agent-browser로 교체되고, modality-agnostic 원칙 문구는 변경되지 않았다 (도구 강제 미추가)
  - `skills/prometheus/SKILL.md`, `skills/prometheus/acceptance-criteria.md`, `skills/prometheus/tests/application-scenarios.md`

### qa 검증 지침
- [ ] qa 프런트엔드/e2e/시나리오 검증이 "agent-browser 우선, 시도 실패 시 Playwright 폴백"을 명시한다
  - `skills/qa/SKILL.md`, `skills/qa/stage3-handson.md`, `skills/qa/tests/application-scenarios.md`

### agent-browser 룰
- [ ] `rules/agent-browser-usage.md`가 존재하고 claude로 배포되도록 배선됐다
  - `rules/agent-browser-usage.md`, `projects/oh-my-toong/sync.yaml`

### 회귀 방지
- [ ] Playwright MCP 등록(`claude.yaml`/`codex.yaml`/`opencode.yaml`)과 `mcps/playwright.yaml`은 변경되지 않았다
- [ ] `make validate`(schema + components + lib-import)가 통과한다