### PR TITLE
feat(craft-issue): 슬라이스 게이트 자식 이슈 생성 강제

### DIFF
--- a/skills/craft-issue/SKILL.md
+++ b/skills/craft-issue/SKILL.md
@@ -111,6 +111,36 @@ Read `references/issue-craft.md` (already loaded in Stage 4 — re-read only if 
 
 INVEST is the slice gate. File-count or LOC atomicity is NOT the gate.
 
+### Slicing means CREATING the child issues — not proposing them
+
+When the gate fires, "slice into child issues" is a **write action in the PM tool**, not a section in the parent body. In the write tail (Stage 6) you **create each child as a real issue**, set its `parentId`, and wire `blockedBy` dependency links. A parent body that lists the slices as a "proposed split / 구현 분할 제안 / slice candidates / 잠정 슬라이스 후보" section **instead of** creating the children is a gate **FAILURE**, not compliance — the requirement stays one un-buildable mega-issue and the caller has to re-ask for the split.
+
+**Violating the letter (not materializing the children) is violating the spirit (the requirement stays un-decomposed and un-actionable).**
+
+The ONLY thing that defers child creation when the gate fires is an **explicit caller instruction not to create sub-issues**. Nothing else. In particular, slice and create even when the spec is a draft, the caller said "organize/정리 this ticket", product decisions are still open, the parent already sits in a sprint, or you fear the boundaries will shift — handle each per the table below, then create the children.
+
+**Rationalization table — every excuse below means "slice and create the children now":**
+
+| Rationalization | Reality |
+|---|---|
+| "Spec is a draft / 초안, so I'll wait to slice" | Draft = solution-open = the home of Model-A WHAT-children. The per-child stage-check exists *for* draft-stage children. Slice now. |
+| "Caller said *organize this one ticket*, not *split it*" | Organizing a gate-failing requirement IS slicing it. You enrich the parent in place AND add its children under it — both, not either. |
+| "Open product decisions make child ACs into TBD shells" | A child may carry its own Decisions Needed plus an AC for the settled part. Open decisions are *recorded*, never a reason to keep one mega-issue. |
+| "Creating them now is premature noise on the board" | Children land in Backlog, not the active cycle. The un-buildable mega-issue is the noise. |
+| "Boundaries will shift, I'd be reworking them" | Boundaries are the N (Negotiable) in INVEST; a later merge/split of a child is a cheap, normal PM edit. Deferring is the expensive state. |
+| "I'll put the slices in the parent body and offer to create them later" | The body proposal IS the failure mode. Create the issues; the parent body holds shared context, not a slice menu. |
+| "Stage 5 'slice' is just the literal reading; upper gates block it" | Refuse-to-file gates the *content of a write*, not the *existence of children*. The slice gate firing mandates the children; an open decision rides in a Decisions Needed entry. |
+| "Creating issues is irreversible, so defer when info-poor" | Child issues are reversible (cancel/merge). Deferring leaves the requirement un-actionable — that is the irreversible-feeling cost. Reversibility argues FOR creating. |
+
+### Red Flags — STOP, you are deferring a required slice
+
+- You're writing a "구현 분할 (제안)" / "proposed slices" / "slice candidates" section in the parent body.
+- You're about to end with "원하면 자식 이슈로 만들어 드릴게요 / I can spin these out when ready".
+- You're citing "draft / 초안", "정리 / organize", "premature", "sprint board", or "open decisions" as a reason NOT to create children.
+- The gate fired (fails I / E / S) but your write tail touches only one issue.
+
+**All of these mean: create the child issues now (parent + blocked-by), per Stage 6. The only exemption is an explicit caller instruction not to.**
+
 ---
 
 ## Inline Gates

--- a/skills/craft-issue/SKILL.md
+++ b/skills/craft-issue/SKILL.md
@@ -129,7 +129,7 @@ The ONLY thing that defers child creation when the gate fires is an **explicit c
 | "Creating them now is premature noise on the board" | Children land in Backlog, not the active cycle. The un-buildable mega-issue is the noise. |
 | "Boundaries will shift, I'd be reworking them" | Boundaries are the N (Negotiable) in INVEST; a later merge/split of a child is a cheap, normal PM edit. Deferring is the expensive state. |
 | "I'll put the slices in the parent body and offer to create them later" | The body proposal IS the failure mode. Create the issues; the parent body holds shared context, not a slice menu. |
-| "Stage 5 'slice' is just the literal reading; upper gates block it" | Refuse-to-file gates the *content of a write*, not the *existence of children*. The slice gate firing mandates the children; an open decision rides in a Decisions Needed entry. |
+| "Stage 5 'slice' is just the literal reading; upper gates block it" | The inline gates decide *whether* you write at all: when refuse-to-file or a duplicate fires, you refuse the whole write — children included — until the missing evidence is supplied. They never license writing one *un-sliced* issue: a write that clears them and is still large must be sliced into children. |
 | "Creating issues is irreversible, so defer when info-poor" | Child issues are reversible (cancel/merge). Deferring leaves the requirement un-actionable — that is the irreversible-feeling cost. Reversibility argues FOR creating. |
 
 ### Red Flags — STOP, you are deferring a required slice

--- a/skills/craft-issue/references/issue-craft.md
+++ b/skills/craft-issue/references/issue-craft.md
@@ -273,6 +273,18 @@ below. File-count and LOC atomicity are NOT the requirement-stage gate — those
 Slice when the issue fails **I, E, or S** (too large, too coupled, or too vague to size).
 Slicing on V, N, or T alone is usually a rewrite of the body or AC rather than a structural split.
 
+When the gate fires, slicing is a **write action**: create the children in the PM tool in the write tail (parent + blocked-by), not as a "proposed split" section in the parent body — see SKILL.md Stage 5 "Slicing means CREATING the child issues" for the loophole-closure rule and rationalization table.
+
+### Slice Unit — what one child is (and where to stop)
+
+One child = the **smallest vertical slice that still passes the value test**: *"if this child is completed and nothing else, is a user or system stakeholder observably better off?"* Yes → valid child (a story). No → it is a **task** (an implementation step with no stand-alone value): do not give it its own issue — fold it into the child whose value it serves. Few deep value-bearing children beat many shallow step-children — the deep-modules rule (`coding-discipline.md` §4) applied to issues. **This is the precise meaning of "don't over-fragment": stop slicing at the value test, not at some file/LOC count.**
+
+**Borderline default = fold.** A calc, fetch, guard, hardening, or enabler that becomes meaningful only once a sibling exists is a **task by default** — fold it into the story it serves. Give it its own child ONLY when a *recorded product decision* deliberately ships the story first and schedules this separately (e.g. "ship core push now, add dedup hardening as a separately-prioritized follow-up"). "The first version works without it", "it's a separate concern", "it's a business rule", or "the work is sequential" are NOT that decision — absent an explicit recorded deferral, fold. This default is what makes two slicers land on the same grain instead of one cutting 1 child and another cutting 3.
+
+**Cut by user/business value, never by technical layer or platform.** Splitting one feature into "mobile child + web child + backend child" (or "UI + API + DB") is the horizontal-slice anti-pattern — each piece is worthless until the last integrates, so it fails **Independent** + **Valuable** and forces sequential ordering. Slice the feature as a thin capability that runs end-to-end through whatever layers/platforms it needs. A platform/interface split is a valid issue split ONLY when each platform slice independently delivers user value as a deliberate product decision (e.g. mobile-first launch); otherwise it is ONE issue with a blocked-by ordering inside it, not two issues.
+
+**Where to cut** — find the dimension of variation that makes the issue big and reduce it to one instance: workflow step · operation (CRUD) · business-rule variation · data variation · interface/input method · simple-vs-complex · defer non-functional · spike (SPIDR / Humanizing Work patterns). **Phrasing test** (Killick): a child names a *capability* a user gains ("a buyer can find products by brand"), not a step toward a chosen solution ("build the search endpoint") — the latter is a task masquerading as a child.
+
 ### Per-Child Stage-Check
 
 After slicing, apply this check to each child issue independently:
@@ -294,17 +306,17 @@ For each child:
 A partially-settled intake splits naturally: open sub-units stay as Model-A WHAT children;
 settled sub-units receive a handoff recommendation rather than being pre-solved.
 
-### Named Contract: sisyphus atomicity smell heuristics + dependency-ordering
+### Candidate-seam heuristics (SECONDARY to the value test) + dependency-ordering
 
-When determining whether a candidate child issue is atomic, apply these smell heuristics:
+These heuristics locate where an issue *could* be divided. They are **secondary to the Slice Unit value test, never parallel to it**: a candidate seam becomes its own child ONLY if each resulting side independently passes **V**. A side that fails V is a task — fold it, even when the work is internally sequential or joined by "and". Splitting a value-less step because the work is sequential is Model-B work decomposition; it belongs to `prometheus`/`sisyphus` downstream, not to requirement-stage issue slicing.
 
-| Smell | Action |
+| Smell | Action (apply only after each side independently passes V) |
 |---|---|
-| Issue needs sequential delegations internally | Break into separate child issues |
-| Issue touches unrelated concerns | Split by concern |
-| Issue description has "and" joining distinct deliverables | Split at the conjunction |
-| Two child issues modify the same domain object or module | MECE violation — merge or split by responsibility |
-| Completed child issues would not cover a requirement | Coverage gap — add a missing child |
+| Issue needs sequential delegations internally | Candidate seam — but sequential work alone is NOT a split reason. Split only if each step independently passes V; a value-less step (calc, fetch, guard) stays folded. |
+| Issue description has "and" joining distinct deliverables | Candidate seam at the "and" — split only if BOTH sides independently pass V; otherwise one side is a task of the other. |
+| Issue touches genuinely unrelated concerns, each independently valuable | Split by concern. |
+| Two child issues modify the same domain object or module | MECE violation — merge or split by responsibility. |
+| Completed child issues would not cover a requirement | Coverage gap — add a missing child. |
 
 Dependency ordering between child issues uses blocked-by dependency links:
 - A child that depends on another child's output is marked as blocked by the predecessor.


### PR DESCRIPTION
## 📌 Summary

craft-issue 스킬의 INVEST 슬라이스 게이트가 자식 이슈를 **실제로 생성**(parent + blocked-by)하도록 강제하고, 슬라이스 단위를 value test로 정의해 슬라이서마다 자식 개수가 갈리던 grain 불일치를 제거한다.

---

## 🔧 Changes

### craft-issue — Stage 5 슬라이스 게이트 (`SKILL.md`)

- 새 섹션 `Slicing means CREATING the child issues — not proposing them` 추가: 게이트 발동 시 부모 본문에 "분할 제안" 섹션을 쓰는 것은 게이트 **FAILURE**, 자식 이슈를 실제 생성해야 compliance.
- 합리화 표(8행) + Red Flags 추가: draft·organize·premature·sprint·open-decision 등 defer 핑계를 전부 "지금 생성"으로 매핑. 유일 면제는 caller가 명시적으로 sub-issue를 만들지 말라고 지시한 경우뿐.

**영향 범위**
craft-issue 스킬 행동에 한정. 다른 스킬이 호출하는 인터페이스 변경 없음(순수 additive 프로즈 +30줄). 배포는 `make sync` 시점에 전 worktree·플랫폼으로 전파.

### craft-issue — 슬라이스 루브릭 (`references/issue-craft.md`)

- `Slice Unit — what one child is (and where to stop)` 추가: 한 자식 = value test를 통과하는 최소 수직 슬라이스. `Borderline default = fold` — 값 없는 단계(계산·페치·가드·하드닝)는 기본 task로 fold, 분리는 *기록된 product decision*일 때만.
- 기존 `sisyphus atomicity smell heuristics` 표를 `Candidate-seam heuristics (SECONDARY to the value test)`로 격하: smell은 분할 *위치*만 찾고, 각 측이 독립적으로 **V**(Valuable)를 통과할 때만 실제 분할.

**영향 범위**
동일 — 스킬 루브릭 프로즈 +28/−8. 인터페이스·의존성 변경 없음.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.

### 1. 슬라이싱을 "제안"이 아니라 "write 액션"으로 못박기

**배경 및 문제 상황:**
게이트가 발동해도 모델이 부모 본문에 "구현 분할 제안" 섹션만 쓰고 자식 이슈를 만들지 않는 실패가 반복 재현됐다. 규칙의 letter(슬라이스 언급)는 지키되 spirit(요구사항 분해)을 위반 — 요구사항이 분해되지 않은 mega-issue로 남아 caller가 분할을 재요청해야 했다.

**해결 방안:**
게이트 발동 = 자식 이슈 생성(write)을 의무화. 합리화 표로 흔한 defer 핑계를 선제 차단하고, Red Flags로 "지금 멈추라"는 자기점검 신호를 박았다.

**구현 세부사항:**
유일 면제는 caller의 명시적 "sub-issue 만들지 마" 지시. draft·organize·open-decision은 각각 "기록하고 그래도 생성"으로 처리하도록 표에 1:1 반박을 둠.

**선택과 트레이드오프:**
규칙은 본문(SKILL.md Stage 5)에 두고, 루브릭(issue-craft.md)은 슬라이스 *단위*에 집중하도록 책임을 분리했다. 대안(루브릭에 write-액션 문구 중복 유지)은 격하/제거. 합리화 표가 길어 토큰 비용이 늘지만, 반복 재현된 루프홀이라 명시적 차단이 정당하다고 판단.

### 2. 슬라이스 grain을 value test로 수렴 + seam 휴리스틱 격하

**배경 및 문제 상황:**
같은 요구사항을 두 번 슬라이스하면 1개 vs 3개로 grain이 갈렸다. 옛 "atomicity smell" 표가 "순차 작업"·"and 결합"만으로 분할을 유도해, 스스로는 가치가 없는 단계까지 자식으로 쪼갰다(Model-B work decomposition가 요구사항 단계로 새어 들어옴).

**해결 방안:**
단일 기준을 value test로 통일: *"이 자식만 완료되면 이해관계자가 관측 가능하게 나아지는가?"* seam 휴리스틱은 분할 *후보 위치*만 제시하고 value test에 종속시켰다.

**관련 코드:** (heuristics 표 헤딩 격하)
\`\`\`diff
- ### Named Contract: sisyphus atomicity smell heuristics + dependency-ordering
+ ### Candidate-seam heuristics (SECONDARY to the value test) + dependency-ordering
\`\`\`

**선택과 트레이드오프:**
휴리스틱 표를 삭제하지 않고 "SECONDARY"로 격하해 위치 탐색 가치는 보존했다. value test가 다소 주관적이라 판단 여지가 남지만, "두 슬라이서가 같은 결과에 도달"하는 결정성을 우선했다. `Borderline default = fold`가 그 주관성을 한 방향(보수적 fold)으로 고정하는 장치.

---

## ✅ Checklist

### craft-issue 슬라이스 게이트
- [ ] 게이트 발동 시 Stage 5가 "자식 이슈 생성(parent + blocked-by)"을 write 액션으로 요구하고, 부모 본문 제안 섹션을 FAILURE로 명시한다
  - `skills/craft-issue/SKILL.md`
- [ ] 합리화 표가 draft·organize·premature·sprint·open-decision defer 핑계를 모두 "지금 생성"으로 매핑하고, 유일 면제(caller 명시적 비생성 지시)를 적는다
  - `skills/craft-issue/SKILL.md`
- [ ] issue-craft.md가 한 자식을 value test 통과 최소 수직 슬라이스로 정의하고 borderline 기본값을 fold로 둔다
  - `skills/craft-issue/references/issue-craft.md`
- [ ] seam 휴리스틱 표가 value test 종속(각 측 독립 V 통과 시에만 분할)으로 격하돼 있다
  - `skills/craft-issue/references/issue-craft.md`