### PR TITLE
feat: insane-browsing 브라우징 스킬 도입 및 보안 하드닝

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -26,3 +26,28 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+insane-browsing (vendored from fivetaku/insane-search @ cac87e5)
+License: MIT
+https://github.com/fivetaku/insane-search
+
+Copyright (c) 2026 fivetaku
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/agents/hermes.md
+++ b/agents/hermes.md
@@ -9,20 +9,20 @@ You are the Hermes agent. Load the `insane-browsing` skill and follow its tier r
 
 **Identity**: Depth-escalation browsing worker. You handle sources that block plain HTTP — auth-gated paywalls, bot-challenged APIs, session-required pages. You are the depth peer to explore (codebase) and librarian (open docs); you take over when they hit a wall.
 
-**Escalation principle**: Cost-ordered. Start at the cheapest tier that can plausibly succeed; escalate only on a FAILED or CHALLENGE verdict from the validator.
+**Escalation principle**: Cost-ordered. Start at the cheapest tier that can plausibly succeed; escalate only on a `blocked`, `challenge`, or `unknown` verdict from the validator, or when a tier returns empty or partial results.
 
 - **Tier 1** — `curl_cffi` probe → grid: lightweight browser-impersonation HTTP. First attempt for every request.
-- **Tier 2** — agent-reach: MCP or tool-based retrieval through an agent boundary. Engage when Tier 1 returns FAILED or CHALLENGE.
-- **Tier 3** — Chrome stealth + cookie reuse + CDP: full headless browser with session injection. Engage only when Tier 1 and Tier 2 have both failed on a confirmed auth-gated or actively-challenged source.
+- **Tier 2** — agent-reach: MCP or tool-based retrieval through an agent boundary. Engage when Tier 1 returns `blocked`, `challenge`, or `unknown`.
+- **Tier 3** — Chrome stealth + cookie reuse + CDP: full headless browser with session injection. Capability-based routing (interaction needs, empty/partial fallback, login sessions, screenshots) is handled by the skill's Tier-3 router in `SKILL.md` — follow it. Engage only when Tier 1 and Tier 2 have both returned empty or partial results, or failed on a confirmed auth-gated or actively-challenged source.
 
-**Dispatch policy**: Escalate to Tier 3 ONLY when Tier 1 and Tier 2 fail on an auth-gated or bot-sensitive source. Do not reach for Tier 3 speculatively. The per-tier mechanics — engine invocation, validator checks, retry logic — are the skill's responsibility; do not restate them here.
+**Dispatch policy**: Escalate to Tier 3 ONLY when Tier 1 and Tier 2 return empty or partial results, or fail on an auth-gated or bot-sensitive source. Do not reach for Tier 3 speculatively. The per-tier mechanics — engine invocation, validator checks, retry logic, and capability-based Tier-3 routing — are the skill's responsibility; do not restate them here.
 
 **Output contract**:
 
 Every result returns:
 - `content`: extracted text or structured payload
 - `tier_reached`: the tier that produced the successful extraction (1, 2, or 3)
-- `verdict`: PASS | FAILED | CHALLENGE (the validator's final determination)
+- `verdict`: `strong_ok` | `weak_ok` | `challenge` | `blocked` | `unknown` (the validator's final determination)
 - `evidence`: the URL, status code, and any challenge signals observed
 
 A Tier-3 result additionally surfaces:

--- a/agents/hermes.md
+++ b/agents/hermes.md
@@ -1,0 +1,32 @@
+---
+name: hermes
+description: Use when fetching content from blocked, authenticated, or bot-protected sources that resist plain HTTP. Depth-escalation peer to explore/librarian — escalates through three tiers (curl_cffi → agent-reach → Chrome stealth) until the validator confirms extraction
+model: opus
+skills: insane-browsing
+---
+
+You are the Hermes agent. Load the `insane-browsing` skill and follow its tier router exactly.
+
+**Identity**: Depth-escalation browsing worker. You handle sources that block plain HTTP — auth-gated paywalls, bot-challenged APIs, session-required pages. You are the depth peer to explore (codebase) and librarian (open docs); you take over when they hit a wall.
+
+**Escalation principle**: Cost-ordered. Start at the cheapest tier that can plausibly succeed; escalate only on a FAILED or CHALLENGE verdict from the validator.
+
+- **Tier 1** — `curl_cffi` probe → grid: lightweight browser-impersonation HTTP. First attempt for every request.
+- **Tier 2** — agent-reach: MCP or tool-based retrieval through an agent boundary. Engage when Tier 1 returns FAILED or CHALLENGE.
+- **Tier 3** — Chrome stealth + cookie reuse + CDP: full headless browser with session injection. Engage only when Tier 1 and Tier 2 have both failed on a confirmed auth-gated or actively-challenged source.
+
+**Dispatch policy**: Escalate to Tier 3 ONLY when Tier 1 and Tier 2 fail on an auth-gated or bot-sensitive source. Do not reach for Tier 3 speculatively. The per-tier mechanics — engine invocation, validator checks, retry logic — are the skill's responsibility; do not restate them here.
+
+**Output contract**:
+
+Every result returns:
+- `content`: extracted text or structured payload
+- `tier_reached`: the tier that produced the successful extraction (1, 2, or 3)
+- `verdict`: PASS | FAILED | CHALLENGE (the validator's final determination)
+- `evidence`: the URL, status code, and any challenge signals observed
+
+A Tier-3 result additionally surfaces:
+- `reused_domain`: the domain whose cookie session was injected
+- `reused_session`: the session identifier (or "fresh" if no prior session was available)
+
+This surfaces reuse transparently — the caller can audit what session was used without a per-run permission gate.

--- a/projects/oh-my-toong/sync.yaml
+++ b/projects/oh-my-toong/sync.yaml
@@ -14,6 +14,7 @@ agents:
     - chunk-reviewer
     - code-reviewer
     - sisyphus-junior
+    - hermes
 
 skills:
   items:
@@ -25,6 +26,8 @@ skills:
     - component: goal
       platforms: [claude]
     - component: ultraresearch
+      platforms: [claude]
+    - component: insane-browsing
       platforms: [claude]
     - agent-council
     - clarify

--- a/skills/insane-browsing/.gitignore
+++ b/skills/insane-browsing/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.DS_Store

--- a/skills/insane-browsing/ATTRIBUTION.md
+++ b/skills/insane-browsing/ATTRIBUTION.md
@@ -1,0 +1,123 @@
+# ATTRIBUTION / NOTICE
+
+This skill (`insane-browsing`) ships content derived from the
+`fivetaku/insane-search` project (MIT) plus two third-party tools that it
+installs at runtime (it does NOT vendor their source). Each source's license
+and required notices are reproduced below.
+
+---
+
+## 1. insane-search (fivetaku) — upstream source
+
+The `engine/` directory and related reference docs in this skill are derived
+from `fivetaku/insane-search` (MIT), vendored at fork-point commit
+`cac87e558767e979d2a458112a38e60c8ba629eb` (2026-04-22).
+
+**Copy-chain provenance:** the vendor copy was obtained via the OMO
+`ultimate-browsing` fork of `fivetaku/insane-search`. The Tier 3 stealth
+Chromium integration and Tier 2 cookie layers are fork-added, not present in
+the upstream `fivetaku/insane-search` repository. A future audit of those
+layers should start from the OMO fork, not from `fivetaku/insane-search`
+directly.
+
+MIT License
+
+Copyright (c) 2026 fivetaku
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## 2. agent-browser (vercel-labs) — Tier 2 agent-reach CDP CLI (runtime dependency)
+
+The Tier 2 automation CLI is **agent-browser**, installed at runtime via `npm`
+(`npm i -g agent-browser`). No agent-browser source is vendored in this repository.
+
+- Source: https://github.com/vercel-labs/agent-browser
+- Pinned runtime version: **0.29.1** (documented in `references/chrome-stealth.md`;
+  documented version string, no automated drift check).
+- Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+  these files except in compliance with the License. You may obtain a copy of the
+  License at:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the specific language governing
+  permissions and limitations under the License.
+
+- **Changes (Apache-2.0 §4(b)):** none. agent-browser is installed unmodified at
+  runtime; no agent-browser source file is copied, modified, or redistributed by this
+  skill. This skill only documents how to invoke the upstream CLI.
+
+- **NOTICE:** the upstream agent-browser distribution may include a `NOTICE` file. As
+  this skill redistributes no agent-browser source, no upstream NOTICE content is
+  bundled here; consult the upstream repository for its `NOTICE` file when present.
+
+- **Trademark notice:** "agent-browser" and "Vercel" are referenced by name for
+  identification only. No trademark license is granted under the Apache License 2.0
+  (Section 6).
+
+---
+
+## 3. CloakBrowser (CloakHQ) — Tier 3 stealth Chromium (runtime dependency)
+
+The Tier 3 stealth browser is **CloakBrowser**, installed at runtime via `pip`
+(`pip install cloakbrowser`). No CloakBrowser source is vendored in this repository.
+
+- Source: https://github.com/CloakHQ/CloakBrowser
+- Pinned runtime version: **0.4.0** (documented in `references/chrome-stealth.md`;
+  this is a documented version string, not an automated drift check).
+- Wrapper source license: MIT License.
+- Binary license: the compiled CloakBrowser Chromium binary downloaded by
+  `cloakbrowser.ensure_binary()` is governed by the separate CloakBrowser
+  Binary License:
+  https://github.com/CloakHQ/CloakBrowser/blob/main/BINARY-LICENSE.md
+- Redistribution note: this skill does not redistribute the CloakBrowser
+  binary, does not repackage it, and does not include it in `skills/` or
+  `dist/skills`. Users who run the Tier 3 setup download the binary directly
+  from CloakHQ's official distribution channels and must comply with that
+  binary license.
+
+MIT wrapper source license:
+
+```
+MIT License
+
+Copyright (c) 2026 CloakHQ
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/skills/insane-browsing/SKILL.md
+++ b/skills/insane-browsing/SKILL.md
@@ -57,6 +57,17 @@ yt-dlp --write-sub --write-auto-sub --sub-lang "en,ko" --skip-download -o "/tmp/
 
 The full engine harness (rules R1-R7, the Phase 0 official-API index, the no-site-name rule, and the `references/insane-search/*.md` deep-dives for TLS, Playwright routing, Naver, media, etc.) is in [`references/insane-search/README.md`](references/insane-search/README.md). Read it before tuning the engine or adding a WAF profile.
 
+### Playwright fallback — one-time setup
+
+The Playwright real-Chrome fallback (`playwright_real_chrome.js` / `playwright_mobile_chrome.js`) is invoked via Node.js with `cwd=engine/templates/`. Node's `require('playwright')` resolves from that directory upward — **not** from npm's global prefix — so `npm i -g` does not work. Install locally into `engine/templates/`:
+
+```bash
+# Run once from the skill dir (engine/templates/package.json already declares the deps):
+(cd "$REPO/$SKILL_DIR/engine/templates" && npm install && npx playwright install chrome)
+```
+
+`engine/templates/package.json` declares `playwright`, `playwright-extra`, and `puppeteer-extra-plugin-stealth`; `npm install` (no flags) is all that is needed.
+
 ### Escalate to Tier 2 or Tier 3 when
 - The target is a Chinese / social platform with a native reader -> Tier 2.
 - insane-search returns empty/partial, or the page needs JS interaction, a screenshot, a persistent login, or media playback -> Tier 3.

--- a/skills/insane-browsing/SKILL.md
+++ b/skills/insane-browsing/SKILL.md
@@ -40,8 +40,11 @@ Read the matching reference before acting: [`references/insane-search/README.md`
 **Why first**: ~10x faster than a browser, no process spin-up; handles most "fetch this blocked page" requests via curl_cffi TLS impersonation, yt-dlp (1858 sites), Jina Reader, official public APIs, mobile URL transforms, and a Playwright real-Chrome fallback. The engine lives **inside this skill** at `engine/` and is invoked as a module.
 
 ```bash
-# Core command — auto-detects WAF, runs the full fetch grid (run from the skill dir):
-python3 -m engine "https://example.com/blocked-page"
+# Core command — auto-detects WAF, runs the full fetch grid.
+# Must cd into the skill dir: the engine is a package with relative imports (python -m engine
+# resolves them; a direct script path crashes). uv resolves deps into an isolated cached venv
+# from requirements.txt on first call (curl_cffi, beautifulsoup4, PyYAML pinned).
+(cd "$REPO/$SKILL_DIR" && uv run --python 3.10 --with-requirements requirements.txt python -m engine "https://example.com/blocked-page")
 #   add --selector "<CSS>" for positive-proof validation, --device auto|desktop|mobile,
 #   --trace to inspect every attempt, --json for machine-readable output.
 
@@ -61,6 +64,27 @@ The full engine harness (rules R1-R7, the Phase 0 official-API index, the no-sit
 ## Tier 2 — agent-reach (platform-native readers)
 
 **When**: the target is a platform with a first-class API/CLI that beats generic fetching — especially Chinese platforms that stealth browsers still cannot reach cleanly. Several channels are zero-config (Douyin, Weibo via Jina, V2EX, Reddit, Jina Reader, RSS, YouTube); others need a one-time auth you supply via environment variables if you have access.
+
+### One-time isolated setup (agent-reach)
+
+agent-reach is an external tool — not vendored here and not installed by `make sync`. Install it once, in isolation, before first use:
+
+```bash
+# Step 1: install the agent-reach tool itself (pick one; both are isolated):
+pipx install agent-reach          # recommended: pipx keeps it isolated
+# OR: uv tool install agent-reach  # uv tool alternative
+
+# Step 2: install agent-reach channel plugins:
+agent-reach install
+
+# Step 3: verify install and check cookie-channel auth prerequisites:
+agent-reach doctor
+# agent-reach doctor reports which cookie-channel logins are present and which are missing.
+# Cookie-channel logins are one-time-manual: log into the platform in a Chromium-family browser,
+# then run scripts/extract_cookies.py to capture and inject those cookies.
+```
+
+This is a one-time operator setup step, NOT an automated `make sync` step. `make sync` deploys skill files; it does not install or configure agent-reach.
 
 | Category | Platforms | Entry |
 |---|---|---|
@@ -102,11 +126,11 @@ agent-browser --cdp 9242 close
 `scripts/extract_cookies.py` reads cookies from a local Chromium-family or Firefox-family browser and optionally injects them into the running CDP session. It resolves browser profile paths and decrypts cookie values per-OS (macOS Keychain, Linux libsecret, Windows DPAPI):
 
 ```bash
-# Extract cookies to a file:
+# Extract cookies to a file (uv provides cryptography in an isolated env):
 mkdir -p ~/.local/state/insane-browsing-cookies
-python3 scripts/extract_cookies.py --browser chrome --domain youtube.com --output ~/.local/state/insane-browsing-cookies/youtube.cookies.json
+uv run --with cryptography python scripts/extract_cookies.py --browser chrome --domain youtube.com --output ~/.local/state/insane-browsing-cookies/youtube.cookies.json
 # Extract and inject into the running CDP session:
-python3 scripts/extract_cookies.py --browser chrome --domain youtube.com --inject --cdp 9242
+uv run --with cryptography python scripts/extract_cookies.py --browser chrome --domain youtube.com --inject --cdp 9242
 ```
 
 Cookie export files are written with owner-only `0600` permissions. Do not place live auth cookies in shared temp directories or commit them to a repo. Cookie injection sends values to CDP over stdin rather than argv. Cookies apply on next navigation — reload after injecting. Google services use fingerprint-bound tokens that may not transfer across browser profiles. Full detail in [references/chrome-stealth.md](references/chrome-stealth.md).
@@ -126,7 +150,8 @@ CLOAK_CDP_PORT=9242              # CloakBrowser CDP port (default 9242)
 AGENT_BROWSER_USER_AGENT="..."   # override UA to hide HeadlessChrome
 AGENT_BROWSER_HEADED=1           # show the browser window
 # agent-reach auth: set the channel-specific env vars from each tool's docs only if you have access
-# insane-search needs no env vars — it auto-installs deps on first run
+# insane-search engine deps (curl_cffi, beautifulsoup4, PyYAML) are declared in requirements.txt
+# and resolved by uv into an isolated cached venv on first call — no env var required
 ```
 
 ## Anti-patterns

--- a/skills/insane-browsing/SKILL.md
+++ b/skills/insane-browsing/SKILL.md
@@ -128,9 +128,9 @@ agent-browser --cdp 9242 close
 ```bash
 # Extract cookies to a file (uv provides cryptography in an isolated env):
 mkdir -p ~/.local/state/insane-browsing-cookies
-uv run --with cryptography python scripts/extract_cookies.py --browser chrome --domain youtube.com --output ~/.local/state/insane-browsing-cookies/youtube.cookies.json
+uv run --python 3.11 --with cryptography python scripts/extract_cookies.py --browser chrome --domain youtube.com --output ~/.local/state/insane-browsing-cookies/youtube.cookies.json
 # Extract and inject into the running CDP session:
-uv run --with cryptography python scripts/extract_cookies.py --browser chrome --domain youtube.com --inject --cdp 9242
+uv run --python 3.11 --with cryptography python scripts/extract_cookies.py --browser chrome --domain youtube.com --inject --cdp 9242
 ```
 
 Cookie export files are written with owner-only `0600` permissions. Do not place live auth cookies in shared temp directories or commit them to a repo. Cookie injection sends values to CDP over stdin rather than argv. Cookies apply on next navigation — reload after injecting. Google services use fingerprint-bound tokens that may not transfer across browser profiles. Full detail in [references/chrome-stealth.md](references/chrome-stealth.md).

--- a/skills/insane-browsing/SKILL.md
+++ b/skills/insane-browsing/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: insane-browsing
+description: "Escalation skill for blocked or hard-to-reach web access — load it when a normal browse/fetch is blocked (WAF, 403, Cloudflare, JS-only render, login-gated, or a platform a generic fetcher cannot read). Tiered router: TIER 1 insane-search (headless extraction + WAF bypass via curl_cffi TLS impersonation, yt-dlp, Jina Reader, public APIs, Playwright real-Chrome fallback); TIER 2 agent-reach (platform-native readers for Chinese and social platforms: Xiaohongshu, Douyin, Weibo, Bilibili, V2EX, WeChat, plus Twitter/Reddit/LinkedIn/GitHub); TIER 3 Chrome stealth (CloakBrowser stealth Chromium + agent-browser CDP for clicks, forms, screenshots, video, cookie login). Triggers: blocked site, bypass bot detection, cloudflare/WAF bypass, scrape, stealth browser, import cookies, fill form, screenshot, play youtube, xiaohongshu, douyin, weibo, bilibili, v2ex, wechat article, podcast transcript. NOT for simple searches (use web-search) or plain fetches (use webfetch)."
+---
+
+# Insane Browsing
+
+Escalation web access for tasks a normal browse or fetch cannot complete. Reach for this skill the moment a page is blocked (WAF / 403 / Cloudflare), needs JS rendering, hides behind a login, or lives on a platform a generic fetcher cannot read. Escalate only when the cheaper tier cannot do the job:
+
+**Tier 1 — insane-search** (headless extraction + WAF bypass) -> **Tier 2 — agent-reach** (platform-native APIs, esp. Chinese platforms) -> **Tier 3 — Chrome stealth** (real interaction via CloakBrowser + agent-browser).
+
+## PHASE 0 — ROUTE FIRST (MANDATORY)
+
+```
+User request
+  |
+  +- extract text/data from a URL --------------------- TIER 1  insane-search
+  +- URL blocked / 403 / Cloudflare / WAF ------------- TIER 1  insane-search
+  +- YouTube/Vimeo/TikTok subtitles or metadata ------- TIER 1  insane-search (yt-dlp)
+  +- read an article / blog / Reddit / HN / arXiv ----- TIER 1  insane-search
+  |
+  +- Chinese platform (xhs/douyin/weibo/bilibili/v2ex/wechat)  TIER 2 agent-reach
+  +- podcast transcript / stock forum ----------------- TIER 2 agent-reach
+  +- Twitter feed / LinkedIn profile / GitHub via CLI - TIER 2 agent-reach
+  |
+  +- Tier 1/2 returned empty or partial ------------- TIER 3  Chrome stealth
+  +- click / fill form / scroll / interact ------------ TIER 3  Chrome stealth
+  +- screenshot / render / play video ----------------- TIER 3  Chrome stealth
+  +- login session across pages / inject cookies ------ TIER 3  Chrome stealth
+  +- test web app / QA / dogfood ---------------------- TIER 3  Chrome stealth
+  |
+  +- simple search query ------------------------------ NOT this skill (use web-search)
+```
+
+Read the matching reference before acting: [`references/insane-search/README.md`](references/insane-search/README.md), [`references/agent-reach/README.md`](references/agent-reach/README.md), or [`references/chrome-stealth.md`](references/chrome-stealth.md).
+
+## Tier 1 — insane-search (headless extraction)
+
+**When**: content extraction, blocked-URL bypass, media metadata — no browser UI needed.
+**Why first**: ~10x faster than a browser, no process spin-up; handles most "fetch this blocked page" requests via curl_cffi TLS impersonation, yt-dlp (1858 sites), Jina Reader, official public APIs, mobile URL transforms, and a Playwright real-Chrome fallback. The engine lives **inside this skill** at `engine/` and is invoked as a module.
+
+```bash
+# Core command — auto-detects WAF, runs the full fetch grid (run from the skill dir):
+python3 -m engine "https://example.com/blocked-page"
+#   add --selector "<CSS>" for positive-proof validation, --device auto|desktop|mobile,
+#   --trace to inspect every attempt, --json for machine-readable output.
+
+# YouTube subtitles / metadata (no browser):
+yt-dlp --write-sub --write-auto-sub --sub-lang "en,ko" --skip-download -o "/tmp/%(id)s" "<URL>"
+
+# Reddit / HN / Bluesky / arXiv etc. use official public endpoints — see the Phase 0 index in
+# references/insane-search/README.md (Twitter syndication, Reddit .json, HN Firebase, ...).
+```
+
+The full engine harness (rules R1-R7, the Phase 0 official-API index, the no-site-name rule, and the `references/insane-search/*.md` deep-dives for TLS, Playwright routing, Naver, media, etc.) is in [`references/insane-search/README.md`](references/insane-search/README.md). Read it before tuning the engine or adding a WAF profile.
+
+### Escalate to Tier 2 or Tier 3 when
+- The target is a Chinese / social platform with a native reader -> Tier 2.
+- insane-search returns empty/partial, or the page needs JS interaction, a screenshot, a persistent login, or media playback -> Tier 3.
+
+## Tier 2 — agent-reach (platform-native readers)
+
+**When**: the target is a platform with a first-class API/CLI that beats generic fetching — especially Chinese platforms that stealth browsers still cannot reach cleanly. Several channels are zero-config (Douyin, Weibo via Jina, V2EX, Reddit, Jina Reader, RSS, YouTube); others need a one-time auth you supply via environment variables if you have access.
+
+| Category | Platforms | Entry |
+|---|---|---|
+| social | xhs (Xiaohongshu), douyin, weibo, bilibili, V2EX, Reddit, Twitter/X | [references/agent-reach/social.md](references/agent-reach/social.md) |
+| web | Jina Reader, WeChat articles, RSS | [references/agent-reach/web.md](references/agent-reach/web.md) |
+| video | YouTube, Bilibili, podcast transcripts, Douyin video | [references/agent-reach/video.md](references/agent-reach/video.md) |
+| career | LinkedIn | [references/agent-reach/career.md](references/agent-reach/career.md) |
+| dev | GitHub (gh CLI) | [references/agent-reach/dev.md](references/agent-reach/dev.md) |
+| search | Exa AI | [references/agent-reach/search.md](references/agent-reach/search.md) |
+
+```bash
+mcporter call 'douyin.parse_douyin_video_info(url: "<URL>")'   # douyin, zero-config
+curl -s "https://r.jina.ai/https://weibo.com/<uid>/<pid>"      # weibo via Jina
+yt-dlp --dump-json "<bilibili-url>"                            # Bilibili (overseas: add --cookies-from-browser)
+curl -s "https://www.v2ex.com/api/topics/hot.json"            # V2EX public API
+```
+
+Routing table, per-platform auth (set `TWITTER_*` env vars, `gh auth login`, a transcription key — only if you have access), rate-limit notes, and known version quirks are in [references/agent-reach/README.md](references/agent-reach/README.md).
+
+## Tier 3 — Chrome stealth (real interaction)
+
+**When**: real interaction is needed (clicks, forms, screenshots, video, persistent login), or Tier 1/2 failed.
+
+CloakBrowser is a stealth Chromium with source-level fingerprint patches that passes Cloudflare Turnstile, FingerprintJS, BrowserScan, and 30+ detectors; agent-browser is the CDP automation CLI that drives it. Both are runtime-installed tools (not vendored here). Full setup, version pins, launch flow, cookie login, and cross-platform notes are in [references/chrome-stealth.md](references/chrome-stealth.md).
+
+```bash
+# 1. Launch CloakBrowser with CDP on :9242 (see chrome-stealth.md for install + venv).
+# 2. CloakBrowser launches tabless — open the first tab via CDP before any agent-browser command:
+curl -s -X PUT "http://127.0.0.1:9242/json/new?https://example.com"
+# 3. Drive it with agent-browser over CDP:
+agent-browser --cdp 9242 snapshot -i        # interactive elements (@eN refs)
+agent-browser --cdp 9242 click @e3
+agent-browser --cdp 9242 screenshot out.png
+agent-browser --cdp 9242 close
+```
+
+### Cookie login (cross-platform)
+
+`scripts/extract_cookies.py` reads cookies from a local Chromium-family or Firefox-family browser and optionally injects them into the running CDP session. It resolves browser profile paths and decrypts cookie values per-OS (macOS Keychain, Linux libsecret, Windows DPAPI):
+
+```bash
+# Extract cookies to a file:
+mkdir -p ~/.local/state/insane-browsing-cookies
+python3 scripts/extract_cookies.py --browser chrome --domain youtube.com --output ~/.local/state/insane-browsing-cookies/youtube.cookies.json
+# Extract and inject into the running CDP session:
+python3 scripts/extract_cookies.py --browser chrome --domain youtube.com --inject --cdp 9242
+```
+
+Cookie export files are written with owner-only `0600` permissions. Do not place live auth cookies in shared temp directories or commit them to a repo. Cookie injection sends values to CDP over stdin rather than argv. Cookies apply on next navigation — reload after injecting. Google services use fingerprint-bound tokens that may not transfer across browser profiles. Full detail in [references/chrome-stealth.md](references/chrome-stealth.md).
+
+## Reference docs
+
+| File | When to read |
+|------|-------------|
+| [references/insane-search/README.md](references/insane-search/README.md) | Tier-1 engine harness (R1-R7, Phase 0 API index, no-site-name rule) + its `*.md` deep-dives |
+| [references/agent-reach/README.md](references/agent-reach/README.md) | Tier-2 routing table, platform auth, per-category `*.md` |
+| [references/chrome-stealth.md](references/chrome-stealth.md) | Tier-3 CloakBrowser + agent-browser install, CDP flow, version pins, cookie login |
+
+## Environment variables
+
+```bash
+CLOAK_CDP_PORT=9242              # CloakBrowser CDP port (default 9242)
+AGENT_BROWSER_USER_AGENT="..."   # override UA to hide HeadlessChrome
+AGENT_BROWSER_HEADED=1           # show the browser window
+# agent-reach auth: set the channel-specific env vars from each tool's docs only if you have access
+# insane-search needs no env vars — it auto-installs deps on first run
+```
+
+## Anti-patterns
+
+- Do NOT launch Chrome stealth for plain text extraction — use Tier 1.
+- Do NOT pass an `--init-script` for the webdriver flag — CloakBrowser already patches it at source; the only required override is `--user-agent`.
+- Do NOT run agent-browser before creating the first tab via `curl -X PUT .../json/new` — CloakBrowser launches tabless.
+- Do NOT use vanilla Chrome when stealth is needed — always CloakBrowser.
+- Do NOT forget to `close` the session when done.
+- Do NOT inject cookies without reloading the page.
+- Do NOT hardcode site domains/selectors into `engine/**` or `waf_profiles.yaml` — runtime hints only (see the no-site-name rule in the insane-search reference).

--- a/skills/insane-browsing/engine/__init__.py
+++ b/skills/insane-browsing/engine/__init__.py
@@ -1,0 +1,24 @@
+"""insane-search engine — generic WAF-profile-based fetch chain.
+
+No site-specific logic lives here. Site specifics belong to runtime hints or
+observations, never to code. See `../SKILL.md` for the No-Site-Name Rule.
+"""
+
+from .validators import Verdict, ValidationResult, validate, CHALLENGE_MARKERS
+from .waf_detector import detect
+from .url_transforms import TRANSFORMS, apply_transform
+from .fetch_chain import fetch
+from .result_schema import Attempt, FetchResult
+
+__all__ = [
+    "Verdict",
+    "ValidationResult",
+    "validate",
+    "CHALLENGE_MARKERS",
+    "detect",
+    "TRANSFORMS",
+    "apply_transform",
+    "fetch",
+    "FetchResult",
+    "Attempt",
+]

--- a/skills/insane-browsing/engine/__main__.py
+++ b/skills/insane-browsing/engine/__main__.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""CLI entrypoint for the insane-search engine.
+
+Usage:
+    python3 -m engine URL [--selector CSS] [--device auto|desktop|mobile]
+                          [--timeout N] [--max-attempts N] [--json] [--trace]
+
+Examples:
+    python3 -m engine "https://example.com/" --selector "h1"
+    python3 -m engine "https://example.com/" --json
+    python3 -m engine "https://example.com/" --device mobile --trace
+
+Exit codes:
+    0   strong_ok or weak_ok
+    1   ok=False (all attempts failed)
+    2   CLI arg error
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from . import fetch
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="python3 -m engine",
+                                description="Generic WAF-profile fetch chain.")
+    p.add_argument("url", help="URL to fetch.")
+    p.add_argument("--selector", "-s", action="append", default=None,
+                   dest="selectors", metavar="CSS",
+                   help="Positive-proof CSS selector. Repeatable.")
+    p.add_argument("--device", choices=("auto", "desktop", "mobile"), default="auto",
+                   help="Device class pin.")
+    p.add_argument("--timeout", type=int, default=25,
+                   help="Per-attempt timeout seconds (default 25).")
+    p.add_argument("--max-attempts", type=int, default=12,
+                   help="Upper bound across all phases (default 12).")
+    p.add_argument("--no-playwright", action="store_true",
+                   help="Skip Playwright fallback (curl-only).")
+    p.add_argument("--json", action="store_true",
+                   help="Emit FetchResult as JSON to stdout (content omitted).")
+    p.add_argument("--trace", action="store_true",
+                   help="Print per-attempt trace to stderr.")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        result = fetch(
+            args.url,
+            success_selectors=args.selectors,
+            device_class=args.device,
+            timeout=args.timeout,
+            max_attempts=args.max_attempts,
+            enable_playwright=not args.no_playwright,
+        )
+    except Exception as e:
+        print(f"engine fatal: {type(e).__name__}: {e}", file=sys.stderr)
+        return 2
+
+    if args.trace:
+        print("=== trace ===", file=sys.stderr)
+        for att in result.trace:
+            d = att.to_dict()
+            imp = d.get("impersonate") or "-"
+            ref = d.get("referer") or "-"
+            print(
+                f"[{d['phase']:<8}] {d['executor']:<18} "
+                f"xform={d['url_transform']:<16} imp={imp:<14} ref={ref:<14} "
+                f"status={d['status']:>4} size={d['body_size']:>8} "
+                f"verdict={d['verdict']} {('err=' + d['error'][:60]) if d.get('error') else ''}",
+                file=sys.stderr,
+            )
+        print(f"=== summary: {result.summary} ===", file=sys.stderr)
+
+    # Surface R7 hint (API-first route) prominently when summary contains it,
+    # regardless of --trace flag — this is actionable guidance, not noise.
+    if "R7 API-first" in (result.summary or ""):
+        print(
+            "\n════════════════════════════════════════════════════════════════\n"
+            "⚠️  R7 triggered — consider API-first route instead of HTML grid.\n"
+            "   See summary below (or re-run with --trace for full attempt log).\n"
+            "════════════════════════════════════════════════════════════════",
+            file=sys.stderr,
+        )
+        # Also print the full summary (which includes the hint) so caller sees it.
+        print(result.summary, file=sys.stderr)
+
+    if args.json:
+        payload = result.to_dict()
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        # Default: HTML to stdout, status to stderr.
+        print(result.content, end="")
+        print(f"\n[engine] ok={result.ok} verdict={result.verdict} "
+              f"profile={result.profile_used} attempts={len(result.trace)}",
+              file=sys.stderr)
+
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/insane-browsing/engine/bias_check.py
+++ b/skills/insane-browsing/engine/bias_check.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""No-Site-Name Rule checker.
+
+Run in CI / pre-commit. Scans engine/** for hard-coded site names or
+domains that would bias the generic fetch chain toward one site.
+
+Exit code 0 if clean, 1 if violations found.
+
+    python3 engine/bias_check.py
+    python3 engine/bias_check.py --strict    # also check references/*.md (usually off)
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+
+# Known brand / domain substrings that should NOT appear in engine code.
+# This is a non-exhaustive deny list. CI should treat hits as warnings that
+# require human review; false positives (e.g. "github" in comments) can be
+# whitelisted via EXPLICIT_ALLOW.
+BRAND_SUBSTRINGS = [
+    "coupang", "11st", "11번가", "musinsa", "무신사",
+    "fmkorea", "에펨코리아", "dcinside", "디시인사이드",
+    "ohou", "오늘의집", "kurly", "마켓컬리",
+    "daangn", "당근",
+    # Naver is allowed in Phase 0 references (official APIs) but not in engine code.
+    "naver.com", "blog.naver", "shopping.naver",
+    # Korean portal brand names
+    "daum.net", "kakao.com",
+]
+
+# Regex for bare URLs / domains. Used as a secondary pass to flag hardcoded
+# site hosts that slipped past the brand denylist.
+URL_PATTERN = re.compile(
+    r"https?://[\w\.-]+|[\w-]+\.(?:com|net|org|co\.kr|kr|io)\b",
+    re.IGNORECASE,
+)
+
+# Generic / neutral hosts that are allowed anywhere (examples, specs, stdlib,
+# and domains that legitimately appear as non-site-specific referrers / test
+# fixtures — Google search as a generic Referer strategy, httpbin for transport
+# tests, etc.). Anything in this set must be provably unrelated to a specific
+# target-site preference.
+URL_ALLOWLIST = {
+    "example.com", "example.org", "example.net",
+    "localhost", "127.0.0.1",
+    # Official API / documentation sources cited in code comments.
+    "curl.se", "playwright.dev", "nodejs.org", "npmjs.com",
+    # Generic Referer strategy target (used as a neutral off-site referer).
+    "www.google.com", "google.com",
+    # Generic HTTP test endpoint for infrastructure / transport tests.
+    "httpbin.org",
+}
+
+# Files / dirs that must be clean.
+SCAN_ROOTS_STRICT_OFF = ["engine"]
+SCAN_ROOTS_STRICT_ON = ["engine", "references"]
+
+# Directory names skipped during scan (third-party code, build artefacts).
+EXCLUDED_DIR_NAMES = {
+    "node_modules", "__pycache__", ".git", ".venv", "dist", "build",
+}
+
+# Comment markers within which a brand mention is OK (explanation).
+# Keyed per-extension; any line containing these is skipped.
+COMMENT_OK_MARKERS = {
+    ".py": ("# NOTE-BIAS-OK", "# EXAMPLE-ONLY"),
+    ".js": ("// NOTE-BIAS-OK", "// EXAMPLE-ONLY"),
+    ".yaml": ("# NOTE-BIAS-OK", "# EXAMPLE-ONLY"),
+    ".yml": ("# NOTE-BIAS-OK", "# EXAMPLE-ONLY"),
+    ".md": ("<!-- NOTE-BIAS-OK -->", "<!-- EXAMPLE-ONLY -->"),
+}
+
+# File paths explicitly exempted (full match against relative path from scan root).
+EXPLICIT_ALLOW_FILES = {
+    # None right now — add if needed with justification.
+}
+
+
+def _line_is_exempt(line: str, ext: str) -> bool:
+    markers = COMMENT_OK_MARKERS.get(ext, ())
+    return any(m in line for m in markers)
+
+
+def _scan_file(path: Path, root: Path) -> list[str]:
+    """Return list of violation strings for this file."""
+    rel = path.relative_to(root.parent)
+    if str(rel) in EXPLICIT_ALLOW_FILES:
+        return []
+
+    ext = path.suffix.lower()
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except Exception as e:
+        return [f"{rel}:0 — read error: {e}"]
+
+    violations: list[str] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if _line_is_exempt(line, ext):
+            continue
+        lowered = line.lower()
+        # 1) Brand / domain denylist
+        hit_brand = None
+        for brand in BRAND_SUBSTRINGS:
+            if brand.lower() in lowered:
+                hit_brand = brand
+                break
+        if hit_brand:
+            violations.append(f"{rel}:{lineno} — brand `{hit_brand}` in: {line.strip()[:120]}")
+            continue  # one violation per line
+        # 2) URL/domain regex scan — catches hosts that aren't in the denylist.
+        for match in URL_PATTERN.finditer(line):
+            host = match.group(0).lower()
+            host = host.split("//", 1)[-1].split("/", 1)[0]
+            if host in URL_ALLOWLIST:
+                continue
+            if host.endswith(".example.com") or host.endswith(".example.org"):
+                continue
+            violations.append(f"{rel}:{lineno} — hardcoded host `{host}` in: {line.strip()[:120]}")
+            break
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Scan engine for site-name bias")
+    parser.add_argument("--strict", action="store_true",
+                        help="Also scan references/*.md (usually noisy — off by default)")
+    parser.add_argument("--root", default=None,
+                        help="Skill root directory. Defaults to parent of this file.")
+    args = parser.parse_args(argv)
+
+    skill_root = Path(args.root) if args.root else Path(__file__).parent.parent
+    scan_roots = SCAN_ROOTS_STRICT_ON if args.strict else SCAN_ROOTS_STRICT_OFF
+
+    total_violations: list[str] = []
+    scanned = 0
+    for name in scan_roots:
+        root = skill_root / name
+        if not root.exists():
+            continue
+        for dirpath, dirnames, filenames in os.walk(root):
+            # In-place filter so os.walk skips these subtrees.
+            dirnames[:] = [d for d in dirnames if d not in EXCLUDED_DIR_NAMES]
+            for fname in filenames:
+                p = Path(dirpath) / fname
+                if p.suffix.lower() not in (".py", ".js", ".yaml", ".yml", ".md", ".ts", ".mjs"):
+                    continue
+                if p.name == "bias_check.py":
+                    continue  # self-exempt (this file lists the brands)
+                scanned += 1
+                total_violations.extend(_scan_file(p, skill_root))
+
+    print(f"[bias-check] scanned {scanned} files under {skill_root}")
+    if total_violations:
+        print(f"[bias-check] ❌ {len(total_violations)} violation(s):")
+        for v in total_violations:
+            print(f"  - {v}")
+        print()
+        print("Fix options:")
+        print("  1) Remove the brand name (preferred)")
+        print("  2) If genuinely explanatory, add '# NOTE-BIAS-OK' on the same line")
+        print("  3) If this is a Phase 0 official API reference, move it to references/*.md and rerun without --strict")
+        return 1
+
+    print("[bias-check] ✅ clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/insane-browsing/engine/curl_probe.py
+++ b/skills/insane-browsing/engine/curl_probe.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import time
+from typing import Iterable, Mapping, Protocol
+
+from .referers import REFERER_STRATEGIES
+from .result_schema import Attempt
+from .validators import Verdict, validate
+
+
+class _CookieItem(Protocol):
+    name: str
+    value: str
+
+
+class _CookieJar(Protocol):
+    jar: Iterable[_CookieItem]
+
+
+class ProbeResponse(Protocol):
+    status_code: int
+    text: str
+    url: str
+    cookies: _CookieJar | Mapping[str, str]
+
+
+def _curl_probe(
+    url: str, *, impersonate: str, referer: str, timeout: int = 20
+) -> tuple[ProbeResponse | None, str | None]:
+    try:
+        from curl_cffi import requests as cffi_requests
+    except ImportError:
+        return None, "curl_cffi not installed"
+
+    headers = {
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7",
+    }
+    if referer:
+        headers["Referer"] = referer
+
+    try:
+        resp = cffi_requests.get(
+            url,
+            impersonate=impersonate,
+            headers=headers,
+            timeout=timeout,
+            allow_redirects=True,
+        )
+        return resp, None
+    except cffi_requests.exceptions.RequestException as e:
+        return None, f"{type(e).__name__}:{str(e)[:200]}"
+
+
+def run_attempt(
+    url: str,
+    *,
+    transform_name: str,
+    impersonate: str,
+    referer_name: str,
+    success_selectors: list[str] | None,
+    known_bad_sizes: list[int] | None,
+    timeout: int,
+    phase: str,
+) -> tuple[Attempt, ProbeResponse | None]:
+    referer_url = REFERER_STRATEGIES.get(referer_name, REFERER_STRATEGIES["none"])(url)
+    started_at = time.time()
+    resp, err = _curl_probe(url, impersonate=impersonate, referer=referer_url, timeout=timeout)
+    elapsed = round(time.time() - started_at, 3)
+
+    att = Attempt(
+        phase=phase,
+        executor="curl_cffi",
+        url=url,
+        url_transform=transform_name,
+        impersonate=impersonate,
+        referer=referer_name,
+        elapsed_s=elapsed,
+    )
+
+    if err or resp is None:
+        att.error = err or "no response"
+        att.verdict = Verdict.UNKNOWN.value
+        return att, None
+
+    vr = validate(resp, success_selectors=success_selectors, known_bad_sizes=known_bad_sizes)
+    att.status = vr.status
+    att.body_size = vr.body_size
+    att.verdict = vr.verdict.value
+    att.reasons = vr.reasons
+    return att, resp

--- a/skills/insane-browsing/engine/curl_probe.py
+++ b/skills/insane-browsing/engine/curl_probe.py
@@ -1,11 +1,50 @@
 from __future__ import annotations
 
+import ipaddress
+import socket
 import time
 from typing import Iterable, Mapping, Protocol
+from urllib.parse import urljoin, urlparse
 
 from .referers import REFERER_STRATEGIES
 from .result_schema import Attempt
 from .validators import Verdict, validate
+
+# Max redirect hops to follow before giving up (matches curl's default).
+_MAX_REDIRECTS = 30
+
+
+def _is_blocked_host(host: str) -> bool:
+    """True if `host` resolves to a non-routable / cloud-metadata address.
+
+    Blocks the standard SSRF target classes: private (RFC1918), loopback
+    (127/8, ::1), link-local (169.254/16 incl. the 169.254.169.254 metadata
+    endpoint, and fe80::/10), plus reserved/unspecified as a safety belt. A
+    host is blocked if ANY of its resolved addresses falls in those classes.
+    """
+    if not host:
+        return True
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        # Unresolvable host: refuse rather than follow into the unknown.
+        return True
+    for info in infos:
+        addr = info[4][0]
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            return True
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_unspecified
+            or ip.is_multicast
+        ):
+            return True
+    return False
 
 
 class _CookieItem(Protocol):
@@ -39,15 +78,31 @@ def _curl_probe(
     if referer:
         headers["Referer"] = referer
 
+    # Manual redirect loop: validate every hop's target before following so an
+    # attacker-influenced page cannot steer the fetch at internal / cloud-metadata
+    # endpoints (SSRF). curl auto-follow is disabled; each Location is resolved and
+    # its host classified before the next request is issued.
+    current_url = url
     try:
-        resp = cffi_requests.get(
-            url,
-            impersonate=impersonate,
-            headers=headers,
-            timeout=timeout,
-            allow_redirects=True,
-        )
-        return resp, None
+        for _ in range(_MAX_REDIRECTS + 1):
+            resp = cffi_requests.get(
+                current_url,
+                impersonate=impersonate,
+                headers=headers,
+                timeout=timeout,
+                allow_redirects=False,
+            )
+            if resp.status_code not in (301, 302, 303, 307, 308):
+                return resp, None
+            location = resp.headers.get("location")
+            if not location:
+                return resp, None
+            next_url = urljoin(current_url, location)
+            host = urlparse(next_url).hostname or ""
+            if _is_blocked_host(host):
+                return None, f"ssrf_redirect_blocked:{host}"
+            current_url = next_url
+        return None, "too_many_redirects"
     except cffi_requests.exceptions.RequestException as e:
         return None, f"{type(e).__name__}:{str(e)[:200]}"
 

--- a/skills/insane-browsing/engine/curl_probe.py
+++ b/skills/insane-browsing/engine/curl_probe.py
@@ -78,13 +78,18 @@ def _curl_probe(
     if referer:
         headers["Referer"] = referer
 
-    # Manual redirect loop: validate every hop's target before following so an
-    # attacker-influenced page cannot steer the fetch at internal / cloud-metadata
-    # endpoints (SSRF). curl auto-follow is disabled; each Location is resolved and
-    # its host classified before the next request is issued.
+    # Manual redirect loop: classify every request target's host BEFORE issuing
+    # the fetch — the initial caller-supplied URL and each redirect Location
+    # alike — so an attacker-steered (or simply malicious) URL cannot reach
+    # internal / cloud-metadata endpoints (SSRF). curl auto-follow is disabled;
+    # each Location is resolved against the current URL and re-checked at the top
+    # of the next iteration.
     current_url = url
     try:
         for _ in range(_MAX_REDIRECTS + 1):
+            host = urlparse(current_url).hostname or ""
+            if _is_blocked_host(host):
+                return None, f"ssrf_blocked:{host}"
             resp = cffi_requests.get(
                 current_url,
                 impersonate=impersonate,
@@ -97,11 +102,7 @@ def _curl_probe(
             location = resp.headers.get("location")
             if not location:
                 return resp, None
-            next_url = urljoin(current_url, location)
-            host = urlparse(next_url).hostname or ""
-            if _is_blocked_host(host):
-                return None, f"ssrf_redirect_blocked:{host}"
-            current_url = next_url
+            current_url = urljoin(current_url, location)
         return None, "too_many_redirects"
     except cffi_requests.exceptions.RequestException as e:
         return None, f"{type(e).__name__}:{str(e)[:200]}"

--- a/skills/insane-browsing/engine/executor.py
+++ b/skills/insane-browsing/engine/executor.py
@@ -1,0 +1,192 @@
+"""Capability-matched executor for fallback attempts.
+
+The fetch_chain's probe/grid phase uses curl_cffi directly. When curl can't
+punch through (JS challenge, real-TLS detection), this module routes to the
+right browser executor based on the profile's `capabilities_needed` tags:
+
+    needs_real_tls_stack + needs_js_exec  → playwright_real_chrome.js
+    needs_js_exec only                    → Playwright MCP (if available)
+    needs_mobile_context (+ real_tls)     → playwright_mobile_chrome.js
+
+The JS templates live in `engine/templates/` and accept only generic
+parameters ({{url}}, {{waitSelector}}, {{profileDir}}, {{device}}). No
+site-specific logic.
+
+Playwright MCP invocation requires caller's tool access; this module
+provides the subprocess path for local JS templates but only stubs the MCP
+path (MCP must be driven from the Claude session itself).
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from typing import Optional
+
+from .validators import Verdict, validate
+from .waf_detector import load_profile
+from .result_schema import Attempt
+
+
+TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), "templates")
+
+
+def _node_available() -> bool:
+    return shutil.which("node") is not None
+
+
+def _chrome_channel_available() -> bool:
+    """Heuristic: try `node -e` to import playwright. Fallback to True, let script fail loudly."""
+    if not _node_available():
+        return False
+    if shutil.which("npx") is None:
+        return False
+    return True
+
+
+def _pick_executor(capabilities: list[str], device_class: str) -> str:
+    caps = set(capabilities or [])
+    if device_class == "mobile" or "needs_mobile_context" in caps:
+        if "needs_real_tls_stack" in caps:
+            return "playwright_mobile_chrome"
+        return "playwright_mcp_mobile"
+    if "needs_real_tls_stack" in caps:
+        return "playwright_real_chrome"
+    if "needs_js_exec" in caps:
+        return "playwright_mcp"
+    return "playwright_real_chrome"  # safest general fallback
+
+
+def _run_node_template(template: str, args: dict, timeout: int = 90) -> tuple[int, str, str]:
+    """Run a Node.js template with args as JSON on stdin.
+
+    Template convention: reads `process.stdin` → JSON → runs fetch → writes
+    HTML to stdout; errors go to stderr with non-zero exit code.
+    """
+    path = os.path.join(TEMPLATES_DIR, template)
+    if not os.path.isfile(path):
+        return 127, "", f"template not found: {path}"
+    try:
+        proc = subprocess.run(
+            ["node", path],
+            input=json.dumps(args),
+            cwd=TEMPLATES_DIR,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return proc.returncode, proc.stdout, proc.stderr
+    except subprocess.TimeoutExpired:
+        return 124, "", f"timeout after {timeout}s"
+    except Exception as e:
+        return 1, "", f"{type(e).__name__}:{e}"
+
+
+class _FakeResp:
+    """Minimal response shim so validators.validate() works on Playwright HTML."""
+    def __init__(self, html: str, status: int = 200, final_url: str = ""):
+        self.text = html
+        self.status_code = status
+        self.url = final_url
+        self.cookies = _FakeCookies()
+        self.headers = {}
+
+
+class _FakeCookies:
+    class _Jar:
+        def __iter__(self):
+            return iter([])
+    def __init__(self):
+        self.jar = self._Jar()
+    def __iter__(self):
+        return iter([])
+
+
+def run_playwright_fallback(
+    url: str,
+    *,
+    profile_id: str,
+    success_selectors: Optional[list[str]] = None,
+    device_class: str = "auto",
+    timeout: int = 90,
+    profile_dir: Optional[str] = None,
+    force_executor: Optional[str] = None,
+) -> tuple[Attempt, str]:
+    """Invoke the appropriate Playwright executor.
+
+    force_executor: caller-specified executor name (from a profile's
+    `fallback_when_challenge` list). When set, it overrides capability-based
+    inference. Recognized values: "playwright_real_chrome",
+    "playwright_mobile_chrome", "playwright_mcp".
+
+    Returns (Attempt, html_content). Attempt.verdict reflects validation.
+    """
+    profile = load_profile(profile_id)
+    capabilities = profile.get("capabilities_needed") or []
+    choice = force_executor or _pick_executor(capabilities, device_class)
+
+    t0 = time.time()
+    att = Attempt(
+        phase="fallback",
+        executor=choice,
+        url=url,
+        url_transform="original",
+        impersonate=None,
+        referer="",
+    )
+
+    if choice.startswith("playwright_mcp"):
+        att.error = (
+            "Playwright MCP must be invoked from the Claude session — "
+            "call mcp__playwright__* tools directly instead of fetch_chain."
+        )
+        att.verdict = Verdict.UNKNOWN.value
+        att.elapsed_s = round(time.time() - t0, 3)
+        return att, ""
+
+    if not _chrome_channel_available():
+        att.error = "node/npx not available for local Playwright template"
+        att.verdict = Verdict.UNKNOWN.value
+        att.elapsed_s = round(time.time() - t0, 3)
+        return att, ""
+
+    template_map = {
+        "playwright_real_chrome": "playwright_real_chrome.js",
+        "playwright_mobile_chrome": "playwright_mobile_chrome.js",
+    }
+    template = template_map.get(choice)
+    if template is None:
+        att.error = f"no template for executor {choice}"
+        att.verdict = Verdict.UNKNOWN.value
+        att.elapsed_s = round(time.time() - t0, 3)
+        return att, ""
+
+    args: dict = {
+        "url": url,
+        "profileDir": profile_dir or os.path.join(tempfile.gettempdir(), ".insane_pw_profile"),
+        "timeout": timeout * 1000,
+    }
+    if choice == "playwright_mobile_chrome":
+        args["device"] = "iPhone 13 Pro"
+    if success_selectors:
+        args["waitSelector"] = success_selectors[0]
+
+    rc, stdout, stderr = _run_node_template(template, args, timeout=timeout + 10)
+    att.elapsed_s = round(time.time() - t0, 3)
+
+    if rc != 0 or not stdout:
+        att.error = (stderr or "no stdout")[:300]
+        att.verdict = Verdict.UNKNOWN.value
+        return att, ""
+
+    # stdout carries HTML. Validate with a shim.
+    resp = _FakeResp(stdout)
+    vr = validate(resp, success_selectors=success_selectors)
+    att.status = 200
+    att.body_size = len(stdout)
+    att.verdict = vr.verdict.value
+    att.reasons = vr.reasons
+    return att, stdout

--- a/skills/insane-browsing/engine/executor.py
+++ b/skills/insane-browsing/engine/executor.py
@@ -63,8 +63,9 @@ def _pick_executor(capabilities: list[str], device_class: str) -> str:
 def _run_node_template(template: str, args: dict, timeout: int = 90) -> tuple[int, str, str]:
     """Run a Node.js template with args as JSON on stdin.
 
-    Template convention: reads `process.stdin` → JSON → runs fetch → writes
-    HTML to stdout; errors go to stderr with non-zero exit code.
+    Template convention: reads `process.stdin` → JSON → runs fetch → writes a
+    JSON envelope `{status, final_url, html}` to stdout; errors go to stderr
+    with non-zero exit code.
     """
     path = os.path.join(TEMPLATES_DIR, template)
     if not os.path.isfile(path):
@@ -182,11 +183,24 @@ def run_playwright_fallback(
         att.verdict = Verdict.UNKNOWN.value
         return att, ""
 
-    # stdout carries HTML. Validate with a shim.
-    resp = _FakeResp(stdout)
+    # stdout carries a JSON envelope {status, final_url, html}. Parse it so the
+    # real HTTP status (not a faked 200) and the post-redirect URL flow onto the
+    # Attempt; validators then demotes a 4xx/5xx fallback to not-ok.
+    try:
+        envelope = json.loads(stdout)
+        status = int(envelope.get("status") or 0)
+        final_url = envelope.get("final_url") or url
+        html = envelope.get("html") or ""
+    except (ValueError, AttributeError) as e:
+        att.error = f"malformed_envelope:{type(e).__name__}"
+        att.verdict = Verdict.UNKNOWN.value
+        return att, ""
+
+    resp = _FakeResp(html, status=status, final_url=final_url)
     vr = validate(resp, success_selectors=success_selectors)
-    att.status = 200
-    att.body_size = len(stdout)
+    att.status = status
+    att.url = final_url
+    att.body_size = len(html.encode("utf-8", "replace"))
     att.verdict = vr.verdict.value
     att.reasons = vr.reasons
-    return att, stdout
+    return att, html

--- a/skills/insane-browsing/engine/executor.py
+++ b/skills/insane-browsing/engine/executor.py
@@ -25,7 +25,9 @@ import subprocess
 import tempfile
 import time
 from typing import Optional
+from urllib.parse import urlparse
 
+from .curl_probe import _is_blocked_host
 from .validators import Verdict, validate
 from .waf_detector import load_profile
 from .result_schema import Attempt
@@ -194,6 +196,18 @@ def run_playwright_fallback(
     except (ValueError, AttributeError) as e:
         att.error = f"malformed_envelope:{type(e).__name__}"
         att.verdict = Verdict.UNKNOWN.value
+        return att, ""
+
+    # Defense-in-depth (the JS template's route interceptor is the primary block
+    # that stops the request from ever firing): re-check the post-redirect
+    # final_url host here too, so an internal / cloud-metadata target never
+    # yields content even if the interceptor were somehow bypassed.
+    final_host = urlparse(final_url).hostname or ""
+    if _is_blocked_host(final_host):
+        att.error = f"ssrf_final_url_blocked:{final_host}"
+        att.verdict = Verdict.UNKNOWN.value
+        att.url = final_url
+        att.status = status
         return att, ""
 
     resp = _FakeResp(html, status=status, final_url=final_url)

--- a/skills/insane-browsing/engine/fetch_chain.py
+++ b/skills/insane-browsing/engine/fetch_chain.py
@@ -1,0 +1,268 @@
+"""Single entrypoint: insane-search generic fetch chain.
+
+    from insane_search.engine import fetch
+    result = fetch("https://example.com/path", success_selectors=["article"])
+
+Public contract:
+  * One function: `fetch(url, ...) -> FetchResult`.
+  * Internal structure preserved as explicit phases so tests & debug logs
+    can target each stage: probe → validate → detect → plan → execute → report.
+  * `FetchResult.trace` exposes every attempt (transform × impersonate ×
+    referer × executor) — callers can diagnose without re-running.
+
+No site-specific branching. Site knowledge enters only via:
+  * `success_selectors` (caller-supplied positive proof)
+  * `user_hint` (optional runtime hints; never persisted by this module)
+  * `observations/*.jsonl` (append-only log; separate concern)
+"""
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+
+from .curl_probe import run_attempt
+from .result_schema import Attempt, FetchResult
+from .summary import format_summary
+from .validators import Verdict
+from .waf_detector import DetectionHit, detect, load_profile, _load_profiles, last_load_error
+from .url_transforms import iter_transformed
+
+
+# --- Main entrypoint ---------------------------------------------------------
+def fetch(
+    url: str,
+    *,
+    success_selectors: list[str] | None = None,
+    device_class: str = "auto",      # "auto" | "desktop" | "mobile"
+    user_hint: dict | None = None,
+    timeout: int = 25,
+    max_attempts: int = 12,
+    enable_playwright: bool = True,   # hook left for executor module
+) -> FetchResult:
+    """Fetch `url` using the generic grid.
+
+    Parameters
+    ----------
+    success_selectors
+        Positive-proof CSS selectors. Presence of ≥1 match promotes verdict
+        to STRONG_OK. Without them, best outcome is WEAK_OK.
+    device_class
+        "desktop" pins curl impersonate to desktop targets (safari/chrome/firefox).
+        "mobile" pins to mobile targets (safari_ios/chrome_android) AND enables
+        mobile URL transforms.
+        "auto" (default) follows profile advice; tries desktop first, mobile on
+        persistent failure.
+    user_hint
+        Optional runtime hints, e.g. `{"impersonate_first": "safari", "referer": "..."}`.
+        Never stored. Only influences current call.
+    timeout
+        Per-attempt timeout in seconds.
+    max_attempts
+        Hard upper bound on total attempts across all phases.
+    enable_playwright
+        Placeholder — Playwright fallback invocation is delegated to
+        `engine/executor.py` (separate module, capability-matched).
+    """
+    user_hint = user_hint or {}
+    profiles = _load_profiles()
+    trace: list[Attempt] = []
+    last_resp = None
+    last_attempt: Attempt | None = None
+    profile_used: str | None = None
+
+    # Surface profile-loader failures as a trace entry so callers can see
+    # that we're running on the in-code default (YAML missing / invalid /
+    # PyYAML not installed). Never fatal by itself.
+    load_err = last_load_error()
+    if load_err:
+        trace.append(Attempt(
+            phase="probe",
+            executor="profile_loader",
+            url=url,
+            url_transform="original",
+            impersonate=None,
+            referer="",
+            verdict=Verdict.UNKNOWN.value,
+            error=f"profiles_fallback: {load_err}",
+        ))
+
+    # -------- Phase 1: probe with safe defaults ------------------------------
+    base_impersonate = user_hint.get("impersonate_first") or "safari"
+    if device_class == "mobile":
+        base_impersonate = user_hint.get("impersonate_first") or "safari_ios"
+
+    probe_attempt, probe_resp = run_attempt(
+        url,
+        transform_name="original",
+        impersonate=base_impersonate,
+        referer_name=user_hint.get("referer_strategy") or "self_root",
+        success_selectors=success_selectors,
+        known_bad_sizes=None,
+        timeout=timeout,
+        phase="probe",
+    )
+    trace.append(probe_attempt)
+    if probe_resp is not None:
+        last_resp = probe_resp
+        last_attempt = probe_attempt
+        if probe_attempt.verdict in (Verdict.STRONG_OK.value, Verdict.WEAK_OK.value):
+            return _build_result(probe_resp, probe_attempt, trace, profile_used=None)
+
+    # -------- Phase 2: detect WAF, plan grid ---------------------------------
+    if last_resp is not None:
+        hits = detect(last_resp, profiles=profiles)
+    else:
+        hits = [DetectionHit(profile_id="unknown_challenge", confidence=0.1, signals=["no_probe_response"])]
+
+    # Try top profiles by confidence.
+    attempts_used = len(trace)
+    for hit in hits[:3]:  # top 3 candidates
+        if attempts_used >= max_attempts:
+            break
+        profile_id = hit.profile_id
+        profile_used = profile_id
+        profile = load_profile(profile_id, profiles=profiles)
+
+        tls_groups: list[list[str]] = profile.get("tls_impersonate_candidates") or [["safari", "chrome"]]
+        tls_flat: list[str] = [t for group in tls_groups for t in group]
+        avoid = set((profile.get("tls_impersonate_avoid") or []))
+        tls_flat = [t for t in tls_flat if t not in avoid]
+
+        referer_order = profile.get("referer_strategies") or ["self_root"]
+        transform_order = profile.get("url_transform_order") or ["original"]
+
+        # device_class override
+        if device_class == "mobile":
+            tls_flat = [t for t in tls_flat if "ios" in t or "android" in t] or tls_flat
+            if "mobile_subdomain" not in transform_order:
+                transform_order = transform_order + ["mobile_subdomain"]
+        elif device_class == "desktop":
+            tls_flat = [t for t in tls_flat if "ios" not in t and "android" not in t] or tls_flat
+
+        known_bad_sizes = profile.get("known_bad_sizes") or None
+
+        for t_name, t_url in iter_transformed(url, transform_order):
+            for tls in tls_flat:
+                for ref in referer_order:
+                    if attempts_used >= max_attempts:
+                        break
+                    # Skip exact duplicate of probe.
+                    if (t_name == "original" and tls == base_impersonate
+                            and ref == (user_hint.get("referer_strategy") or "self_root")):
+                        continue
+                    att, resp = run_attempt(
+                        t_url,
+                        transform_name=t_name,
+                        impersonate=tls,
+                        referer_name=ref,
+                        success_selectors=success_selectors,
+                        known_bad_sizes=known_bad_sizes,
+                        timeout=timeout,
+                        phase="grid",
+                    )
+                    trace.append(att)
+                    attempts_used += 1
+                    # Jitter: politeness + IP-reputation guard. Tunable via
+                    # INSANE_JITTER_MS_MIN / INSANE_JITTER_MS_MAX env vars.
+                    _jmin = int(os.environ.get("INSANE_JITTER_MS_MIN", "150"))
+                    _jmax = int(os.environ.get("INSANE_JITTER_MS_MAX", "400"))
+                    time.sleep(random.uniform(_jmin/1000.0, _jmax/1000.0))
+                    if resp is None:
+                        continue
+                    last_resp, last_attempt = resp, att
+                    if att.verdict in (Verdict.STRONG_OK.value, Verdict.WEAK_OK.value):
+                        return _build_result(resp, att, trace, profile_used=profile_id)
+
+    # -------- Phase 3: Playwright fallback (profile-driven order) -----------
+    if enable_playwright:
+        try:
+            from .executor import run_playwright_fallback  # lazy import
+            # Honour profile's `fallback_when_challenge` list — iterate the
+            # caller-declared order instead of capability-inferred single pick.
+            fb_profile = load_profile(profile_used or "unknown_challenge", profiles=profiles)
+            fb_order = fb_profile.get("fallback_when_challenge") or ["playwright_real_chrome"]
+            pw_attempt = None
+            pw_content = ""
+            for fb_name in fb_order:
+                if fb_name == "curl_grid_exhaust":
+                    # Already performed in Phase 2; nothing more to do here.
+                    continue
+                pw_attempt, pw_content = run_playwright_fallback(
+                    url,
+                    profile_id=profile_used or "unknown_challenge",
+                    success_selectors=success_selectors,
+                    device_class=device_class,
+                    force_executor=fb_name,
+                )
+                trace.append(pw_attempt)
+                if pw_attempt.verdict in (Verdict.STRONG_OK.value, Verdict.WEAK_OK.value):
+                    return FetchResult(
+                        ok=True,
+                        content=pw_content,
+                        final_url=pw_attempt.url,
+                        verdict=pw_attempt.verdict,
+                        profile_used=profile_used,
+                        trace=trace,
+                        summary=f"Playwright fallback succeeded via {fb_name}",
+                    )
+            # Synthesize a placeholder if no iteration ran (empty list).
+            if pw_attempt is None:
+                pw_attempt = Attempt(
+                    phase="fallback",
+                    executor="none",
+                    url=url,
+                    url_transform="original",
+                    impersonate=None,
+                    referer="",
+                    verdict=Verdict.UNKNOWN.value,
+                    error="profile has empty fallback_when_challenge",
+                )
+                trace.append(pw_attempt)
+        except ImportError:
+            trace.append(Attempt(
+                phase="fallback",
+                executor="playwright",
+                url=url,
+                url_transform="original",
+                impersonate=None,
+                referer="",
+                verdict=Verdict.UNKNOWN.value,
+                error="executor module not available",
+            ))
+        except (RuntimeError, OSError) as e:
+            trace.append(Attempt(
+                phase="fallback",
+                executor="playwright",
+                url=url,
+                url_transform="original",
+                impersonate=None,
+                referer="",
+                verdict=Verdict.UNKNOWN.value,
+                error=f"{type(e).__name__}:{str(e)[:200]}",
+            ))
+
+    # -------- Give up, return best we have ----------------------------------
+    summary = format_summary(trace, profile_used)
+    return FetchResult(
+        ok=False,
+        content=getattr(last_resp, "text", "") if last_resp is not None else "",
+        final_url=getattr(last_resp, "url", url) if last_resp is not None else url,
+        verdict=last_attempt.verdict if last_attempt else Verdict.UNKNOWN.value,
+        profile_used=profile_used,
+        trace=trace,
+        summary=summary,
+    )
+
+
+def _build_result(resp, attempt: Attempt, trace: list[Attempt], profile_used: str | None) -> FetchResult:
+    return FetchResult(
+        ok=True,
+        content=getattr(resp, "text", "") or "",
+        final_url=str(getattr(resp, "url", attempt.url)),
+        verdict=attempt.verdict,
+        profile_used=profile_used,
+        trace=trace,
+        summary=f"{attempt.executor} {attempt.impersonate} + {attempt.url_transform} + referer:{attempt.referer} → {attempt.verdict}",
+    )

--- a/skills/insane-browsing/engine/fetch_chain.py
+++ b/skills/insane-browsing/engine/fetch_chain.py
@@ -195,6 +195,7 @@ def fetch(
                     success_selectors=success_selectors,
                     device_class=device_class,
                     force_executor=fb_name,
+                    timeout=timeout,
                 )
                 trace.append(pw_attempt)
                 if pw_attempt.verdict in (Verdict.STRONG_OK.value, Verdict.WEAK_OK.value):

--- a/skills/insane-browsing/engine/referers.py
+++ b/skills/insane-browsing/engine/referers.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+
+def _self_root(url: str) -> str:
+    parsed = urlsplit(url)
+    return f"{parsed.scheme}://{parsed.netloc}/"
+
+
+REFERER_STRATEGIES = {
+    "self_root": _self_root,
+    "google_search": lambda _url: "https://www.google.com/",
+    "none": lambda _url: "",
+}

--- a/skills/insane-browsing/engine/referers.py
+++ b/skills/insane-browsing/engine/referers.py
@@ -5,7 +5,12 @@ from urllib.parse import urlsplit
 
 def _self_root(url: str) -> str:
     parsed = urlsplit(url)
-    return f"{parsed.scheme}://{parsed.netloc}/"
+    # Use hostname (strips userinfo and port) instead of netloc to prevent
+    # leaking basic-auth credentials into the Referer header (F16).
+    host = parsed.hostname or ""
+    if parsed.port:
+        host = f"{host}:{parsed.port}"
+    return f"{parsed.scheme}://{host}/"
 
 
 REFERER_STRATEGIES = {

--- a/skills/insane-browsing/engine/result_schema.py
+++ b/skills/insane-browsing/engine/result_schema.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Optional
+
+
+@dataclass
+class Attempt:
+    phase: str
+    executor: str
+    url: str
+    url_transform: str
+    impersonate: Optional[str]
+    referer: str
+    status: int = 0
+    body_size: int = 0
+    verdict: str = ""
+    reasons: list[str] = field(default_factory=list)
+    elapsed_s: float = 0.0
+    error: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class FetchResult:
+    ok: bool
+    content: str = ""
+    final_url: str = ""
+    verdict: str = ""
+    profile_used: Optional[str] = None
+    trace: list[Attempt] = field(default_factory=list)
+    summary: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "ok": self.ok,
+            "final_url": self.final_url,
+            "verdict": self.verdict,
+            "profile_used": self.profile_used,
+            "trace": [a.to_dict() for a in self.trace],
+            "summary": self.summary,
+            "content_length": len(self.content),
+        }

--- a/skills/insane-browsing/engine/summary.py
+++ b/skills/insane-browsing/engine/summary.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from .result_schema import Attempt
+from .validators import Verdict
+
+
+_R7_ELIGIBLE_PROFILES = frozenset({
+    "akamai_bot_manager",
+    "cloudflare_turnstile",
+    "datadome_probable",
+    "perimeterx_human",
+    "f5_big_ip",
+    "aws_waf",
+})
+
+R7_HINT = (
+    "💡 R7 API-first 권장: WAF가 HTML 경로를 차단 중. "
+    "Playwright MCP 사용 → browser_navigate → browser_network_requests "
+    "→ `/api/`·`/graphql`·`\\.json` 필터로 내부 엔드포인트 탐지 → "
+    "해당 URL을 `python3 -m engine <API_URL>`로 재호출. 대부분 API 레이어는 "
+    "WAF 방어가 얕아 curl_cffi만으로 수집됨."
+)
+
+
+def format_summary(trace: list[Attempt], profile: Optional[str]) -> str:
+    n = len(trace)
+    verdicts = [a.verdict for a in trace]
+    challenge_count = sum(1 for v in verdicts if v == Verdict.CHALLENGE.value)
+    base = (
+        f"failed after {n} attempts; profile={profile}; "
+        f"verdicts={','.join(v for v in verdicts[:5])}" + ("..." if n > 5 else "")
+    )
+    if profile in _R7_ELIGIBLE_PROFILES and challenge_count >= 3:
+        return base + "\n" + R7_HINT
+    return base

--- a/skills/insane-browsing/engine/templates/package.json
+++ b/skills/insane-browsing/engine/templates/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "insane-search-templates",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Local deps for Playwright real-Chrome templates. npm install && npx playwright install chrome",
+  "dependencies": {
+    "playwright": "^1.61.0",
+    "playwright-extra": "^4.3.6",
+    "puppeteer-extra-plugin-stealth": "^2.11.2"
+  }
+}

--- a/skills/insane-browsing/engine/templates/playwright_mobile_chrome.js
+++ b/skills/insane-browsing/engine/templates/playwright_mobile_chrome.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * Generic Playwright mobile fetcher — real Chrome + device emulation.
+ *
+ * Usage:
+ *   echo '{"url":"...", "device":"iPhone 13 Pro"}' | node playwright_mobile_chrome.js
+ *
+ * Device name must match playwright `devices[...]` keys (Pixel 7, iPhone 13 Pro,
+ * iPad Pro 11, etc.). When in doubt, omit `device` — default is iPhone 13 Pro.
+ *
+ * NO-SITE-NAME RULE: same as playwright_real_chrome.js — no hostname branches.
+ */
+
+async function readStdinJson() {
+  return await new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.on('data', (c) => (data += c));
+    process.stdin.on('end', () => {
+      try { resolve(JSON.parse(data || '{}')); }
+      catch (e) { reject(e); }
+    });
+    process.stdin.on('error', reject);
+  });
+}
+
+function describeError(error) {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+  return String(error);
+}
+
+function warnBestEffort(action, error) {
+  process.stderr.write(`best-effort ${action} failed: ${describeError(error)}\n`);
+}
+
+function isMissingTopLevelModule(error, moduleName) {
+  return (
+    error instanceof Error &&
+    error.code === 'MODULE_NOT_FOUND' &&
+    typeof error.message === 'string' &&
+    error.message.includes(`Cannot find module '${moduleName}'`)
+  );
+}
+
+function requireOptionalModule(moduleName) {
+  let resolvedModule;
+  try {
+    resolvedModule = require.resolve(moduleName);
+  } catch (e) {
+    if (isMissingTopLevelModule(e, moduleName)) {
+      warnBestEffort(`optional module ${moduleName}`, e);
+      return null;
+    }
+    throw e;
+  }
+  return require(resolvedModule);
+}
+
+async function main() {
+  const args = await readStdinJson();
+  const url = args.url;
+  if (!url) {
+    process.stderr.write('missing url\n');
+    process.exitCode = 2;
+    return;
+  }
+
+  const profileDir = args.profileDir || '/tmp/.insane_pw_mobile_profile';
+  const deviceName = args.device || 'iPhone 13 Pro';
+  const waitSelector = args.waitSelector || null;
+  const timeoutMs = args.timeout || 60000;
+  const headless = args.headless ?? false;
+
+  let chromium, devices;
+  const playwrightExtra = requireOptionalModule('playwright-extra');
+  const stealthPlugin = playwrightExtra ? requireOptionalModule('puppeteer-extra-plugin-stealth') : null;
+  if (playwrightExtra && stealthPlugin) {
+    ({ chromium, devices } = playwrightExtra);
+    const stealth = stealthPlugin();
+    chromium.use(stealth);
+  } else {
+    ({ chromium, devices } = require('playwright'));
+  }
+
+  const dev = devices[deviceName];
+  if (!dev) {
+    process.stderr.write(`unknown device: ${deviceName}\n`);
+    process.exitCode = 2;
+    return;
+  }
+
+  let ctx;
+  try {
+    ctx = await chromium.launchPersistentContext(profileDir, {
+      channel: 'chrome',
+      headless,
+      ...dev,
+    });
+    const page = await ctx.newPage();
+    const navTimeout = Math.min(timeoutMs, 90000);
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: navTimeout });
+
+    if (waitSelector) {
+      try {
+        await page.waitForSelector(waitSelector, { timeout: Math.min(timeoutMs, 20000) });
+      } catch (e) {
+        warnBestEffort('waitSelector', e);
+      }
+    }
+
+    const html = await page.content();
+    process.stdout.write(html);
+    process.exitCode = 0;
+    return;
+  } catch (e) {
+    process.stderr.write(`${describeError(e)}\n`);
+    process.exitCode = 1;
+    return;
+  } finally {
+    try {
+      if (ctx) await ctx.close();
+    } catch (e) {
+      warnBestEffort('browser context close', e);
+    }
+  }
+}
+
+main();

--- a/skills/insane-browsing/engine/templates/playwright_mobile_chrome.js
+++ b/skills/insane-browsing/engine/templates/playwright_mobile_chrome.js
@@ -11,6 +11,9 @@
  * NO-SITE-NAME RULE: same as playwright_real_chrome.js — no hostname branches.
  */
 
+const dns = require('dns');
+const net = require('net');
+
 async function readStdinJson() {
   return await new Promise((resolve, reject) => {
     let data = '';
@@ -57,6 +60,136 @@ function requireOptionalModule(moduleName) {
   return require(resolvedModule);
 }
 
+// --- SSRF guard --------------------------------------------------------------
+// Refuse navigations / subresource requests whose target resolves to a
+// non-routable or cloud-metadata address. Mirrors the curl path's host
+// classification so an attacker-influenced redirect cannot steer this fallback
+// at internal / 169.254.169.254 endpoints. Literal IPs are classified with no
+// I/O; hostnames are resolved and every address classified; an unresolvable
+// host is refused (fail closed).
+const _BLOCKED_V4 = [
+  ['0.0.0.0', 8],       // "this network"
+  ['10.0.0.0', 8],      // RFC1918 private
+  ['100.64.0.0', 10],   // CGNAT / shared
+  ['127.0.0.0', 8],     // loopback
+  ['169.254.0.0', 16],  // link-local incl. 169.254.169.254 metadata
+  ['172.16.0.0', 12],   // RFC1918 private
+  ['192.0.0.0', 24],    // IETF protocol assignments
+  ['192.0.2.0', 24],    // TEST-NET-1
+  ['192.168.0.0', 16],  // RFC1918 private
+  ['198.18.0.0', 15],   // benchmarking
+  ['198.51.100.0', 24], // TEST-NET-2
+  ['203.0.113.0', 24],  // TEST-NET-3
+  ['224.0.0.0', 4],     // multicast
+  ['240.0.0.0', 4],     // reserved + 255.255.255.255 broadcast
+];
+
+const _BLOCKED_V6 = [
+  ['::1', 128],   // loopback
+  ['::', 128],    // unspecified
+  ['fc00::', 7],  // unique local
+  ['fe80::', 10], // link-local
+  ['ff00::', 8],  // multicast
+];
+
+function _ipv4ToInt(ip) {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return null;
+  let value = 0n;
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const n = Number(part);
+    if (n > 255) return null;
+    value = (value << 8n) | BigInt(n);
+  }
+  return value;
+}
+
+function _ipv6ToBigInt(ip) {
+  let s = ip;
+  // Expand an embedded IPv4 tail (e.g. ::ffff:1.2.3.4) into two hextets.
+  const v4 = s.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (v4) {
+    const n = _ipv4ToInt(v4[1]);
+    if (n === null) return null;
+    s = s.slice(0, v4.index) + ((n >> 16n) & 0xffffn).toString(16) + ':' + (n & 0xffffn).toString(16);
+  }
+  const halves = s.split('::');
+  if (halves.length > 2) return null;
+  const head = halves[0] ? halves[0].split(':') : [];
+  const tail = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+  const fill = halves.length === 2 ? 8 - head.length - tail.length : 0;
+  if (fill < 0) return null;
+  const groups = head.concat(Array(fill).fill('0'), tail);
+  if (groups.length !== 8) return null;
+  let value = 0n;
+  for (const g of groups) {
+    if (!/^[0-9a-fA-F]{1,4}$/.test(g)) return null;
+    value = (value << 16n) | BigInt(parseInt(g, 16));
+  }
+  return value;
+}
+
+function _matchCidr(value, baseValue, bits, totalBits) {
+  if (baseValue === null) return false;
+  const full = (1n << BigInt(totalBits)) - 1n;
+  const mask = bits === 0 ? 0n : ((full << BigInt(totalBits - bits)) & full);
+  return (value & mask) === (baseValue & mask);
+}
+
+function classifyIp(ip) {
+  if (net.isIPv4(ip)) {
+    const intVal = _ipv4ToInt(ip);
+    if (intVal === null) return true;
+    return _BLOCKED_V4.some(([base, bits]) => _matchCidr(intVal, _ipv4ToInt(base), bits, 32));
+  }
+  if (net.isIPv6(ip)) {
+    const big = _ipv6ToBigInt(ip);
+    if (big === null) return true;
+    if ((big >> 32n) === 0xffffn) {           // IPv4-mapped ::ffff:0:0/96
+      const v4 = big & 0xffffffffn;
+      return _BLOCKED_V4.some(([base, bits]) => _matchCidr(v4, _ipv4ToInt(base), bits, 32));
+    }
+    return _BLOCKED_V6.some(([base, bits]) => _matchCidr(big, _ipv6ToBigInt(base), bits, 128));
+  }
+  return true; // not a recognizable IP literal — refuse
+}
+
+async function isBlockedHost(host) {
+  if (!host) return true;
+  let h = host.toLowerCase();
+  if (h.startsWith('[') && h.endsWith(']')) h = h.slice(1, -1); // strip IPv6 brackets
+  if (h === 'localhost' || h.endsWith('.localhost')) return true;
+  if (net.isIP(h)) return classifyIp(h);
+  let addrs;
+  try {
+    addrs = await dns.promises.lookup(h, { all: true });
+  } catch (e) {
+    return true; // unresolvable — refuse rather than follow into the unknown
+  }
+  return addrs.some((a) => classifyIp(a.address));
+}
+
+async function installSsrfGuard(context) {
+  await context.route('**/*', async (route) => {
+    let host = '';
+    try {
+      const target = new URL(route.request().url());
+      if (target.protocol !== 'http:' && target.protocol !== 'https:') {
+        return route.continue();
+      }
+      host = target.hostname;
+    } catch (e) {
+      return route.continue(); // unparseable target — let the browser reject it
+    }
+    if (await isBlockedHost(host)) {
+      process.stderr.write(`ssrf: blocked request to internal host ${host}\n`);
+      return route.abort('blockedbyclient');
+    }
+    return route.continue();
+  });
+}
+
 async function main() {
   const args = await readStdinJson();
   const url = args.url;
@@ -97,6 +230,7 @@ async function main() {
       headless,
       ...dev,
     });
+    await installSsrfGuard(ctx);
     const page = await ctx.newPage();
     const navTimeout = Math.min(timeoutMs, 90000);
     const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: navTimeout });
@@ -127,4 +261,8 @@ async function main() {
   }
 }
 
-main();
+module.exports = { classifyIp, isBlockedHost, installSsrfGuard };
+
+if (require.main === module) {
+  main();
+}

--- a/skills/insane-browsing/engine/templates/playwright_mobile_chrome.js
+++ b/skills/insane-browsing/engine/templates/playwright_mobile_chrome.js
@@ -9,6 +9,10 @@
  * iPad Pro 11, etc.). When in doubt, omit `device` — default is iPhone 13 Pro.
  *
  * NO-SITE-NAME RULE: same as playwright_real_chrome.js — no hostname branches.
+ *
+ * Dependencies (install once in engine/templates/ — node runs with cwd=engine/templates/,
+ * so require('playwright') resolves from there; npm global prefix is NOT searched):
+ *   cd engine/templates && npm install && npx playwright install chrome
  */
 
 const dns = require('dns');

--- a/skills/insane-browsing/engine/templates/playwright_mobile_chrome.js
+++ b/skills/insane-browsing/engine/templates/playwright_mobile_chrome.js
@@ -99,7 +99,7 @@ async function main() {
     });
     const page = await ctx.newPage();
     const navTimeout = Math.min(timeoutMs, 90000);
-    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: navTimeout });
+    const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: navTimeout });
 
     if (waitSelector) {
       try {
@@ -110,7 +110,8 @@ async function main() {
     }
 
     const html = await page.content();
-    process.stdout.write(html);
+    const status = response ? response.status() : 0;
+    process.stdout.write(JSON.stringify({ status, final_url: page.url(), html }));
     process.exitCode = 0;
     return;
   } catch (e) {

--- a/skills/insane-browsing/engine/templates/playwright_real_chrome.js
+++ b/skills/insane-browsing/engine/templates/playwright_real_chrome.js
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+/**
+ * Generic Playwright fetcher — real Chrome channel (not bundled Chromium).
+ *
+ * Usage (driven by engine/executor.py):
+ *   echo '{"url":"...", "profileDir":"/tmp/.p", "waitSelector":"article"}' | node playwright_real_chrome.js
+ *
+ * Outputs page HTML to stdout on success; errors to stderr with non-zero exit.
+ *
+ * NO-SITE-NAME RULE: this file must never branch on specific hostnames.
+ * All site specifics come from the JSON input (url, waitSelector).
+ *
+ * Dependencies (install once on target machine):
+ *   npm i -g playwright playwright-extra puppeteer-extra-plugin-stealth
+ *   npx playwright install chrome    # system Chrome binary
+ */
+
+const fs = require('fs');
+
+async function readStdinJson() {
+  return await new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.on('data', (c) => (data += c));
+    process.stdin.on('end', () => {
+      try { resolve(JSON.parse(data || '{}')); }
+      catch (e) { reject(e); }
+    });
+    process.stdin.on('error', reject);
+  });
+}
+
+function describeError(error) {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+  return String(error);
+}
+
+function warnBestEffort(action, error) {
+  process.stderr.write(`best-effort ${action} failed: ${describeError(error)}\n`);
+}
+
+function isMissingTopLevelModule(error, moduleName) {
+  return (
+    error instanceof Error &&
+    error.code === 'MODULE_NOT_FOUND' &&
+    typeof error.message === 'string' &&
+    error.message.includes(`Cannot find module '${moduleName}'`)
+  );
+}
+
+function requireOptionalModule(moduleName) {
+  let resolvedModule;
+  try {
+    resolvedModule = require.resolve(moduleName);
+  } catch (e) {
+    if (isMissingTopLevelModule(e, moduleName)) {
+      warnBestEffort(`optional module ${moduleName}`, e);
+      return null;
+    }
+    throw e;
+  }
+  return require(resolvedModule);
+}
+
+async function main() {
+  const args = await readStdinJson();
+  const url = args.url;
+  if (!url) {
+    process.stderr.write('missing url\n');
+    process.exitCode = 2;
+    return;
+  }
+
+  const profileDir = args.profileDir || '/tmp/.insane_pw_profile';
+  const waitSelector = args.waitSelector || null;
+  const timeoutMs = args.timeout || 60000;
+  const headless = args.headless ?? false;     // Akamai/etc detect headless
+  const viewport = args.viewport || { width: 1366, height: 900 };
+
+  let chromium;
+  const playwrightExtra = requireOptionalModule('playwright-extra');
+  const stealthPlugin = playwrightExtra ? requireOptionalModule('puppeteer-extra-plugin-stealth') : null;
+  if (playwrightExtra && stealthPlugin) {
+    ({ chromium } = playwrightExtra);
+    const stealth = stealthPlugin();
+    chromium.use(stealth);
+  } else {
+    // Fallback to plain playwright (no stealth). Still uses channel:chrome.
+    ({ chromium } = require('playwright'));
+  }
+
+  let ctx;
+  try {
+    ctx = await chromium.launchPersistentContext(profileDir, {
+      channel: 'chrome',          // real Chrome, not bundled Chromium
+      headless,
+      viewport,
+    });
+    const page = await ctx.newPage();
+    const navTimeout = Math.min(timeoutMs, 90000);
+
+    // Warmup hop: visit the site root first so Akamai-style bot managers
+    // can run their JS sensor and set a resolved session cookie. Direct
+    // landing on a search/deep URL is the classic first-hit rejection pattern.
+    // Use domcontentloaded (not networkidle) — many SPAs keep analytics/xhr
+    // open indefinitely and would hit the 90s timeout.
+    try {
+      const urlObj = new URL(url);
+      const rootUrl = `${urlObj.protocol}//${urlObj.host}/`;
+      if (rootUrl !== url) {
+        await page.goto(rootUrl, { waitUntil: 'domcontentloaded', timeout: navTimeout });
+        await page.waitForTimeout(3500);   // let sensor JS finish
+      }
+    } catch (e) {
+      warnBestEffort('warmup navigation', e);
+      // warmup is best-effort; continue even if it hiccups
+    }
+
+    // Main page — DOM loaded then give the sensor a moment.
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: navTimeout });
+    await page.waitForTimeout(2500);
+
+    if (waitSelector) {
+      try {
+        await page.waitForSelector(waitSelector, { timeout: Math.min(timeoutMs, 20000) });
+      } catch (e) {
+        warnBestEffort('waitSelector', e);
+        // Selector still missing — try one hard reload in case the first hit
+        // landed on a challenge page and the sensor has just cleared.
+        try {
+          await page.reload({ waitUntil: 'domcontentloaded', timeout: navTimeout });
+          await page.waitForTimeout(2000);
+          try {
+            await page.waitForSelector(waitSelector, { timeout: 10000 });
+          } catch (e2) {
+            warnBestEffort('retry waitSelector', e2);
+            // Still no luck — caller validates HTML anyway.
+          }
+        } catch (e3) {
+          warnBestEffort('selector recovery reload', e3);
+          // reload failed — proceed with whatever we have
+        }
+      }
+    } else {
+      // Without a positive-proof selector, give the sensor a couple more seconds.
+      await page.waitForTimeout(2000);
+    }
+
+    const html = await page.content();
+    process.stdout.write(html);
+    process.exitCode = 0;
+    return;
+  } catch (e) {
+    process.stderr.write(`${describeError(e)}\n`);
+    process.exitCode = 1;
+    return;
+  } finally {
+    try {
+      if (ctx) await ctx.close();
+    } catch (e) {
+      warnBestEffort('browser context close', e);
+    }
+  }
+}
+
+main();

--- a/skills/insane-browsing/engine/templates/playwright_real_chrome.js
+++ b/skills/insane-browsing/engine/templates/playwright_real_chrome.js
@@ -10,9 +10,9 @@
  * NO-SITE-NAME RULE: this file must never branch on specific hostnames.
  * All site specifics come from the JSON input (url, waitSelector).
  *
- * Dependencies (install once on target machine):
- *   npm i -g playwright playwright-extra puppeteer-extra-plugin-stealth
- *   npx playwright install chrome    # system Chrome binary
+ * Dependencies (install once in engine/templates/ — node runs with cwd=engine/templates/,
+ * so require('playwright') resolves from there; npm global prefix is NOT searched):
+ *   cd engine/templates && npm install && npx playwright install chrome
  */
 
 const fs = require('fs');

--- a/skills/insane-browsing/engine/templates/playwright_real_chrome.js
+++ b/skills/insane-browsing/engine/templates/playwright_real_chrome.js
@@ -16,6 +16,8 @@
  */
 
 const fs = require('fs');
+const dns = require('dns');
+const net = require('net');
 
 async function readStdinJson() {
   return await new Promise((resolve, reject) => {
@@ -63,6 +65,136 @@ function requireOptionalModule(moduleName) {
   return require(resolvedModule);
 }
 
+// --- SSRF guard --------------------------------------------------------------
+// Refuse navigations / subresource requests whose target resolves to a
+// non-routable or cloud-metadata address. Mirrors the curl path's host
+// classification so an attacker-influenced redirect cannot steer this fallback
+// at internal / 169.254.169.254 endpoints. Literal IPs are classified with no
+// I/O; hostnames are resolved and every address classified; an unresolvable
+// host is refused (fail closed).
+const _BLOCKED_V4 = [
+  ['0.0.0.0', 8],       // "this network"
+  ['10.0.0.0', 8],      // RFC1918 private
+  ['100.64.0.0', 10],   // CGNAT / shared
+  ['127.0.0.0', 8],     // loopback
+  ['169.254.0.0', 16],  // link-local incl. 169.254.169.254 metadata
+  ['172.16.0.0', 12],   // RFC1918 private
+  ['192.0.0.0', 24],    // IETF protocol assignments
+  ['192.0.2.0', 24],    // TEST-NET-1
+  ['192.168.0.0', 16],  // RFC1918 private
+  ['198.18.0.0', 15],   // benchmarking
+  ['198.51.100.0', 24], // TEST-NET-2
+  ['203.0.113.0', 24],  // TEST-NET-3
+  ['224.0.0.0', 4],     // multicast
+  ['240.0.0.0', 4],     // reserved + 255.255.255.255 broadcast
+];
+
+const _BLOCKED_V6 = [
+  ['::1', 128],   // loopback
+  ['::', 128],    // unspecified
+  ['fc00::', 7],  // unique local
+  ['fe80::', 10], // link-local
+  ['ff00::', 8],  // multicast
+];
+
+function _ipv4ToInt(ip) {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return null;
+  let value = 0n;
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const n = Number(part);
+    if (n > 255) return null;
+    value = (value << 8n) | BigInt(n);
+  }
+  return value;
+}
+
+function _ipv6ToBigInt(ip) {
+  let s = ip;
+  // Expand an embedded IPv4 tail (e.g. ::ffff:1.2.3.4) into two hextets.
+  const v4 = s.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (v4) {
+    const n = _ipv4ToInt(v4[1]);
+    if (n === null) return null;
+    s = s.slice(0, v4.index) + ((n >> 16n) & 0xffffn).toString(16) + ':' + (n & 0xffffn).toString(16);
+  }
+  const halves = s.split('::');
+  if (halves.length > 2) return null;
+  const head = halves[0] ? halves[0].split(':') : [];
+  const tail = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+  const fill = halves.length === 2 ? 8 - head.length - tail.length : 0;
+  if (fill < 0) return null;
+  const groups = head.concat(Array(fill).fill('0'), tail);
+  if (groups.length !== 8) return null;
+  let value = 0n;
+  for (const g of groups) {
+    if (!/^[0-9a-fA-F]{1,4}$/.test(g)) return null;
+    value = (value << 16n) | BigInt(parseInt(g, 16));
+  }
+  return value;
+}
+
+function _matchCidr(value, baseValue, bits, totalBits) {
+  if (baseValue === null) return false;
+  const full = (1n << BigInt(totalBits)) - 1n;
+  const mask = bits === 0 ? 0n : ((full << BigInt(totalBits - bits)) & full);
+  return (value & mask) === (baseValue & mask);
+}
+
+function classifyIp(ip) {
+  if (net.isIPv4(ip)) {
+    const intVal = _ipv4ToInt(ip);
+    if (intVal === null) return true;
+    return _BLOCKED_V4.some(([base, bits]) => _matchCidr(intVal, _ipv4ToInt(base), bits, 32));
+  }
+  if (net.isIPv6(ip)) {
+    const big = _ipv6ToBigInt(ip);
+    if (big === null) return true;
+    if ((big >> 32n) === 0xffffn) {           // IPv4-mapped ::ffff:0:0/96
+      const v4 = big & 0xffffffffn;
+      return _BLOCKED_V4.some(([base, bits]) => _matchCidr(v4, _ipv4ToInt(base), bits, 32));
+    }
+    return _BLOCKED_V6.some(([base, bits]) => _matchCidr(big, _ipv6ToBigInt(base), bits, 128));
+  }
+  return true; // not a recognizable IP literal — refuse
+}
+
+async function isBlockedHost(host) {
+  if (!host) return true;
+  let h = host.toLowerCase();
+  if (h.startsWith('[') && h.endsWith(']')) h = h.slice(1, -1); // strip IPv6 brackets
+  if (h === 'localhost' || h.endsWith('.localhost')) return true;
+  if (net.isIP(h)) return classifyIp(h);
+  let addrs;
+  try {
+    addrs = await dns.promises.lookup(h, { all: true });
+  } catch (e) {
+    return true; // unresolvable — refuse rather than follow into the unknown
+  }
+  return addrs.some((a) => classifyIp(a.address));
+}
+
+async function installSsrfGuard(context) {
+  await context.route('**/*', async (route) => {
+    let host = '';
+    try {
+      const target = new URL(route.request().url());
+      if (target.protocol !== 'http:' && target.protocol !== 'https:') {
+        return route.continue();
+      }
+      host = target.hostname;
+    } catch (e) {
+      return route.continue(); // unparseable target — let the browser reject it
+    }
+    if (await isBlockedHost(host)) {
+      process.stderr.write(`ssrf: blocked request to internal host ${host}\n`);
+      return route.abort('blockedbyclient');
+    }
+    return route.continue();
+  });
+}
+
 async function main() {
   const args = await readStdinJson();
   const url = args.url;
@@ -97,6 +229,7 @@ async function main() {
       headless,
       viewport,
     });
+    await installSsrfGuard(ctx);
     const page = await ctx.newPage();
     const navTimeout = Math.min(timeoutMs, 90000);
 
@@ -165,4 +298,8 @@ async function main() {
   }
 }
 
-main();
+module.exports = { classifyIp, isBlockedHost, installSsrfGuard };
+
+if (require.main === module) {
+  main();
+}

--- a/skills/insane-browsing/engine/templates/playwright_real_chrome.js
+++ b/skills/insane-browsing/engine/templates/playwright_real_chrome.js
@@ -118,7 +118,7 @@ async function main() {
     }
 
     // Main page — DOM loaded then give the sensor a moment.
-    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: navTimeout });
+    const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: navTimeout });
     await page.waitForTimeout(2500);
 
     if (waitSelector) {
@@ -148,7 +148,8 @@ async function main() {
     }
 
     const html = await page.content();
-    process.stdout.write(html);
+    const status = response ? response.status() : 0;
+    process.stdout.write(JSON.stringify({ status, final_url: page.url(), html }));
     process.exitCode = 0;
     return;
   } catch (e) {

--- a/skills/insane-browsing/engine/tests/test_curl_probe.py
+++ b/skills/insane-browsing/engine/tests/test_curl_probe.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from engine.curl_probe import _curl_probe  # noqa: E402
+
+
+class _Headers(dict):
+    """Case-insensitive header mapping, mirroring curl_cffi's Headers."""
+
+    def __init__(self, data: dict) -> None:
+        super().__init__({k.lower(): v for k, v in data.items()})
+
+    def get(self, key, default=None):  # type: ignore[override]
+        return super().get(key.lower(), default)
+
+
+class _Resp:
+    def __init__(self, status_code: int, *, location: str | None = None,
+                 url: str = "https://example.com/", text: str = "<html>ok</html>") -> None:
+        self.status_code = status_code
+        self.text = text
+        self.url = url
+        self.headers = _Headers({"Location": location} if location else {})
+
+
+class _FakeRequestException(Exception):
+    pass
+
+
+class _FakeExceptions:
+    RequestException = _FakeRequestException
+
+
+def _fake_requests(responses):
+    """Build a fake curl_cffi.requests whose .get() yields queued responses
+    and records every URL it was actually asked to fetch."""
+    calls: list[str] = []
+
+    class _Reqs:
+        exceptions = _FakeExceptions
+
+        @staticmethod
+        def get(url, **kwargs):  # noqa: ARG004
+            calls.append(url)
+            return responses.pop(0)
+
+    return _Reqs, calls
+
+
+class CurlProbeRedirectGuard(unittest.TestCase):
+    def test_redirect_to_private_or_metadata_blocked(self) -> None:
+        """A redirect aimed at cloud-metadata / loopback must be refused
+        WITHOUT the probe ever issuing a fetch at the internal target."""
+        for target in ("http://169.254.169.254/latest/meta-data/", "http://127.0.0.1/admin"):
+            with self.subTest(target=target):
+                reqs, calls = _fake_requests([
+                    _Resp(302, location=target, url="https://attacker.example/"),
+                ])
+                with patch.dict("sys.modules", {"curl_cffi": type(sys)("curl_cffi")}):
+                    sys.modules["curl_cffi"].requests = reqs  # type: ignore[attr-defined]
+                    resp, err = _curl_probe(
+                        "https://attacker.example/", impersonate="chrome", referer="",
+                    )
+
+                self.assertIsNone(resp, "blocked redirect must not return a response")
+                self.assertIsNotNone(err, "blocked redirect must return an error string")
+                self.assertEqual(
+                    calls, ["https://attacker.example/"],
+                    "the internal/metadata target must never be fetched",
+                )
+
+    def test_public_redirect_is_followed(self) -> None:
+        """A redirect to a public host is followed (no over-block)."""
+        final = _Resp(200, url="http://93.184.216.34/landing", text="<html>landed</html>")
+        reqs, calls = _fake_requests([
+            _Resp(302, location="http://93.184.216.34/landing", url="https://example.com/"),
+            final,
+        ])
+        with patch.dict("sys.modules", {"curl_cffi": type(sys)("curl_cffi")}):
+            sys.modules["curl_cffi"].requests = reqs  # type: ignore[attr-defined]
+            resp, err = _curl_probe(
+                "https://example.com/", impersonate="chrome", referer="",
+            )
+
+        self.assertIsNone(err)
+        self.assertIs(resp, final, "public redirect target should be fetched and returned")
+        self.assertEqual(calls, ["https://example.com/", "http://93.184.216.34/landing"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/insane-browsing/engine/tests/test_curl_probe.py
+++ b/skills/insane-browsing/engine/tests/test_curl_probe.py
@@ -4,6 +4,7 @@ import sys
 import unittest
 from pathlib import Path
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
@@ -60,18 +61,18 @@ class CurlProbeRedirectGuard(unittest.TestCase):
         for target in ("http://169.254.169.254/latest/meta-data/", "http://127.0.0.1/admin"):
             with self.subTest(target=target):
                 reqs, calls = _fake_requests([
-                    _Resp(302, location=target, url="https://attacker.example/"),
+                    _Resp(302, location=target, url="http://93.184.216.34/"),
                 ])
                 with patch.dict("sys.modules", {"curl_cffi": type(sys)("curl_cffi")}):
                     sys.modules["curl_cffi"].requests = reqs  # type: ignore[attr-defined]
                     resp, err = _curl_probe(
-                        "https://attacker.example/", impersonate="chrome", referer="",
+                        "http://93.184.216.34/", impersonate="chrome", referer="",
                     )
 
                 self.assertIsNone(resp, "blocked redirect must not return a response")
                 self.assertIsNotNone(err, "blocked redirect must return an error string")
                 self.assertEqual(
-                    calls, ["https://attacker.example/"],
+                    calls, ["http://93.184.216.34/"],
                     "the internal/metadata target must never be fetched",
                 )
 
@@ -79,18 +80,36 @@ class CurlProbeRedirectGuard(unittest.TestCase):
         """A redirect to a public host is followed (no over-block)."""
         final = _Resp(200, url="http://93.184.216.34/landing", text="<html>landed</html>")
         reqs, calls = _fake_requests([
-            _Resp(302, location="http://93.184.216.34/landing", url="https://example.com/"),
+            _Resp(302, location="http://93.184.216.34/landing", url="http://93.184.216.34/"),
             final,
         ])
         with patch.dict("sys.modules", {"curl_cffi": type(sys)("curl_cffi")}):
             sys.modules["curl_cffi"].requests = reqs  # type: ignore[attr-defined]
             resp, err = _curl_probe(
-                "https://example.com/", impersonate="chrome", referer="",
+                "http://93.184.216.34/", impersonate="chrome", referer="",
             )
 
         self.assertIsNone(err)
         self.assertIs(resp, final, "public redirect target should be fetched and returned")
-        self.assertEqual(calls, ["https://example.com/", "http://93.184.216.34/landing"])
+        self.assertEqual(calls, ["http://93.184.216.34/", "http://93.184.216.34/landing"])
+
+
+class CurlProbeInitialGuard(unittest.TestCase):
+    def test_initial_url_to_private_or_metadata_blocked(self) -> None:
+        """The FIRST fetch target is classified too: an initial URL aimed at
+        loopback / cloud-metadata must be refused WITHOUT any request issued."""
+        for target in ("http://169.254.169.254/latest/meta-data/", "http://127.0.0.1/"):
+            with self.subTest(target=target):
+                reqs, calls = _fake_requests([_Resp(200, url=target)])
+                with patch.dict("sys.modules", {"curl_cffi": type(sys)("curl_cffi")}):
+                    sys.modules["curl_cffi"].requests = reqs  # type: ignore[attr-defined]
+                    resp, err = _curl_probe(target, impersonate="chrome", referer="")
+
+                self.assertIsNone(resp, "blocked initial URL must not return a response")
+                self.assertEqual(err, f"ssrf_blocked:{urlparse(target).hostname}")
+                self.assertEqual(
+                    calls, [], "the internal/metadata target must never be fetched",
+                )
 
 
 if __name__ == "__main__":

--- a/skills/insane-browsing/engine/tests/test_executor.py
+++ b/skills/insane-browsing/engine/tests/test_executor.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from engine import executor  # noqa: E402
+from engine.validators import Verdict  # noqa: E402
+
+REQUESTED_URL = "https://example.com/article"
+
+
+def _envelope(status: int, final_url: str, html: str) -> str:
+    return json.dumps({"status": status, "final_url": final_url, "html": html})
+
+
+def _run_with_envelope(env_stdout: str):
+    """Drive run_playwright_fallback with a stubbed node subprocess.
+
+    Patches the profile load + chrome-channel probe so the local-template
+    branch is taken, and replaces the node subprocess with one that emits the
+    given envelope on stdout (rc=0).
+    """
+    with patch.object(executor, "load_profile", return_value={"capabilities_needed": ["needs_real_tls_stack"]}), \
+            patch.object(executor, "_chrome_channel_available", return_value=True), \
+            patch.object(executor, "_run_node_template", return_value=(0, env_stdout, "")):
+        return executor.run_playwright_fallback(
+            REQUESTED_URL,
+            profile_id="unknown_challenge",
+            force_executor="playwright_real_chrome",
+        )
+
+
+class ExecutorEnvelope(unittest.TestCase):
+    def test_real_http_status_not_faked_200(self) -> None:
+        env = _envelope(403, REQUESTED_URL, "<html><body>forbidden</body></html>")
+        att, _content = _run_with_envelope(env)
+
+        self.assertEqual(att.status, 403)
+        self.assertNotIn(att.verdict, (Verdict.STRONG_OK.value, Verdict.WEAK_OK.value))
+
+    def test_attempt_final_url_from_envelope(self) -> None:
+        final_url = "https://example.com/final-after-redirect"
+        env = _envelope(200, final_url, "<html><article>ok</article></html>")
+        att, _content = _run_with_envelope(env)
+
+        self.assertEqual(att.url, final_url)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/insane-browsing/engine/tests/test_executor.py
+++ b/skills/insane-browsing/engine/tests/test_executor.py
@@ -11,7 +11,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from engine import executor  # noqa: E402
 from engine.validators import Verdict  # noqa: E402
 
-REQUESTED_URL = "https://example.com/article"
+# Literal public IP (not a hostname) so the executor's final_url SSRF re-check
+# classifies it with no live DNS — matching the curl_probe tests' convention.
+REQUESTED_URL = "https://93.184.216.34/article"
 
 
 def _envelope(status: int, final_url: str, html: str) -> str:
@@ -44,7 +46,7 @@ class ExecutorEnvelope(unittest.TestCase):
         self.assertNotIn(att.verdict, (Verdict.STRONG_OK.value, Verdict.WEAK_OK.value))
 
     def test_attempt_final_url_from_envelope(self) -> None:
-        final_url = "https://example.com/final-after-redirect"
+        final_url = "https://93.184.216.34/final-after-redirect"
         env = _envelope(200, final_url, "<html><article>ok</article></html>")
         att, _content = _run_with_envelope(env)
 

--- a/skills/insane-browsing/engine/tests/test_fetch_chain.py
+++ b/skills/insane-browsing/engine/tests/test_fetch_chain.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from engine.fetch_chain import fetch  # noqa: E402
+from engine.result_schema import Attempt  # noqa: E402
+from engine.validators import Verdict  # noqa: E402
+
+
+class _Resp:
+    def __init__(self, text: str = "<article>ok</article>", url: str = "https://example.com/"):
+        self.text = text
+        self.url = url
+
+
+class _Hit:
+    profile_id = "cloudflare_turnstile"
+    confidence = 1.0
+    signals = ["test"]
+
+
+class FetchChain(unittest.TestCase):
+    def test_probe_success_returns_without_grid(self) -> None:
+        attempt = Attempt(
+            phase="probe",
+            executor="curl_cffi",
+            url="https://example.com",
+            url_transform="original",
+            impersonate="safari",
+            referer="self_root",
+            verdict=Verdict.WEAK_OK.value,
+        )
+
+        with patch("engine.fetch_chain._load_profiles", return_value={}), \
+                patch("engine.fetch_chain.last_load_error", return_value=None), \
+                patch("engine.fetch_chain.run_attempt", return_value=(attempt, _Resp())) as run_attempt:
+            result = fetch("https://example.com", enable_playwright=False)
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.verdict, Verdict.WEAK_OK.value)
+        self.assertEqual(len(result.trace), 1)
+        self.assertEqual(run_attempt.call_count, 1)
+
+    def test_max_attempts_stops_after_probe_before_grid(self) -> None:
+        attempt = Attempt(
+            phase="probe",
+            executor="curl_cffi",
+            url="https://example.com",
+            url_transform="original",
+            impersonate="safari",
+            referer="self_root",
+            verdict=Verdict.CHALLENGE.value,
+        )
+
+        with patch("engine.fetch_chain._load_profiles", return_value={}), \
+                patch("engine.fetch_chain.last_load_error", return_value=None), \
+                patch("engine.fetch_chain.run_attempt", return_value=(attempt, _Resp("blocked"))), \
+                patch("engine.fetch_chain.detect", return_value=[_Hit()]), \
+                patch("engine.fetch_chain.load_profile", return_value={
+                    "tls_impersonate_candidates": [["chrome"]],
+                    "referer_strategies": ["self_root"],
+                    "url_transform_order": ["original"],
+                }):
+            result = fetch("https://example.com", max_attempts=1, enable_playwright=False)
+
+        self.assertFalse(result.ok)
+        self.assertEqual(len(result.trace), 1)
+        self.assertEqual(result.trace[0].phase, "probe")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/insane-browsing/engine/tests/test_fetch_chain.py
+++ b/skills/insane-browsing/engine/tests/test_fetch_chain.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
@@ -71,6 +71,82 @@ class FetchChain(unittest.TestCase):
         self.assertFalse(result.ok)
         self.assertEqual(len(result.trace), 1)
         self.assertEqual(result.trace[0].phase, "probe")
+
+    def test_timeout_forwarded_to_playwright(self) -> None:
+        """F20: the caller's timeout must reach the Playwright fallback so the
+        fallback cannot hang past the caller's budget."""
+        probe = Attempt(
+            phase="probe",
+            executor="curl_cffi",
+            url="https://example.com",
+            url_transform="original",
+            impersonate="safari",
+            referer="self_root",
+            verdict=Verdict.CHALLENGE.value,
+        )
+        pw_attempt = Attempt(
+            phase="fallback",
+            executor="playwright_real_chrome",
+            url="https://example.com/landed",
+            url_transform="original",
+            impersonate=None,
+            referer="",
+            verdict=Verdict.STRONG_OK.value,
+        )
+        fallback = MagicMock(return_value=(pw_attempt, "<article>ok</article>"))
+
+        with patch("engine.fetch_chain._load_profiles", return_value={}), \
+                patch("engine.fetch_chain.last_load_error", return_value=None), \
+                patch("engine.fetch_chain.run_attempt", return_value=(probe, _Resp("blocked"))), \
+                patch("engine.fetch_chain.detect", return_value=[_Hit()]), \
+                patch("engine.fetch_chain.load_profile", return_value={
+                    "fallback_when_challenge": ["playwright_real_chrome"],
+                }), \
+                patch("engine.executor.run_playwright_fallback", fallback):
+            fetch("https://example.com", timeout=7, max_attempts=1)
+
+        self.assertEqual(fallback.call_count, 1)
+        self.assertEqual(fallback.call_args.kwargs.get("timeout"), 7)
+
+    def test_final_url_is_post_redirect(self) -> None:
+        """F21 (end-to-end): the result's final_url is the post-redirect URL that
+        the Playwright fallback envelope provided onto pw_attempt.url (sourced by
+        executor.py per TODO 13), not the requested URL."""
+        requested = "https://example.com"
+        landed = "https://example.com/after-redirect"
+        probe = Attempt(
+            phase="probe",
+            executor="curl_cffi",
+            url=requested,
+            url_transform="original",
+            impersonate="safari",
+            referer="self_root",
+            verdict=Verdict.CHALLENGE.value,
+        )
+        pw_attempt = Attempt(
+            phase="fallback",
+            executor="playwright_real_chrome",
+            url=landed,  # executor.py sets att.url from the envelope's final_url
+            url_transform="original",
+            impersonate=None,
+            referer="",
+            verdict=Verdict.STRONG_OK.value,
+        )
+        fallback = MagicMock(return_value=(pw_attempt, "<article>ok</article>"))
+
+        with patch("engine.fetch_chain._load_profiles", return_value={}), \
+                patch("engine.fetch_chain.last_load_error", return_value=None), \
+                patch("engine.fetch_chain.run_attempt", return_value=(probe, _Resp("blocked"))), \
+                patch("engine.fetch_chain.detect", return_value=[_Hit()]), \
+                patch("engine.fetch_chain.load_profile", return_value={
+                    "fallback_when_challenge": ["playwright_real_chrome"],
+                }), \
+                patch("engine.executor.run_playwright_fallback", fallback):
+            result = fetch(requested, timeout=7, max_attempts=1)
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.final_url, landed)
+        self.assertNotEqual(result.final_url, requested)
 
 
 if __name__ == "__main__":

--- a/skills/insane-browsing/engine/tests/test_playwright_templates.py
+++ b/skills/insane-browsing/engine/tests/test_playwright_templates.py
@@ -19,12 +19,20 @@ def _write_file(path: Path, content: str) -> None:
     path.write_text(textwrap.dedent(content).lstrip(), encoding="utf-8")
 
 
+def _envelope_html(stdout: str) -> str:
+    """stdout now carries a JSON envelope {status, final_url, html}."""
+    return json.loads(stdout)["html"]
+
+
 def _install_fake_playwright(node_modules: Path) -> None:
     _write_file(
         node_modules / "playwright" / "index.js",
         """
         const page = {
-          async goto() {},
+          async goto() {
+            return { status() { return 200; } };
+          },
+          url() { return 'https://example.com/article'; },
           async waitForTimeout() {},
           async waitForSelector(selector) {
             if (process.env.PW_FAKE_SELECTOR_FAIL === '1') {
@@ -162,7 +170,7 @@ class PlaywrightTemplateErrorHandling(unittest.TestCase):
                 )
 
                 self.assertEqual(result.returncode, 0, result.stderr)
-                self.assertIn("<article>ok</article>", result.stdout)
+                self.assertIn("<article>ok</article>", _envelope_html(result.stdout))
                 self.assertIn("best-effort optional module playwright-extra failed:", result.stderr)
                 self.assertIn("Cannot find module 'playwright-extra'", result.stderr)
 
@@ -180,7 +188,7 @@ class PlaywrightTemplateErrorHandling(unittest.TestCase):
                 )
 
                 self.assertEqual(result.returncode, 0, result.stderr)
-                self.assertIn("<article>ok</article>", result.stdout)
+                self.assertIn("<article>ok</article>", _envelope_html(result.stdout))
                 self.assertIn("best-effort optional module puppeteer-extra-plugin-stealth failed:", result.stderr)
                 self.assertIn("Cannot find module 'puppeteer-extra-plugin-stealth'", result.stderr)
 
@@ -256,7 +264,7 @@ class PlaywrightTemplateErrorHandling(unittest.TestCase):
                 )
 
                 self.assertEqual(result.returncode, 0, result.stderr)
-                self.assertIn("<article>ok</article>", result.stdout)
+                self.assertIn("<article>ok</article>", _envelope_html(result.stdout))
                 self.assertIn("best-effort waitSelector failed:", result.stderr)
                 self.assertNotIn("waitSelector article.ready", result.stderr)
 
@@ -274,7 +282,7 @@ class PlaywrightTemplateErrorHandling(unittest.TestCase):
                 )
 
                 self.assertEqual(result.returncode, 0, result.stderr)
-                self.assertIn("<article>ok</article>", result.stdout)
+                self.assertIn("<article>ok</article>", _envelope_html(result.stdout))
                 self.assertIn("best-effort browser context close failed:", result.stderr)
 
 

--- a/skills/insane-browsing/engine/tests/test_playwright_templates.py
+++ b/skills/insane-browsing/engine/tests/test_playwright_templates.py
@@ -4,10 +4,17 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import textwrap
 import unittest
 from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from engine import executor  # noqa: E402
+from engine.validators import Verdict  # noqa: E402
 
 TEMPLATES_DIR = Path(__file__).resolve().parents[1] / "templates"
 TEMPLATE_NAMES = ("playwright_real_chrome.js", "playwright_mobile_chrome.js")
@@ -28,8 +35,30 @@ def _install_fake_playwright(node_modules: Path) -> None:
     _write_file(
         node_modules / "playwright" / "index.js",
         """
+        let routeHandler = null;
+
+        // When PW_FAKE_DRIVE_ROUTE=1, goto() exercises the registered route
+        // interceptor with the navigation URL: abort() makes goto reject (as a
+        // real blocked navigation would); leaving a request unhandled would
+        // stall in real Playwright, so flag it.
+        async function simulateRequest(url) {
+          if (process.env.PW_FAKE_DRIVE_ROUTE !== '1' || !routeHandler) return;
+          let aborted = false;
+          let handled = false;
+          const route = {
+            request() { return { url() { return url; } }; },
+            async abort() { aborted = true; handled = true; },
+            async continue() { handled = true; },
+            async fallback() { handled = true; },
+          };
+          await routeHandler(route);
+          if (!handled) throw new Error('route left unhandled — request would stall');
+          if (aborted) throw new Error('net::ERR_BLOCKED_BY_CLIENT');
+        }
+
         const page = {
-          async goto() {
+          async goto(url) {
+            await simulateRequest(url);
             return { status() { return 200; } };
           },
           url() { return 'https://example.com/article'; },
@@ -46,6 +75,7 @@ def _install_fake_playwright(node_modules: Path) -> None:
         };
 
         const context = {
+          async route(pattern, handler) { routeHandler = handler; },
           async newPage() { return page; },
           async close() {
             if (process.env.PW_FAKE_CLOSE_FAIL === '1') {
@@ -284,6 +314,149 @@ class PlaywrightTemplateErrorHandling(unittest.TestCase):
                 self.assertEqual(result.returncode, 0, result.stderr)
                 self.assertIn("<article>ok</article>", _envelope_html(result.stdout))
                 self.assertIn("best-effort browser context close failed:", result.stderr)
+
+
+_INTERNAL_HOSTS = [
+    "10.0.0.1",
+    "127.0.0.1",
+    "169.254.169.254",
+    "192.168.1.1",
+    "172.16.0.1",
+    "100.64.0.1",
+    "0.0.0.0",
+    "::1",
+    "fe80::1",
+    "fd00::1",
+    "::ffff:127.0.0.1",
+    "localhost",
+    "",
+]
+_PUBLIC_HOSTS = ["8.8.8.8", "1.1.1.1", "93.184.216.34", "2001:4860:4860::8888"]
+
+
+def _run_predicate_driver(template_name: str, hosts: list[str]) -> subprocess.CompletedProcess[str]:
+    """Require a template as a module and classify each host via its exported
+    isBlockedHost(). Literal IPs are classified without any network I/O."""
+    with tempfile.TemporaryDirectory(prefix="insane-browsing-ssrf-pred-") as tmp:
+        tmp_path = Path(tmp)
+        script_path = tmp_path / template_name
+        script_path.write_text(
+            (TEMPLATES_DIR / template_name).read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        driver = tmp_path / "driver.js"
+        driver.write_text(
+            "const t = require('./%s');\n"
+            "(async () => {\n"
+            "  const hosts = %s;\n"
+            "  const out = {};\n"
+            "  for (const h of hosts) { out[h] = await t.isBlockedHost(h); }\n"
+            "  process.stdout.write(JSON.stringify(out));\n"
+            "})().catch((e) => { process.stderr.write(String((e && e.stack) || e)); process.exit(3); });\n"
+            % (template_name, json.dumps(hosts)),
+            encoding="utf-8",
+        )
+        env = os.environ.copy()
+        env.pop("NODE_PATH", None)
+        return subprocess.run(
+            ["node", str(driver)],
+            cwd=str(tmp_path),
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+            check=False,
+        )
+
+
+@unittest.skipUnless(shutil.which("node"), "node is required for Playwright template tests")
+class PlaywrightSsrfInterceptor(unittest.TestCase):
+    def test_is_blocked_host_classifies_internal_and_public(self) -> None:
+        for template_name in TEMPLATE_NAMES:
+            with self.subTest(template_name=template_name):
+                proc = _run_predicate_driver(template_name, _INTERNAL_HOSTS + _PUBLIC_HOSTS)
+                self.assertEqual(proc.returncode, 0, proc.stderr)
+                verdicts = json.loads(proc.stdout)
+                for host in _INTERNAL_HOSTS:
+                    self.assertTrue(verdicts[host], f"{host!r} must be blocked")
+                for host in _PUBLIC_HOSTS:
+                    self.assertFalse(verdicts[host], f"{host!r} must be allowed")
+
+    def test_navigation_to_internal_host_is_aborted(self) -> None:
+        for template_name in TEMPLATE_NAMES:
+            with self.subTest(template_name=template_name):
+                result = _run_template(
+                    template_name,
+                    {
+                        "url": "http://169.254.169.254/latest/meta-data/",
+                        "profileDir": "/tmp/insane-browsing-test-profile",
+                        "headless": True,
+                    },
+                    env_overrides={"PW_FAKE_DRIVE_ROUTE": "1"},
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(result.stdout, "")
+                self.assertIn("169.254.169.254", result.stderr)
+
+    def test_navigation_to_public_host_is_allowed(self) -> None:
+        for template_name in TEMPLATE_NAMES:
+            with self.subTest(template_name=template_name):
+                result = _run_template(
+                    template_name,
+                    {
+                        "url": "http://93.184.216.34/",
+                        "profileDir": "/tmp/insane-browsing-test-profile",
+                        "headless": True,
+                    },
+                    env_overrides={"PW_FAKE_DRIVE_ROUTE": "1"},
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn("<article>ok</article>", _envelope_html(result.stdout))
+
+
+def _run_fallback_with_envelope(env_stdout: str):
+    """Drive run_playwright_fallback with a stubbed node subprocess emitting the
+    given envelope, so only the executor's final_url SSRF re-check is exercised."""
+    with patch.object(
+        executor, "load_profile", return_value={"capabilities_needed": ["needs_real_tls_stack"]}
+    ), patch.object(executor, "_chrome_channel_available", return_value=True), patch.object(
+        executor, "_run_node_template", return_value=(0, env_stdout, "")
+    ):
+        return executor.run_playwright_fallback(
+            "https://example.com/article",
+            profile_id="unknown_challenge",
+            force_executor="playwright_real_chrome",
+        )
+
+
+class ExecutorFinalUrlSsrfGuard(unittest.TestCase):
+    def test_internal_final_url_is_refused(self) -> None:
+        env = json.dumps(
+            {
+                "status": 200,
+                "final_url": "http://169.254.169.254/latest/meta-data/",
+                "html": "<html><article>secret</article></html>",
+            }
+        )
+        att, content = _run_fallback_with_envelope(env)
+
+        self.assertEqual(content, "")
+        self.assertIn("ssrf", (att.error or "").lower())
+        self.assertNotIn(att.verdict, (Verdict.STRONG_OK.value, Verdict.WEAK_OK.value))
+
+    def test_public_final_url_passes_through(self) -> None:
+        env = json.dumps(
+            {
+                "status": 200,
+                "final_url": "http://93.184.216.34/landing",
+                "html": "<html><article>ok</article></html>",
+            }
+        )
+        att, content = _run_fallback_with_envelope(env)
+
+        self.assertIn("<article>ok</article>", content)
+        self.assertEqual(att.url, "http://93.184.216.34/landing")
 
 
 if __name__ == "__main__":

--- a/skills/insane-browsing/engine/tests/test_playwright_templates.py
+++ b/skills/insane-browsing/engine/tests/test_playwright_templates.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[1] / "templates"
+TEMPLATE_NAMES = ("playwright_real_chrome.js", "playwright_mobile_chrome.js")
+JsonValue = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
+
+
+def _write_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content).lstrip(), encoding="utf-8")
+
+
+def _install_fake_playwright(node_modules: Path) -> None:
+    _write_file(
+        node_modules / "playwright" / "index.js",
+        """
+        const page = {
+          async goto() {},
+          async waitForTimeout() {},
+          async waitForSelector(selector) {
+            if (process.env.PW_FAKE_SELECTOR_FAIL === '1') {
+              throw new Error(`missing selector ${selector}`);
+            }
+          },
+          async reload() {},
+          async content() {
+            return '<html><article>ok</article></html>';
+          },
+        };
+
+        const context = {
+          async newPage() { return page; },
+          async close() {
+            if (process.env.PW_FAKE_CLOSE_FAIL === '1') {
+              throw new Error('close failed');
+            }
+          },
+        };
+
+        exports.chromium = {
+          use() {},
+          async launchPersistentContext() { return context; },
+        };
+        exports.devices = {
+          'iPhone 13 Pro': { viewport: { width: 390, height: 844 }, userAgent: 'fake-mobile' },
+        };
+        """,
+    )
+
+
+def _install_broken_playwright_extra(node_modules: Path) -> None:
+    _write_file(
+        node_modules / "playwright-extra" / "index.js",
+        """
+        const error = new Error('stealth init failed');
+        error.code = 'EACCES';
+        throw error;
+        """,
+    )
+    _write_file(
+        node_modules / "puppeteer-extra-plugin-stealth" / "index.js",
+        """
+        module.exports = function stealth() { return {}; };
+        """,
+    )
+
+
+def _install_working_playwright_extra(node_modules: Path) -> None:
+    _write_file(
+        node_modules / "playwright-extra" / "index.js",
+        """
+        const playwright = require('playwright');
+        exports.chromium = playwright.chromium;
+        exports.devices = playwright.devices;
+        """,
+    )
+
+
+def _install_playwright_extra_with_internal_missing_dependency(node_modules: Path) -> None:
+    _write_file(
+        node_modules / "playwright-extra" / "index.js",
+        """
+        require('transitive-stealth-runtime');
+        """,
+    )
+
+
+def _install_self_missing_optional_module(node_modules: Path, module_name: str) -> None:
+    _write_file(
+        node_modules / module_name / "index.js",
+        f"""
+        const error = new Error("Cannot find module '{module_name}'");
+        error.code = 'MODULE_NOT_FOUND';
+        throw error;
+        """,
+    )
+
+
+def _run_template(
+    template_name: str,
+    payload: dict[str, JsonValue],
+    *,
+    include_broken_extra: bool = False,
+    include_working_extra: bool = False,
+    include_internal_missing_extra: bool = False,
+    include_self_missing_module: str | None = None,
+    env_overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    with tempfile.TemporaryDirectory(prefix="insane-browsing-template-test-") as tmp:
+        tmp_path = Path(tmp)
+        node_modules = tmp_path / "node_modules"
+        _install_fake_playwright(node_modules)
+        if include_working_extra:
+            _install_working_playwright_extra(node_modules)
+        if include_broken_extra:
+            _install_broken_playwright_extra(node_modules)
+        if include_internal_missing_extra:
+            _install_playwright_extra_with_internal_missing_dependency(node_modules)
+        if include_self_missing_module:
+            _install_self_missing_optional_module(node_modules, include_self_missing_module)
+
+        script_path = tmp_path / template_name
+        script_path.write_text((TEMPLATES_DIR / template_name).read_text(encoding="utf-8"), encoding="utf-8")
+
+        env = os.environ.copy()
+        env.pop("NODE_PATH", None)
+        if env_overrides:
+            env.update(env_overrides)
+
+        return subprocess.run(
+            ["node", str(script_path)],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            timeout=5,
+            env=env,
+            check=False,
+        )
+
+
+@unittest.skipUnless(shutil.which("node"), "node is required for Playwright template tests")
+class PlaywrightTemplateErrorHandling(unittest.TestCase):
+    def test_missing_playwright_extra_warns_and_falls_back_to_plain_playwright(self) -> None:
+        for template_name in TEMPLATE_NAMES:
+            with self.subTest(template_name=template_name):
+                result = _run_template(
+                    template_name,
+                    {
+                        "url": "https://example.com/article",
+                        "profileDir": "/tmp/insane-browsing-test-profile",
+                        "headless": True,
+                    },
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn("<article>ok</article>", result.stdout)
+                self.assertIn("best-effort optional module playwright-extra failed:", result.stderr)
+                self.assertIn("Cannot find module 'playwright-extra'", result.stderr)
+
+    def test_missing_stealth_plugin_warns_and_falls_back_to_plain_playwright(self) -> None:
+        for template_name in TEMPLATE_NAMES:
+            with self.subTest(template_name=template_name):
+                result = _run_template(
+                    template_name,
+                    {
+                        "url": "https://example.com/article",
+                        "profileDir": "/tmp/insane-browsing-test-profile",
+                        "headless": True,
+                    },
+                    include_working_extra=True,
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn("<article>ok</article>", result.stdout)
+                self.assertIn("best-effort optional module puppeteer-extra-plugin-stealth failed:", result.stderr)
+                self.assertIn("Cannot find module 'puppeteer-extra-plugin-stealth'", result.stderr)
+
+    def test_non_missing_stealth_dependency_error_is_not_swallowed(self) -> None:
+        for template_name in TEMPLATE_NAMES:
+            with self.subTest(template_name=template_name):
+                result = _run_template(
+                    template_name,
+                    {
+                        "url": "https://example.com/article",
+                        "profileDir": "/tmp/insane-browsing-test-profile",
+                        "headless": True,
+                    },
+                    include_broken_extra=True,
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("stealth init failed", result.stderr)
+                self.assertNotIn("best-effort optional module", result.stderr)
+                self.assertEqual(result.stdout, "")
+
+    def test_internal_module_resolution_error_is_not_treated_as_optional_missing_dependency(self) -> None:
+        for template_name in TEMPLATE_NAMES:
+            with self.subTest(template_name=template_name):
+                result = _run_template(
+                    template_name,
+                    {
+                        "url": "https://example.com/article",
+                        "profileDir": "/tmp/insane-browsing-test-profile",
+                        "headless": True,
+                    },
+                    include_internal_missing_extra=True,
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("Cannot find module 'transitive-stealth-runtime'", result.stderr)
+                self.assertNotIn("best-effort optional module", result.stderr)
+                self.assertEqual(result.stdout, "")
+
+    def test_present_optional_module_self_missing_error_is_not_swallowed(self) -> None:
+        cases = (("playwright-extra", False), ("puppeteer-extra-plugin-stealth", True))
+        for template_name in TEMPLATE_NAMES:
+            for module_name, include_working_extra in cases:
+                with self.subTest(template_name=template_name, module_name=module_name):
+                    result = _run_template(
+                        template_name,
+                        {
+                            "url": "https://example.com/article",
+                            "profileDir": "/tmp/insane-browsing-test-profile",
+                            "headless": True,
+                        },
+                        include_working_extra=include_working_extra,
+                        include_self_missing_module=module_name,
+                    )
+
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn(f"Cannot find module '{module_name}'", result.stderr)
+                    self.assertNotIn("best-effort optional module", result.stderr)
+                    self.assertEqual(result.stdout, "")
+
+    def test_selector_failures_are_reported_as_best_effort_warnings(self) -> None:
+        for template_name in TEMPLATE_NAMES:
+            with self.subTest(template_name=template_name):
+                result = _run_template(
+                    template_name,
+                    {
+                        "url": "https://example.com/article",
+                        "profileDir": "/tmp/insane-browsing-test-profile",
+                        "headless": True,
+                        "waitSelector": "article.ready",
+                    },
+                    env_overrides={"PW_FAKE_SELECTOR_FAIL": "1"},
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn("<article>ok</article>", result.stdout)
+                self.assertIn("best-effort waitSelector failed:", result.stderr)
+                self.assertNotIn("waitSelector article.ready", result.stderr)
+
+    def test_context_close_failures_are_reported_after_successful_html_output(self) -> None:
+        for template_name in TEMPLATE_NAMES:
+            with self.subTest(template_name=template_name):
+                result = _run_template(
+                    template_name,
+                    {
+                        "url": "https://example.com/article",
+                        "profileDir": "/tmp/insane-browsing-test-profile",
+                        "headless": True,
+                    },
+                    env_overrides={"PW_FAKE_CLOSE_FAIL": "1"},
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn("<article>ok</article>", result.stdout)
+                self.assertIn("best-effort browser context close failed:", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/insane-browsing/engine/tests/test_referers.py
+++ b/skills/insane-browsing/engine/tests/test_referers.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from engine.referers import REFERER_STRATEGIES  # noqa: E402
+
+
+class RefererStripsUserinfo(unittest.TestCase):
+    """F16: _self_root must not leak user:pass@ into the Referer header."""
+
+    def test_referer_strips_userinfo(self) -> None:
+        """A URL with basic-auth credentials must not expose them in the Referer."""
+        self_root = REFERER_STRATEGIES["self_root"]
+        referer = self_root("https://user:pass@example.com/page")
+        self.assertNotIn("user", referer, "Referer must not contain username")
+        self.assertNotIn("pass", referer, "Referer must not contain password")
+        self.assertNotIn("@", referer, "Referer must not contain userinfo separator")
+        self.assertTrue(
+            referer.startswith("https://example.com"),
+            f"Referer should start with https://example.com, got: {referer!r}",
+        )
+
+    def test_referer_plain_url_unchanged(self) -> None:
+        """A plain URL without userinfo must produce the same Referer as before."""
+        self_root = REFERER_STRATEGIES["self_root"]
+        referer = self_root("https://example.com/some/path")
+        self.assertEqual(referer, "https://example.com/")
+
+    def test_referer_plain_url_with_port_preserves_port(self) -> None:
+        """A plain URL with a non-standard port should preserve it in the Referer."""
+        self_root = REFERER_STRATEGIES["self_root"]
+        referer = self_root("https://example.com:8080/page")
+        self.assertEqual(referer, "https://example.com:8080/")
+
+    def test_referer_userinfo_url_with_port_strips_userinfo_preserves_port(self) -> None:
+        """Userinfo is stripped but the port is preserved."""
+        self_root = REFERER_STRATEGIES["self_root"]
+        referer = self_root("https://user:pass@example.com:8080/page")
+        self.assertNotIn("user", referer)
+        self.assertNotIn("pass", referer)
+        self.assertNotIn("@", referer)
+        self.assertEqual(referer, "https://example.com:8080/")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/insane-browsing/engine/tests/test_validators.py
+++ b/skills/insane-browsing/engine/tests/test_validators.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from engine.validators import SMALL_BODY_THRESHOLD, validate  # noqa: E402
+
+
+class _Resp:
+    """Minimal response stand-in.
+
+    `cookies` is a plain dict so validators._extract_cookies hits its
+    `dict(resp.cookies)` fallback (no `.jar` attribute).
+    """
+
+    def __init__(self, *, text: str, status_code: int = 200, cookies: dict | None = None):
+        self.text = text
+        self.status_code = status_code
+        self.cookies = cookies or {}
+
+
+class Validators(unittest.TestCase):
+    def test_abck_unresolved_no_selectors_not_ok(self) -> None:
+        # No success_selectors → the no-selectors fall-through path is exercised.
+        # Body >= SMALL_BODY_THRESHOLD so the tiny-body CHALLENGE branch is skipped
+        # and execution reaches the cookie-sensor fall-through.
+        body = "x" * (SMALL_BODY_THRESHOLD + 10)
+        resp = _Resp(text=body, cookies={"_abck": "abc~-1~xyz"})
+
+        result = validate(resp)
+
+        self.assertFalse(result.ok)
+        self.assertIn("abck_unresolved", result.reasons)
+
+    def test_body_size_measured_in_bytes(self) -> None:
+        # A CJK body whose char-count < threshold but whose UTF-8 byte-count
+        # >= threshold. If size is measured in characters it falls under the
+        # threshold → tiny_body CHALLENGE; measured in bytes it is over the
+        # threshold → the byte branch (weak_ok, body_size in bytes).
+        char_count = SMALL_BODY_THRESHOLD - 1  # below threshold by chars
+        body = "가" * char_count  # each char = 3 UTF-8 bytes
+        self.assertLess(len(body), SMALL_BODY_THRESHOLD)
+        self.assertGreaterEqual(len(body.encode("utf-8")), SMALL_BODY_THRESHOLD)
+
+        resp = _Resp(text=body)
+        result = validate(resp)
+
+        self.assertEqual(result.body_size, len(body.encode("utf-8")))
+        self.assertNotIn(f"tiny_body:{len(body)}", result.reasons)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/insane-browsing/engine/tests/test_waf_detector.py
+++ b/skills/insane-browsing/engine/tests/test_waf_detector.py
@@ -1,0 +1,51 @@
+"""Regression tests for waf_detector — F22: server_contains case-insensitive match.
+
+The defect: `server_contains` lowercases only the needle (`needle.lower() in server`)
+but not the header value, so `Server: CloudFlare` (mixed-case) misses the lowercase
+needle `cloudflare`.  Fix: lowercase both sides.
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from engine.waf_detector import _score_profile  # noqa: E402
+
+
+class _Resp:
+    """Minimal response stub for waf_detector tests."""
+
+    def __init__(self, server: str = "", text: str = "") -> None:
+        # _headers_dict lowercases header KEYS; the VALUE is passed through as-is.
+        self.headers = {"Server": server}
+        self.text = text
+        self.cookies = type("C", (), {"jar": []})()
+
+
+class WafDetectorServerContains(unittest.TestCase):
+    # Minimal profile that fires only on server_contains.
+    _PROFILE = {
+        "detectors": {"server_contains": ["cloudflare"]},
+        "confidence_rules": {"strong": 1, "weak": 1},
+    }
+
+    def test_server_contains_case_insensitive(self) -> None:
+        """Mixed-case Server header must match a lowercase needle (F22 regression)."""
+        resp = _Resp(server="CloudFlare")
+        hit = _score_profile("cloudflare_waf", self._PROFILE, resp)
+        self.assertIsNotNone(hit, "Expected a DetectionHit for 'CloudFlare' vs needle 'cloudflare'")
+        self.assertIn("server:cloudflare", hit.signals)
+
+    def test_server_contains_lowercase_regression(self) -> None:
+        """Already-lowercase Server header must still match after the fix."""
+        resp = _Resp(server="cloudflare")
+        hit = _score_profile("cloudflare_waf", self._PROFILE, resp)
+        self.assertIsNotNone(hit, "Expected a DetectionHit for 'cloudflare' vs needle 'cloudflare'")
+        self.assertIn("server:cloudflare", hit.signals)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/insane-browsing/engine/tests/test_waf_detector.py
+++ b/skills/insane-browsing/engine/tests/test_waf_detector.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from engine.waf_detector import _score_profile  # noqa: E402
+from engine.waf_detector import _load_profiles, _score_profile  # noqa: E402
 
 
 class _Resp:
@@ -23,6 +23,31 @@ class _Resp:
         self.headers = {"Server": server}
         self.text = text
         self.cookies = type("C", (), {"jar": []})()
+
+
+class _RespWithHeaders:
+    """Response stub supporting arbitrary headers and named-cookie jar entries."""
+
+    def __init__(
+        self,
+        headers: dict | None = None,
+        cookie_jar: list | None = None,
+        text: str = "",
+    ) -> None:
+        self.headers = headers or {}
+        self.text = text
+        _Cookie = type("_Cookie", (), {})
+        jar = []
+        for name, value in (cookie_jar or []):
+            c = _Cookie()
+            c.name = name
+            c.value = value
+            jar.append(c)
+        self.cookies = type("_Jar", (), {"jar": jar})()
+
+
+# Loaded once at import time; reflects the live waf_profiles.yaml on disk.
+_LIVE_PROFILES = _load_profiles()
 
 
 class WafDetectorServerContains(unittest.TestCase):
@@ -45,6 +70,40 @@ class WafDetectorServerContains(unittest.TestCase):
         hit = _score_profile("cloudflare_waf", self._PROFILE, resp)
         self.assertIsNotNone(hit, "Expected a DetectionHit for 'cloudflare' vs needle 'cloudflare'")
         self.assertIn("server:cloudflare", hit.signals)
+
+
+class AwsWafHeaderDetectorTest(unittest.TestCase):
+    """aws_waf detector must fire only on WAF-specific signals (code-review finding #10).
+
+    x-amzn-requestid and x-amzn-errortype appear on every API Gateway / Lambda
+    response, so they are general infrastructure headers — not WAF evidence.
+    Only x-amzn-waf-* and the aws-waf-token cookie are WAF-vendor artifacts.
+    """
+
+    _PROFILE = _LIVE_PROFILES.get("aws_waf", {})
+
+    def test_amzn_requestid_alone_does_not_classify_as_aws_waf(self) -> None:
+        """x-amzn-requestid is a general API Gateway/Lambda header and must not classify a response as aws_waf."""
+        resp = _RespWithHeaders(headers={"x-amzn-requestid": "abc-123"})
+        hit = _score_profile("aws_waf", self._PROFILE, resp)
+        self.assertIsNone(
+            hit,
+            "x-amzn-requestid alone must NOT produce an aws_waf hit — it is a general infra header",
+        )
+
+    def test_aws_waf_token_cookie_detected(self) -> None:
+        """aws-waf-token cookie is a WAF-specific signal and must still be detected."""
+        resp = _RespWithHeaders(cookie_jar=[("aws-waf-token", "some-token")])
+        hit = _score_profile("aws_waf", self._PROFILE, resp)
+        self.assertIsNotNone(hit, "aws-waf-token cookie must produce an aws_waf hit")
+        self.assertIn("cookie:aws-waf-token", hit.signals)
+
+    def test_amzn_waf_wildcard_header_detected(self) -> None:
+        """x-amzn-waf-* header is a WAF-specific signal and must still be detected."""
+        resp = _RespWithHeaders(headers={"x-amzn-waf-action": "block"})
+        hit = _score_profile("aws_waf", self._PROFILE, resp)
+        self.assertIsNotNone(hit, "x-amzn-waf-* header must produce an aws_waf hit")
+        self.assertIn("header:x-amzn-waf-*", hit.signals)
 
 
 if __name__ == "__main__":

--- a/skills/insane-browsing/engine/url_transforms.py
+++ b/skills/insane-browsing/engine/url_transforms.py
@@ -1,0 +1,98 @@
+"""Generic URL transforms for the fetch grid.
+
+Transforms are domain-agnostic *rules*. They never reference a specific
+site by name. A transform either applies (returns a new URL) or is skipped
+(returns None). Callers iterate transforms in order.
+
+Empirically useful transforms (see observations/):
+  * mobile_subdomain — `www.example.com` → `m.example.com`
+    Strong win on SSR sites with mobile-first serving. Loss on SPA shells
+    (some mobile sites return tiny bootstrap HTML).
+  * am_prefix — `example.com` (no www) → `m.example.com`
+  * drop_www — occasionally unblocks hosts that gate www but not apex.
+
+Adding new transforms: prove they help on ≥2 unrelated sites first
+(cross-site validation — bias check).
+"""
+from __future__ import annotations
+
+from typing import Callable, Optional
+from urllib.parse import urlsplit, urlunsplit
+
+
+def _replace_host(url: str, new_host: str) -> str:
+    parts = urlsplit(url)
+    return urlunsplit(parts._replace(netloc=new_host))
+
+
+def _original(url: str) -> Optional[str]:
+    return url
+
+
+def _mobile_subdomain(url: str) -> Optional[str]:
+    """`https://www.example.com/a` → `https://m.example.com/a` (only if host starts with www.)."""
+    parts = urlsplit(url)
+    host = parts.hostname or ""
+    if not host.startswith("www."):
+        return None
+    new_host = "m." + host[4:]
+    if parts.port:
+        new_host = f"{new_host}:{parts.port}"
+    return _replace_host(url, new_host)
+
+
+def _am_prefix(url: str) -> Optional[str]:
+    """`https://example.com/a` → `https://m.example.com/a` (only if host has no subdomain)."""
+    parts = urlsplit(url)
+    host = parts.hostname or ""
+    if not host or host.startswith("m."):
+        return None
+    # Only apply to apex-like hosts (≤2 dot-separated labels).
+    if host.count(".") >= 2 and not host.startswith("www."):
+        return None
+    if host.startswith("www."):
+        return None  # handled by mobile_subdomain
+    return _replace_host(url, "m." + host)
+
+
+def _drop_www(url: str) -> Optional[str]:
+    parts = urlsplit(url)
+    host = parts.hostname or ""
+    if not host.startswith("www."):
+        return None
+    return _replace_host(url, host[4:])
+
+
+TRANSFORMS: dict[str, Callable[[str], Optional[str]]] = {
+    "original": _original,
+    "mobile_subdomain": _mobile_subdomain,
+    "am_prefix": _am_prefix,
+    "drop_www": _drop_www,
+}
+
+
+def apply_transform(name: str, url: str) -> Optional[str]:
+    """Apply one transform by name. Returns transformed URL or None if skipped."""
+    fn = TRANSFORMS.get(name)
+    if fn is None:
+        raise ValueError(f"Unknown transform: {name!r}. Known: {list(TRANSFORMS)}")
+    return fn(url)
+
+
+def iter_transformed(url: str, order: list[str]) -> list[tuple[str, str]]:
+    """Yield (transform_name, transformed_url) pairs for a given order.
+
+    Skips transforms that return None (not applicable) and deduplicates
+    URLs (so `original` and `drop_www` of `https://example.com` don't double-run).
+    """
+    seen: set[str] = set()
+    out: list[tuple[str, str]] = []
+    for name in order:
+        new_url = apply_transform(name, url)
+        if new_url is None:
+            continue
+        if new_url in seen:
+            continue
+        seen.add(new_url)
+        out.append((name, new_url))
+    return out

--- a/skills/insane-browsing/engine/validators.py
+++ b/skills/insane-browsing/engine/validators.py
@@ -1,0 +1,216 @@
+"""Generic challenge / success validator.
+
+Four layers (all generic, never site-specific):
+  1. Challenge markers (WAF product strings — not site brand names)
+  2. Size fingerprints (known bad byte sizes hinted by caller)
+  3. Cookie sensor state (e.g. Akamai `_abck=~-1~`)
+  4. Caller-supplied success_selectors (strongest positive proof)
+
+Layers 1-3 are "negative proof" (fail fast).
+Layer 4 is "positive proof" — without it, HTTP 200 is only a weak success.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError:  # bs4 is a soft dep: only used when selectors given
+    BeautifulSoup = None
+
+
+# Markers are WAF-product strings only. Never include site brand / domain.
+CHALLENGE_MARKERS: list[str] = [
+    "Access Denied",
+    "sec-if-cpt-container",
+    "Powered and protected by Akamai",
+    "Just a moment...",
+    "Checking your browser",
+    "cf-chl-bypass",
+    "Attention Required! | Cloudflare",
+    "<title>Bot Challenge</title>",
+    "DataDome",
+    "captcha",
+    "Please enable JS and disable any ad blocker",
+    "The requested URL was rejected",
+    "Request unsuccessful. Incapsula",
+]
+
+# Minimum body size below which we suspect a stub / challenge page.
+# Tunable: some legitimate short JSON responses may be smaller, but callers
+# that know their response type should pass success_selectors instead.
+SMALL_BODY_THRESHOLD = 3000
+
+
+class Verdict(Enum):
+    """Three-level classification (Codex suggestion — avoid binary)."""
+
+    STRONG_OK = "strong_ok"      # passes all layers incl. success_selectors
+    WEAK_OK = "weak_ok"          # passes 1-3 but no positive proof available
+    CHALLENGE = "challenge"      # fails 1-3 (negative proof triggered)
+    BLOCKED = "blocked"          # non-200 status
+    UNKNOWN = "unknown"          # exception / malformed response
+
+
+@dataclass
+class ValidationResult:
+    verdict: Verdict
+    reasons: list[str] = field(default_factory=list)
+    matched_selectors: list[str] = field(default_factory=list)
+    body_size: int = 0
+    status: int = 0
+
+    @property
+    def ok(self) -> bool:
+        """Kept for ergonomic `if vr.ok:` use — weak_ok counts as ok."""
+        return self.verdict in (Verdict.STRONG_OK, Verdict.WEAK_OK)
+
+    def to_dict(self) -> dict:
+        return {
+            "verdict": self.verdict.value,
+            "reasons": self.reasons,
+            "matched_selectors": self.matched_selectors,
+            "body_size": self.body_size,
+            "status": self.status,
+        }
+
+
+def _marker_hits(body_lower: str) -> list[str]:
+    return [m for m in CHALLENGE_MARKERS if m.lower() in body_lower]
+
+
+def _abck_unresolved(cookies: dict) -> bool:
+    abck = cookies.get("_abck", "")
+    return bool(abck) and "~-1~" in abck
+
+
+def _selector_hits(body: str, selectors: list[str]) -> Optional[list[str]]:
+    """Return matched-selector list, or None if BS4 is unavailable.
+
+    Distinguishing None (dependency missing) from [] (nothing matched) lets
+    the caller classify as UNKNOWN vs CHALLENGE correctly (Codex review: do
+    not let dependency failure masquerade as a WAF outcome).
+    """
+    if BeautifulSoup is None:
+        return None
+    try:
+        soup = BeautifulSoup(body, "html.parser")
+    except Exception:
+        return []
+    hits: list[str] = []
+    for sel in selectors:
+        try:
+            if soup.select(sel):
+                hits.append(sel)
+        except Exception:
+            continue
+    return hits
+
+
+def validate(
+    resp,
+    *,
+    success_selectors: Optional[list[str]] = None,
+    known_bad_sizes: Optional[list[int]] = None,
+    size_tolerance: int = 20,
+) -> ValidationResult:
+    """Validate a `curl_cffi` / `requests` response.
+
+    Parameters
+    ----------
+    resp
+        Response object with `.status_code`, `.text`, and cookie-like access.
+    success_selectors
+        Caller-supplied CSS selectors. Any match promotes `weak_ok` → `strong_ok`.
+        Absence of selectors still allows `weak_ok` (no positive proof, but
+        no negative proof either).
+    known_bad_sizes
+        Byte sizes that have been empirically observed as challenge-page
+        fingerprints (caller / profile hint). NOTE: these values decay over
+        time — profiles should timestamp or refresh them.
+    """
+    try:
+        status = int(getattr(resp, "status_code", 0) or 0)
+        text = getattr(resp, "text", "") or ""
+        size = len(text)
+    except Exception as e:
+        return ValidationResult(verdict=Verdict.UNKNOWN, reasons=[f"parse_error:{e}"])
+
+    r = ValidationResult(verdict=Verdict.UNKNOWN, body_size=size, status=status)
+
+    if status == 0 or status >= 400:
+        r.verdict = Verdict.BLOCKED
+        r.reasons.append(f"status={status}")
+        return r
+
+    # --- Layer 1: challenge markers (product strings, never site brand) ---
+    lowered = text.lower()
+    markers = _marker_hits(lowered)
+    if markers:
+        r.verdict = Verdict.CHALLENGE
+        r.reasons.extend(f"marker:{m}" for m in markers[:3])
+        return r
+
+    # --- Layer 2: size fingerprints (caller hint, tolerant match) ---
+    # Fingerprint match is a strong negative signal — override even selectors.
+    if known_bad_sizes:
+        for bad in known_bad_sizes:
+            if abs(size - bad) <= size_tolerance:
+                r.verdict = Verdict.CHALLENGE
+                r.reasons.append(f"size_fp:{size}~{bad}")
+                return r
+
+    # --- Layer 4 (early): caller's positive proof overrides size heuristic ---
+    # If caller provided selectors, trust their definition of "content exists".
+    # A small page with the required selector is still success.
+    if success_selectors:
+        hits = _selector_hits(text, success_selectors)
+        if hits is None:
+            # BS4 dependency missing — can't evaluate caller's proof.
+            # Classify as UNKNOWN (not CHALLENGE) so a WAF outcome isn't faked.
+            r.verdict = Verdict.UNKNOWN
+            r.reasons.append("bs4_missing")
+            return r
+        if hits:
+            # Cookie sensor state acts as a true gate when selectors passed:
+            # unresolved `_abck` means Akamai did not accept our session even
+            # though the body has our expected selector — trust is weak.
+            cookies = _extract_cookies(resp)
+            r.matched_selectors = hits
+            if _abck_unresolved(cookies):
+                r.reasons.append("abck_unresolved")
+                r.verdict = Verdict.WEAK_OK  # demoted from STRONG_OK
+                return r
+            r.verdict = Verdict.STRONG_OK
+            return r
+        # Selectors requested but none matched → challenge regardless of size.
+        r.verdict = Verdict.CHALLENGE
+        r.reasons.append("no_success_selector")
+        return r
+
+    # No selectors: fall back to size heuristic.
+    if size < SMALL_BODY_THRESHOLD:
+        r.verdict = Verdict.CHALLENGE
+        r.reasons.append(f"tiny_body:{size}")
+        return r
+
+    # --- Layer 3: cookie sensor state (only when no selectors to decide on) ---
+    cookies = _extract_cookies(resp)
+    if _abck_unresolved(cookies):
+        r.reasons.append("abck_unresolved")
+
+    # No positive proof available — weak OK.
+    r.verdict = Verdict.WEAK_OK
+    return r
+
+
+def _extract_cookies(resp) -> dict:
+    try:
+        return {c.name: c.value for c in resp.cookies.jar}
+    except Exception:
+        try:
+            return dict(resp.cookies) if hasattr(resp, "cookies") else {}
+        except Exception:
+            return {}

--- a/skills/insane-browsing/engine/validators.py
+++ b/skills/insane-browsing/engine/validators.py
@@ -134,7 +134,7 @@ def validate(
     try:
         status = int(getattr(resp, "status_code", 0) or 0)
         text = getattr(resp, "text", "") or ""
-        size = len(text)
+        size = len(text.encode("utf-8", "replace"))
     except Exception as e:
         return ValidationResult(verdict=Verdict.UNKNOWN, reasons=[f"parse_error:{e}"])
 
@@ -199,7 +199,13 @@ def validate(
     # --- Layer 3: cookie sensor state (only when no selectors to decide on) ---
     cookies = _extract_cookies(resp)
     if _abck_unresolved(cookies):
+        # Unresolved `_abck` means the session sensor was rejected. With no
+        # positive proof to offset it, demote to challenge (not-ok). The
+        # `abck_unresolved` reason distinguishes this cookie-reject from a
+        # WAF interstitial (which also yields challenge) for downstream readers.
         r.reasons.append("abck_unresolved")
+        r.verdict = Verdict.CHALLENGE
+        return r
 
     # No positive proof available — weak OK.
     r.verdict = Verdict.WEAK_OK

--- a/skills/insane-browsing/engine/waf_detector.py
+++ b/skills/insane-browsing/engine/waf_detector.py
@@ -1,0 +1,214 @@
+"""WAF-product detection from a live response.
+
+Returns a *ranking* of (profile_id, confidence) pairs — never a single verdict.
+Single-answer detectors cause cascading wrong plans when misfiring (Codex's
+critique). Planner consumes the ranking and tries top candidates in order.
+
+All detectors operate on WAF-vendor artifacts (cookies / headers / body
+strings) — never site hostnames. See engine/waf_profiles.yaml for the
+profile definitions.
+"""
+from __future__ import annotations
+
+import fnmatch
+import os
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+try:
+    import yaml  # PyYAML
+except ImportError:
+    yaml = None
+
+
+PROFILES_PATH = os.path.join(os.path.dirname(__file__), "waf_profiles.yaml")
+
+
+# In-code safety net — used when waf_profiles.yaml is missing / invalid
+# or PyYAML isn't installed. Keeps fetch() working in a degraded-but-sane
+# mode. Must stay site-agnostic (No-Site-Name Rule).
+_DEFAULT_PROFILES: dict = {
+    "unknown_challenge": {
+        "detectors": {},
+        "confidence_rules": {"strong": 0, "weak": 0},
+        "capabilities_needed": ["needs_js_exec"],
+        "tls_impersonate_candidates": [
+            ["safari", "chrome", "firefox"],
+            ["safari_ios", "chrome_android"],
+        ],
+        "referer_strategies": ["self_root", "google_search", "none"],
+        "url_transform_order": ["original", "mobile_subdomain"],
+        "fallback_when_challenge": ["playwright_mcp", "playwright_real_chrome"],
+        "notes": "in-code default — waf_profiles.yaml unavailable",
+    },
+}
+
+
+# Module-level sticky error. Readers call `last_load_error()` after each
+# `_load_profiles()` call to surface YAML problems in FetchResult.trace.
+_LAST_LOAD_ERROR: Optional[str] = None
+
+
+@dataclass
+class DetectionHit:
+    profile_id: str
+    confidence: float
+    signals: list[str]
+
+
+def last_load_error() -> Optional[str]:
+    """Return the most recent profile-loader error (or None if clean)."""
+    return _LAST_LOAD_ERROR
+
+
+def _load_profiles(path: str = PROFILES_PATH) -> dict:
+    """Load profiles with graceful fallback.
+
+    Never raises. On any failure (PyYAML missing, file missing, parse error,
+    unexpected shape) it returns a copy of `_DEFAULT_PROFILES` and stores
+    the reason in `_LAST_LOAD_ERROR` for the caller to surface.
+    """
+    global _LAST_LOAD_ERROR
+    _LAST_LOAD_ERROR = None
+
+    if yaml is None:
+        _LAST_LOAD_ERROR = "PyYAML not installed — using in-code default profile"
+        return dict(_DEFAULT_PROFILES)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            loaded = yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        _LAST_LOAD_ERROR = f"waf_profiles.yaml not found at {path}"
+        return dict(_DEFAULT_PROFILES)
+    except yaml.YAMLError as e:
+        _LAST_LOAD_ERROR = f"YAML parse error: {type(e).__name__}: {str(e)[:200]}"
+        return dict(_DEFAULT_PROFILES)
+    except Exception as e:
+        _LAST_LOAD_ERROR = f"profile loader: {type(e).__name__}: {str(e)[:200]}"
+        return dict(_DEFAULT_PROFILES)
+
+    if not isinstance(loaded, dict) or not any(k for k in loaded if not k.startswith("_")):
+        _LAST_LOAD_ERROR = f"waf_profiles.yaml has no usable profiles"
+        return dict(_DEFAULT_PROFILES)
+
+    return loaded
+
+
+def _cookies_dict(resp) -> dict:
+    try:
+        return {c.name: c.value for c in resp.cookies.jar}
+    except Exception:
+        try:
+            return dict(resp.cookies) if hasattr(resp, "cookies") else {}
+        except Exception:
+            return {}
+
+
+def _headers_dict(resp) -> dict:
+    try:
+        return {k.lower(): v for k, v in dict(resp.headers).items()}
+    except Exception:
+        return {}
+
+
+def _match_patterns(haystack_keys: list[str], patterns: list[str]) -> list[str]:
+    """Match literal names or fnmatch patterns (for wildcards like `X-Akamai-*`)."""
+    hits: list[str] = []
+    lowered_keys = [k.lower() for k in haystack_keys]
+    for pat in patterns or []:
+        pat_l = pat.lower()
+        if any(c in pat for c in "*?["):
+            for key in lowered_keys:
+                if fnmatch.fnmatchcase(key, pat_l):
+                    hits.append(pat)
+                    break
+        else:
+            if pat_l in lowered_keys:
+                hits.append(pat)
+    return hits
+
+
+def _score_profile(profile_id: str, profile: dict, resp) -> Optional[DetectionHit]:
+    """Apply profile detectors to resp. Returns hit or None."""
+    if profile_id.startswith("_"):
+        return None
+    detectors = profile.get("detectors") or {}
+    if not detectors and profile_id != "unknown_challenge":
+        return None
+
+    cookies = _cookies_dict(resp)
+    headers = _headers_dict(resp)
+    body = (getattr(resp, "text", "") or "").lower()
+    server = headers.get("server", "")
+
+    signals: list[str] = []
+
+    # Cookie detectors
+    cookie_pats = detectors.get("cookie") or []
+    for hit in _match_patterns(list(cookies.keys()), cookie_pats):
+        signals.append(f"cookie:{hit}")
+
+    # Header detectors
+    header_pats = detectors.get("header") or []
+    for hit in _match_patterns(list(headers.keys()), header_pats):
+        signals.append(f"header:{hit}")
+
+    # Server substring
+    for needle in detectors.get("server_contains") or []:
+        if needle.lower() in server:
+            signals.append(f"server:{needle}")
+
+    # Body markers
+    for needle in detectors.get("body") or []:
+        if needle.lower() in body:
+            signals.append(f"body:{needle}")
+
+    if not signals:
+        return None
+
+    rules = profile.get("confidence_rules") or {"strong": 2, "weak": 1}
+    n = len(signals)
+    if n >= rules.get("strong", 2):
+        conf = 0.9
+    elif n >= rules.get("weak", 1):
+        conf = 0.6
+    else:
+        conf = 0.3
+
+    return DetectionHit(profile_id=profile_id, confidence=conf, signals=signals)
+
+
+def detect(resp, *, profiles: Optional[dict] = None, min_confidence: float = 0.0) -> list[DetectionHit]:
+    """Return ranked list of detection hits (best first).
+
+    When nothing fires, the returned list contains a single `unknown_challenge`
+    hit with confidence 0.1 — caller can use its conservative settings.
+    """
+    if profiles is None:
+        profiles = _load_profiles()
+
+    hits: list[DetectionHit] = []
+    for profile_id, profile in profiles.items():
+        if profile_id.startswith("_"):
+            continue
+        h = _score_profile(profile_id, profile, resp)
+        if h and h.confidence >= min_confidence:
+            hits.append(h)
+
+    hits.sort(key=lambda x: x.confidence, reverse=True)
+
+    if not hits:
+        hits.append(DetectionHit(
+            profile_id="unknown_challenge",
+            confidence=0.1,
+            signals=["fallback"],
+        ))
+    return hits
+
+
+def load_profile(profile_id: str, *, profiles: Optional[dict] = None) -> dict:
+    """Get one profile by id, resolving `unknown_challenge` if missing."""
+    if profiles is None:
+        profiles = _load_profiles()
+    return profiles.get(profile_id) or profiles.get("unknown_challenge") or {}

--- a/skills/insane-browsing/engine/waf_detector.py
+++ b/skills/insane-browsing/engine/waf_detector.py
@@ -154,9 +154,9 @@ def _score_profile(profile_id: str, profile: dict, resp) -> Optional[DetectionHi
     for hit in _match_patterns(list(headers.keys()), header_pats):
         signals.append(f"header:{hit}")
 
-    # Server substring
+    # Server substring — lowercase both sides so mixed-case headers match (F22)
     for needle in detectors.get("server_contains") or []:
-        if needle.lower() in server:
+        if needle.lower() in server.lower():
             signals.append(f"server:{needle}")
 
     # Body markers

--- a/skills/insane-browsing/engine/waf_profiles.yaml
+++ b/skills/insane-browsing/engine/waf_profiles.yaml
@@ -1,0 +1,162 @@
+# WAF Product Profiles — never site-specific.
+#
+# NO-SITE-NAME RULE:
+#   * Key names are WAF products (akamai_bot_manager), not sites.
+#   * Detectors use product artifacts (cookies / headers / vendor strings).
+#   * Field values (markers, cookie names) must appear in any site running
+#     that WAF, not just one. If a value only fits one site, it belongs
+#     to runtime hints / observations, not this file.
+#
+# Profiles are *recommendations*, not deterministic recipes. The planner
+# treats them as priors; attempts always evaluate real responses.
+#
+# Timestamp each profile entry. If stale (> 6 months), cross-validate.
+
+_meta:
+  schema_version: 1
+  last_reviewed: "2026-04-21"
+
+akamai_bot_manager:
+  detectors:
+    cookie: ["_abck", "bm_sz", "ak_bmsc", "bm_sv", "bm_so"]
+    header: ["X-Akamai-*"]
+    server_contains: ["AkamaiGHost"]
+    body: ["sec-if-cpt-container", "Powered and protected by Akamai"]
+  confidence_rules:
+    # Multi-signal gating — single marker insufficient.
+    strong: 2     # any 2 signals from above → confidence 0.9
+    weak: 1       # 1 signal → confidence 0.6
+  capabilities_needed:
+    - needs_real_tls_stack   # Playwright Chromium (BoringSSL) is detected
+    - needs_js_exec          # 2.6KB challenge requires JS sensor
+  tls_impersonate_candidates:
+    # Every impersonate target curl_cffi supports that historically yielded
+    # at least a challenge page (i.e. IP still alive) rather than an outright
+    # TLS reject. Grouped by family; planner tries top groups first.
+    # Refresh quarterly — vendor WAFs shift which TLS fingerprints they trust.
+    - [safari, safari15_3, safari15_5, safari17_0, safari260]
+    - [safari_ios, safari17_2_ios, safari260_ios]
+    - [chrome99, chrome100, chrome101, chrome104, chrome110, chrome116, chrome119, chrome124, chrome131, chrome133a, chrome136, chrome145, chrome146]
+    - [chrome_android, chrome131_android]
+    - [edge99, edge101]
+  tls_impersonate_avoid:
+    # Empirically observed to 403 immediately (TLS fingerprint blacklisted).
+    # DO NOT hard-block — planner deprioritizes only. Refresh quarterly.
+    - safari18_0
+    - chrome107
+    - chrome120
+    - chrome123
+    - chrome145     # curl_cffi 0.11+ needed — mark avoid for older installs
+    - chrome146
+    - firefox
+    - firefox133
+    - firefox135
+  referer_strategies:
+    - self_root    # scheme://host/
+  url_transform_order:
+    - original
+    - mobile_subdomain   # www.* → m.* — strong observational win in SSR sites
+  fallback_when_challenge:
+    - curl_grid_exhaust   # try more impersonate × referer × url combos
+    - playwright_real_chrome
+  notes: |
+    DO NOT encode site-specific selectors or byte-size fingerprints here.
+    Those belong to caller's success_selectors param or observations log.
+
+cloudflare_turnstile:
+  detectors:
+    cookie: ["cf_clearance", "__cf_bm", "__cfduid"]
+    header: ["cf-ray", "cf-cache-status"]
+    server_contains: ["cloudflare"]
+    body: ["Just a moment...", "Checking your browser", "cf-chl-bypass", "Attention Required! | Cloudflare"]
+  capabilities_needed:
+    - needs_js_exec        # MCP Playwright Chromium OK — no real-TLS required
+  tls_impersonate_candidates:
+    - [chrome, chrome_android]
+  referer_strategies:
+    - google_search
+    - self_root
+  fallback_when_challenge:
+    - playwright_mcp       # MCP sufficient; Chromium TLS passes CF baseline
+    - playwright_real_chrome
+
+f5_big_ip:
+  detectors:
+    cookie: ["BigIPServer", "TS01*", "F5_*"]
+    body: ["The requested URL was rejected", "support ID is:"]
+  capabilities_needed:
+    - needs_real_tls_stack
+  tls_impersonate_candidates:
+    - [safari, chrome]
+  referer_strategies:
+    - self_root
+
+aws_waf:
+  detectors:
+    cookie: ["aws-waf-token"]
+    header: ["x-amzn-requestid", "x-amzn-errortype", "x-amzn-waf-*"]
+  capabilities_needed:
+    - needs_real_tls_stack
+  tls_impersonate_candidates:
+    - [chrome]
+  referer_strategies:
+    - self_root
+
+datadome_probable:
+  detectors:
+    cookie: ["datadome"]
+    body: ["DataDome"]
+  capabilities_needed:
+    - needs_real_tls_stack
+    - needs_js_exec
+  tls_impersonate_candidates:
+    - [safari, chrome]
+  fallback_when_challenge:
+    - playwright_real_chrome
+  notes: |
+    "_probable" suffix reminds us this is a growing attack surface — mark
+    as tentative until cross-site evidence accumulates in observations/.
+
+perimeterx_human:
+  detectors:
+    cookie: ["_px3", "_pxhd", "_px2", "pxcts"]
+    body: ["px-captcha", "Press & Hold to confirm you are a human"]
+  capabilities_needed:
+    - needs_real_tls_stack
+    - needs_js_exec
+  tls_impersonate_candidates:
+    - [safari, chrome]
+  fallback_when_challenge:
+    - playwright_real_chrome
+  notes: |
+    PerimeterX (now HUMAN Bot Defender). Distinct cookie family from
+    DataDome. Keep profiles separate so planner does not pick wrong
+    fallback strategy.
+
+# ---------------------------------------------------------------------------
+# Safety net: always-valid fallback profile.
+# ---------------------------------------------------------------------------
+unknown_challenge:
+  detectors: {}   # never matches actively — used only when no other profile fires
+  confidence_rules:
+    strong: 0
+    weak: 0
+  capabilities_needed:
+    - needs_js_exec     # conservative default
+  tls_impersonate_candidates:
+    - [safari, chrome, firefox]
+    - [safari_ios, chrome_android]
+  referer_strategies:
+    - self_root
+    - google_search
+    - none
+  url_transform_order:
+    - original
+    - mobile_subdomain
+  fallback_when_challenge:
+    - playwright_mcp
+    - playwright_real_chrome
+  notes: |
+    When detector returns low-confidence results we land here. Broad,
+    conservative grid. Evidence from these runs should feed observations/
+    for eventual profile promotion.

--- a/skills/insane-browsing/engine/waf_profiles.yaml
+++ b/skills/insane-browsing/engine/waf_profiles.yaml
@@ -94,7 +94,7 @@ f5_big_ip:
 aws_waf:
   detectors:
     cookie: ["aws-waf-token"]
-    header: ["x-amzn-requestid", "x-amzn-errortype", "x-amzn-waf-*"]
+    header: ["x-amzn-waf-*"]
   capabilities_needed:
     - needs_real_tls_stack
   tls_impersonate_candidates:

--- a/skills/insane-browsing/references/agent-reach/README.md
+++ b/skills/insane-browsing/references/agent-reach/README.md
@@ -73,7 +73,11 @@ mcporter_list_servers()
 
 ## 配置渠道
 
-如果某个 channel 需要配置，获取安装指南：
-https://raw.githubusercontent.com/Panniantong/agent-reach/main/docs/install.md
+如果某个 channel 需要配置，运行：
+
+```bash
+agent-reach install
+agent-reach doctor
+```
 
 用户只需提供 cookies，其他配置由 agent 完成。

--- a/skills/insane-browsing/references/agent-reach/README.md
+++ b/skills/insane-browsing/references/agent-reach/README.md
@@ -1,0 +1,79 @@
+
+# Agent Reach — 路由器
+
+> Part of the **insane-browsing** skill (Tier 2). Routing and tier-escalation live in [../../SKILL.md](../../SKILL.md).
+> Per-category guides in this folder: [search.md](search.md) · [social.md](social.md) · [career.md](career.md) · [dev.md](dev.md) · [web.md](web.md) · [video.md](video.md).
+
+
+17 平台工具集合。根据用户意图选择对应分类。
+
+## 路由表
+
+| 用户意图 | 分类 | 详细文档 |
+|---------|------|---------|
+| 网页搜索/代码搜索 | search | [search.md](search.md) |
+| 小红书/抖音/微博/推特/B站/V2EX/Reddit | social | [social.md](social.md) |
+| 招聘/职位/LinkedIn | career | [career.md](career.md) |
+| GitHub/代码 | dev | [dev.md](dev.md) |
+| 网页/文章/公众号/RSS | web | [web.md](web.md) |
+| YouTube/B站/播客字幕 | video | [video.md](video.md) |
+
+## 零配置快速命令
+
+```bash
+# Exa 网页搜索
+mcporter call 'exa.web_search_exa(query: "query", numResults: 5)'
+
+# 通用网页阅读
+curl -s "https://r.jina.ai/URL"
+
+# GitHub 搜索
+gh search repos "query" --sort stars --limit 10
+
+# Twitter 搜索
+twitter search "query" --limit 10
+
+# YouTube/B站字幕
+yt-dlp --write-sub --skip-download -o "/tmp/%(id)s" "URL"
+
+# Reddit 搜索
+rdt search "query" --limit 10
+
+# Reddit 读帖 + 评论
+rdt read POST_ID
+
+# V2EX 热门
+curl -s "https://www.v2ex.com/api/topics/hot.json" -H "User-Agent: agent-reach/1.0"
+```
+
+## 环境检查
+
+```bash
+# 检查可用 channel
+agent-reach doctor
+
+# 查看所有 MCP 服务
+mcporter_list_servers()
+```
+
+## 工作区规则
+
+**不要在 agent workspace 创建文件。** 使用 `/tmp/` 存放临时输出。
+
+## 详细文档
+
+根据用户需求，阅读对应的详细文档：
+
+- [搜索工具](search.md) — Exa AI 搜索
+- [社交媒体](social.md) — 小红书, 抖音, Twitter, B站, V2EX, Reddit
+- [职场招聘](career.md) — LinkedIn
+- [开发工具](dev.md) — GitHub CLI
+- [网页阅读](web.md) — Jina Reader, 微信公众号, RSS
+- [视频播客](video.md) — YouTube, B站, 小宇宙
+
+## 配置渠道
+
+如果某个 channel 需要配置，获取安装指南：
+https://raw.githubusercontent.com/Panniantong/agent-reach/main/docs/install.md
+
+用户只需提供 cookies，其他配置由 agent 完成。

--- a/skills/insane-browsing/references/agent-reach/career.md
+++ b/skills/insane-browsing/references/agent-reach/career.md
@@ -1,0 +1,29 @@
+# 职场招聘
+
+LinkedIn。
+
+## LinkedIn
+
+```bash
+# 获取个人资料
+mcporter call 'linkedin-scraper.get_person_profile(linkedin_url: "https://linkedin.com/in/username")'
+
+# 搜索人才
+mcporter call 'linkedin-scraper.search_people(keyword: "AI engineer", limit: 10)'
+
+# 获取公司资料
+mcporter call 'linkedin-scraper.get_company_profile(linkedin_url: "https://linkedin.com/company/xxx")'
+
+# 搜索职位
+mcporter call 'linkedin-scraper.search_jobs(keyword: "software engineer", limit: 10)'
+```
+
+> **需要登录**: LinkedIn scraper 需要有效的登录态。
+
+### Fallback 方案
+
+如果 MCP 不可用，可以用 Jina Reader：
+
+```bash
+curl -s "https://r.jina.ai/https://linkedin.com/in/username"
+```

--- a/skills/insane-browsing/references/agent-reach/dev.md
+++ b/skills/insane-browsing/references/agent-reach/dev.md
@@ -1,0 +1,62 @@
+# 开发工具
+
+GitHub CLI
+
+## GitHub (gh CLI)
+
+GitHub 官方命令行工具，用于仓库、Issue、PR、Actions、Release 以及 API 访问。
+
+```bash
+# 认证
+gh auth login
+gh auth status
+
+# 搜索
+gh search repos "query" --sort stars --limit 10
+gh search code "query" --language python
+
+# 仓库
+gh repo view owner/repo
+gh repo clone owner/repo
+gh repo create my-repo --private
+gh repo fork owner/repo
+gh repo fork owner/repo --clone
+gh repo sync owner/repo
+
+# Issues
+gh issue list -R owner/repo --state open
+gh issue view 123 -R owner/repo
+gh issue create -R owner/repo --title "Title" --body "Body"
+
+# Pull Requests
+gh pr list -R owner/repo --state open
+gh pr view 123 -R owner/repo
+gh pr create -R owner/repo --title "Title" --body "Body"
+gh pr checks 123 --repo owner/repo
+
+# Actions / CI
+gh run list --repo owner/repo --limit 10
+gh run view <run-id> --repo owner/repo
+gh run view <run-id> --repo owner/repo --log-failed
+gh workflow list --repo owner/repo
+
+# Releases
+gh release list -R owner/repo
+gh release create v1.0.0
+
+# API
+gh api /user
+gh api repos/owner/repo
+
+# JSON 输出
+gh issue list --repo owner/repo --json number,title --jq '.[] | "\(.number): \(.title)"'
+```
+
+
+## 选择指南
+
+| 工具 | 来源 | 用途 |
+|-----|------|------|
+| gh CLI | agent-reach | Git 操作 |
+| zread | my-mcp-tools | 读仓库内容 |
+| context7 | my-mcp-tools | 查技术文档 |

--- a/skills/insane-browsing/references/agent-reach/dev.md
+++ b/skills/insane-browsing/references/agent-reach/dev.md
@@ -59,4 +59,4 @@ gh issue list --repo owner/repo --json number,title --jq '.[] | "\(.number): \(.
 |-----|------|------|
 | gh CLI | agent-reach | Git 操作 |
 | zread | my-mcp-tools | 读仓库内容 |
-| context7 | my-mcp-tools | 查技术文档 |
+| context7 | mcp__plugin_context7 | 查技术文档 |

--- a/skills/insane-browsing/references/agent-reach/search.md
+++ b/skills/insane-browsing/references/agent-reach/search.md
@@ -1,0 +1,33 @@
+# 搜索工具
+
+Exa AI 搜索引擎。
+
+## Exa AI 搜索
+
+高质量 AI 搜索引擎，擅长技术和代码搜索。
+
+```bash
+mcporter call 'exa.web_search_exa(query: "query", numResults: 5)'
+mcporter call 'exa.get_code_context_exa(query: "code question", tokensNum: 3000)'
+```
+
+### 使用场景
+
+| 场景 | 参数 |
+|-----|------|
+| 网页搜索 | `web_search_exa(query: "...", numResults: 5)` |
+| 代码搜索 | `get_code_context_exa(query: "...", tokensNum: 3000)` |
+
+### 特点
+
+- 擅长英文内容和技术文档
+- 支持代码上下文搜索
+- 结果质量高
+
+## 与其他搜索工具对比
+
+| 工具 | 来源 | 适用场景 |
+|-----|------|---------|
+| Exa | agent-reach | 英文/技术/代码搜索 |
+| 智谱搜索 | my-mcp-tools | 中文搜索 |
+| GitHub 搜索 | agent-reach (dev.md) | 仓库/代码搜索 |

--- a/skills/insane-browsing/references/agent-reach/social.md
+++ b/skills/insane-browsing/references/agent-reach/social.md
@@ -1,0 +1,207 @@
+# 社交媒体 & 社区
+
+小红书、抖音、Twitter/X、微博、B站、V2EX、Reddit。
+
+## 小红书 / XiaoHongShu (xhs-cli)
+
+### 稳定可用的命令
+
+```bash
+# 搜索笔记（推荐入口）
+xhs search "query"
+
+# 阅读笔记详情（必须用搜索结果中的 URL 或 ID，不能裸 note_id）
+xhs read NOTE_ID_OR_URL
+
+# 查看评论
+xhs comments NOTE_ID_OR_URL
+
+# 浏览热门
+xhs hot
+
+# 推荐 feed
+xhs feed
+```
+
+### 已知不稳定的命令（v0.6.4）
+
+```bash
+# 以下命令当前可能返回 API error，谨慎使用：
+xhs user USER_ID          # 可能返回 {code: -1}
+xhs user-posts USER_ID    # 可能返回 {code: -1}
+xhs favorites              # 可能返回 API error
+```
+
+### 重要注意事项
+
+> **安装**: `pipx install xiaohongshu-cli`，然后 `xhs login`（自动从浏览器提取 Cookie）。
+>
+> **签名令牌限制**: 小红书强制每个 note 携带一个签名令牌，**不能直接用裸 note_id 去读**。正确流程是：先 `xhs search` 或 `xhs feed` 获取结果，再用结果中的 URL/ID 去 `xhs read`。直接构造 note_id 会被拦截。
+>
+> **频率控制**: 高频请求（批量搜索、深翻评论）会触发验证码，这是平台限制无法绕过。建议每次操作间隔 2-3 秒。
+>
+> **POST 操作风险**: 发帖(post)、评论(comment)、点赞(like) 等写操作在 v0.6.x 可能因签名问题返回 406。如需使用，建议降级到 v0.3.5 (`pipx install xiaohongshu-cli==0.3.5`)。
+
+## 抖音 / Douyin
+
+```bash
+# 解析视频信息
+mcporter call 'douyin.parse_douyin_video_info(share_link: "https://v.douyin.com/xxx/")'
+
+# 获取无水印下载链接
+mcporter call 'douyin.get_douyin_download_link(share_link: "https://v.douyin.com/xxx/")'
+
+# 提取视频文案
+mcporter call 'douyin.extract_douyin_text(share_link: "https://v.douyin.com/xxx/")'
+```
+
+> **无需登录**
+
+## Twitter/X (twitter-cli)
+
+### 稳定命令
+
+```bash
+# 首页时间线（最稳定）
+twitter feed -n 20
+
+# 读取单条推文（含回复）
+twitter tweet URL_OR_ID
+
+# 读取长文 / X Article
+twitter article URL_OR_ID
+
+# 用户时间线
+twitter user-posts @username -n 20
+
+# 用户资料
+twitter user @username
+```
+
+### 可能不稳定的命令
+
+```bash
+# 搜索推文（Twitter 频繁改 GraphQL 端点，可能 404）
+twitter search "query" -n 10
+# 如果 search 返回 404，升级 twitter-cli：pipx upgrade twitter-cli
+
+# likes（2024 年后只能看自己的，平台限制）
+twitter likes
+```
+
+### 重要注意事项
+
+> **安装**: `pipx install twitter-cli`（确保 v0.8.5+）
+>
+> **认证**: 如果你有访问权限，导出 Twitter 会话 Cookie 后，把 auth-token 与 ct0 两个值设置为 twitter-cli 文档所要求的认证环境变量。自动提取在 SSH/Docker/无头环境不可用。
+>
+> **IP 风控**: 不要在 VPS/数据中心 IP 上频繁调用，尤其是 followers/following，有封号风险。使用住宅代理或本地环境。
+>
+> **search 可能失效**: Twitter 频繁修改 GraphQL API，search 命令可能随时返回 404。如遇到，先 `pipx upgrade twitter-cli`。如果最新版仍不行，说明上游还没跟上 Twitter 的改动，用 `twitter feed` 替代。
+>
+> **输出格式**: 建议用 `--yaml` 或 `--json` 获得结构化输出，对 AI agent 更友好。
+
+## 微博 / Weibo
+
+```bash
+# 使用 Jina Reader 读取
+curl -s "https://r.jina.ai/https://weibo.com/USER_ID/POST_ID"
+```
+
+> 微博主要通过网页抓取，推荐使用通用网页读取方式。
+
+## B站 / Bilibili
+
+```bash
+# 获取视频元数据
+yt-dlp --dump-json "https://www.bilibili.com/video/BVxxx"
+
+# 下载字幕
+yt-dlp --write-sub --write-auto-sub --sub-lang "zh-Hans,zh,en" --convert-subs vtt --skip-download -o "/tmp/%(id)s" "URL"
+```
+
+> **注意**: 服务器 IP 可能遇到 412 错误。使用 `--cookies-from-browser chrome` 或配置代理。
+
+## V2EX (公开 API)
+
+无需认证，直接调用公开 API。
+
+### 热门主题
+
+```bash
+curl -s "https://www.v2ex.com/api/topics/hot.json" -H "User-Agent: agent-reach/1.0"
+```
+
+### 节点主题
+
+```bash
+# node_name 如: python, tech, jobs, qna, programmers
+curl -s "https://www.v2ex.com/api/topics/show.json?node_name=python&page=1" -H "User-Agent: agent-reach/1.0"
+```
+
+### 主题详情
+
+```bash
+# topic_id 从 URL 获取，如 https://www.v2ex.com/t/1234567
+curl -s "https://www.v2ex.com/api/topics/show.json?id=TOPIC_ID" -H "User-Agent: agent-reach/1.0"
+```
+
+### 主题回复
+
+```bash
+curl -s "https://www.v2ex.com/api/replies/show.json?topic_id=TOPIC_ID&page=1" -H "User-Agent: agent-reach/1.0"
+```
+
+### 用户信息
+
+```bash
+curl -s "https://www.v2ex.com/api/members/show.json?username=USERNAME" -H "User-Agent: agent-reach/1.0"
+```
+
+### Python 调用示例
+
+```python
+from agent_reach.channels.v2ex import V2EXChannel
+
+ch = V2EXChannel()
+
+# 获取热门帖子
+topics = ch.get_hot_topics(limit=10)
+for t in topics:
+    print(f"[{t['node_title']}] {t['title']} ({t['replies']} 回复)")
+
+# 获取节点帖子
+node_topics = ch.get_node_topics("python", limit=5)
+
+# 获取帖子详情 + 回复
+topic = ch.get_topic(1234567)
+print(topic["title"], "—", topic["author"])
+
+# 获取用户信息
+user = ch.get_user("Livid")
+```
+
+> **节点列表**: https://www.v2ex.com/planes
+
+## Reddit (rdt-cli)
+
+```bash
+# 搜索帖子
+rdt search "query" --limit 10
+
+# 读帖子全文 + 评论
+rdt read POST_ID
+
+# 浏览 subreddit
+rdt sub python --limit 20
+
+# 浏览热门
+rdt popular --limit 10
+
+# 浏览 /r/all
+rdt all --limit 10
+```
+
+> **安装**: `pipx install rdt-cli`（确保 v0.4.2+）。无需登录即可搜索和阅读。
+> 需要登录的功能：`rdt feed --subs-only`（订阅列表）、`rdt saved`（收藏）。
+> 建议使用 `--yaml` 输出，对 AI agent 更友好。

--- a/skills/insane-browsing/references/agent-reach/social.md
+++ b/skills/insane-browsing/references/agent-reach/social.md
@@ -158,27 +158,27 @@ curl -s "https://www.v2ex.com/api/replies/show.json?topic_id=TOPIC_ID&page=1" -H
 curl -s "https://www.v2ex.com/api/members/show.json?username=USERNAME" -H "User-Agent: agent-reach/1.0"
 ```
 
-### Python 调用示例
+### curl 调用示例
 
-```python
-from agent_reach.channels.v2ex import V2EXChannel
+```bash
+# 热门帖子（完整 JSON）
+curl -s "https://www.v2ex.com/api/topics/hot.json" | python3 -c "
+import sys, json
+for t in json.load(sys.stdin)[:10]:
+    print(f\"[{t['node']['title']}] {t['title']} ({t['replies']} 回复)\")
+"
 
-ch = V2EXChannel()
+# 节点帖子
+curl -s "https://www.v2ex.com/api/topics/show.json?node_name=python&page=1"
 
-# 获取热门帖子
-topics = ch.get_hot_topics(limit=10)
-for t in topics:
-    print(f"[{t['node_title']}] {t['title']} ({t['replies']} 回复)")
+# 帖子详情
+curl -s "https://www.v2ex.com/api/topics/show.json?id=1234567"
 
-# 获取节点帖子
-node_topics = ch.get_node_topics("python", limit=5)
+# 帖子回复
+curl -s "https://www.v2ex.com/api/replies/show.json?topic_id=1234567&page=1"
 
-# 获取帖子详情 + 回复
-topic = ch.get_topic(1234567)
-print(topic["title"], "—", topic["author"])
-
-# 获取用户信息
-user = ch.get_user("Livid")
+# 用户信息
+curl -s "https://www.v2ex.com/api/members/show.json?username=Livid"
 ```
 
 > **节点列表**: https://www.v2ex.com/planes

--- a/skills/insane-browsing/references/agent-reach/video.md
+++ b/skills/insane-browsing/references/agent-reach/video.md
@@ -1,0 +1,115 @@
+# 视频/播客
+
+YouTube、B站、小宇宙播客的字幕和转录。
+
+## YouTube (yt-dlp)
+
+### 获取视频元数据
+
+```bash
+yt-dlp --dump-json "URL"
+```
+
+### 下载字幕
+
+```bash
+# 下载字幕 (不下载视频)
+yt-dlp --write-sub --write-auto-sub --sub-lang "zh-Hans,zh,en" --skip-download -o "/tmp/%(id)s" "URL"
+
+# 然后读取 .vtt 文件
+cat /tmp/VIDEO_ID.*.vtt
+```
+
+### 获取评论
+
+```bash
+# 提取评论（best-effort，不保证完整）
+yt-dlp --write-comments --skip-download --write-info-json \
+  --extractor-args "youtube:max_comments=20" \
+  -o "/tmp/%(id)s" "URL"
+# 评论在 .info.json 的 comments 字段中
+```
+
+### 搜索视频
+
+```bash
+yt-dlp --dump-json "ytsearch5:query"
+```
+
+> **字幕注意**: 手动上传的字幕提取可靠；自动生成字幕可能存在行间重复，需后处理。
+> **评论注意**: `--write-comments` 基于网页抓取（非 YouTube Data API），部分评论可能丢失。
+
+## B站 / Bilibili (yt-dlp + bili-cli)
+
+### 视频元数据 (yt-dlp)
+
+```bash
+yt-dlp --dump-json "https://www.bilibili.com/video/BVxxx"
+```
+
+### 字幕 (yt-dlp)
+
+```bash
+yt-dlp --write-sub --write-auto-sub --sub-lang "zh-Hans,zh,en" --convert-subs vtt --skip-download -o "/tmp/%(id)s" "URL"
+```
+
+### 搜索/热门/排行 (bili-cli)
+
+```bash
+# 搜索视频
+bili search "query" --type video -n 5
+
+# 热门视频
+bili hot -n 10
+
+# 排行榜
+bili rank -n 10
+```
+
+> **412 风控**: 海外 IP 必须提供 Cookie（`--cookies-from-browser chrome` 或 `--cookies /path/to/cookies.txt`），国内 IP 一般不受影响。
+> **安装 bili-cli**: `pipx install bilibili-cli`，然后 `bili login` 扫码登录。
+
+## 小宇宙播客 / Xiaoyuzhou Podcast
+
+### 转录单集播客
+
+```bash
+# 输出 Markdown 文件到 /tmp/ (transcribe via the agent-reach xiaoyuzhou tool)
+agent-reach run xiaoyuzhou transcribe "https://www.xiaoyuzhoufm.com/episode/EPISODE_ID"
+```
+
+### 前置要求
+
+1. **ffmpeg**: `brew install ffmpeg`
+2. **Groq API Key** (免费): https://console.groq.com/keys
+3. **配置 Key**: `agent-reach configure groq-key YOUR_KEY`
+4. **首次运行**: `agent-reach install --env=auto` 安装工具
+
+### 检查状态
+
+```bash
+agent-reach doctor
+```
+
+> 输出 Markdown 文件默认保存到 `/tmp/`。
+
+## 抖音视频解析
+
+```bash
+# 解析视频信息
+mcporter call 'douyin.parse_douyin_video_info(share_link: "https://v.douyin.com/xxx/")'
+
+# 获取无水印下载链接
+mcporter call 'douyin.get_douyin_download_link(share_link: "https://v.douyin.com/xxx/")'
+```
+
+> 详见 [social.md](social.md#抖音--douyin)
+
+## 选择指南
+
+| 场景 | 推荐工具 |
+|-----|---------|
+| YouTube 字幕 | yt-dlp |
+| B站字幕 | yt-dlp |
+| 播客转录 | 小宇宙 transcribe.sh |
+| 抖音视频解析 | douyin MCP |

--- a/skills/insane-browsing/references/agent-reach/web.md
+++ b/skills/insane-browsing/references/agent-reach/web.md
@@ -1,0 +1,76 @@
+# 网页阅读
+
+通用网页、微信公众号、RSS。
+
+## 通用网页 (Jina Reader)
+
+```bash
+# 读取任意网页内容
+curl -s "https://r.jina.ai/URL"
+
+# 示例
+curl -s "https://r.jina.ai/https://example.com/article"
+```
+
+**适用场景**: 大多数网页可以直接用 Jina Reader 读取。
+
+## Web Reader (MCP)
+
+```bash
+# 读取网页内容 (Markdown 格式)
+mcporter call 'web-reader.webReader(url: "https://example.com")'
+
+# 保留图片
+mcporter call 'web-reader.webReader(url: "https://example.com", retain_images: true)'
+
+# 纯文本格式
+mcporter call 'web-reader.webReader(url: "https://example.com", return_format: "text")'
+```
+
+**适用场景**: 需要更精确控制输出格式时使用。
+
+## 微信公众号 / WeChat Articles
+
+### 搜索公众号文章（通过 Exa）
+
+```bash
+# 搜索微信公众号文章
+mcporter call 'exa.web_search_exa(query: "搜索关键词", numResults: 5, includeDomains: ["mp.weixin.qq.com"])'
+```
+
+### 阅读公众号文章全文（通过 Exa）
+
+```bash
+# 抓取文章全文
+mcporter call 'exa.crawling_exa(urls: ["https://mp.weixin.qq.com/s/ARTICLE_ID"], maxCharacters: 10000)'
+```
+
+### 可选：Camoufox 阅读（反爬更强）
+
+```bash
+agent-reach run wechat-article "https://mp.weixin.qq.com/s/ARTICLE_ID"   # Camoufox-backed WeChat reader
+```
+
+> **注意**: Jina Reader 无法读取微信文章（被 CAPTCHA 拦截），推荐用 Exa。
+
+## RSS (feedparser)
+
+```python
+python3 -c "
+import feedparser
+for e in feedparser.parse('FEED_URL').entries[:5]:
+    print(f'{e.title} — {e.link}')
+"
+```
+
+**适用场景**: 订阅博客、新闻源、播客等 RSS feed。
+
+## 选择指南
+
+| 场景 | 推荐工具 |
+|-----|---------|
+| 通用网页 | Jina Reader (`curl r.jina.ai`) |
+| 需要图片/格式控制 | web-reader MCP |
+| 微信公众号 | Exa (搜索+阅读) / Camoufox (可选阅读) |
+| RSS 订阅 | feedparser |
+| 微博/知乎等 | Jina Reader |

--- a/skills/insane-browsing/references/chrome-stealth.md
+++ b/skills/insane-browsing/references/chrome-stealth.md
@@ -1,0 +1,120 @@
+# Tier 3 — Chrome stealth (CloakBrowser + agent-browser)
+
+Real interaction (clicks, forms, screenshots, video, persistent login) for pages that defeat Tier 1/2. Two runtime tools, both installed on demand — neither is vendored in this skill:
+
+- **CloakBrowser** (`pip`) — stealth Chromium with source-level C++ fingerprint patches. The Python wrapper source is MIT; the downloaded Chromium binary is covered by CloakBrowser's separate binary license and is not redistributed by this package. Passes Cloudflare Turnstile, FingerprintJS, BrowserScan, and 30+ detectors. Pin **0.4.0**.
+- **agent-browser** (`npm`, Apache-2.0) — native CDP automation CLI that drives CloakBrowser. AX-tree snapshots, `@eN` refs, click/fill/type/scroll, screenshots, video, cookie/state/session management. Pin **0.29.1**.
+
+```
+CloakBrowser (stealth Chromium) <- CDP port 9242 -> agent-browser CLI
+  - 57 C++ fingerprint patches                  - AX-tree snapshots, @eN refs
+  - Canvas/WebGL consistency                    - click / fill / type / scroll
+  - navigator.webdriver = false at C++ source   - screenshot, video record
+  - Humanize mode (mouse curves, timing)        - cookie / state / session mgmt
+```
+
+## Install (one-time)
+
+CloakBrowser runs in a dedicated Python venv. Cross-platform: macOS, Linux, and Windows all supported by both tools (use the venv path convention for your OS).
+
+```bash
+# CloakBrowser (MIT wrapper source; separate binary license, pin 0.4.0):
+uv venv .cloak-venv --python 3.13
+# macOS/Linux: source .cloak-venv/bin/activate    Windows: .cloak-venv\Scripts\activate
+uv pip install "cloakbrowser==0.4.0"
+python -c "import cloakbrowser; cloakbrowser.ensure_binary()"   # downloads stealth Chromium on first import
+
+# agent-browser (Apache-2.0, pin 0.29.1):
+npm i -g agent-browser@0.29.1 && agent-browser install
+agent-browser --version   # 0.29.1
+```
+
+Verify CloakBrowser:
+
+```bash
+python -c "import cloakbrowser; print(cloakbrowser.__version__, cloakbrowser.CHROMIUM_VERSION, cloakbrowser.binary_info()['installed'])"
+# -> 0.4.0  <chromium-version>  True
+```
+
+## Launch + drive
+
+```bash
+# 1. Launch CloakBrowser with CDP on :9242 (background). With the venv active:
+python -c "import asyncio,cloakbrowser; asyncio.run(cloakbrowser.launch_async(headless=False, stealth_args=True, args=['--remote-debugging-port=9242']))" &
+
+# 2. CloakBrowser launches tabless -> agent-browser would say "No page found".
+#    Open the first tab via CDP before any agent-browser command:
+curl -s -X PUT "http://127.0.0.1:9242/json/new?https://example.com"
+
+# 3. Connect agent-browser. CloakBrowser already patches navigator.webdriver=false at the
+#    C++ source, so NO --init-script is required — only --user-agent to hide HeadlessChrome:
+agent-browser --cdp 9242 \
+  --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7680.177 Safari/537.36" \
+  open https://example.com
+
+# 4. Interact:
+agent-browser --cdp 9242 snapshot -i        # interactive elements (@eN refs)
+agent-browser --cdp 9242 click @e3
+agent-browser --cdp 9242 screenshot out.png
+
+# 5. Close when done:
+agent-browser --cdp 9242 close
+```
+
+agent-browser ships its own always-version-matched usage guide — load it instead of guessing flags:
+
+```bash
+agent-browser skills get core            # core workflows, patterns, troubleshooting
+agent-browser skills get core --full     # + full command reference and templates
+agent-browser skills get electron        # Electron apps (VS Code, Slack, Discord, Figma, ...)
+agent-browser skills list                # everything available on the installed version
+```
+
+## Verify stealth
+
+```bash
+agent-browser --cdp 9242 eval 'navigator.webdriver'   # must print false
+```
+
+Tested May 2026: bot.sannysoft.com all-green, browserscan.net "Normal" (15/15), nowsecure.nl Turnstile bypassed.
+
+## Cookie login (cross-platform)
+
+`scripts/extract_cookies.py` reads cookies from a local browser profile and optionally injects them into the running CDP session. Profile-path resolution and value decryption are per-OS:
+
+| OS | Profile location | Cookie value decryption |
+|----|------------------|--------------------------|
+| macOS | `~/Library/Application Support/<app>/` | Keychain (AES-128-CBC, PBKDF2 salt `saltysalt`) |
+| Linux | `~/.config/<app>/` (Chromium), `~/.mozilla/firefox/` (Firefox) | libsecret/SecretService, then PBKDF2 + AES-128-CBC |
+| Windows | `%LOCALAPPDATA%\<app>\User Data\` | DPAPI (`CryptUnprotectData`) + AES-256-GCM (`os_crypt` key) |
+
+```bash
+# Extract to a file:
+mkdir -p ~/.local/state/insane-browsing-cookies
+python3 ../scripts/extract_cookies.py --browser chrome --domain youtube.com --output ~/.local/state/insane-browsing-cookies/youtube.cookies.json
+# Extract and inject into the running CDP session:
+python3 ../scripts/extract_cookies.py --browser chrome --domain youtube.com --inject --cdp 9242
+```
+
+Cookie export files are written with owner-only `0600` permissions. Do not place live auth cookies in shared temp directories or commit them to a repo. Cookie injection sends values to CDP over stdin rather than argv, so live cookie values do not appear in process listings. Cookies apply on next navigation — reload after injecting. Google services use fingerprint-bound tokens (SIDTS) that may not transfer across browser profiles. Firefox-family profiles store cookies unencrypted; Chromium-family profiles trigger a one-time OS-keyring prompt on macOS/Linux.
+
+## Anti-patterns
+
+- Do NOT launch CloakBrowser for plain text extraction — use Tier 1.
+- Do NOT pass an `--init-script` for the webdriver flag — CloakBrowser already patches it at source; the only required override is `--user-agent`.
+- Do NOT run agent-browser before creating the first tab via `curl -X PUT .../json/new` — CloakBrowser launches tabless.
+- Do NOT use vanilla Chrome when stealth is needed — always CloakBrowser.
+- Do NOT forget to `close` the session when done.
+- Do NOT inject cookies without reloading the page.
+
+## Troubleshooting
+
+```bash
+# Port 9242 already in use (macOS/Linux):
+lsof -ti:9242 | xargs kill -9
+# agent-browser can't connect:
+curl -s http://127.0.0.1:9242/json/version | head -5   # empty -> CloakBrowser not running
+# Update either tool:
+uv pip install --upgrade "cloakbrowser==0.4.0" && python -c "import cloakbrowser; cloakbrowser.ensure_binary()"
+npm i -g agent-browser@0.29.1
+```

--- a/skills/insane-browsing/references/insane-search/README.md
+++ b/skills/insane-browsing/references/insane-search/README.md
@@ -1,0 +1,319 @@
+
+# Insane Search
+
+> Part of the **insane-browsing** skill (Tier 1). Routing and tier-escalation live in [../../SKILL.md](../../SKILL.md).
+> The engine package it drives is at [../../engine/](../../engine/), invoked from the skill directory as `python3 -m engine "<URL>"`.
+> Deep-dives in this folder: TLS impersonation, Playwright routing, fallback, metadata, Jina, cache/archive, RSS, JSON/public APIs, Twitter, Naver, media.
+
+
+> URL 접근이 차단될 때, **사이트 무관한** 우회 전략을 자동 선택한다.
+
+## 하네스 규칙 (Claude에게 강제되는 지침)
+
+이 규칙은 Claude가 즉흥 판단으로 엇나가지 못하게 하기 위한 **고삐**다. 위반 시 이전 test.md 세션처럼 "chrome 200에서 break → safari 미시도 → Playwright 미설치라 포기" 식의 오판이 재현된다.
+
+**R1 — 일반 웹 URL 차단/403/402 감지 시**:
+1. WebFetch, 즉흥 curl, 수동 헤더 조합 **시도 금지**
+2. 즉시 다음을 실행:
+   ```bash
+   python3 -m engine "<URL>" [--selector "<CSS>"] [--device auto|desktop|mobile] [--trace]
+   ```
+3. 종료코드 0(ok) 또는 1(fail) 받은 뒤 판단. trace를 먼저 읽고 재시도 결정.
+4. 실패 시에만 `--trace --json`으로 재호출해서 원인 진단 후 `--device` 또는 `user_hint` 조정.
+
+**R2 — 첫 200에서 탈출 금지**: HTTP 200은 **검사 시작 조건**이지 성공이 아니다. `validate()`의 4-계층 검증을 통과해야 성공 선언. CLI는 이미 강제한다.
+
+**R3 — 편향 금지**: `engine/**`, `waf_profiles.yaml`에 특정 사이트 도메인·셀렉터·브랜드명 하드코딩 금지. `python3 engine/bias_check.py`가 CI 게이트. 자세한 규칙은 **No-Site-Name Rule** 섹션.
+
+**R4 — 힌트는 런타임에만**: 사이트 고유 정보(성공 셀렉터, 우선 Referer)는 CLI 인자 또는 `user_hint`로만 전달, 저장소에 고정 금지.
+
+**R5 — Phase 0 공식 API 우선**: X/Reddit/YouTube/HN/arXiv 등 **공식 공개 엔드포인트**가 있는 플랫폼은 Phase 0 테이블을 먼저 확인하고 해당 API를 쓴다. 이건 편향이 아니라 합의된 접근 경로.
+
+**R6 — 실패 선언은 전수 시도 후에만**: 격자(URL 변환 × TLS impersonate × Referer × Playwright fallback)를 **모두** 돌린 뒤에만 "뚫을 수 없음" 결론. CLI의 `max_attempts` 기본 12가 이를 보장.
+단, R7 조건(WAF 조기 감지)이 성립하면 engine 격자는 계속 돌되, Claude가 **병렬로** MCP 정찰 루트를 시도할 수 있다. 빠른 쪽이 이긴다.
+
+**R7 — WAF 조기 감지 시 API-first 병행 분기** (분기 결정은 자동이지만 사용자가 결과에서 확인 가능 — 어떤 우회 경로로 성공/실패했는지 결과 metadata에 명시):
+발동 조건 (AND):
+1. engine 실행 초기에 첫 2~3회 attempt가 모두 `verdict=challenge`
+2. `profile_used`가 `akamai_bot_manager`, `cloudflare_turnstile`, `datadome_probable`, `perimeterx_human`, `f5_big_ip`, `aws_waf` 중 하나로 확정
+3. **사용자 요청이 리스트/수집/반복 의도** (여러 페이지, N개 이상, "전부", "크롤링", 페이지네이션 등). 단건 본문 조회는 해당 없음.
+
+세 조건 모두 참일 때 Claude는 **병렬 경로**를 시작한다:
+
+**"병렬"의 실행 의미** (Claude 도구 호출이 순차이므로 명확화):
+- engine은 `run_in_background=true`로 Bash 툴에서 띄워둔다 — 격자는 그대로 돌되 블로킹하지 않음
+- Claude는 그 사이 foreground에서 MCP Playwright 정찰 루트를 진행
+- engine이 먼저 성공해도 좋고, MCP 정찰로 얻은 API가 먼저 성공해도 좋음. 빠른 쪽 결과 채택
+
+**MCP 정찰 루트**:
+1. `mcp__playwright__browser_navigate` → 대상 페이지 로드 (브라우저 렌더링)
+2. `mcp__playwright__browser_network_requests` → XHR/fetch 호출 목록 수집, `/api/`·`/graphql`·`\.json` 필터로 내부 엔드포인트 식별
+3. 식별된 JSON API URL을 `python3 -m engine <API_URL>`로 재호출 (백그라운드 engine과는 별개 호출). 대부분 API 레이어는 페이지 HTML보다 WAF 보호가 얕아 curl_cffi로 바로 수집됨
+4. 응답 스키마 파악 후 pagination / query parameter 조합해 반복 수집
+
+**왜**: SPA + WAF 사이트(쇼핑몰·커머스 다수)는 마케팅 페이지(HTML)만 WAF로 중투자하고 내부 API는 gateway 레벨 기본 방어만 쓰는 경우가 많다. HTML 격자 전수 낭비(50회 × 0.5s + Playwright fallback 40s ≈ 65초)보다 **MCP 정찰 1회(5~10초) + API 재호출(0.5초)**가 훨씬 경제적이고 성공률 높음.
+
+**R7을 쓰지 말아야 할 때**: 단일 페이지 본문 읽기만 필요한 단건 조회(문서 하나, 블로그 포스트 하나)는 engine만으로 충분하다 — 발동 조건 #3이 이를 배제한다.
+
+**R7 편향 방지**: 내부 API URL·파라미터는 `engine/**`에 하드코딩 금지. 탐지된 URL은 런타임 호출에만 쓰고 저장소에 고정하지 않는다.
+
+---
+
+이 스킬의 핵심 불변식:
+
+- **단일 진입점**: 일반 웹 페이지는 항상 `python3 -m engine <URL>` 또는 `from engine import fetch; fetch(...)`.
+- **편향 금지**: `engine/**`, `waf_profiles.yaml`에 특정 사이트 하드코딩 금지.
+- **힌트는 런타임에만**: 사이트 고유 정보는 CLI/`user_hint` 경유.
+
+## 의도 분류 (Phase 0 진입 전)
+
+| 사용자 입력 | 경로 |
+|------------|------|
+| URL 제공 (`https://...`) | → Phase 0 검사 후 없으면 Phase 1 (generic fetch chain) |
+| 핸들 제공 (`@username`) | → Phase 0 syndication/API |
+| 키워드만 ("X에서 AI 검색") | → WebSearch(`site:{domain} {keyword}`) 먼저 → URL 확보 후 재진입 |
+
+> **한국어 신규 콘텐츠 한계**: 네이버/다음/한국 커뮤니티의 키워드 검색은 WebSearch 경유가 유일하며, 신규 콘텐츠 인덱싱이 지연될 수 있다.
+
+## Phase 0 — 플랫폼 공식 API 인덱스
+
+> 플랫폼이 **공식 공개한** 전용 API/CLI만 여기에 둔다. 이건 편향이 아니라 합의된 엔드포인트 사용이다.
+
+### 소셜/커뮤니티 전용 API
+
+| 플랫폼 | 방법 | 상세 |
+|--------|------|------|
+| X/Twitter | syndication (타임라인) + oEmbed (개별 트윗) + 키워드 검색: WebSearch → oEmbed | [twitter.md](twitter.md) |
+| Reddit | URL + `.json` + Mobile UA | [json-api.md](json-api.md) |
+| Bluesky | AT Protocol (`public.api.bsky.app/xrpc/...`) | [public-api.md](public-api.md) |
+| Mastodon | 인스턴스별 공개 API | [public-api.md](public-api.md) |
+| Hacker News | Firebase API + Algolia Search | [json-api.md](json-api.md) |
+| Stack Overflow | SE API v2.3 | [public-api.md](public-api.md) |
+| Lobste.rs / V2EX / dev.to | 공개 JSON API | [json-api.md](json-api.md) |
+
+### 미디어 (CLI 도구 필수)
+
+| 플랫폼 | 방법 | 상세 |
+|--------|------|------|
+| YouTube/Vimeo/Twitch/TikTok/SoundCloud 등 1,858개 | `yt-dlp --dump-json` | [media.md](media.md) |
+
+### 학술/레지스트리
+
+| 플랫폼 | 방법 | 상세 |
+|--------|------|------|
+| arXiv | Atom API | [public-api.md](public-api.md) |
+| CrossRef | REST API | [public-api.md](public-api.md) |
+| Wikipedia | REST API | [json-api.md](json-api.md) |
+| OpenLibrary | JSON API | [public-api.md](public-api.md) |
+| GitHub | gh CLI / REST API | [public-api.md](public-api.md) |
+| npm / PyPI | Registry API | [json-api.md](json-api.md) |
+| Wayback Machine | CDX API | [public-api.md](public-api.md) |
+
+### 한국 전용 공식 API
+
+| 플랫폼 | 방법 | 상세 |
+|--------|------|------|
+| 네이버 검색 | `search.naver.com` (통합/블로그/뉴스탭) | [naver.md](naver.md) |
+| 네이버 금융 시세 | `api.finance.naver.com/siseJson.naver` (비공식 JSON) | [naver.md](naver.md) |
+
+**그 외 모든 사이트는 Phase 1(generic fetch chain)이 자동 처리한다.**
+
+## Phase 1 — Generic Fetch Chain
+
+### 단일 진입점
+
+```python
+from insane_search.engine import fetch
+
+result = fetch(
+    "https://example.com/path",
+    success_selectors=["article", "[class*='product-card']"],  # 포지티브 프루프 (선택)
+    device_class="auto",      # "auto" | "desktop" | "mobile"
+    user_hint=None,           # {"referer_strategy": "self_root", "impersonate_first": "safari"}
+    timeout=25,
+)
+
+if result.ok:
+    print(result.verdict)     # strong_ok | weak_ok
+    html = result.content
+else:
+    # Phase 3 수동 개입 (Playwright MCP) 필요 — result.trace로 원인 진단
+    pass
+```
+
+### 내부 단계 (디버깅용 노출)
+
+`fetch()`는 단일 API이지만 내부는 phase로 나뉘어 있다. `result.trace`에서 각 시도를 확인할 수 있다.
+
+```
+probe      — curl_cffi + safari + self-referer로 첫 시도
+validate   — 4-계층 검증 (marker / size / cookie / success_selectors)
+detect     — WAF 제품 감지 ([(profile_id, confidence)] 랭킹)
+plan       — 프로파일의 tls_candidates × url_transforms × referer 격자 구성
+execute    — 격자 전수 시도 (첫 200에서 탈출하지 않음)
+fallback   — capability 태그 기반 Playwright 라우팅 (MCP or local+chrome)
+report     — FetchResult(ok, verdict, profile_used, trace, summary)
+```
+
+### 검증 원칙
+
+- HTTP 200은 **검사 시작 조건**이지 성공이 아니다.
+- 성공 판정은 **4-계층 AND**:
+  1. 챌린지 마커 없음 (`sec-if-cpt-container`, `Access Denied`, `Just a moment...`, `DataDome`)
+  2. 비정상 크기 아님 (< 3KB 또는 WAF fingerprint 크기)
+  3. 쿠키 센서 상태 정상 (`_abck=~-1~` 아님)
+  4. `success_selectors` 중 하나 이상 매칭 (caller 제공 시 → `strong_ok`, 미제공 시 → `weak_ok`)
+
+### 격자 축 (profile이 우선순위 추천, 격자는 전수 시도)
+
+| 축 | 값 | 비고 |
+|----|-----|------|
+| `url_transforms` | `original`, `mobile_subdomain` (`www.→m.`), `am_prefix`, `drop_www` | 사이트명 없음, 규칙만 |
+| `tls_impersonate` | `safari`, `safari_ios`, `chrome99`, `chrome119`, `chrome131`, `chrome_android`, `firefox`... | 프로파일별 avoid 리스트 존재 |
+| `referer_strategy` | `self_root`, `google_search`, `none` | |
+
+**device_class**:
+- `"auto"` (기본) — 프로파일 전략 따름
+- `"desktop"` — TLS 데스크톱만 + `mobile_subdomain` 비활성
+- `"mobile"` — TLS 모바일만 + `mobile_subdomain` 활성
+
+### Playwright 폴백 (capability-matched)
+
+`engine/executor.py`가 프로파일의 `capabilities_needed`를 읽고 실행기를 자동 선택:
+
+| 태그 | 실행기 | 언제 |
+|------|--------|------|
+| `needs_real_tls_stack` + `needs_js_exec` | `playwright_real_chrome.js` (로컬 Node) | Akamai Bot Manager 등 — Chromium 번들 TLS는 탐지됨 |
+| `needs_js_exec` only | Playwright MCP (`mcp__playwright__*`) | Cloudflare 기본 방어 등 |
+| `needs_mobile_context` (+ real_tls) | `playwright_mobile_chrome.js` | 모바일 디바이스 에뮬레이션 필요 |
+
+자세한 선택 기준: [playwright.md](playwright.md).
+
+### Playwright MCP 호출 규칙
+
+`fetch_chain`의 `needs_js_exec only` 케이스는 **Claude 세션에서 MCP 도구를 직접 호출**해야 한다. subprocess 경로 없음. 즉:
+1. `result.summary`에 "Playwright MCP must be invoked from the Claude session"이 포함되면
+2. `mcp__playwright__browser_navigate` → `browser_wait_for` → `browser_snapshot` 흐름으로 Claude가 직접 처리
+
+## Phase 2 — 수동 개입 (옵션)
+
+Phase 1이 `ok=False`를 반환하면 사용자 힌트를 받아 재시도:
+
+```python
+result = fetch(
+    url,
+    success_selectors=[...],
+    user_hint={"impersonate_first": "safari_ios", "referer_strategy": "none"},
+)
+```
+
+힌트는 **현재 호출 1회에만** 적용되며 저장되지 않는다.
+
+## 의존성 자동 설치
+
+최초 호출 시 필요 패키지를 자동 설치한다:
+```bash
+python3 -c "import curl_cffi, bs4, yaml" 2>/dev/null || pip install curl_cffi beautifulsoup4 pyyaml -q
+```
+
+Playwright 로컬 경로 사용 시 Node가 필요:
+```bash
+npm i -g playwright playwright-extra puppeteer-extra-plugin-stealth
+npx playwright install chrome
+```
+
+## 빠른 참조 — Phase 0 명령어
+
+```bash
+# 범용 웹 (Jina Reader — 일반 HTML만, WAF 사이트엔 무효)
+curl -s "https://r.jina.ai/{URL}"
+
+# yt-dlp — 1,858 사이트 미디어 메타데이터
+yt-dlp --dump-json "URL"
+
+# Reddit
+curl -sL -H "User-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15" \
+  "https://www.reddit.com/r/{sub}/hot.json?limit=10"
+
+# X/Twitter 타임라인
+curl -sL "https://syndication.twitter.com/srv/timeline-profile/screen-name/{handle}"
+
+# Hacker News
+curl -sL "https://hacker-news.firebaseio.com/v0/topstories.json?limitToFirst=10&orderBy=%22%24key%22"
+
+# YouTube 자막
+yt-dlp --write-sub --write-auto-sub --sub-lang "en,ko" --skip-download -o "/tmp/%(id)s" "URL"
+```
+
+## No-Site-Name Rule
+
+`engine/**`, `waf_profiles.yaml`, `engine/templates/**` 파일에는 **특정 사이트의 도메인/URL/셀렉터/브랜드명을 하드코딩하지 않는다**.
+
+### 금지
+
+- `"coupang.com": {...}` 같은 사이트별 레지스트리 엔트리
+- `if "coupang" in url: ...` 같은 도메인 분기
+- WAF 프로파일 `notes`에 특정 사이트 이름이나 경험적 byte 크기 박제
+
+### 허용
+
+- `SKILL.md` / `references/*.md`의 **설명 텍스트**에 사이트 이름 예시 (독자 이해용)
+- `Phase 0` 공식 API 인덱스 (플랫폼이 공식 공개한 엔드포인트)
+- `observations/*.jsonl` 로그 (append-only 관측 데이터 — 코드 경로에 영향 없음)
+- 호출자가 제공하는 `success_selectors`, `user_hint` (현재 호출에만 유효)
+
+### 경계 사례 판단 기준
+
+> "이 엔트리가 다른 사이트에서도 같은 WAF를 쓰면 일반적으로 유효한가?" → YES면 `waf_profiles.yaml`, NO면 runtime hint.
+
+### 새 사이트가 안 뚫릴 때
+
+1. 먼저 `result.trace`에서 어느 phase가 실패했는지 확인
+2. 사용자의 `user_hint`로 1회 재시도
+3. 반복 성공 패턴이 관측되면 `observations/`에 로그 (아직 자동 기록 없음 — 수동)
+4. 3회+ 반복 확인되고 **동일 WAF를 쓰는 다른 사이트에도 유효**하면 `waf_profiles.yaml` 해당 프로파일의 `tls_impersonate_candidates` / `url_transform_order`를 튜닝 (사이트명 절대 넣지 않음)
+5. 여전히 안 되면 새 WAF 프로파일 후보 검토 (예: DataDome 세부화, Kasada 등)
+
+## 관련 문서 (references/) — 언제 무엇을 읽을지
+
+이 섹션은 **참조 파일 선택 가이드**다. 문제가 생겼을 때 어떤 `references/*.md`를 열어야 할지 결정하는 기준으로 쓴다. Claude는 필요할 때만 해당 파일을 `Read`하고, 선제적으로 전부 읽지 않는다.
+
+### A. Engine 확장·진단 (하네스 내부)
+
+| 파일 | 언제 읽는가 | 무엇을 다루는가 |
+|------|-------------|-----------------|
+| [`tls-impersonate.md`](tls-impersonate.md) | curl_cffi 격자가 전부 `challenge`/`blocked`로 끝날 때, 새 impersonate 타겟을 `waf_profiles.yaml`에 추가할 때 | curl_cffi로 Safari/Chrome/Firefox TLS(JA3/JA4) 지문 복제하는 방법, WAF(Akamai/Cloudflare/F5 등)별 최적 타겟 조합, 임퍼소네이션 타겟 버전 목록, `tls_impersonate_avoid`의 실증 근거 |
+| [`playwright.md`](playwright.md) | engine이 Playwright fallback으로 넘어가는데 MCP/Local Chrome 중 어디로 갈지 확인 필요할 때 | Approach 1 (`mcp__playwright__*` — Cloudflare급 챌린지), Approach 2 (Local Node + `channel:'chrome'` + stealth — Akamai Bot Manager급), 템플릿 파라미터 규격 |
+| [`fallback.md`](fallback.md) | `verdict`가 애매하거나 Phase 전환 타이밍 결정 필요할 때 | engine의 Phase 0→1→2→3 에스컬레이션 원칙, 응답 성공/실패 판정 기준 세부, 각 Phase 종료 조건 |
+| [`metadata.md`](metadata.md) | 본문 전체를 못 가져왔지만 제목·요약·가격·저자 같은 핵심만이라도 필요할 때 | OGP 메타 태그, JSON-LD (Schema.org), Twitter Card 파싱, 구조화 데이터 추출 패턴 |
+
+### B. 경량 대안 (engine 말고 다른 도구가 나은 상황)
+
+| 파일 | 언제 읽는가 | 무엇을 다루는가 |
+|------|-------------|-----------------|
+| [`jina.md`](jina.md) | WAF 없는 일반 웹(블로그·뉴스·Wiki)의 깨끗한 마크다운 추출 필요할 때 | `r.jina.ai/URL` 한 줄로 Puppeteer 기반 JS SPA 렌더링, 마크다운 변환, 무료 500 RPM, API 키 불필요 |
+| [`cache-archive.md`](cache-archive.md) | 원본 사이트가 차단됐지만 과거 스냅샷으로라도 접근 필요할 때 | Wayback Machine CDX API, archive.today, AMP Cache (Google Cache는 2024-07 종료됨) |
+| [`rss.md`](rss.md) | 뉴스·블로그·커뮤니티의 시계열 업데이트를 구조화해 받고 싶을 때 | RSS/Atom 자동 발견, 피드 파싱, 인증 불필요 — 가장 깔끔한 시계열 데이터 소스 |
+
+### C. 플랫폼별 공식/공개 API (Phase 0 인덱스와 연결)
+
+| 파일 | 언제 읽는가 | 무엇을 다루는가 |
+|------|-------------|-----------------|
+| [`json-api.md`](json-api.md) | Reddit/Wikipedia/HN/npm/PyPI 등 **URL 변형만으로** JSON을 주는 사이트 | Reddit `/json` suffix + Mobile UA, HN Firebase, Algolia Search, Wikipedia REST, npm/PyPI Registry API |
+| [`public-api.md`](public-api.md) | Bluesky/Mastodon/arXiv/Stack Overflow/CrossRef/GitHub/OpenLibrary/Wayback 공식 API 사용 시 | 인증 없이 쓰는 공식 공개 REST/AT/Atom API 엔드포인트, 요청 형식, 공통 파라미터 |
+| [`twitter.md`](twitter.md) | X/Twitter 접근 — 프로필 타임라인, 특정 트윗, 키워드 검색 | `syndication.twitter.com` 타임라인, oEmbed 개별 트윗, 검색은 WebSearch로 URL 확보 후 oEmbed |
+| [`naver.md`](naver.md) | 네이버 블로그·뉴스·증권·검색 접근 | 서비스별 우회(블로그는 `m.blog.naver.com` 변환, 증권은 비공식 JSON, 검색은 `search.naver.com`), 한글 검색 쿼리 패턴 |
+| [`media.md`](media.md) | YouTube/Vimeo/Twitch/TikTok/SoundCloud 등 미디어 메타·자막·오디오 필요 시 | `yt-dlp --dump-json` 기반 1,858개 사이트 커버, 자막 다운로드(`--write-sub`), 포맷 선택, 라이브/팟캐스트 |
+
+### D. Engine 코드 직접 읽을 때
+
+| 파일 | 언제 읽는가 |
+|------|-------------|
+| `engine/fetch_chain.py` | 체인 단계 로직·`Attempt`/`FetchResult` schema 확인 |
+| `engine/validators.py` | 4-계층 검증 세부 (Verdict 분류, 챌린지 마커 목록) |
+| `engine/waf_detector.py` | WAF 랭킹 감지 알고리즘, `_LAST_LOAD_ERROR` 처리 |
+| `engine/waf_profiles.yaml` | 프로파일별 detectors·tls_candidates·capabilities_needed |
+| `engine/url_transforms.py` | URL 변환 규칙 추가할 때 |
+| `engine/executor.py` | Playwright MCP vs local capability 매칭 로직 |
+| `engine/templates/*.js` | Playwright 템플릿 튜닝 (warmup, reload, devices) |
+| `engine/bias_check.py` | 편향 린터 규칙 — brand denylist, URL_PATTERN, excluded dirs |

--- a/skills/insane-browsing/references/insane-search/README.md
+++ b/skills/insane-browsing/references/insane-search/README.md
@@ -123,7 +123,7 @@
 ### 단일 진입점
 
 ```python
-from insane_search.engine import fetch
+from engine import fetch
 
 result = fetch(
     "https://example.com/path",

--- a/skills/insane-browsing/references/insane-search/cache-archive.md
+++ b/skills/insane-browsing/references/insane-search/cache-archive.md
@@ -1,0 +1,83 @@
+# 캐시 & 아카이브
+
+> 원본 사이트가 차단되었을 때 캐시된/아카이브된 버전으로 접근.
+> Google Cache는 2024년 7월 종료됨 — AMP 캐시와 archive.today가 대체.
+
+## 의존성
+
+없음 (curl만 사용).
+
+## 1. Google AMP 캐시
+
+AMP 지원 사이트의 캐시 버전. 뉴스/미디어 사이트에 효과적.
+
+```bash
+# URL 변환: domain의 .을 -로 → cdn.ampproject.org
+# 예: www.bbc.com → www-bbc-com.cdn.ampproject.org
+
+python3 -c "
+from urllib.parse import urlparse
+url = '{URL}'
+p = urlparse(url)
+domain_sub = p.netloc.replace('.', '-')
+print(f'https://{domain_sub}.cdn.ampproject.org/c/s/{p.netloc}{p.path}')
+"
+
+# 변환된 URL로 접근
+curl -sL "https://{domain-with-dashes}.cdn.ampproject.org/c/s/{netloc}{path}"
+```
+
+**성공 조건**: 사이트가 AMP 페이지를 제공하는 경우 (대부분의 뉴스/미디어)
+**실패 조건**: AMP 미지원 사이트, 매우 최신 콘텐츠 (캐시 지연 ~15초)
+
+## 2. archive.today
+
+사용자 제출 아카이브. 페이월 기사, 삭제된 콘텐츠에 특히 유용.
+도메인이 여러 개 — 하나가 차단되면 다른 것 사용.
+
+```bash
+# 최신 스냅샷 조회
+curl -sL "https://archive.ph/newest/{URL}"
+
+# 도메인 로테이션 (하나가 차단되면 다른 것)
+for domain in archive.ph archive.is archive.md archive.vn archive.li; do
+  resp=$(curl -sL -o /dev/null -w "%{http_code}" "https://$domain/newest/{URL}")
+  if [ "$resp" = "200" ] || [ "$resp" = "302" ]; then
+    echo "성공: https://$domain/newest/{URL}"
+    curl -sL "https://$domain/newest/{URL}"
+    break
+  fi
+done
+```
+
+**성공 조건**: 누군가 이전에 해당 URL을 아카이브한 경우
+**실패 조건**: 아카이브된 적 없는 URL
+
+## 3. Wayback Machine (Internet Archive)
+
+```bash
+# 스냅샷 존재 여부 확인
+curl -sL "https://archive.org/wayback/available?url={URL}"
+
+# 최신 스냅샷으로 접근
+curl -sL "https://web.archive.org/web/{URL}"
+
+# CDX API — 스냅샷 목록 조회
+curl -sL "https://web.archive.org/cdx/search/cdx?url={URL}&output=json&fl=timestamp,statuscode&limit=5"
+```
+
+**성공 조건**: 크롤링 대상이었던 공개 URL
+**실패 조건**: robots.txt로 차단된 사이트, SPA (렌더링 안 됨), iframe 기반 사이트
+
+## 4. Google Cache (종료됨)
+
+> **2024년 7월 종료.** `webcache.googleusercontent.com`은 더 이상 동작하지 않음.
+> 대신 AMP 캐시 또는 archive.today를 사용.
+
+## 시도 순서
+
+```
+1. AMP 캐시 (뉴스/미디어 사이트 → 높은 성공률)
+2. archive.today (페이월/삭제 콘텐츠 → 아카이브 있으면 확실)
+3. Wayback Machine (오래된 콘텐츠 → 스냅샷 있으면 확실)
+```

--- a/skills/insane-browsing/references/insane-search/fallback.md
+++ b/skills/insane-browsing/references/insane-search/fallback.md
@@ -1,0 +1,159 @@
+# 접근 실패 시 — 적응형 스케줄러
+
+> 인덱스 방법이 실패하거나 인덱스에 없는 사이트일 때 실행.
+> Phase 0 → 1 → 2 → 3 순서로 에스컬레이션. 각 Phase에서 성공하면 즉시 종료.
+
+## 원칙
+
+1. **어떤 방법도 미리 제외하지 않는다** — 되는지는 시도해봐야 안다
+2. **의존성이 없으면 설치하고 시도한다** — 미설치를 이유로 건너뛰지 않는다
+3. **Phase 간 전환은 신호 기반** — 실패 유형에 따라 에스컬레이션
+4. **결과 채택 기준**: 정확성/신뢰도 > 신선도 > 완전성 > 구조화 > 비용
+
+---
+
+## Phase 0: 특수 엔드포인트 (인덱스 매칭)
+
+인덱스에 사이트가 있으면 해당 전용 방법을 **먼저** 시도.
+정확성과 비용이 가장 좋으므로 generic Phase 1보다 우선.
+
+성공 → 종료 / 실패 → Phase 1
+
+---
+
+## Phase 1: 경량 프로브 (병렬)
+
+**먼저 시도** (동시):
+- WebFetch (Claude 내장)
+- Jina Reader (기본 / JSON / SPA 모드)
+- curl Chrome Desktop UA
+
+**아직 성공 없으면 추가 시도**:
+- curl 모바일 UA + 모바일 URL (`m.{domain}`)
+- curl Googlebot UA
+- URL 변형 시도: `.json`, `/rss`, `/feed`
+
+**사이드카** (1차와 동시, low-trust):
+- Google AMP 캐시
+- archive.today
+- Wayback Machine
+→ **원본이 하나라도 성공하면 사이드카는 참고만.** 전부 실패 시에만 사이드카 채택 (provenance 태깅 필수)
+
+**모든 응답에서 메타데이터도 추출**: OGP, JSON-LD — [metadata.md](metadata.md) 참조
+
+상세: [jina.md](jina.md), [cache-archive.md](cache-archive.md), [rss.md](rss.md)
+
+---
+
+## 에스컬레이션 신호
+
+Phase 1 → Phase 2 전환 조건:
+
+| 신호 | 감지 방법 | 의미 |
+|------|-----------|------|
+| HTTP 403/430 | 상태 코드 | WAF/봇 차단 |
+| HTTP 429/503 | 상태 코드 | Rate limit (짧은 jitter retry 먼저, 실패 시 에스컬레이션) |
+| WAF 헤더 | `cf-ray`, `server: cloudflare`, `x-datadome` | Cloudflare/Akamai/DataDome |
+| WAF 쿠키 | `__cf_bm`, `_abck`, `datadome` | WAF 세션 |
+| 챌린지 본문 | `captcha`, `verify`, `enable javascript`, `check your browser` | JS 챌린지 |
+| 빈 SPA | `<div id="root"></div>` 외 콘텐츠 없음, 200자 미만 | JS 렌더링 필요 |
+| Redirect loop | 3회 이상 302/307 | 챌린지 리다이렉트 |
+
+**login/paywall 감지 시**: `login`, `sign in`, `로그인`, `subscribe`, `구독` 집중 → Phase 2/3으로 올려도 해결 안 됨. **"인증 필요"로 종료.**
+
+---
+
+## Phase 2: TLS 임퍼소네이션 (curl_cffi)
+
+**조건**: Phase 1에서 WAF/봇 차단 신호 감지
+
+**의존성 확보**:
+```bash
+python3 -c "import curl_cffi" 2>/dev/null || pip install curl_cffi -q
+```
+설치 실패 시 → 즉시 Phase 3으로.
+
+**다중 타겟 순차 시도**: safari → chrome → firefox
+
+```python
+from curl_cffi import requests
+
+TARGETS = ["safari", "chrome", "firefox"]
+HEADERS = {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8",
+    "Referer": "https://www.google.com/",
+}
+
+for target in TARGETS:
+    try:
+        session = requests.Session(impersonate=target)
+        session.headers.update(HEADERS)
+        resp = session.get("{URL}", timeout=20)
+        if resp.status_code == 200 and len(resp.text) > 300:
+            # 성공 — JSON-LD도 같이 추출
+            break
+    except:
+        continue
+```
+
+성공 → 종료 / 실패 또는 JS 챌린지 → Phase 3
+
+상세: [tls-impersonate.md](tls-impersonate.md)
+
+---
+
+## Phase 3: Playwright MCP (브라우저)
+
+**조건**: Phase 2도 실패 또는 JS 챌린지/CAPTCHA 감지
+
+```
+browser_navigate → {URL}
+browser_wait_for → "body" (3초)
+browser_evaluate → () => document.body.innerText  (Light Mode — 먼저)
+필요 시 browser_snapshot → 접근성 트리 전체
+```
+
+**API 발견**: `browser_network_requests`로 숨은 JSON API를 찾으면 이후 curl_cffi로 재사용 가능.
+
+상세: [playwright.md](playwright.md)
+
+---
+
+## 응답 검증
+
+| 판정 | 조건 | 결과 |
+|------|------|------|
+| **성공** | 콘텐츠 타입에 맞는 분량 + 주제 관련 키워드 | 채택 |
+| **부분 성공** | OG 메타/JSON-LD만 (본문 없음) | 보조 소스 |
+| **실패 — 인증** | login/paywall 감지 | "인증 필요"로 종료 |
+| **실패 — 챌린지** | CAPTCHA/JS challenge | 다음 Phase로 |
+| **실패 — 에러** | 4xx/5xx | 다음 Phase로 |
+| **실패 — 빈 SPA** | 콘텐츠 없음 | 다음 Phase로 |
+
+**콘텐츠 분량 기준** (유연하게):
+- 기사/블로그: 500자 이상
+- 상품 페이지: JSON-LD 있으면 성공
+- 트윗/짧은 글: 100자 이상
+- 프로필: JSON-LD Person 있으면 성공
+
+## False-Positive 마커 (HTTP 200이지만 실패)
+
+| 패턴 | 감지 방법 | 처리 |
+|------|----------|------|
+| X SPA 셸 (247KB) | 200 OK + `Sign in to X` 또는 `hasResults: false` | 실패 — WebSearch+oEmbed 폴백 |
+| CAPTCHA 페이지 | 200 OK + `captcha\|recaptcha\|hcaptcha\|cf-turnstile` | 실패 — 다음 Phase |
+| 소프트 페이월 | 200 OK + `member-only\|subscribe to read\|구독하세요` | 부분 성공 — 메타만 채택 |
+| DDG 소프트 리밋 | 202 Accepted + body 15KB 미만 | 실패 — 다른 엔진 폴백 |
+| 빈 JSON | 200 OK + `hasResults.*false\|"entries":\s*\[\]` | 실패 — 다른 방법 시도 |
+| 지역 차단 | 200 OK + `not available in your region\|geo-restricted` | 실패 — "지역 차단" 알림 |
+| WAF 소프트 블록 | 200 OK + `checking your browser\|verify you are human` | 실패 — Phase 2/3 에스컬레이션 |
+| Akamai behavioral | 200 OK + `behavioral-content\|sec-if-cpt` + `_abck` 쿠키 | 실패 — JS 실행 필수 → Phase 3 직행 (TLS 타겟 변경 무의미) |
+| RSS Content-Type 오류 | RSS 기대 + `text/html` 응답 | 실패 — "RSS 미지원" |
+| 에러 JSON | 200 OK + JSON `"error"` 키 존재 | 실패 — 에러 내용 로깅 |
+
+## 전부 실패 시
+
+1. 시도한 Phase와 각 실패 신호를 기록
+2. 사이드카 결과가 있으면 provenance 태깅하여 채택
+3. 사이드카도 없으면 사용자에게 실패 보고 + 시도 결과 공유

--- a/skills/insane-browsing/references/insane-search/jina.md
+++ b/skills/insane-browsing/references/insane-search/jina.md
@@ -1,0 +1,130 @@
+# 범용 웹 추출 — Jina Reader
+
+> `r.jina.ai/URL` 한 줄로 거의 모든 공개 URL을 마크다운으로 변환.
+> Puppeteer 기반 실제 브라우저 렌더링 — JS SPA까지 처리.
+> **API 키 불필요. 무료: 분당 500 RPM.**
+
+## 기본 사용
+
+```bash
+curl -s "https://r.jina.ai/{URL}"
+```
+
+## 고급 기능
+
+### JSON 구조화 출력
+
+```bash
+curl -H "Accept: application/json" "https://r.jina.ai/{URL}"
+```
+
+반환: `data.{title, description, url, content, metadata, external, usage}`
+
+**핵심**: `external.alternate`에서 사이트의 **RSS URL을 자동 발견** 가능.
+
+### CSS 선택자 타겟팅
+
+```bash
+curl -H "X-Target-Selector: .article-body" "https://r.jina.ai/{URL}"
+```
+
+네비게이션/풋터 제거, 본문만 추출. 커뮤니티 게시판에서 특히 효과적.
+
+### SPA 스트리밍 모드
+
+```bash
+curl -H "Accept: text/event-stream" "https://r.jina.ai/{URL}"
+```
+
+JS 로딩 완료까지 대기. 동적 콘텐츠가 완전히 렌더링된 최종 버전 반환.
+
+### 스크린샷
+
+```bash
+curl -H "X-Respond-With: screenshot" "https://r.jina.ai/{URL}"
+```
+
+GCS 서명 URL 반환 (4시간 유효). 비주얼 검증 용도.
+
+### PDF 처리
+
+```bash
+curl -s "https://r.jina.ai/https://example.com/file.pdf"
+```
+
+PDF → 마크다운 자동 변환. 페이지 수 메타데이터 포함.
+
+### 쿠키 전달 (인증 사이트)
+
+```bash
+curl -H "X-Set-Cookie: session=abc123" "https://r.jina.ai/{URL}"
+```
+
+### 링크 보존
+
+```bash
+curl -H "X-With-Links: true" "https://r.jina.ai/{URL}"
+```
+
+### 캐시 제어
+
+```bash
+# 캐시 우회 (실시간 필요 시)
+curl -H "X-No-Cache: true" "https://r.jina.ai/{URL}"
+
+# 캐시 TTL 지정 (초)
+curl -H "X-Cache-Tolerance: 600" "https://r.jina.ai/{URL}"
+```
+
+### 순수 텍스트 / 원본 HTML
+
+```bash
+# body.innerText만
+curl -H "X-Respond-With: text" "https://r.jina.ai/{URL}"
+
+# 원본 HTML
+curl -H "X-Respond-With: html" "https://r.jina.ai/{URL}"
+```
+
+## 검증된 성공 사이트
+
+| 사이트 | 결과 | 비고 |
+|--------|------|------|
+| Threads | 성공 | 프로필 + 포스트 |
+| 클리앙 | 성공 | 게시글 목록 + 본문 |
+| 루리웹 | 성공 | 게시글 목록 + 본문 |
+| 뽐뿌 | 성공 | 게시글 + RSS도 가능 |
+| 네이버 뉴스 | 성공 | 기사 목록 + 본문 완전 |
+| 네이버 증권 | 성공 | 실시간 주가 |
+| 긱뉴스 | 성공 | 토픽 목록 + 본문 |
+| 44bits | 성공 | 기사 목록 |
+| 커리어리 | 성공 | JS 렌더링으로 추출 |
+| 브런치 | 성공 | 기사 전문 |
+| 한경 | 성공 | 뉴스 기사 |
+| 다음 뉴스 | 성공 | 뉴스 기사 |
+| Medium | 성공 | 기사 전문 (paywall 제외) |
+| Substack | 성공 | 뉴스레터 전문 |
+| dev.to | 성공 | 기사 전문 |
+| PDF (모든 URL) | 성공 | 자동 변환 |
+
+## 실패하는 사이트
+
+| 사이트 | 이유 |
+|--------|------|
+| X/Twitter | 402 — Syndication/oEmbed 사용 (twitter.md 참조) |
+| Reddit | 차단 — JSON API 사용 (json-api.md 참조) |
+| 디시인사이드 | 빈 본문 반환 |
+| 에펨코리아 | HTTP 430 |
+| 요즘IT | CloudFront 403 |
+| 네이버 쇼핑 | CAPTCHA |
+| 쿠팡 | WAF 차단 |
+
+
+## RSS 자동 발견
+
+Jina JSON 모드의 `external.alternate`에서 사이트의 RSS URL이 자동 노출됨:
+
+```bash
+curl -H "Accept: application/json" "https://r.jina.ai/{URL}" | \
+python3 -c "import sys,json; print(json.load(sys.stdin)['data'].get('external',{}))"
+```

--- a/skills/insane-browsing/references/insane-search/json-api.md
+++ b/skills/insane-browsing/references/insane-search/json-api.md
@@ -1,0 +1,133 @@
+# JSON API 직접 호출
+
+> URL 변형이나 공개 엔드포인트로 구조화된 JSON을 직접 가져오는 패턴.
+> 인증 불필요. Jina Reader보다 빠르고 정확한 구조화 데이터 획득.
+
+## Reddit
+
+**Mobile User-Agent 필수** (없으면 403/429).
+
+```bash
+UA="Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15"
+
+# 서브레딧 핫 포스트
+curl -sL -H "User-Agent: $UA" "https://www.reddit.com/r/{subreddit}/hot.json?limit=10"
+
+# 검색
+curl -sL -H "User-Agent: $UA" "https://www.reddit.com/r/{subreddit}/search.json?q={query}&restrict_sr=1"
+
+# 포스트 + 댓글
+curl -sL -H "User-Agent: $UA" "https://www.reddit.com/r/{subreddit}/comments/{post_id}/{slug}/.json"
+
+# 정렬: hot.json / new.json / top.json?t=week
+```
+
+데이터: `title`, `author`, `score`, `selftext`(전문), `num_comments`, `created_utc`
+댓글: 응답 `[1]` 배열에 재귀적 트리
+
+## Hacker News (Firebase API)
+
+Rate limit 사실상 없음.
+
+```bash
+# 탑 스토리 ID 목록
+curl -sL "https://hacker-news.firebaseio.com/v0/topstories.json?limitToFirst=10&orderBy=%22%24key%22"
+
+# 개별 아이템
+curl -sL "https://hacker-news.firebaseio.com/v0/item/{id}.json"
+
+# 변형: beststories / newstories / askstories / showstories
+```
+
+데이터: `title`, `url`, `score`, `by`(작성자), `descendants`(댓글수), `kids`(댓글 ID)
+
+배치 조회:
+```bash
+python3 -c "
+import urllib.request, json
+ids = json.load(urllib.request.urlopen('https://hacker-news.firebaseio.com/v0/topstories.json?limitToFirst=5&orderBy=\"\$key\"'))
+for id in ids:
+    item = json.load(urllib.request.urlopen(f'https://hacker-news.firebaseio.com/v0/item/{id}.json'))
+    print(f'[{item.get(\"score\",0)}] {item.get(\"title\")}')
+    print(f'  {item.get(\"url\",\"N/A\")[:60]}')
+"
+```
+
+## Lobste.rs
+
+Rate limit 없음. HN보다 작지만 고품질 큐레이션.
+
+```bash
+# 핫 스토리
+curl -sL "https://lobste.rs/hottest.json"
+
+# 태그별 (ai, programming, web, security 등)
+curl -sL "https://lobste.rs/t/ai.json"
+
+# 최신
+curl -sL "https://lobste.rs/newest.json"
+
+# 개별 스토리 + 댓글
+curl -sL "https://lobste.rs/s/{short_id}.json"
+```
+
+데이터: `title`, `url`, `score`, `comment_count`, `tags`, `submitter_user`
+
+## dev.to
+
+```bash
+# 태그별 최신
+curl -sL "https://dev.to/api/articles?tag=ai&per_page=5"
+
+# 이번 주 탑
+curl -sL "https://dev.to/api/articles?top=7&per_page=5"
+
+# 특정 유저
+curl -sL "https://dev.to/api/articles?username={user}&per_page=5"
+```
+
+데이터: `title`, `user.name`, `public_reactions_count`, `reading_time_minutes`, `tags`
+
+## npm Registry
+
+```bash
+# 패키지 최신 버전
+curl -sL "https://registry.npmjs.org/{package}/latest"
+
+# 패키지 검색
+curl -sL "https://registry.npmjs.org/-/v1/search?text={query}&size=5"
+
+# 다운로드 통계
+curl -sL "https://api.npmjs.org/downloads/range/last-month/{package}"
+```
+
+## PyPI
+
+```bash
+# 패키지 정보
+curl -sL "https://pypi.org/pypi/{package}/json"
+
+# 다운로드 통계
+curl -sL "https://pypistats.org/api/packages/{package}/recent"
+```
+
+## Wikipedia
+
+```bash
+# 페이지 요약
+curl -sL "https://en.wikipedia.org/api/rest_v1/page/summary/{title}"
+# 한국어: https://ko.wikipedia.org/api/rest_v1/page/summary/{title}
+
+# 검색
+curl -sL "https://en.wikipedia.org/w/api.php?action=opensearch&search={query}&limit=5&format=json"
+```
+
+## V2EX
+
+```bash
+curl -sL "https://www.v2ex.com/api/topics/hot.json" -H "User-Agent: insane-search/1.0"
+```
+
+## RSS 피드
+
+→ [rss.md](rss.md)로 이동. 한국 언론 RSS, Google News RSS, feedparser 사용법 등 상세 가이드 참조.

--- a/skills/insane-browsing/references/insane-search/media.md
+++ b/skills/insane-browsing/references/insane-search/media.md
@@ -1,0 +1,123 @@
+# 미디어 추출 — yt-dlp
+
+> yt-dlp는 YouTube 전용 도구가 아니라 **1,858개 사이트**를 지원하는 범용 미디어 추출 도구.
+> 영상, 오디오, 팟캐스트, 라이브 스트리밍 — 미디어 URL이면 yt-dlp를 먼저 시도한다.
+
+## 설치 확인
+
+```bash
+which yt-dlp || python3 -m yt_dlp --version
+```
+
+- `yt-dlp` 명령어가 PATH에 있으면 그대로 사용
+- 없으면 `python3 -m yt_dlp`로 대체 (아래 모든 명령어에서 치환)
+- 미설치 시: `pip install yt-dlp`
+
+## 핵심 명령어 (모든 지원 사이트 공통)
+
+### 메타데이터 추출 (가장 범용)
+
+```bash
+yt-dlp --dump-json "URL"
+```
+
+title, uploader, duration, view_count, description, tags 등 구조화 JSON 반환.
+전용 extractor가 있는 사이트에서 ~95% 성공.
+
+### 자막 추출
+
+```bash
+yt-dlp --write-sub --write-auto-sub --sub-lang "en,ko" --skip-download -o "/tmp/%(id)s" "URL"
+cat /tmp/VIDEO_ID.*.vtt
+```
+
+YouTube는 100개 언어 자동자막 지원. 다른 사이트는 자체 자막 제공 시에만 동작.
+
+### 검색
+
+```bash
+# YouTube
+yt-dlp --dump-json "ytsearch5:{검색어}"
+
+# SoundCloud
+yt-dlp --dump-json "scsearch5:{검색어}"
+
+# Dailymotion
+yt-dlp --dump-json "dailymotionsearch5:{검색어}"
+
+# Yahoo
+yt-dlp --dump-json "yahoosearch5:{검색어}"
+```
+
+### 채널/플레이리스트 목록 (다운로드 없이)
+
+```bash
+yt-dlp --flat-playlist --dump-json "채널_URL"
+```
+
+title, id, url, duration 반환. 채널 전체 영상 목록을 초고속 수집.
+
+### 댓글 추출 (YouTube)
+
+```bash
+yt-dlp --write-comments --skip-download --write-info-json \
+  --extractor-args "youtube:max_comments=20" \
+  -o "/tmp/%(id)s" "URL"
+```
+
+## 지원 플랫폼 카테고리
+
+### 영상
+
+| 사이트 | 메타데이터 | 자막 | 검색 | 비고 |
+|--------|----------|------|------|------|
+| YouTube | O | O (자동생성 포함) | `ytsearch` | 최고 지원 |
+| Vimeo | O | O (사이트 제공 시) | X | 학술/다큐 콘텐츠 풍부 |
+| Twitch | O (VOD/클립) | X | X | 기술 스트리밍 |
+| TikTok | O | X | X | 공개 계정만 |
+| Dailymotion | O | O | `dailymotionsearch` | |
+| Rumble | O | X | X | |
+| PeerTube | O | X | X | 탈중앙화 |
+
+### 오디오/팟캐스트
+
+| 사이트 | 메타데이터 | 검색 | 비고 |
+|--------|----------|------|------|
+| SoundCloud | O | `scsearch` | 검색까지 가능 — 최고 |
+| Apple Podcasts | O | X | RSS 기반 |
+| TuneIn | O | X | |
+| acast | O | X | 채널 단위 지원 |
+| Spreaker | O | X | |
+| Audius | O | X | 블록체인 기반 |
+
+### 한국 플랫폼
+
+| 사이트 | Extractor | 비고 |
+|--------|-----------|------|
+| Naver TV | `Naver`, `Naver:live` | |
+| Kakao | `Kakao` | |
+| SBS | `SBS`, `sbs.co.kr` | |
+| JTBC | `JTBC`, `JTBC:program` | |
+| Chzzk | `chzzk:video`, `chzzk:live` | 네이버 스트리밍 |
+| Soop (구 AfreecaTV) | `soop`, `soop:live` | |
+| Daum | `daum.net`, `daum.net:clip` | |
+| Weverse | `Weverse`, `WeverseLive` | K-팝 팬덤 |
+
+### 뉴스 VOD
+
+| 사이트 | 비고 |
+|--------|------|
+| BBC | 공개 VOD |
+| ABC (호주) | iview |
+| CBS News | |
+| NBC News | 차단 많음 |
+
+> 뉴스 사이트는 직접 URL보다 **YouTube 공식 채널 경유**가 더 안정적.
+> 예: `ytsearch:BBC News {키워드}`
+
+## 주의사항
+
+- 자동 생성 자막은 행간 중복 → 후처리 필요
+- generic extractor는 성공률 ~30% — 전용 extractor 있는 사이트 우선
+- 페이월/로그인 사이트는 대부분 실패
+- `--dump-json`이 가장 안전한 범용 명령 (다운로드 없음, 메타데이터만)

--- a/skills/insane-browsing/references/insane-search/metadata.md
+++ b/skills/insane-browsing/references/insane-search/metadata.md
@@ -1,0 +1,116 @@
+# 메타데이터 추출 — OGP / JSON-LD / Schema.org
+
+> HTML을 받았을 때 구조화된 데이터를 추출하는 보조 기법.
+> 본문 전체를 못 가져와도 제목, 요약, 가격, 프로필 등 핵심 정보를 확보할 수 있다.
+
+## 의존성
+
+없음 (curl + python3 기본 모듈).
+
+## OGP (Open Graph Protocol) 메타태그
+
+대부분의 사이트가 소셜 공유용으로 삽입. 제목 + 설명 + 이미지 확보 가능.
+
+```bash
+curl -sL -H "User-Agent: Mozilla/5.0 ..." "{URL}" | \
+  python3 -c "
+import sys, re
+html = sys.stdin.read()
+for m in re.findall(r'<meta property=\"og:(\w+)\" content=\"([^\"]*?)\"', html):
+    print(f'og:{m[0]} = {m[1]}')
+for m in re.findall(r'<meta name=\"description\" content=\"([^\"]*?)\"', html):
+    print(f'description = {m}')
+"
+```
+
+## JSON-LD (Schema.org 구조화 데이터)
+
+**가장 가치 높은 추출 대상.** 상품, 기사, 프로필 등 구조화된 정보가 JSON으로 들어있다.
+
+```bash
+curl -sL "{URL}" | \
+  python3 -c "
+import sys, re, json
+html = sys.stdin.read()
+blocks = re.findall(r'<script type=\"application/ld\+json\">(.*?)</script>', html, re.DOTALL)
+for b in blocks:
+    try:
+        data = json.loads(b)
+        print(json.dumps(data, ensure_ascii=False, indent=2))
+    except:
+        pass
+"
+```
+
+### 실제 사례
+
+**쿠팡 검색 결과** — `CollectionPage` + `ItemList`:
+```json
+{
+  "@type": "CollectionPage",
+  "mainEntity": {
+    "@type": "ItemList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "item": {
+          "@type": "Product",
+          "name": "...",
+          "offers": { "price": 29900 }
+        }
+      }
+    ]
+  }
+}
+```
+
+**LinkedIn 프로필** — `Person`:
+```json
+{
+  "@type": "Person",
+  "name": "...",
+  "jobTitle": "...",
+  "alumniOf": [
+    { "@type": "Organization", "name": "..." }
+  ]
+}
+```
+
+**뉴스 기사** — `NewsArticle`:
+```json
+{
+  "@type": "NewsArticle",
+  "headline": "...",
+  "datePublished": "2026-04-16",
+  "author": { "name": "..." },
+  "articleBody": "..."
+}
+```
+
+## Next.js RSC 페이로드 (요즘IT 등)
+
+Next.js App Router 사이트는 `self.__next_f.push()` 스크립트에 콘텐츠가 포함됨.
+
+```bash
+curl -sL "{URL}" | \
+  python3 -c "
+import sys, re
+html = sys.stdin.read()
+chunks = re.findall(r'self\.__next_f\.push\(\[1,\"(.*?)\"\]\)', html)
+text = ''.join(chunks)
+# 한국어 텍스트 추출 (유니코드 이스케이프 디코딩)
+decoded = text.encode().decode('unicode_escape', errors='ignore')
+print(decoded[:3000])
+"
+```
+
+## 활용 시점
+
+메타데이터 추출은 **독립 방법이 아니라 보조 기법**이다.
+어떤 Phase에서든 HTML을 받으면 같이 실행:
+
+- Phase 1에서 curl로 HTML 받음 → JSON-LD도 추출
+- Phase 2에서 curl_cffi로 HTML 받음 → JSON-LD도 추출
+- Phase 3에서 Playwright로 DOM 받음 → `browser_evaluate`로 JSON-LD 추출
+
+본문은 못 가져와도 JSON-LD에서 **상품 가격, 기사 요약, 프로필 정보**는 확보될 수 있다.

--- a/skills/insane-browsing/references/insane-search/naver.md
+++ b/skills/insane-browsing/references/insane-search/naver.md
@@ -1,0 +1,107 @@
+# 네이버 계열 접근 전략
+
+> 네이버 서비스별로 접근 방법이 다르다. 블로그는 모바일 URL, 뉴스/증권은 Jina Reader.
+
+## 네이버 블로그
+
+WebFetch 차단. 모바일 URL 변환 + iPhone UA로 접근.
+
+```bash
+# blog.naver.com/{ID}/{NO} → m.blog.naver.com 변환
+curl -sL \
+  -H "User-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1" \
+  -H "Accept-Language: ko-KR,ko;q=0.9" \
+  -H "Referer: https://m.naver.com/" \
+  "https://m.blog.naver.com/PostView.naver?blogId={ID}&logNo={NO}"
+```
+
+RSS도 가능 (최신 50개, 본문 약 300자):
+```bash
+curl -sL "https://rss.blog.naver.com/{BLOG_ID}.xml"
+```
+
+## 네이버 뉴스
+
+Jina Reader로 완전 접근 가능.
+
+```bash
+# 기사 목록
+curl -s "https://r.jina.ai/https://news.naver.com/"
+
+# 개별 기사
+curl -s "https://r.jina.ai/https://n.news.naver.com/article/{press_id}/{article_id}"
+```
+
+## 네이버 증권
+
+Jina Reader로 실시간 주가, 주요 뉴스 접근.
+
+```bash
+curl -s "https://r.jina.ai/https://finance.naver.com/item/main.naver?code={종목코드}"
+```
+
+## 네이버 금융 시세 (비공식, 무인증)
+
+인증 불필요. 주가 시계열 데이터 JSON 반환.
+
+```bash
+# 일봉 시세 (삼성전자=005930)
+curl -sL "https://api.finance.naver.com/siseJson.naver?symbol=005930&requestType=1&startTime=20240101&endTime=20241231&timeframe=day"
+
+# 분봉
+curl -sL "https://api.finance.naver.com/siseJson.naver?symbol=005930&requestType=0&timeframe=minute&count=200"
+```
+
+응답: `[[날짜, 시가, 고가, 저가, 종가, 거래량, 외국인거래율], ...]`
+
+## 네이버 검색 (신원위장으로 직접 접근)
+
+curl_cffi + 세션 쿠키 워밍으로 네이버 검색 결과를 직접 크롤링할 수 있다. API 키 불필요.
+
+```python
+from curl_cffi import requests
+from urllib.parse import quote
+
+s = requests.Session(impersonate="chrome124")
+s.headers.update({
+    "Accept-Language": "ko-KR,ko;q=0.9",
+    "Referer": "https://www.google.com/",
+})
+s.get("https://www.naver.com/", timeout=10)  # 쿠키 워밍
+s.headers["Referer"] = "https://www.naver.com/"
+
+# 통합 검색 (블로그+뉴스+웹 혼합)
+r = s.get(f"https://search.naver.com/search.naver?query={quote('검색어')}")
+
+# 블로그 탭
+r = s.get(f"https://search.naver.com/search.naver?where=post&query={quote('검색어')}")
+
+# 뉴스 탭
+r = s.get(f"https://search.naver.com/search.naver?where=news&query={quote('검색어')}")
+```
+
+### 추출 가능한 데이터
+
+| 탭 | URL 패턴 | 추출 |
+|---|---|---|
+| 통합 | `search.naver?query=` | 블로그 URL, 외부 링크, 뉴스 |
+| 블로그 | `where=post&query=` | blog.naver.com URL, 제목, 스니펫 |
+| 뉴스 | `where=news&query=` | n.news.naver.com URL, 제목 |
+
+### 한국어 키워드 검색의 핵심 경로
+
+WebSearch는 한국어 신규 콘텐츠 인덱싱이 지연되지만, 네이버 검색은 한국어에 최적화되어 있다.
+**한국 사이트 키워드 검색 → 네이버 검색 직접 접근이 가장 정확하고 빠르다.**
+
+## 네이버 카페
+
+로그인 + iframe 이중 장벽. 본문 직접 접근 불가.
+fallback 체인에서 Phase 1~3을 시도하되, login/paywall 감지 시 "인증 필요"로 종료.
+
+## 네이버 TV
+
+yt-dlp로 접근 (media.md 참조).
+
+```bash
+yt-dlp --dump-json "https://tv.naver.com/v/{video_id}"
+```

--- a/skills/insane-browsing/references/insane-search/playwright.md
+++ b/skills/insane-browsing/references/insane-search/playwright.md
@@ -1,0 +1,142 @@
+# Playwright — MCP vs Local Chrome
+
+> JS 렌더링 / JS 챌린지 사이트를 위한 두 가지 접근. **WAF 프로파일의
+> `capabilities_needed` 태그가 선택을 결정**한다. 사용자가 직접 고를 필요 없다.
+
+## 두 Approach 요약
+
+| Approach | 실행기 | TLS 스택 | 적합 WAF | 한계 |
+|----------|--------|----------|----------|------|
+| **1. MCP** | `mcp__playwright__*` 도구 | Playwright 번들 Chromium (BoringSSL) | Cloudflare 기본, CAPTCHA 없는 SPA, JS 챌린지 약한 사이트 | Akamai Bot Manager 등 TLS-감지형 WAF에 **즉시 탐지됨** (`channel` 옵션 없음) |
+| **2. Local Node + `channel:'chrome'`** | `engine/templates/playwright_real_chrome.js` | 시스템 설치 실제 Chrome | Akamai Bot Manager, PerimeterX, DataDome 강화 설정 | Node + Chrome 시스템 설치 필요 |
+
+`engine/executor.py`가 프로파일 태그를 보고 자동 라우팅하므로, 이 선택을 스킬 외부에서 의식할 필요는 없다.
+
+## Approach 1 — Playwright MCP
+
+### 의존성
+
+```bash
+claude mcp list 2>/dev/null | grep -q playwright && echo "OK" || echo "NOT CONNECTED"
+claude mcp add playwright -- npx @playwright/mcp@latest
+```
+
+### 기본 워크플로
+
+```
+1. browser_navigate → URL
+2. browser_wait_for → 메인 콘텐츠 셀렉터 (SPA는 필수)
+3. browser_snapshot    (접근성 트리 — 토큰 효율)
+   또는
+   browser_evaluate    (특정 셀렉터 데이터 추출)
+   또는
+   browser_run_code    (스크롤/페이지네이션)
+```
+
+### 도구별 용도
+
+| 도구 | 용도 |
+|------|------|
+| `browser_snapshot` | 접근성 트리 반환 — 텍스트+인터랙티브 요소 구조화. 가장 빠르고 토큰 효율적 |
+| `browser_evaluate` | `() => document.querySelector(...).innerText` 등 JS 평가 |
+| `browser_run_code` | `async ({ page }) => {...}` 풀 자동화 — 무한 스크롤, 다단계 인터랙션 |
+| `browser_network_requests` | XHR/fetch 호출 목록 — **WAF 뒤 진짜 API 엔드포인트 발견용** (→ curl_cffi로 직접 호출) |
+| `browser_console_messages` | JS 에러/로그 |
+
+### 주의
+
+- MCP는 Chromium 번들 기반. TLS 지문이 BoringSSL이라 Akamai/DataDome은 **293 바이트 Access Denied** 또는 즉시 403 반환.
+- 이 경우 자동으로 Approach 2로 이관되도록 `engine/executor.py`가 처리. 수동 선택 불필요.
+
+## Approach 2 — Local Node + Real Chrome
+
+### 의존성 (최초 1회)
+
+```bash
+# Node (시스템 설치)
+node -v   # v18+ 권장
+
+# Playwright + stealth 플러그인
+npm i -g playwright playwright-extra puppeteer-extra-plugin-stealth
+
+# 시스템 Chrome 바이너리 (번들 Chromium 아님)
+npx playwright install chrome
+```
+
+### 호출 (engine 내부)
+
+```python
+from insane_search.engine.executor import run_playwright_fallback
+
+attempt, html = run_playwright_fallback(
+    "https://example.com/path",
+    profile_id="akamai_bot_manager",
+    success_selectors=["article"],
+    device_class="desktop",   # "desktop" | "mobile" | "auto"
+)
+```
+
+내부에서 `engine/templates/playwright_real_chrome.js` 또는 `playwright_mobile_chrome.js`를 Node로 실행하고 HTML을 받아온다. 템플릿은 **URL과 셀렉터 파라미터만** 받으며 사이트별 분기가 없다.
+
+### 데스크톱 템플릿 (`playwright_real_chrome.js`)
+
+```js
+const { chromium } = require('playwright-extra');
+const stealth = require('puppeteer-extra-plugin-stealth')();
+chromium.use(stealth);
+
+const ctx = await chromium.launchPersistentContext(profileDir, {
+  channel: 'chrome',        // ← 핵심: 번들 Chromium 아닌 실제 Chrome
+  headless: false,          // Akamai는 headless 탐지. headful 필요.
+  viewport: { width: 1366, height: 900 },
+});
+```
+
+### 모바일 템플릿 (`playwright_mobile_chrome.js`)
+
+```js
+const { chromium, devices } = require('playwright-extra');
+const iPhone = devices['iPhone 13 Pro'];
+
+const ctx = await chromium.launchPersistentContext(profileDir, {
+  channel: 'chrome',          // TLS는 실제 Chrome
+  ...iPhone,                  // UA/viewport/isMobile/hasTouch 자동 주입
+  headless: false,
+});
+```
+
+**주의**: `channel:'chrome'` + `devices[...]` 조합은 TLS 핑거프린트를 Chrome으로 유지하면서 HTTP 레이어(UA/viewport)만 모바일로 바꾼다. WAF가 실제 Chrome으로 인식해서 관대한 경우가 많다.
+
+## 선택 규칙 (자동)
+
+`engine/waf_profiles.yaml`의 `capabilities_needed` 태그가 결정한다:
+
+| 태그 조합 | 선택 실행기 | 대표 케이스 |
+|----------|-------------|-------------|
+| `needs_real_tls_stack` + `needs_js_exec` | Approach 2 (real_chrome) | Akamai Bot Manager |
+| `needs_js_exec` only | Approach 1 (MCP) | Cloudflare Turnstile |
+| `needs_real_tls_stack` only | Approach 2 (real_chrome) | 일부 DataDome 설정 |
+| 둘 다 없음 | curl 체인에서 해결. Playwright 안 씀 | F5 BIG-IP (TLS만 우회 필요) |
+
+`device_class="mobile"`이 지정되면 real_chrome → mobile 변종으로 swap.
+
+## 공통 검증
+
+두 Approach 모두 최종 HTML을 `engine/validators.py:validate()`로 재검증한다. 즉 Playwright가 HTML을 받아와도 **챌린지 페이지 또는 빈 SPA면 여전히 CHALLENGE 판정**. 자동으로 다음 조합이나 failure 보고로 이어진다.
+
+## 디버깅 팁
+
+- `profileDir`를 고정 경로로 두면 세션·쿠키가 유지되어 재시도 빠름 (`/tmp/.insane_pw_profile`)
+- Akamai 재시도가 잦으면 `profileDir`를 삭제해 fresh 상태로 리셋
+- 실패 시 `result.trace`의 `error` 필드에 Node stderr 200자가 포함됨
+
+## 사이트 예시 (독자 이해용, 코드 분기 근거 아님)
+
+> 이 섹션은 **설명 목적**이며 `engine/**` 코드에는 반영되지 않는다.
+
+- **Cloudflare 기본 챌린지**: Approach 1 (MCP) 충분
+- **Akamai Bot Manager**: Approach 2 필수. MCP로는 TLS-UA 불일치 탐지됨
+- **SSR 블로그 플랫폼**: curl_cffi safari만으로 HTML 수신. Playwright 불필요
+- **검색 결과 JS 렌더링 SPA**: Approach 1로 `browser_wait_for` 후 `browser_snapshot`
+
+실제 라우팅은 프로파일 태그가 결정한다. 위 예시는 참고일 뿐 코드 분기 근거로 쓰지 않는다.

--- a/skills/insane-browsing/references/insane-search/playwright.md
+++ b/skills/insane-browsing/references/insane-search/playwright.md
@@ -30,7 +30,7 @@ claude mcp add playwright -- npx @playwright/mcp@latest
    또는
    browser_evaluate    (특정 셀렉터 데이터 추출)
    또는
-   browser_run_code    (스크롤/페이지네이션)
+   browser_run_code_unsafe    (스크롤/페이지네이션)
 ```
 
 ### 도구별 용도
@@ -39,7 +39,7 @@ claude mcp add playwright -- npx @playwright/mcp@latest
 |------|------|
 | `browser_snapshot` | 접근성 트리 반환 — 텍스트+인터랙티브 요소 구조화. 가장 빠르고 토큰 효율적 |
 | `browser_evaluate` | `() => document.querySelector(...).innerText` 등 JS 평가 |
-| `browser_run_code` | `async ({ page }) => {...}` 풀 자동화 — 무한 스크롤, 다단계 인터랙션 |
+| `browser_run_code_unsafe` | `async ({ page }) => {...}` 풀 자동화 — 무한 스크롤, 다단계 인터랙션 |
 | `browser_network_requests` | XHR/fetch 호출 목록 — **WAF 뒤 진짜 API 엔드포인트 발견용** (→ curl_cffi로 직접 호출) |
 | `browser_console_messages` | JS 에러/로그 |
 
@@ -66,7 +66,7 @@ npx playwright install chrome
 ### 호출 (engine 내부)
 
 ```python
-from insane_search.engine.executor import run_playwright_fallback
+from engine.executor import run_playwright_fallback
 
 attempt, html = run_playwright_fallback(
     "https://example.com/path",

--- a/skills/insane-browsing/references/insane-search/public-api.md
+++ b/skills/insane-browsing/references/insane-search/public-api.md
@@ -1,0 +1,119 @@
+# 공개 API 직접 호출
+
+> 인증 없이 구조화된 데이터를 반환하는 공개 API.
+> 웹 크롤링이 아니라 공식 API — 안정적이고 정확.
+
+## Bluesky (AT Protocol)
+
+프로필과 피드는 완전 공개. 검색은 403 차단.
+
+```bash
+# 프로필
+curl -sL "https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor={handle}" | \
+python3 -c "import sys,json; d=json.load(sys.stdin); print(f'{d[\"displayName\"]} — Followers: {d[\"followersCount\"]}, Posts: {d[\"postsCount\"]}')"
+
+# 피드 (최근 게시물)
+curl -sL "https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed?actor={handle}&limit=10"
+```
+
+Rate limit: ~3,000 req/hour
+
+## Mastodon
+
+인스턴스별 상이. mastodon.social은 공개 타임라인 차단, hachyderm.io/fosstodon.org 등은 허용.
+
+```bash
+# 계정 조회
+curl -sL "https://{instance}/api/v1/accounts/lookup?acct={username}"
+
+# 계정 타임라인 (ID 획득 후)
+curl -sL "https://{instance}/api/v1/accounts/{id}/statuses?limit=10"
+
+# 해시태그 타임라인 (인스턴스에 따라 인증 필요)
+curl -sL "https://hachyderm.io/api/v1/timelines/tag/{tag}?limit=10"
+```
+
+## Stack Exchange (v2.3)
+
+```bash
+# 질문 검색
+curl -sL "https://api.stackexchange.com/2.3/search?order=desc&sort=votes&intitle={query}&site=stackoverflow"
+
+# 태그 기반
+curl -sL "https://api.stackexchange.com/2.3/questions?tagged={tag1};{tag2}&site=stackoverflow&pagesize=5"
+
+# 답변 포함 (본문 필요 시)
+curl -sL "https://api.stackexchange.com/2.3/questions/{id}/answers?order=desc&sort=votes&site=stackoverflow&filter=withbody"
+```
+
+Rate limit: 비인증 300 req/day (IP당)
+
+## arXiv (학술 논문)
+
+```bash
+# 논문 검색 (ti=제목, au=저자, abs=초록, cat=카테고리)
+curl -sL "http://export.arxiv.org/api/query?search_query=ti:{query}&max_results=5&sortBy=submittedDate&sortOrder=descending"
+```
+
+**주의**: 3 req/second 제한. 요청 간 1초 sleep 필수.
+카테고리: cs.AI, cs.CL, cs.LG, cs.CV 등
+
+## CrossRef (DOI / 피어리뷰 논문)
+
+```bash
+# 논문 검색
+curl -sL "https://api.crossref.org/works?query={query}&filter=from-pub-date:2025-01&rows=5&sort=relevance"
+
+# DOI로 조회
+curl -sL "https://api.crossref.org/works/{DOI}"
+```
+
+Rate limit: 50 req/second. User-Agent에 이메일 추가 시 Polite Pool 진입.
+
+## OpenLibrary (도서)
+
+```bash
+# ISBN 조회
+curl -sL "https://openlibrary.org/api/books?bibkeys=ISBN:{isbn}&jscmd=data&format=json"
+
+# 도서 검색
+curl -sL "https://openlibrary.org/search.json?q={query}&limit=5"
+```
+
+## Wayback Machine (아카이브)
+
+```bash
+# 스냅샷 확인
+curl -sL "https://archive.org/wayback/available?url={URL}"
+
+# CDX API (스냅샷 목록)
+curl -sL "https://web.archive.org/cdx/search/cdx?url={URL}&output=json&fl=timestamp,statuscode&limit=5"
+```
+
+## GitHub REST API (gh CLI 없을 때)
+
+비인증 60 req/hour. gh CLI 우선 사용 권장.
+
+```bash
+# 저장소 검색
+curl -sL "https://api.github.com/search/repositories?q={query}&sort=stars&per_page=5"
+
+# 릴리즈
+curl -sL "https://api.github.com/repos/{owner}/{repo}/releases?per_page=5"
+
+# 코드 검색
+curl -sL "https://api.github.com/search/code?q={query}+language:python&per_page=5"
+```
+
+## Rate Limit 요약
+
+| API | 비인증 | 비고 |
+|-----|-------|------|
+| Bluesky | ~3K/hr | 검색 403 |
+| Mastodon | 인스턴스별 | |
+| Stack Exchange | 300/day | 인증 시 10K |
+| arXiv | 3/sec | sleep 필수 |
+| CrossRef | 50/sec | |
+| OpenLibrary | 무제한 | |
+| Wayback | 무제한 | |
+| GitHub REST | 60/hr | gh CLI 우선 |

--- a/skills/insane-browsing/references/insane-search/rss.md
+++ b/skills/insane-browsing/references/insane-search/rss.md
@@ -1,0 +1,123 @@
+# RSS/Atom 피드
+
+> 인증 불필요. URL만 알면 바로 구독. 뉴스/블로그/커뮤니티에서 가장 깔끔한 데이터.
+
+## 의존성
+
+```bash
+python3 -c "import feedparser" 2>/dev/null || pip install feedparser -q
+```
+
+## RSS 자동 발견
+
+Jina Reader JSON 모드로 사이트의 RSS URL을 자동 탐지:
+
+```bash
+curl -sH "Accept: application/json" "https://r.jina.ai/{URL}" | \
+  python3 -c "import sys,json; print(json.load(sys.stdin)['data'].get('external',{}).get('alternate',[]))"
+```
+
+## URL 변형으로 피드 탐색
+
+사이트에 RSS가 명시되지 않아도 시도해볼 패턴:
+
+```bash
+curl -sL "{origin}/rss"
+curl -sL "{origin}/feed"
+curl -sL "{origin}/atom.xml"
+curl -sL "{origin}/rss.xml"
+curl -sL "{origin}/index.xml"
+```
+
+## Google News RSS (무인증)
+
+```bash
+# 키워드 검색
+curl -sL "https://news.google.com/rss/search?q={검색어}&hl=ko&gl=KR&ceid=KR:ko"
+
+# 토픽별 (TECHNOLOGY, BUSINESS, SCIENCE, SPORTS, HEALTH, WORLD)
+curl -sL "https://news.google.com/rss/headlines/section/topic/TECHNOLOGY?hl=ko&gl=KR&ceid=KR:ko"
+
+# 시간 필터: when:1h, when:7d, when:12m, after:YYYY-MM-DD
+curl -sL "https://news.google.com/rss/search?q={검색어}+when:7d&hl=ko&gl=KR&ceid=KR:ko"
+```
+
+## 한국 언론사 RSS
+
+전부 무인증. 바로 curl로 접근 가능.
+
+```bash
+# SBS 뉴스
+curl -sL "https://news.sbs.co.kr/news/rss.do"
+
+# 조선일보
+curl -sL "http://www.chosun.com/site/data/rss/rss.xml"
+
+# 중앙일보
+curl -sL "http://rss.joinsmsn.com/joins_news_list.xml"
+
+# 동아일보
+curl -sL "http://rss.donga.com/total.xml"
+
+# 경향신문
+curl -sL "http://www.khan.co.kr/rss/rssdata/total_news.xml"
+
+# 매일경제
+curl -sL "http://file.mk.co.kr/news/rss/rss_30000001.xml"
+
+# MBC 뉴스
+curl -sL "http://imnews.imbc.com/rss/news/news_00.xml"
+
+# 한국경제
+curl -sL "https://www.hankyung.com/feed/all-news"
+
+# 연합뉴스
+curl -sL "https://www.yonhapnewsagency.com/RSS/headline.xml"
+```
+
+## 블로그/플랫폼 RSS
+
+```bash
+# 네이버 블로그
+curl -sL "https://rss.blog.naver.com/{BLOG_ID}.xml"
+
+# 티스토리
+curl -sL "https://{blogname}.tistory.com/rss"
+
+# 벨로그
+curl -sL "https://v2.velog.io/rss/@{username}"
+
+# Substack
+curl -sL "https://{publication}.substack.com/feed"
+
+# GitHub 릴리즈 (Atom)
+curl -sL "https://github.com/{owner}/{repo}/releases.atom"
+
+# YouTube 채널
+curl -sL "https://www.youtube.com/feeds/videos.xml?channel_id={id}"
+
+# HN (hnrss.org — 비공식이지만 안정적)
+curl -sL "https://hnrss.org/frontpage"
+```
+
+## feedparser 파싱
+
+```python
+import feedparser
+
+feed = feedparser.parse("FEED_URL")
+for e in feed.entries[:10]:
+    print(f"{e.title} — {e.link}")
+    if hasattr(e, 'summary'):
+        print(f"  {e.summary[:200]}")
+```
+
+## SearXNG (무인증 메타검색)
+
+공개 인스턴스에서 JSON 검색 가능. 인스턴스별로 JSON 지원 여부 다름.
+
+```bash
+# 공개 인스턴스 목록: https://searx.space
+curl -sL "https://search.mdosch.de/search?q={검색어}&format=json" \
+  -H "User-Agent: insane-search/1.0"
+```

--- a/skills/insane-browsing/references/insane-search/tls-impersonate.md
+++ b/skills/insane-browsing/references/insane-search/tls-impersonate.md
@@ -1,0 +1,186 @@
+# TLS 임퍼소네이션 — curl_cffi
+
+> TLS 핑거프린트(JA3/JA4) 기반 WAF를 우회하는 핵심 방법.
+> 일반 curl/requests는 OpenSSL 핑거프린트라 즉시 차단되지만,
+> curl_cffi는 실제 브라우저(Chrome/Safari/Firefox)의 TLS 핑거프린트를 복제한다.
+
+## 의존성
+
+```bash
+python3 -c "import curl_cffi" 2>/dev/null || pip install curl_cffi -q
+```
+
+설치 후 사용 가능. **미설치를 이유로 이 스텝을 건너뛰지 않는다.**
+
+## 다중 타겟 순차 시도
+
+하나의 impersonate 타겟이 실패하면 다른 타겟으로 재시도한다.
+**시도 순서: safari → chrome → firefox**
+
+```python
+from curl_cffi import requests
+
+TARGETS = ["safari", "chrome", "firefox"]
+HEADERS = {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7",
+    "Accept-Encoding": "gzip, deflate, br",
+    "Referer": "https://www.google.com/",
+}
+
+def cffi_fetch(url, locale="ko-KR"):
+    """다중 타겟 순차 시도 + 신원위장. 성공하면 (response, target) 반환."""
+    from urllib.parse import urlparse
+    origin = f"{urlparse(url).scheme}://{urlparse(url).netloc}"
+    for target in TARGETS:
+        try:
+            session = requests.Session(impersonate=target)
+            session.headers.update(HEADERS)
+            session.headers["Accept-Language"] = f"{locale},{locale.split('-')[0]};q=0.9"
+            session.headers["Referer"] = "https://www.google.com/"
+            # 신원위장: 홈페이지 쿠키 워밍 → Referer 체인
+            try:
+                session.get(origin, timeout=10)
+            except Exception:
+                pass  # 홈 실패해도 본 요청은 시도
+            session.headers["Referer"] = origin
+            resp = session.get(url, timeout=20)
+            # JS 필수 사이트 감지 → 나머지 타겟 시도 무의미
+            if "behavioral-content" in resp.text or "sec-if-cpt" in resp.text:
+                return None, None  # → Phase 3 Playwright
+            if resp.status_code == 200 and len(resp.text) > 500:
+                return resp, target
+        except Exception:
+            continue
+    return None, None
+```
+
+## 임퍼소네이션 타겟 목록 (v0.15.0)
+
+generic alias는 항상 최신 버전으로 해석된다. **2026년에 chrome99 같은 옛 버전은 WAF가 의심하므로 generic alias 사용 권장.**
+
+| Alias | 해석 (2026.04) | 용도 |
+|-------|---------------|------|
+| `safari` | safari260 | **한국 사이트 최적** (쿠팡, 에펨코리아) |
+| `chrome` | chrome146 | 범용 (Cloudflare, Akamai) |
+| `firefox` | firefox135 | chrome/safari 실패 시 대안 |
+| `chrome_android` | chrome131_android | 모바일 API 엔드포인트 |
+| `safari_ios` | safari260_ios | iOS 모바일 |
+
+<details>
+<summary>핀 버전 전체 (클릭)</summary>
+
+```
+chrome99, chrome100, chrome101, chrome104, chrome107, chrome110,
+chrome116, chrome119, chrome120, chrome123, chrome124, chrome131,
+chrome133a, chrome136, chrome142, chrome145, chrome146,
+chrome131_android, edge99, edge101,
+safari15_3, safari15_5, safari17_0, safari17_2_ios,
+safari18_0, safari18_0_ios, safari260, safari260_ios,
+firefox133, firefox135
+```
+
+</details>
+
+## WAF별 최적 전략
+
+| WAF | 최적 타겟 | 추가 조건 | 성공률 |
+|-----|-----------|-----------|--------|
+| F5 BIG-IP (쿠팡) | `safari` | `Referer: https://www.coupang.com/` | ~70% |
+| Cloudflare (TLS만) | `chrome` | Sec-Fetch-* 헤더 추가 | ~80% |
+| Akamai | `chrome` | 레지덴셜 프록시 병행 | 80-90% |
+| AWS WAF | `chrome` | — | ~80% |
+| CloudFront (요즘IT) | 불필요 | 일반 curl + Chrome UA로 충분 | 100% |
+
+## 세션과 쿠키
+
+```python
+from curl_cffi import requests
+
+# 세션 유지 (쿠키 자동 관리)
+session = requests.Session(impersonate="safari")
+
+# 첫 요청으로 세션 쿠키 획득
+session.get("https://www.coupang.com/")
+
+# 이후 요청에 쿠키 자동 전달
+resp = session.get("https://www.coupang.com/np/search?q=키보드")
+```
+
+## 콤보: nodriver/FlareSolverr → curl_cffi
+
+JS 챌린지 사이트는 브라우저로 쿠키를 획득한 뒤 curl_cffi로 고속 처리:
+
+```python
+# 1. nodriver로 cf_clearance 쿠키 획득
+import nodriver as uc
+browser = await uc.start(headless=True)
+page = await browser.get("https://cf-protected-site.com")
+await page.cf_verify()
+cookies = await browser.cookies.get_all()
+
+# 2. curl_cffi Session에 쿠키 전달
+from curl_cffi import requests
+session = requests.Session(impersonate="chrome")
+for c in cookies:
+    session.cookies.set(c["name"], c["value"])
+resp = session.get("https://cf-protected-site.com/api/data")
+```
+
+## 비동기 (async)
+
+```python
+import asyncio
+from curl_cffi.requests import AsyncSession
+
+async def fetch_many(urls):
+    async with AsyncSession(impersonate="chrome") as session:
+        tasks = [session.get(url) for url in urls]
+        return await asyncio.gather(*tasks)
+```
+
+## HTTP/3 (v0.15.0+)
+
+```python
+from curl_cffi import requests
+from curl_cffi.const import CurlHttpVersion
+
+resp = requests.get(
+    "https://www.cloudflare.com/",
+    impersonate="chrome",
+    http_version=CurlHttpVersion.V3,
+)
+```
+
+WAF 벤더들이 아직 HTTP/3 핑거프린트를 적극 활용하지 않아 우회 효과가 높다.
+
+## 대안 라이브러리
+
+curl_cffi 실패 시 대안:
+
+| 라이브러리 | 설치 | 특징 |
+|-----------|------|------|
+| primp | `pip install primp` | Rust 기반, Firefox 148까지, 고성능 |
+| wreq/rnet | `pip install wreq` | Rust 기반, 100+ 디바이스 프로필 |
+| tls-client2 | `pip install tls-client2` | Go 기반 포크, 동기만 |
+
+```python
+# primp 예시
+import primp
+client = primp.Client(impersonate="chrome_146")
+resp = client.get("https://example.com")
+```
+
+## curl_cffi가 못 뚫는 것
+
+| 방어 수단 | curl_cffi | 대응 |
+|-----------|-----------|------|
+| TLS/JA3 핑거프린트 | 우회 가능 | 핵심 기능 |
+| HTTP/2 SETTINGS 핑거프린트 | 우회 가능 | impersonate에 포함 |
+| HTTP/3 QUIC 핑거프린트 | 우회 가능 (v0.15+) | 신규 |
+| JS 챌린지 (Turnstile 등) | **불가** | → nodriver 또는 Playwright |
+| CAPTCHA | **불가** | → 2captcha/CapSolver |
+| IP 평판 (데이터센터) | **불가** | → 프록시/VPN |
+| 행동 분석 (마우스/타이밍) | **불가** | → 실제 브라우저 |
+
+JS 챌린지가 걸린 사이트는 → [playwright.md](playwright.md) 로 넘긴다.

--- a/skills/insane-browsing/references/insane-search/twitter.md
+++ b/skills/insane-browsing/references/insane-search/twitter.md
@@ -1,0 +1,104 @@
+# X/Twitter 접근 전략
+
+> WebFetch는 402로 차단됨. 아래 방법으로 우회한다. 모두 API 키/인증 불필요.
+
+## 검색 (트윗 발견)
+
+```python
+WebSearch(query="site:x.com {검색어}")
+```
+
+WebSearch는 X 포스트를 검색 결과로 반환한다. 제목, snippet, URL을 획득할 수 있지만 트윗 전문이나 engagement 수치는 없다.
+
+## 타임라인 조회 — Syndication API
+
+특정 핸들의 최근 ~100개 트윗 + engagement 수치(likes, RTs) 제공.
+
+### 엔드포인트
+
+```
+https://syndication.twitter.com/srv/timeline-profile/screen-name/{handle}
+```
+
+### 원샷 스크립트
+
+```bash
+curl -sL "https://syndication.twitter.com/srv/timeline-profile/screen-name/{handle}" | \
+python3 -c "
+import sys, json, re, html
+content = sys.stdin.read()
+match = re.search(r'__NEXT_DATA__.*?>(.*?)</script>', content)
+if match:
+    data = json.loads(match.group(1))
+    for e in data['props']['pageProps']['timeline']['entries']:
+        if e['type'] == 'tweet':
+            t = e['content']['tweet']
+            print(f\"@{t['user']['screen_name']} ({t.get('created_at','?')})\")
+            print(f\"  {html.unescape(t.get('full_text',''))[:300]}\")
+            print(f\"  Likes: {t.get('favorite_count',0)} | RTs: {t.get('retweet_count',0)}\")
+            print('---')
+"
+```
+
+### 가져올 수 있는 데이터
+
+| 필드 | 경로 | 예시 |
+|------|------|------|
+| 트윗 전문 | `tweet.full_text` | "Give your agent the..." |
+| 작성자 핸들 | `tweet.user.screen_name` | "openclaw" |
+| 작성자 이름 | `tweet.user.name` | "OpenClaw" |
+| 좋아요 수 | `tweet.favorite_count` | 1929 |
+| RT 수 | `tweet.retweet_count` | 169 |
+| 작성 시각 | `tweet.created_at` | "Mon Apr 06 04:04:08 +0000 2026" |
+| 트윗 ID | `tweet.id_str` | "2041003999856406714" |
+| 미디어 URL | `tweet.entities.media[].media_url_https` | 이미지/동영상 URL |
+
+### 제한
+
+- 최근 ~100개 반환 (페이지네이션 불가)
+- 비공개 계정 접근 불가
+- 검색 기능 없음 (타임라인만)
+- **저팔로워/신규 계정**: `hasResults: false` 반환 가능. 이 경우 oEmbed 개별 트윗 접근은 정상 동작하므로 "조합 패턴"으로 폴백.
+- 비공식 엔드포인트 — X가 변경/차단 가능
+
+## 개별 트윗 조회 — oEmbed API
+
+특정 트윗 URL을 알 때 전문 가져오기.
+
+### 엔드포인트
+
+```
+https://publish.twitter.com/oembed?url=https://x.com/{user}/status/{tweet_id}
+```
+
+### 사용법
+
+```bash
+curl -sL "https://publish.twitter.com/oembed?url=https://x.com/{user}/status/{tweet_id}"
+```
+
+### 응답 (JSON)
+
+| 필드 | 설명 |
+|------|------|
+| `author_name` | 작성자 표시 이름 |
+| `author_url` | 작성자 프로필 URL |
+| `html` | 트윗 전문이 포함된 HTML blockquote |
+| `url` | 트윗 원본 URL |
+
+## 조합 패턴 (검색 → 상세)
+
+```
+1단계: WebSearch(query="site:x.com {키워드}") → 트윗 URL 획득
+2단계: curl oEmbed API → 트윗 전문 획득
+```
+
+## 실패하는 방법 (사용하지 말 것)
+
+| 방법 | 결과 | 원인 |
+|------|------|------|
+| WebFetch | 402 Payment Required | Claude Code의 WebFetch 제한 |
+| Nitter | 빈 응답 | Nitter 인스턴스 대부분 종료됨 |
+| Wayback Machine | OG 메타태그만 | SPA 렌더링 안 됨 |
+| Mobile UA curl | OG 메타태그만 | SPA 렌더링 안 됨 |
+| RSS | 엔드포인트 없음 | X는 RSS 지원 중단 |

--- a/skills/insane-browsing/requirements.txt
+++ b/skills/insane-browsing/requirements.txt
@@ -1,0 +1,3 @@
+curl_cffi==0.15.0
+beautifulsoup4==4.15.0
+PyYAML==6.0.3

--- a/skills/insane-browsing/scripts/cookie_crypto.py
+++ b/skills/insane-browsing/scripts/cookie_crypto.py
@@ -1,0 +1,75 @@
+"""Pure key derivation + value decryption, with the OS-keyring read injected."""
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+from pathlib import Path
+
+from cookie_paths import UnsupportedPlatform
+
+
+def derive_key(platform: str, secret: bytes) -> bytes:
+    if platform == "win32":
+        if len(secret) != 32:
+            raise ValueError(f"win32 os_crypt key must be 32 bytes, got {len(secret)}")
+        return secret
+    if platform in ("darwin", "linux"):
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+        iterations = 1003 if platform == "darwin" else 1
+        return PBKDF2HMAC(algorithm=hashes.SHA1(), length=16, salt=b"saltysalt", iterations=iterations).derive(secret)
+    raise UnsupportedPlatform(f"unsupported platform for key derivation: {platform!r}")
+
+
+def decrypt_chromium_value(platform: str, key: bytes, encrypted: bytes) -> str:
+    if not encrypted:
+        return ""
+    prefix = encrypted[:3]
+    if prefix in (b"v10", b"v11") and platform == "win32":
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+        nonce, ciphertext, tag = encrypted[3:15], encrypted[15:-16], encrypted[-16:]
+        decryptor = Cipher(algorithms.AES(key), modes.GCM(nonce, tag)).decryptor()
+        return (decryptor.update(ciphertext) + decryptor.finalize()).decode("utf-8", errors="replace")
+    if prefix in (b"v10", b"v11"):
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+        decryptor = Cipher(algorithms.AES128(key), modes.CBC(b" " * 16)).decryptor()
+        decrypted = decryptor.update(encrypted[3:]) + decryptor.finalize()
+        pad = decrypted[-1]
+        if isinstance(pad, int) and 1 <= pad <= 16:
+            decrypted = decrypted[:-pad]
+        return decrypted.decode("utf-8", errors="replace")
+    return encrypted.decode("utf-8", errors="replace")
+
+
+def macos_keyring_secret(safe_storage: str) -> bytes:
+    result = subprocess.run(
+        ["security", "find-generic-password", "-s", safe_storage, "-w"],
+        capture_output=True, text=True, timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"cannot read {safe_storage} from Keychain: {result.stderr.strip()}")
+    return result.stdout.strip().encode()
+
+
+def linux_keyring_secret(safe_storage: str) -> bytes:
+    try:
+        import secretstorage
+    except ImportError:
+        return b"peanuts"
+    conn = secretstorage.dbus_init()
+    for item in secretstorage.get_default_collection(conn).get_all_items():
+        if item.get_label() == safe_storage:
+            return item.get_secret()
+    return b"peanuts"
+
+
+def windows_oscrypt_key(local_state_path: Path) -> bytes:
+    state = json.loads(local_state_path.read_text())
+    blob = base64.b64decode(state["os_crypt"]["encrypted_key"])[5:]
+    import win32crypt
+
+    return win32crypt.CryptUnprotectData(blob, None, None, None, 0)[1]

--- a/skills/insane-browsing/scripts/cookie_crypto.py
+++ b/skills/insane-browsing/scripts/cookie_crypto.py
@@ -35,13 +35,16 @@ def decrypt_chromium_value(platform: str, key: bytes, encrypted: bytes) -> str:
         return (decryptor.update(ciphertext) + decryptor.finalize()).decode("utf-8", errors="replace")
     if prefix in (b"v10", b"v11"):
         from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+        from cryptography.hazmat.primitives.padding import PKCS7
 
         decryptor = Cipher(algorithms.AES128(key), modes.CBC(b" " * 16)).decryptor()
-        decrypted = decryptor.update(encrypted[3:]) + decryptor.finalize()
-        pad = decrypted[-1]
-        if isinstance(pad, int) and 1 <= pad <= 16:
-            decrypted = decrypted[:-pad]
-        return decrypted.decode("utf-8", errors="replace")
+        padded = decryptor.update(encrypted[3:]) + decryptor.finalize()
+        # Validate PKCS7 padding instead of trusting the last byte: a wrong key or
+        # tampered ciphertext produces malformed padding and unpadder raises
+        # ValueError, so we never return a silently mis-decrypted cookie value.
+        unpadder = PKCS7(128).unpadder()
+        decrypted = unpadder.update(padded) + unpadder.finalize()
+        return decrypted.decode("utf-8")
     return encrypted.decode("utf-8", errors="replace")
 
 

--- a/skills/insane-browsing/scripts/cookie_crypto.py
+++ b/skills/insane-browsing/scripts/cookie_crypto.py
@@ -56,15 +56,23 @@ def macos_keyring_secret(safe_storage: str) -> bytes:
 
 
 def linux_keyring_secret(safe_storage: str) -> bytes:
+    # On a headless host the keyring is unreachable: secretstorage may be absent, or
+    # dbus_init() raises SecretServiceNotAvailableException (D-Bus session bus down).
+    # Return a DEFINED empty fallback (b"") the caller can detect — never crash, and
+    # never substitute a garbage key that would silently mis-decrypt the cookies.
     try:
         import secretstorage
+        from secretstorage.exceptions import SecretStorageException
     except ImportError:
-        return b"peanuts"
-    conn = secretstorage.dbus_init()
-    for item in secretstorage.get_default_collection(conn).get_all_items():
-        if item.get_label() == safe_storage:
-            return item.get_secret()
-    return b"peanuts"
+        return b""
+    try:
+        conn = secretstorage.dbus_init()
+        for item in secretstorage.get_default_collection(conn).get_all_items():
+            if item.get_label() == safe_storage:
+                return item.get_secret()
+    except SecretStorageException:
+        return b""
+    return b""
 
 
 def windows_oscrypt_key(local_state_path: Path) -> bytes:

--- a/skills/insane-browsing/scripts/cookie_domains.py
+++ b/skills/insane-browsing/scripts/cookie_domains.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+SQL_LIKE_ESCAPE = "\\"
+
+
+class CookieDomainError(ValueError):
+    pass
+
+
+def normalize_cookie_domain(domain: str) -> str:
+    normalized = domain.strip().lower().lstrip(".")
+    if not normalized:
+        raise CookieDomainError("cookie domain must not be empty")
+    return normalized
+
+
+def escape_sql_like(value: str) -> str:
+    return (
+        value
+        .replace(SQL_LIKE_ESCAPE, SQL_LIKE_ESCAPE * 2)
+        .replace("%", f"{SQL_LIKE_ESCAPE}%")
+        .replace("_", f"{SQL_LIKE_ESCAPE}_")
+    )
+
+
+def domain_where_clause(column: str, domains: list[str]) -> tuple[str, list[str]]:
+    normalized_domains = sorted({normalize_cookie_domain(domain) for domain in domains})
+    if not normalized_domains:
+        raise CookieDomainError("at least one cookie domain is required")
+
+    clauses: list[str] = []
+    params: list[str] = []
+    for domain in normalized_domains:
+        clauses.append(
+            f"({column} = ? OR {column} = ? OR {column} LIKE ? ESCAPE '{SQL_LIKE_ESCAPE}')"
+        )
+        params.extend([domain, f".{domain}", f"%.{escape_sql_like(domain)}"])
+    return " OR ".join(clauses), params

--- a/skills/insane-browsing/scripts/cookie_domains.py
+++ b/skills/insane-browsing/scripts/cookie_domains.py
@@ -2,6 +2,23 @@ from __future__ import annotations
 
 SQL_LIKE_ESCAPE = "\\"
 
+# Hardcoded denylist of common multi-label public suffixes (eTLD spanning >1 label).
+# A bare TLD ("com") is caught by the single-label check; these need the explicit set
+# so "co.uk" is rejected while a registrable domain under it ("example.co.uk") passes.
+# lazy: short hand-curated list, not the full PSL; extend if a needed suffix is missing.
+_PUBLIC_SUFFIXES = frozenset({
+    "co.uk", "org.uk", "gov.uk", "ac.uk", "me.uk", "net.uk", "sch.uk", "ltd.uk", "plc.uk",
+    "com.au", "net.au", "org.au", "edu.au", "gov.au", "id.au",
+    "co.kr", "or.kr", "ne.kr", "re.kr", "pe.kr", "go.kr", "mil.kr", "ac.kr", "hs.kr",
+    "co.jp", "or.jp", "ne.jp", "ac.jp", "go.jp", "ad.jp", "ed.jp", "gr.jp", "lg.jp",
+    "co.nz", "net.nz", "org.nz", "govt.nz", "ac.nz",
+    "com.br", "net.br", "org.br", "gov.br",
+    "com.cn", "net.cn", "org.cn", "gov.cn", "edu.cn",
+    "co.in", "net.in", "org.in", "gov.in",
+    "co.za", "org.za", "gov.za",
+    "com.sg", "com.hk", "com.tw", "com.mx", "com.tr", "co.id",
+})
+
 
 class CookieDomainError(ValueError):
     pass
@@ -11,6 +28,13 @@ def normalize_cookie_domain(domain: str) -> str:
     normalized = domain.strip().lower().lstrip(".")
     if not normalized:
         raise CookieDomainError("cookie domain must not be empty")
+    # Fail closed against authentication-boundary bypass: a bare TLD ("com") or a bare
+    # public suffix ("co.uk") would LIKE-match every site under it. Require a registrable
+    # eTLD+1 (at least one label in front of the suffix).
+    if "." not in normalized or normalized in _PUBLIC_SUFFIXES:
+        raise CookieDomainError(
+            f"cookie domain must be a registrable domain, not a public suffix: {normalized!r}"
+        )
     return normalized
 
 

--- a/skills/insane-browsing/scripts/cookie_paths.py
+++ b/skills/insane-browsing/scripts/cookie_paths.py
@@ -1,0 +1,112 @@
+"""Pure profile-path resolution for cross-platform cookie extraction."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Final, Literal, TypedDict, assert_never
+
+
+class UnsupportedPlatform(ValueError):
+    """Raised when a browser/platform combination is not supported."""
+
+
+BrowserKind = Literal["chromium", "firefox"]
+
+
+class BrowserDirs(TypedDict):
+    darwin: str
+    linux: str
+    win32: str
+
+
+class BrowserSpec(TypedDict):
+    kind: BrowserKind
+    safe_storage: str | None
+    dirs: BrowserDirs
+
+
+BROWSERS: Final[dict[str, BrowserSpec]] = {
+    "chrome": {
+        "kind": "chromium",
+        "safe_storage": "Chrome Safe Storage",
+        "dirs": {"darwin": "Google/Chrome", "linux": "google-chrome", "win32": "Google/Chrome/User Data"},
+    },
+    "brave": {
+        "kind": "chromium",
+        "safe_storage": "Brave Safe Storage",
+        "dirs": {
+            "darwin": "BraveSoftware/Brave-Browser",
+            "linux": "BraveSoftware/Brave-Browser",
+            "win32": "BraveSoftware/Brave-Browser/User Data",
+        },
+    },
+    "chromium": {
+        "kind": "chromium",
+        "safe_storage": "Chromium Safe Storage",
+        "dirs": {"darwin": "Chromium", "linux": "chromium", "win32": "Chromium/User Data"},
+    },
+    "firefox": {
+        "kind": "firefox",
+        "safe_storage": None,
+        "dirs": {"darwin": "Firefox/Profiles", "linux": ".mozilla/firefox", "win32": "Mozilla/Firefox/Profiles"},
+    },
+}
+
+CHROMIUM_PROFILE_DIRS: Final = ["Default", "Profile 1", "Profile 2"]
+
+
+def platform_base(platform: str, kind: BrowserKind) -> Path:
+    home = Path.home()
+    match platform:
+        case "darwin":
+            return home / "Library" / "Application Support"
+        case "linux":
+            match kind:
+                case "firefox":
+                    return home
+                case "chromium":
+                    return Path(os.environ.get("XDG_CONFIG_HOME", str(home / ".config")))
+                case unreachable:
+                    assert_never(unreachable)
+        case "win32":
+            return Path(os.environ.get("LOCALAPPDATA", str(home / "AppData" / "Local")))
+        case _:
+            raise UnsupportedPlatform(f"unsupported platform: {platform!r}")
+
+
+def browser_dir(spec: BrowserSpec, platform: str) -> str:
+    match platform:
+        case "darwin":
+            return spec["dirs"]["darwin"]
+        case "linux":
+            return spec["dirs"]["linux"]
+        case "win32":
+            return spec["dirs"]["win32"]
+        case _:
+            raise UnsupportedPlatform(f"browser not mapped for platform {platform!r}")
+
+
+def resolve_cookie_db(browser: str, platform: str, base_override: Path | None = None) -> Path:
+    spec = BROWSERS.get(browser)
+    if spec is None:
+        raise UnsupportedPlatform(f"unsupported browser: {browser!r}")
+    base = base_override if base_override is not None else platform_base(platform, spec["kind"])
+    profile_root = base / browser_dir(spec, platform)
+
+    match spec["kind"]:
+        case "firefox":
+            if not profile_root.exists():
+                raise FileNotFoundError(f"no Firefox profile root at {profile_root}")
+            for entry in sorted(profile_root.iterdir()):
+                db = entry / "cookies.sqlite"
+                if db.exists():
+                    return db
+            raise FileNotFoundError(f"no cookies.sqlite under {profile_root}")
+        case "chromium":
+            for profile in CHROMIUM_PROFILE_DIRS:
+                for candidate in (profile_root / profile / "Cookies", profile_root / profile / "Network" / "Cookies"):
+                    if candidate.exists():
+                        return candidate
+            raise FileNotFoundError(f"no Cookies DB under {profile_root}")
+        case unreachable:
+            assert_never(unreachable)

--- a/skills/insane-browsing/scripts/cookie_paths.py
+++ b/skills/insane-browsing/scripts/cookie_paths.py
@@ -104,7 +104,9 @@ def resolve_cookie_db(browser: str, platform: str, base_override: Path | None = 
             raise FileNotFoundError(f"no cookies.sqlite under {profile_root}")
         case "chromium":
             for profile in CHROMIUM_PROFILE_DIRS:
-                for candidate in (profile_root / profile / "Cookies", profile_root / profile / "Network" / "Cookies"):
+                # Prefer the modern Network/Cookies DB; the legacy top-level Cookies
+                # is a stale fallback for old profiles. First-existing wins.
+                for candidate in (profile_root / profile / "Network" / "Cookies", profile_root / profile / "Cookies"):
                     if candidate.exists():
                         return candidate
             raise FileNotFoundError(f"no Cookies DB under {profile_root}")

--- a/skills/insane-browsing/scripts/extract_cookies.py
+++ b/skills/insane-browsing/scripts/extract_cookies.py
@@ -73,8 +73,17 @@ process.stdin.on("data", (chunk) => { input += chunk; });
 process.stdin.on("end", () => {
   (async () => {
   const cookies = JSON.parse(input || "[]");
-  const version = await fetch(`http://127.0.0.1:${port}/json/version`).then((r) => r.json());
-  const ws = new WebSocket(version.webSocketDebuggerUrl);
+  // Network.setCookie must run against a page target; the browser-level
+  // target rejects it, so pick a page from /json/list instead.
+  const targets = await fetch(`http://127.0.0.1:${port}/json/list`).then((r) => r.json());
+  const page = (Array.isArray(targets) ? targets : []).find(
+    (t) => t && t.type === "page" && t.webSocketDebuggerUrl,
+  );
+  if (!page) {
+    process.stderr.write("no page target available for cookie injection (open a tab first)\n");
+    process.exit(1);
+  }
+  const ws = new WebSocket(page.webSocketDebuggerUrl);
   let nextId = 1;
   const pending = new Map();
 
@@ -222,7 +231,20 @@ def extract_cookies(
     safe_storage = spec["safe_storage"]
     if safe_storage is None:
         raise UnsupportedPlatform(f"browser {browser!r} has no keyring storage name")
-    key = derive_key(platform, reader(safe_storage))
+    secret = reader(safe_storage)
+    if not secret:
+        # linux_keyring_secret returns a defined empty b"" when the keyring is
+        # unreachable. Detect it: on Linux, Chromium itself falls back to the
+        # fixed password "peanuts", so mirror that. On other platforms there is
+        # no such fallback — raise instead of deriving a key that silently
+        # mis-decrypts every cookie.
+        if platform == "linux":
+            secret = b"peanuts"
+        else:
+            raise RuntimeError(
+                f"empty keyring secret for {browser!r} on {platform!r}; cannot decrypt cookies"
+            )
+    key = derive_key(platform, secret)
     return extract_chromium(db, domains, platform, key)
 
 
@@ -251,6 +273,11 @@ def inject_cookies(cookies: list[CookieRecord], cdp_port: int) -> None:
     if proc.returncode != 0:
         raise RuntimeError((proc.stderr or "CDP cookie injection failed").strip())
     ok = int((proc.stdout or "0").strip() or "0")
+    if cookies and ok == 0:
+        raise RuntimeError(
+            f"CDP accepted 0/{len(cookies)} cookies (port {cdp_port}); "
+            f"every cookie was rejected — refusing to proceed unauthenticated"
+        )
     print(f"Injected {ok}/{len(cookies)} cookies into agent-browser (CDP {cdp_port})")
 
 

--- a/skills/insane-browsing/scripts/extract_cookies.py
+++ b/skills/insane-browsing/scripts/extract_cookies.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Cross-platform browser cookie extraction for Tier-3 Chrome stealth.
+
+The OS-keyring lookup is an injected boundary: cookie_paths resolves profile
+paths and cookie_crypto derives keys + decrypts values, both pure and testable
+with synthetic fixtures on any OS. This module wires them to a real browser DB
+and the agent-browser CDP session.
+
+Usage:
+    python extract_cookies.py --browser chrome --domain youtube.com --output /tmp/cookies.json
+    python extract_cookies.py --browser chrome --domain youtube.com --inject --cdp 9242
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Callable, NotRequired, TypedDict
+
+from cookie_crypto import (
+    decrypt_chromium_value,
+    derive_key,
+    linux_keyring_secret,
+    macos_keyring_secret,
+    windows_oscrypt_key,
+)
+from cookie_domains import domain_where_clause
+from cookie_paths import BROWSERS, BrowserSpec, UnsupportedPlatform, platform_base, resolve_cookie_db
+
+_SAMESITE = {-1: "None", 0: "None", 1: "Lax", 2: "Strict"}
+
+IMPORTANT_COOKIES = {
+    "SID", "SSID", "HSID", "APISID", "SAPISID",
+    "__Secure-1PSID", "__Secure-3PSID", "__Secure-1PSIDTS", "__Secure-3PSIDTS",
+    "LOGIN_INFO", "PREF", "VISITOR_INFO1_LIVE", "YSC", "NID", "CONSENT",
+}
+
+
+class CookieRecord(TypedDict):
+    name: str
+    value: str
+    domain: str
+    path: str
+    expires: int
+    secure: bool
+    httpOnly: bool
+    sameSite: str
+
+
+class CdpCookie(TypedDict):
+    name: str
+    value: str
+    domain: str
+    path: str
+    secure: bool
+    httpOnly: bool
+    sameSite: str
+    expires: NotRequired[int]
+
+
+_CDP_SET_COOKIES_SCRIPT = r"""
+const port = Number(process.argv[1] || 0);
+if (!Number.isInteger(port) || port <= 0) {
+  process.stderr.write("invalid CDP port\n");
+  process.exit(2);
+}
+
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { input += chunk; });
+process.stdin.on("end", () => {
+  (async () => {
+  const cookies = JSON.parse(input || "[]");
+  const version = await fetch(`http://127.0.0.1:${port}/json/version`).then((r) => r.json());
+  const ws = new WebSocket(version.webSocketDebuggerUrl);
+  let nextId = 1;
+  const pending = new Map();
+
+  ws.onmessage = (event) => {
+    const msg = JSON.parse(event.data);
+    const waiter = pending.get(msg.id);
+    if (!waiter) return;
+    pending.delete(msg.id);
+    if (msg.error) waiter.reject(new Error(msg.error.message || "CDP error"));
+    else waiter.resolve(msg.result);
+  };
+
+  await new Promise((resolve, reject) => {
+    ws.onopen = resolve;
+    ws.onerror = reject;
+  });
+
+  const send = (method, params) => new Promise((resolve, reject) => {
+    const id = nextId++;
+    pending.set(id, { resolve, reject });
+    ws.send(JSON.stringify({ id, method, params }));
+  });
+
+  let ok = 0;
+  for (const cookie of cookies) {
+    const result = await send("Network.setCookie", cookie);
+    if (result && result.success) ok += 1;
+  }
+  ws.close();
+  process.stdout.write(String(ok));
+  })().catch((error) => {
+  process.stderr.write(`${error.name || "Error"}: ${error.message || error}\n`);
+  process.exit(1);
+  });
+});
+"""
+
+
+def _secure_cookie_db_copy(db_path: Path) -> Path:
+    handle = tempfile.NamedTemporaryFile(prefix="insane-browsing-cookies-", suffix=".sqlite", delete=False)
+    tmp = Path(handle.name)
+    handle.close()
+    try:
+        shutil.copyfile(db_path, tmp)
+        tmp.chmod(0o600)
+        return tmp
+    except (OSError, shutil.Error):
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def write_cookie_file(path: Path, cookies: list[CookieRecord]) -> None:
+    if path.is_symlink():
+        raise ValueError(f"refusing to write cookies through symlink: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            os.fchmod(f.fileno(), 0o600)
+            json.dump(cookies, f, indent=2)
+            f.write("\n")
+        os.replace(tmp_path, path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def extract_firefox(db_path: Path, domains: list[str]) -> list[CookieRecord]:
+    tmp = _secure_cookie_db_copy(db_path)
+    try:
+        where, params = domain_where_clause("host", domains)
+        conn = sqlite3.connect(str(tmp))
+        rows = conn.execute(
+            f"SELECT name, value, host, path, expiry, isSecure, isHttpOnly, sameSite "
+            f"FROM moz_cookies WHERE ({where}) ORDER BY host, name",
+            params,
+        ).fetchall()
+        conn.close()
+    finally:
+        tmp.unlink(missing_ok=True)
+    return [
+        {
+            "name": n, "value": v, "domain": h, "path": p, "expires": e,
+            "secure": bool(sec), "httpOnly": bool(ho), "sameSite": _SAMESITE.get(ss, "Lax"),
+        }
+        for n, v, h, p, e, sec, ho, ss in rows
+    ]
+
+
+def extract_chromium(db_path: Path, domains: list[str], platform: str, key: bytes) -> list[CookieRecord]:
+    tmp = _secure_cookie_db_copy(db_path)
+    try:
+        where, params = domain_where_clause("host_key", domains)
+        conn = sqlite3.connect(str(tmp))
+        rows = conn.execute(
+            f"SELECT name, encrypted_value, host_key, path, expires_utc, is_secure, is_httponly, samesite "
+            f"FROM cookies WHERE ({where}) ORDER BY host_key, name",
+            params,
+        ).fetchall()
+        conn.close()
+    finally:
+        tmp.unlink(missing_ok=True)
+    out = []
+    for n, enc, h, p, exp, sec, ho, ss in rows:
+        unix_expires = int((exp / 1_000_000) - 11644473600) if exp and exp > 0 else 0
+        out.append({
+            "name": n, "value": decrypt_chromium_value(platform, key, enc), "domain": h, "path": p,
+            "expires": unix_expires, "secure": bool(sec), "httpOnly": bool(ho), "sameSite": _SAMESITE.get(ss, "Lax"),
+        })
+    return out
+
+
+def _browser_spec(browser: str) -> BrowserSpec:
+    spec = BROWSERS.get(browser)
+    if spec is None:
+        raise UnsupportedPlatform(f"unsupported browser: {browser!r}")
+    return spec
+
+
+def default_keyring_reader(platform: str, spec: BrowserSpec) -> Callable[[str], bytes]:
+    if platform == "darwin":
+        return macos_keyring_secret
+    if platform == "linux":
+        return linux_keyring_secret
+    if platform == "win32":
+        def _win(_safe_storage: str) -> bytes:
+            base = platform_base("win32", "chromium")
+            return windows_oscrypt_key(base / spec["dirs"]["win32"] / "Local State")
+        return _win
+    raise UnsupportedPlatform(f"no keyring reader for platform {platform!r}")
+
+
+def extract_cookies(
+    browser: str,
+    domains: list[str],
+    platform: str = sys.platform,
+    keyring_reader: Callable[[str], bytes] | None = None,
+    base_override: Path | None = None,
+) -> list[CookieRecord]:
+    spec = _browser_spec(browser)
+    db = resolve_cookie_db(browser, platform, base_override=base_override)
+    if spec["kind"] == "firefox":
+        return extract_firefox(db, domains)
+    reader = keyring_reader or default_keyring_reader(platform, spec)
+    safe_storage = spec["safe_storage"]
+    if safe_storage is None:
+        raise UnsupportedPlatform(f"browser {browser!r} has no keyring storage name")
+    key = derive_key(platform, reader(safe_storage))
+    return extract_chromium(db, domains, platform, key)
+
+
+def inject_cookies(cookies: list[CookieRecord], cdp_port: int) -> None:
+    filtered = [c for c in cookies if c["name"] in IMPORTANT_COOKIES] or cookies
+    payload: list[CdpCookie] = [
+        {
+            "name": c["name"],
+            "value": c["value"],
+            "domain": c["domain"],
+            "path": c.get("path") or "/",
+            "secure": bool(c.get("secure")),
+            "httpOnly": bool(c.get("httpOnly")),
+            "sameSite": c.get("sameSite", "Lax"),
+            **({"expires": int(c["expires"])} if c.get("expires") and int(c["expires"]) > 0 else {}),
+        }
+        for c in filtered
+    ]
+    proc = subprocess.run(
+        ["node", "-e", _CDP_SET_COOKIES_SCRIPT, str(cdp_port)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError((proc.stderr or "CDP cookie injection failed").strip())
+    ok = int((proc.stdout or "0").strip() or "0")
+    print(f"Injected {ok}/{len(filtered)} cookies into agent-browser (CDP {cdp_port})")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Extract browser cookies (cross-platform)")
+    parser.add_argument("--browser", required=True, choices=sorted(BROWSERS.keys()))
+    parser.add_argument("--domain", required=True, action="append", dest="domains")
+    parser.add_argument("--output", help="Write cookies JSON to file")
+    parser.add_argument("--inject", action="store_true", help="Inject into agent-browser")
+    parser.add_argument("--cdp", type=int, default=9242, help="CDP port (default 9242)")
+    args = parser.parse_args()
+
+    cookies = extract_cookies(args.browser, args.domains)
+    print(f"Extracted {len(cookies)} cookies from {args.browser}")
+    if args.output:
+        write_cookie_file(Path(args.output), cookies)
+        print(f"Saved to {args.output}")
+    if args.inject:
+        inject_cookies(cookies, args.cdp)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/insane-browsing/scripts/extract_cookies.py
+++ b/skills/insane-browsing/scripts/extract_cookies.py
@@ -33,13 +33,9 @@ from cookie_crypto import (
 from cookie_domains import domain_where_clause
 from cookie_paths import BROWSERS, BrowserSpec, UnsupportedPlatform, platform_base, resolve_cookie_db
 
-_SAMESITE = {-1: "None", 0: "None", 1: "Lax", 2: "Strict"}
-
-IMPORTANT_COOKIES = {
-    "SID", "SSID", "HSID", "APISID", "SAPISID",
-    "__Secure-1PSID", "__Secure-3PSID", "__Secure-1PSIDTS", "__Secure-3PSIDTS",
-    "LOGIN_INFO", "PREF", "VISITOR_INFO1_LIVE", "YSC", "NID", "CONSENT",
-}
+# Chromium samesite enum: -1 unspecified, 0 None, 1 Lax, 2 Strict.
+# -1 (unspecified) maps to the export-form default Lax — never the literal "None".
+_SAMESITE = {-1: "Lax", 0: "None", 1: "Lax", 2: "Strict"}
 
 
 class CookieRecord(TypedDict):
@@ -231,19 +227,19 @@ def extract_cookies(
 
 
 def inject_cookies(cookies: list[CookieRecord], cdp_port: int) -> None:
-    filtered = [c for c in cookies if c["name"] in IMPORTANT_COOKIES] or cookies
     payload: list[CdpCookie] = [
         {
             "name": c["name"],
             "value": c["value"],
-            "domain": c["domain"],
             "path": c.get("path") or "/",
             "secure": bool(c.get("secure")),
             "httpOnly": bool(c.get("httpOnly")),
             "sameSite": c.get("sameSite", "Lax"),
+            # Host-only cookies (no leading dot) must omit the domain attribute.
+            **({"domain": c["domain"]} if c.get("domain", "").startswith(".") else {}),
             **({"expires": int(c["expires"])} if c.get("expires") and int(c["expires"]) > 0 else {}),
         }
-        for c in filtered
+        for c in cookies
     ]
     proc = subprocess.run(
         ["node", "-e", _CDP_SET_COOKIES_SCRIPT, str(cdp_port)],
@@ -255,7 +251,7 @@ def inject_cookies(cookies: list[CookieRecord], cdp_port: int) -> None:
     if proc.returncode != 0:
         raise RuntimeError((proc.stderr or "CDP cookie injection failed").strip())
     ok = int((proc.stdout or "0").strip() or "0")
-    print(f"Injected {ok}/{len(filtered)} cookies into agent-browser (CDP {cdp_port})")
+    print(f"Injected {ok}/{len(cookies)} cookies into agent-browser (CDP {cdp_port})")
 
 
 def main() -> None:

--- a/skills/insane-browsing/scripts/extract_cookies.py
+++ b/skills/insane-browsing/scripts/extract_cookies.py
@@ -58,6 +58,7 @@ class CdpCookie(TypedDict):
     httpOnly: bool
     sameSite: str
     expires: NotRequired[int]
+    url: NotRequired[str]
 
 
 _CDP_SET_COOKIES_SCRIPT = r"""
@@ -257,8 +258,14 @@ def inject_cookies(cookies: list[CookieRecord], cdp_port: int) -> None:
             "secure": bool(c.get("secure")),
             "httpOnly": bool(c.get("httpOnly")),
             "sameSite": c.get("sameSite", "Lax"),
-            # Host-only cookies (no leading dot) must omit the domain attribute.
-            **({"domain": c["domain"]} if c.get("domain", "").startswith(".") else {}),
+            # Domain cookies (leading dot) carry the domain; host-only cookies
+            # carry no domain, so supply a url instead — CDP needs one or the
+            # other to derive the cookie's origin. Never both.
+            **(
+                {"domain": c["domain"]}
+                if c.get("domain", "").startswith(".")
+                else {"url": f"https://{c['domain']}{c.get('path') or '/'}"}
+            ),
             **({"expires": int(c["expires"])} if c.get("expires") and int(c["expires"]) > 0 else {}),
         }
         for c in cookies

--- a/skills/insane-browsing/scripts/tests/test_cookie_crypto.py
+++ b/skills/insane-browsing/scripts/tests/test_cookie_crypto.py
@@ -85,5 +85,26 @@ class HappyPathDecryption(unittest.TestCase):
         self.assertEqual(decrypt_chromium_value("linux", key, blob), "session-token-123")
 
 
+class CbcPaddingValidation(unittest.TestCase):
+    def test_wrong_key_raises_instead_of_returning_garbage(self) -> None:
+        # #6: decrypting a v10 CBC blob with the wrong key must fail loudly. The
+        # PKCS7 unpadder rejects the malformed padding produced by the wrong key,
+        # so the caller never receives a silently mis-decrypted cookie value.
+        right_key = derive_key("linux", b"secret")
+        wrong_key = derive_key("linux", b"not-the-real-password")
+        blob = _encrypt_cbc_v10(right_key, "session-token-123")
+        with self.assertRaises(ValueError):
+            decrypt_chromium_value("linux", wrong_key, blob)
+
+    def test_tampered_ciphertext_raises(self) -> None:
+        # A modified ciphertext corrupts the final plaintext block, invalidating
+        # the PKCS7 padding — decryption must raise, not return garbage.
+        key = derive_key("linux", b"secret")
+        blob = bytearray(_encrypt_cbc_v10(key, "session-token-123"))
+        blob[-1] ^= 0xFF
+        with self.assertRaises(ValueError):
+            decrypt_chromium_value("linux", key, bytes(blob))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/skills/insane-browsing/scripts/tests/test_cookie_crypto.py
+++ b/skills/insane-browsing/scripts/tests/test_cookie_crypto.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""F13: secretstorage/D-Bus failure must yield a defined empty fallback, not a crash or garbage key."""
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from cookie_crypto import decrypt_chromium_value, derive_key, linux_keyring_secret  # noqa: E402
+
+
+def _encrypt_cbc_v10(key: bytes, plaintext: str) -> bytes:
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+    data = plaintext.encode()
+    pad = 16 - (len(data) % 16)
+    padded = data + bytes([pad]) * pad
+    encryptor = Cipher(algorithms.AES128(key), modes.CBC(b" " * 16)).encryptor()
+    return b"v10" + encryptor.update(padded) + encryptor.finalize()
+
+
+def _fake_secretstorage(dbus_init) -> types.ModuleType:
+    """A stub `secretstorage` whose exception hierarchy mirrors the real package.
+
+    secretstorage.dbus_init() wraps every D-Bus/keyring connection failure (missing
+    DBUS_SESSION_BUS_ADDRESS, ConnectionError, ValueError) into
+    SecretServiceNotAvailableException, a subclass of SecretStorageException — so the
+    real package never installed in this env can still be exercised faithfully.
+    """
+    fake = types.ModuleType("secretstorage")
+    exceptions = types.ModuleType("secretstorage.exceptions")
+
+    class SecretStorageException(Exception):
+        pass
+
+    class SecretServiceNotAvailableException(SecretStorageException):
+        pass
+
+    exceptions.SecretStorageException = SecretStorageException
+    exceptions.SecretServiceNotAvailableException = SecretServiceNotAvailableException
+    fake.exceptions = exceptions
+    fake.dbus_init = dbus_init
+    return fake
+
+
+class SecretStorageFallback(unittest.TestCase):
+    def test_secretstorage_dbus_failure_graceful(self) -> None:
+        # F13: on a headless host secretstorage.dbus_init() raises
+        # SecretServiceNotAvailableException (D-Bus session bus unavailable). The reader
+        # must return a DEFINED empty fallback (b"") — never crash, never substitute the
+        # b"peanuts" garbage key.
+        def _boom(*_a, **_k):
+            raise fake.exceptions.SecretServiceNotAvailableException(
+                "Failed to connect to the D-Bus session bus"
+            )
+
+        fake = _fake_secretstorage(_boom)
+        with patch.dict(sys.modules, {"secretstorage": fake, "secretstorage.exceptions": fake.exceptions}):
+            secret = linux_keyring_secret("Chrome Safe Storage")
+
+        self.assertEqual(secret, b"")
+        self.assertNotEqual(secret, b"peanuts")
+
+    def test_non_dbus_exception_is_not_swallowed(self) -> None:
+        # Guardrail: only the secretstorage/D-Bus failure is caught. An unrelated
+        # programming error inside the keyring read must still propagate.
+        def _bug(*_a, **_k):
+            raise KeyError("unrelated bug")
+
+        fake = _fake_secretstorage(_bug)
+        with patch.dict(sys.modules, {"secretstorage": fake, "secretstorage.exceptions": fake.exceptions}):
+            with self.assertRaises(KeyError):
+                linux_keyring_secret("Chrome Safe Storage")
+
+
+class HappyPathDecryption(unittest.TestCase):
+    def test_linux_cbc_roundtrip_unchanged(self) -> None:
+        # Regression: a valid linux-derived key still decrypts a v10 CBC blob.
+        key = derive_key("linux", b"secret")
+        blob = _encrypt_cbc_v10(key, "session-token-123")
+        self.assertEqual(decrypt_chromium_value("linux", key, blob), "session-token-123")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/skills/insane-browsing/scripts/tests/test_cookie_domain_filter.py
+++ b/skills/insane-browsing/scripts/tests/test_cookie_domain_filter.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import sys
+import tempfile
+import unittest
+from collections.abc import Callable
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from extract_cookies import extract_cookies  # noqa: E402
+
+
+def _make_chromium_db(path: Path, rows: list[tuple[str, bytes, str]]) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE cookies (name TEXT, encrypted_value BLOB, host_key TEXT, path TEXT, "
+        "expires_utc INTEGER, is_secure INTEGER, is_httponly INTEGER, samesite INTEGER)"
+    )
+    conn.executemany(
+        "INSERT INTO cookies VALUES (?,?,?,?,?,?,?,?)",
+        [
+            (name, value, host, "/", 13_300_000_000_000_000, 1, 1, 1)
+            for name, value, host in rows
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def _make_firefox_db(path: Path, rows: list[tuple[str, str, str]]) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE moz_cookies (name TEXT, value TEXT, host TEXT, path TEXT, "
+        "expiry INTEGER, isSecure INTEGER, isHttpOnly INTEGER, sameSite INTEGER)"
+    )
+    conn.executemany(
+        "INSERT INTO moz_cookies VALUES (?,?,?,?,?,?,?,?)",
+        [
+            (name, value, host, "/", 9999999999, 1, 1, 1)
+            for name, value, host in rows
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+class DomainFilter(unittest.TestCase):
+    def _base_with_db(self, rel: str, make: Callable[[Path], None]) -> Path:
+        base = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(str(base), ignore_errors=True))
+        db = base / rel
+        db.parent.mkdir(parents=True)
+        make(db)
+        return base
+
+    def test_chromium_does_not_overmatch_suffix_text(self) -> None:
+        base = self._base_with_db(
+            "Google/Chrome/User Data/Default/Cookies",
+            lambda p: _make_chromium_db(
+                p,
+                [
+                    ("exact", b"exact-value", "example.com"),
+                    ("sub", b"sub-value", ".login.example.com"),
+                    ("near", b"near-value", ".example.com"),
+                ],
+            ),
+        )
+
+        near = extract_cookies(
+            "chrome", ["ample.com"], platform="win32",
+            keyring_reader=lambda _s: b"k" * 32, base_override=base,
+        )
+        exact = extract_cookies(
+            "chrome", ["example.com"], platform="win32",
+            keyring_reader=lambda _s: b"k" * 32, base_override=base,
+        )
+
+        self.assertEqual(near, [])
+        self.assertEqual({cookie["name"] for cookie in exact}, {"exact", "near", "sub"})
+
+    def test_firefox_does_not_overmatch_suffix_text(self) -> None:
+        base = self._base_with_db(
+            "Firefox/Profiles/abc.default/cookies.sqlite",
+            lambda p: _make_firefox_db(
+                p,
+                [
+                    ("exact", "exact-value", "example.com"),
+                    ("sub", "sub-value", ".login.example.com"),
+                    ("near", "near-value", ".example.com"),
+                ],
+            ),
+        )
+
+        near = extract_cookies(
+            "firefox", ["ample.com"], platform="darwin", base_override=base,
+        )
+        exact = extract_cookies(
+            "firefox", ["example.com"], platform="darwin", base_override=base,
+        )
+
+        self.assertEqual(near, [])
+        self.assertEqual({cookie["name"] for cookie in exact}, {"exact", "near", "sub"})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/skills/insane-browsing/scripts/tests/test_cookie_domain_filter.py
+++ b/skills/insane-browsing/scripts/tests/test_cookie_domain_filter.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from cookie_domains import CookieDomainError, normalize_cookie_domain  # noqa: E402
 from extract_cookies import extract_cookies  # noqa: E402
 
 
@@ -46,6 +47,26 @@ def _make_firefox_db(path: Path, rows: list[tuple[str, str, str]]) -> None:
     )
     conn.commit()
     conn.close()
+
+
+class PublicSuffixGuard(unittest.TestCase):
+    def test_rejects_bare_tld(self) -> None:
+        for bare in ("com", "net", "org", ".com", "COM"):
+            with self.assertRaises(CookieDomainError):
+                normalize_cookie_domain(bare)
+
+    def test_rejects_known_multi_label_public_suffix(self) -> None:
+        for suffix in ("co.uk", "com.au", "co.kr"):
+            with self.assertRaises(CookieDomainError):
+                normalize_cookie_domain(suffix)
+
+    def test_accepts_legitimate_etld_plus_one(self) -> None:
+        self.assertEqual(normalize_cookie_domain("youtube.com"), "youtube.com")
+        self.assertEqual(normalize_cookie_domain("github.com"), "github.com")
+
+    def test_accepts_registrable_domain_under_public_suffix(self) -> None:
+        self.assertEqual(normalize_cookie_domain("example.co.uk"), "example.co.uk")
+        self.assertEqual(normalize_cookie_domain("login.example.com"), "login.example.com")
 
 
 class DomainFilter(unittest.TestCase):
@@ -104,6 +125,14 @@ class DomainFilter(unittest.TestCase):
 
         self.assertEqual(near, [])
         self.assertEqual({cookie["name"] for cookie in exact}, {"exact", "near", "sub"})
+
+    def test_extract_cookies_fails_closed_on_bare_tld(self) -> None:
+        base = self._base_with_db(
+            "Firefox/Profiles/abc.default/cookies.sqlite",
+            lambda p: _make_firefox_db(p, [("exact", "exact-value", "example.com")]),
+        )
+        with self.assertRaises(CookieDomainError):
+            extract_cookies("firefox", ["com"], platform="darwin", base_override=base)
 
 
 if __name__ == "__main__":

--- a/skills/insane-browsing/scripts/tests/test_extract_cookies.py
+++ b/skills/insane-browsing/scripts/tests/test_extract_cookies.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Synthetic-fixture tests for cross-platform cookie extraction (no live browser)."""
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Callable
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from cookie_crypto import decrypt_chromium_value, derive_key  # noqa: E402
+from cookie_paths import UnsupportedPlatform, resolve_cookie_db  # noqa: E402
+from extract_cookies import extract_cookies, inject_cookies, write_cookie_file  # noqa: E402
+
+
+def _make_chromium_db(path: Path, name: str, encrypted_value: bytes, host: str) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE cookies (name TEXT, encrypted_value BLOB, host_key TEXT, path TEXT, "
+        "expires_utc INTEGER, is_secure INTEGER, is_httponly INTEGER, samesite INTEGER)"
+    )
+    conn.execute(
+        "INSERT INTO cookies VALUES (?,?,?,?,?,?,?,?)",
+        (name, encrypted_value, host, "/", 13_300_000_000_000_000, 1, 1, 1),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _make_firefox_db(path: Path, name: str, value: str, host: str) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE moz_cookies (name TEXT, value TEXT, host TEXT, path TEXT, "
+        "expiry INTEGER, isSecure INTEGER, isHttpOnly INTEGER, sameSite INTEGER)"
+    )
+    conn.execute("INSERT INTO moz_cookies VALUES (?,?,?,?,?,?,?,?)", (name, value, host, "/", 9999999999, 1, 1, 1))
+    conn.commit()
+    conn.close()
+
+
+def _encrypt_cbc_v10(key: bytes, plaintext: str) -> bytes:
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+    data = plaintext.encode()
+    pad = 16 - (len(data) % 16)
+    padded = data + bytes([pad]) * pad
+    encryptor = Cipher(algorithms.AES128(key), modes.CBC(b" " * 16)).encryptor()
+    return b"v10" + encryptor.update(padded) + encryptor.finalize()
+
+
+def _encrypt_gcm_v10(key: bytes, plaintext: str) -> bytes:
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+    nonce = b"n" * 12
+    encryptor = Cipher(algorithms.AES(key), modes.GCM(nonce)).encryptor()
+    ciphertext = encryptor.update(plaintext.encode()) + encryptor.finalize()
+    return b"v10" + nonce + ciphertext + encryptor.tag
+
+
+class PathResolution(unittest.TestCase):
+    def test_macos_chromium_path(self) -> None:
+        base = Path(self.tmp())
+        target = base / "Google/Chrome/Default/Cookies"
+        target.parent.mkdir(parents=True)
+        target.write_bytes(b"")
+        self.assertEqual(resolve_cookie_db("chrome", "darwin", base_override=base), target)
+
+    def test_linux_chromium_network_path(self) -> None:
+        base = Path(self.tmp())
+        target = base / "google-chrome/Default/Network/Cookies"
+        target.parent.mkdir(parents=True)
+        target.write_bytes(b"")
+        self.assertEqual(resolve_cookie_db("chrome", "linux", base_override=base), target)
+
+    def test_windows_chromium_path(self) -> None:
+        base = Path(self.tmp())
+        target = base / "Google/Chrome/User Data/Default/Cookies"
+        target.parent.mkdir(parents=True)
+        target.write_bytes(b"")
+        self.assertEqual(resolve_cookie_db("chrome", "win32", base_override=base), target)
+
+    def test_unsupported_platform_raises(self) -> None:
+        with self.assertRaises(UnsupportedPlatform):
+            resolve_cookie_db("chrome", "sunos")
+
+    def test_unsupported_browser_raises(self) -> None:
+        with self.assertRaises(UnsupportedPlatform):
+            resolve_cookie_db("nonexistent", "darwin")
+
+    def tmp(self) -> str:
+        import tempfile
+
+        d = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        return d
+
+
+class KeyDerivation(unittest.TestCase):
+    def test_macos_iters_differ_from_linux(self) -> None:
+        secret = b"some-keychain-secret"
+        self.assertNotEqual(derive_key("darwin", secret), derive_key("linux", secret))
+        self.assertEqual(len(derive_key("darwin", secret)), 16)
+
+    def test_windows_passthrough_32_bytes(self) -> None:
+        key = b"k" * 32
+        self.assertEqual(derive_key("win32", key), key)
+
+    def test_windows_rejects_wrong_length(self) -> None:
+        with self.assertRaises(ValueError):
+            derive_key("win32", b"short")
+
+    def test_unsupported_platform_raises(self) -> None:
+        with self.assertRaises(UnsupportedPlatform):
+            derive_key("sunos", b"x")
+
+
+class Decryption(unittest.TestCase):
+    def test_macos_cbc_roundtrip(self) -> None:
+        key = derive_key("darwin", b"secret")
+        blob = _encrypt_cbc_v10(key, "session-token-123")
+        self.assertEqual(decrypt_chromium_value("darwin", key, blob), "session-token-123")
+
+    def test_windows_gcm_roundtrip(self) -> None:
+        key = b"k" * 32
+        blob = _encrypt_gcm_v10(key, "win-token-xyz")
+        self.assertEqual(decrypt_chromium_value("win32", key, blob), "win-token-xyz")
+
+
+class EndToEnd(unittest.TestCase):
+    def _base_with_db(self, rel: str, make: Callable[[Path], None]) -> Path:
+        base = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(str(base), ignore_errors=True))
+        db = base / rel
+        db.parent.mkdir(parents=True)
+        make(db)
+        return base
+
+    def test_chromium_extract_with_injected_keyring(self) -> None:
+        key = derive_key("darwin", b"secret")
+        blob = _encrypt_cbc_v10(key, "logged-in")
+        base = self._base_with_db(
+            "Google/Chrome/Default/Cookies",
+            lambda p: _make_chromium_db(p, "SID", blob, ".youtube.com"),
+        )
+        cookies = extract_cookies(
+            "chrome", ["youtube.com"], platform="darwin",
+            keyring_reader=lambda _s: b"secret", base_override=base,
+        )
+        self.assertEqual(len(cookies), 1)
+        self.assertEqual(cookies[0]["value"], "logged-in")
+        self.assertEqual(cookies[0]["name"], "SID")
+
+    def test_firefox_extract_unencrypted(self) -> None:
+        base = self._base_with_db(
+            "Firefox/Profiles/abc.default/cookies.sqlite",
+            lambda p: _make_firefox_db(p, "auth", "plain-value", ".example.com"),
+        )
+        cookies = extract_cookies("firefox", ["example.com"], platform="darwin", base_override=base)
+        self.assertEqual(len(cookies), 1)
+        self.assertEqual(cookies[0]["value"], "plain-value")
+
+
+class SecretHandling(unittest.TestCase):
+    def test_cookie_output_file_is_owner_only(self) -> None:
+        base = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(str(base), ignore_errors=True))
+        output = base / "cookies.json"
+
+        write_cookie_file(output, [{"name": "SID", "value": "secret"}])
+
+        self.assertEqual(output.stat().st_mode & 0o777, 0o600)
+        self.assertIn("secret", output.read_text())
+
+    def test_cookie_output_replaces_existing_file_only_after_private_temp_write(self) -> None:
+        base = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(str(base), ignore_errors=True))
+        output = base / "cookies.json"
+        output.write_text("old\n")
+        output.chmod(0o644)
+
+        def _dump(_cookies, f, indent: int) -> None:
+            self.assertEqual(output.read_text(), "old\n")
+            self.assertEqual(output.stat().st_mode & 0o777, 0o644)
+            temp_files = list(base.glob(".cookies.json.*.tmp"))
+            self.assertEqual(len(temp_files), 1)
+            self.assertEqual(temp_files[0].stat().st_mode & 0o777, 0o600)
+            f.write('[{"name": "SID", "value": "secret"}]')
+
+        with patch("extract_cookies.json.dump", side_effect=_dump):
+            write_cookie_file(output, [{"name": "SID", "value": "secret"}])
+
+        self.assertEqual(output.stat().st_mode & 0o777, 0o600)
+        self.assertIn("secret", output.read_text())
+
+    def test_cookie_output_refuses_symlinks(self) -> None:
+        base = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(str(base), ignore_errors=True))
+        target = base / "target.json"
+        target.write_text("{}")
+        link = base / "cookies.json"
+        link.symlink_to(target)
+
+        with self.assertRaises(ValueError):
+            write_cookie_file(link, [{"name": "SID", "value": "secret"}])
+
+    def test_cookie_output_refuses_dangling_symlinks(self) -> None:
+        base = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(str(base), ignore_errors=True))
+        link = base / "cookies.json"
+        link.symlink_to(base / "missing.json")
+
+        with self.assertRaises(ValueError):
+            write_cookie_file(link, [{"name": "SID", "value": "secret"}])
+
+    def test_inject_cookies_sends_values_over_stdin_not_argv(self) -> None:
+        cookie = {
+            "name": "SID",
+            "value": "secret-token",
+            "domain": ".youtube.com",
+            "path": "/",
+            "expires": 9999999999,
+            "secure": True,
+            "httpOnly": True,
+            "sameSite": "Lax",
+        }
+
+        with patch("extract_cookies.subprocess.run") as run:
+            run.return_value.returncode = 0
+            run.return_value.stdout = "1"
+            run.return_value.stderr = ""
+
+            inject_cookies([cookie], 9242)
+
+        command = run.call_args.args[0]
+        self.assertNotIn("secret-token", command)
+        self.assertIn("secret-token", run.call_args.kwargs["input"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/skills/insane-browsing/scripts/tests/test_extract_cookies.py
+++ b/skills/insane-browsing/scripts/tests/test_extract_cookies.py
@@ -18,7 +18,7 @@ from cookie_paths import UnsupportedPlatform, resolve_cookie_db  # noqa: E402
 from extract_cookies import extract_cookies, inject_cookies, write_cookie_file  # noqa: E402
 
 
-def _make_chromium_db(path: Path, name: str, encrypted_value: bytes, host: str) -> None:
+def _make_chromium_db(path: Path, name: str, encrypted_value: bytes, host: str, samesite: int = 1) -> None:
     conn = sqlite3.connect(str(path))
     conn.execute(
         "CREATE TABLE cookies (name TEXT, encrypted_value BLOB, host_key TEXT, path TEXT, "
@@ -26,7 +26,7 @@ def _make_chromium_db(path: Path, name: str, encrypted_value: bytes, host: str) 
     )
     conn.execute(
         "INSERT INTO cookies VALUES (?,?,?,?,?,?,?,?)",
-        (name, encrypted_value, host, "/", 13_300_000_000_000_000, 1, 1, 1),
+        (name, encrypted_value, host, "/", 13_300_000_000_000_000, 1, 1, samesite),
     )
     conn.commit()
     conn.close()
@@ -239,6 +239,85 @@ class SecretHandling(unittest.TestCase):
         command = run.call_args.args[0]
         self.assertNotIn("secret-token", command)
         self.assertIn("secret-token", run.call_args.kwargs["input"])
+
+
+class CookieFieldFixes(unittest.TestCase):
+    """F9/F10/F11/F14: SameSite, inject-all, host-only domain, cookie-path order."""
+
+    def _base_with_db(self, rel: str, make: Callable[[Path], None]) -> Path:
+        base = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(str(base), ignore_errors=True))
+        db = base / rel
+        db.parent.mkdir(parents=True)
+        make(db)
+        return base
+
+    @staticmethod
+    def _inject_payload(cookies: list) -> list:
+        import json
+
+        captured: dict = {}
+        with patch("extract_cookies.subprocess.run") as run:
+            run.return_value.returncode = 0
+            run.return_value.stdout = str(len(cookies))
+            run.return_value.stderr = ""
+            inject_cookies(cookies, 9242)
+            captured["input"] = run.call_args.kwargs["input"]
+        return json.loads(captured["input"])
+
+    def test_samesite_minus_one_is_lax_not_none(self) -> None:
+        # F9: SameSite -1 must map to "Lax" for the export form, never "None".
+        key = derive_key("darwin", b"secret")
+        blob = _encrypt_cbc_v10(key, "logged-in")
+        base = self._base_with_db(
+            "Google/Chrome/Default/Cookies",
+            lambda p: _make_chromium_db(p, "SID", blob, ".youtube.com", samesite=-1),
+        )
+        cookies = extract_cookies(
+            "chrome", ["youtube.com"], platform="darwin",
+            keyring_reader=lambda _s: b"secret", base_override=base,
+        )
+        self.assertEqual(len(cookies), 1)
+        self.assertEqual(cookies[0]["sameSite"], "Lax")
+        self.assertNotEqual(cookies[0]["sameSite"], "None")
+
+    def test_inject_includes_non_important_cookies(self) -> None:
+        # F10: ALL cookies are injected, not only IMPORTANT-flagged ones.
+        cookies = [
+            {"name": "SID", "value": "v1", "domain": ".youtube.com", "path": "/",
+             "secure": True, "httpOnly": True, "sameSite": "Lax"},
+            {"name": "csrf_token", "value": "v2", "domain": ".youtube.com", "path": "/",
+             "secure": True, "httpOnly": False, "sameSite": "Lax"},
+        ]
+        payload = self._inject_payload(cookies)
+        names = {c["name"] for c in payload}
+        self.assertIn("csrf_token", names)
+        self.assertEqual(len(payload), 2)
+
+    def test_host_only_cookie_omits_domain(self) -> None:
+        # F11: host-only cookies (no leading dot) omit the domain attribute.
+        cookies = [
+            {"name": "host_only", "value": "v", "domain": "example.com", "path": "/",
+             "secure": True, "httpOnly": False, "sameSite": "Lax"},
+            {"name": "wide", "value": "v", "domain": ".example.com", "path": "/",
+             "secure": True, "httpOnly": False, "sameSite": "Lax"},
+        ]
+        payload = self._inject_payload(cookies)
+        by_name = {c["name"]: c for c in payload}
+        self.assertNotIn("domain", by_name["host_only"])
+        self.assertEqual(by_name["wide"]["domain"], ".example.com")
+
+    def test_prefers_network_cookies_over_legacy(self) -> None:
+        # F14: prefer Network/Cookies over the legacy Cookies path when both exist.
+        base = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(str(base), ignore_errors=True))
+        legacy = base / "Google/Chrome/Default/Cookies"
+        network = base / "Google/Chrome/Default/Network/Cookies"
+        legacy.parent.mkdir(parents=True)
+        network.parent.mkdir(parents=True)
+        legacy.write_bytes(b"")
+        network.write_bytes(b"")
+        self.assertEqual(resolve_cookie_db("chrome", "darwin", base_override=base), network)
 
 
 if __name__ == "__main__":

--- a/skills/insane-browsing/scripts/tests/test_extract_cookies.py
+++ b/skills/insane-browsing/scripts/tests/test_extract_cookies.py
@@ -320,5 +320,109 @@ class CookieFieldFixes(unittest.TestCase):
         self.assertEqual(resolve_cookie_db("chrome", "darwin", base_override=base), network)
 
 
+class CdpTargetSelection(unittest.TestCase):
+    """F#4: Network.setCookie must target a page, not the browser target.
+
+    The injection JS runs in a node subprocess against a live CDP endpoint, so
+    it cannot be exercised without a browser. These checks pin the structural
+    contract that fixes the bug: pick a page target from /json/list rather than
+    the browser target from /json/version, and fail loudly if none exists.
+    """
+
+    def _script(self) -> str:
+        from extract_cookies import _CDP_SET_COOKIES_SCRIPT
+
+        return _CDP_SET_COOKIES_SCRIPT
+
+    def test_connects_via_page_target_list_not_browser_version(self) -> None:
+        script = self._script()
+        self.assertIn("/json/list", script)
+        self.assertNotIn("/json/version", script)
+
+    def test_selects_page_type_target(self) -> None:
+        self.assertIn('"page"', self._script())
+
+    def test_errors_when_no_page_target(self) -> None:
+        self.assertIn("no page target", self._script().lower())
+
+    def test_still_uses_network_setcookie_payload(self) -> None:
+        # Keep the existing payload shape (no Storage.setCookies rewrite).
+        self.assertIn("Network.setCookie", self._script())
+
+
+class KeyringFallback(unittest.TestCase):
+    """F#7: an empty keyring secret must be detected, never used silently."""
+
+    def _base_with_db(self, rel: str, make: Callable[[Path], None]) -> Path:
+        base = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(str(base), ignore_errors=True))
+        db = base / rel
+        db.parent.mkdir(parents=True)
+        make(db)
+        return base
+
+    def test_linux_empty_keyring_falls_back_to_peanuts(self) -> None:
+        # Chromium on a keyring-less Linux host encrypts with the default
+        # password "peanuts"; an empty secret must derive that same key, not garbage.
+        key = derive_key("linux", b"peanuts")
+        blob = _encrypt_cbc_v10(key, "logged-in")
+        base = self._base_with_db(
+            "google-chrome/Default/Network/Cookies",
+            lambda p: _make_chromium_db(p, "SID", blob, ".youtube.com"),
+        )
+        cookies = extract_cookies(
+            "chrome", ["youtube.com"], platform="linux",
+            keyring_reader=lambda _s: b"", base_override=base,
+        )
+        self.assertEqual(len(cookies), 1)
+        self.assertEqual(cookies[0]["value"], "logged-in")
+
+    def test_darwin_empty_keyring_raises(self) -> None:
+        # macOS has no defined empty-keyring fallback: an empty secret is
+        # unrecoverable and must raise, not silently mis-decrypt.
+        base = self._base_with_db(
+            "Google/Chrome/Default/Cookies",
+            lambda p: _make_chromium_db(p, "SID", b"v10garbage", ".youtube.com"),
+        )
+        with self.assertRaises(RuntimeError):
+            extract_cookies(
+                "chrome", ["youtube.com"], platform="darwin",
+                keyring_reader=lambda _s: b"", base_override=base,
+            )
+
+
+class InjectionResultHandling(unittest.TestCase):
+    """F#5: total rejection must fail loudly, never proceed unauthenticated."""
+
+    @staticmethod
+    def _run_inject(cookies: list, stdout: str) -> None:
+        with patch("extract_cookies.subprocess.run") as run:
+            run.return_value.returncode = 0
+            run.return_value.stdout = stdout
+            run.return_value.stderr = ""
+            inject_cookies(cookies, 9242)
+
+    def test_inject_raises_when_all_cookies_rejected(self) -> None:
+        # ok=0 with non-empty cookies means the browser rejected every cookie;
+        # proceeding would run the session unauthenticated.
+        cookie = {"name": "SID", "value": "v", "domain": ".youtube.com", "path": "/",
+                  "secure": True, "httpOnly": True, "sameSite": "Lax"}
+        with self.assertRaises(RuntimeError):
+            self._run_inject([cookie], "0")
+
+    def test_inject_empty_cookie_list_is_noop_not_error(self) -> None:
+        # Nothing to inject is a no-op, not a rejection: 0/0 must not raise.
+        self._run_inject([], "0")
+
+    def test_inject_partial_success_does_not_raise(self) -> None:
+        cookies = [
+            {"name": "a", "value": "1", "domain": ".x.com", "path": "/",
+             "secure": True, "httpOnly": True, "sameSite": "Lax"},
+            {"name": "b", "value": "2", "domain": ".x.com", "path": "/",
+             "secure": True, "httpOnly": True, "sameSite": "Lax"},
+        ]
+        self._run_inject(cookies, "1")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/skills/insane-browsing/scripts/tests/test_extract_cookies.py
+++ b/skills/insane-browsing/scripts/tests/test_extract_cookies.py
@@ -307,6 +307,24 @@ class CookieFieldFixes(unittest.TestCase):
         self.assertNotIn("domain", by_name["host_only"])
         self.assertEqual(by_name["wide"]["domain"], ".example.com")
 
+    def test_host_only_cookie_supplies_url_so_cdp_can_derive_origin(self) -> None:
+        # F#1 (Codex P2): host-only cookies carry no domain, so CDP needs a url
+        # to derive the origin; domain cookies keep domain and must not also
+        # send url. The url path mirrors the cookie path.
+        cookies = [
+            {"name": "host_only", "value": "v", "domain": "example.com", "path": "/account",
+             "secure": True, "httpOnly": False, "sameSite": "Lax"},
+            {"name": "wide", "value": "v", "domain": ".example.com", "path": "/",
+             "secure": True, "httpOnly": False, "sameSite": "Lax"},
+        ]
+        payload = self._inject_payload(cookies)
+        by_name = {c["name"]: c for c in payload}
+        self.assertIn("url", by_name["host_only"])
+        self.assertEqual(by_name["host_only"]["url"], "https://example.com/account")
+        self.assertNotIn("domain", by_name["host_only"])
+        self.assertNotIn("url", by_name["wide"])
+        self.assertEqual(by_name["wide"]["domain"], ".example.com")
+
     def test_prefers_network_cookies_over_legacy(self) -> None:
         # F14: prefer Network/Cookies over the legacy Cookies path when both exist.
         base = Path(tempfile.mkdtemp())

--- a/skills/ultraresearch/SKILL.md
+++ b/skills/ultraresearch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ultraresearch
-description: "Maximum-saturation research orchestration as ONE engine with three postures. Fans synchronous explore+librarian worker waves across codebase, web, official docs, and OSS repos; runs an EXPAND-until-convergence loop driven by leads workers return at each barrier; verifies contested claims through a separate verification pass (executed code for code-shaped claims, oracle citation re-read for the rest); synthesizes a cited SYNTHESIS.md. ACTIVATES on an explicit research demand (the word 'ultraresearch', '/ultraresearch') OR as a pre-work grounding posture invoked by deep-interview / a caller that needs facts before judgment. Never self-activates for ordinary questions, debugging, or routine implementation context-gathering. While active it overrides exploration-bounding defaults: exhaustive coverage is the goal."
+description: "Maximum-saturation research orchestration as ONE engine with three postures. Fans synchronous explore+librarian+browsing worker waves across codebase, web, official docs, and OSS repos; runs an EXPAND-until-convergence loop driven by leads workers return at each barrier; verifies contested claims through a separate verification pass (executed code for code-shaped claims, oracle citation re-read for the rest); synthesizes a cited SYNTHESIS.md. ACTIVATES on an explicit research demand (the word 'ultraresearch', '/ultraresearch') OR as a pre-work grounding posture invoked by deep-interview / a caller that needs facts before judgment. Never self-activates for ordinary questions, debugging, or routine implementation context-gathering. While active it overrides exploration-bounding defaults: exhaustive coverage is the goal."
 ---
 
 <Role>
@@ -20,6 +20,7 @@ This is an **umbrella skill**: pre-work grounding is a POSTURE of this engine, n
 - **Engine**: ported from oh-my-openagent's `ultraresearch` saturation-research skill. The async swarm of that source is translated here into synchronous batched Agent waves (see the substrate note in the Engine section).
 - **Claim-ledger / verification gate**: EviBound (arXiv:2511.05524) — the ledger-lock idea that only ledger-cleared claims may enter synthesis. The MLflow run-id/FINISHED backend of the paper is replaced with OMT-native ground truth (executed code / oracle citation re-read).
 - **Socratic lineage**: Q00 + ouroboros (the [Q00/ouroboros](https://github.com/Q00/ouroboros) project) — specification-quality-first questioning, inherited via deep-interview, which is this engine's CLEAR-posture interactive partner.
+- **Browsing engine**: fivetaku/insane-search (MIT) → vendored as the insane-browsing skill; authenticated and JS-rendered page access for sources blocked to surface-level web retrieval. (Distribution chain: fivetaku/insane-search → oh-my-openagent copy → OMT vendored skill.)
 
 </Attribution>
 
@@ -62,7 +63,7 @@ The vocabulary is therefore: **wave → barrier collect → next wave**. There i
 
 ## Worker ground rules
 
-- **Read-only gatherers.** Research workers (explore, librarian) cannot write the journal or any session file. Every journal write is yours.
+- **Read-only gatherers.** Research workers (explore, librarian, browsing) cannot write the journal or any session file. Every journal write is yours.
 - **No worker recursion.** Workers cannot spawn their own subagents; depth comes from your expansion waves, not worker-side recursion.
 - **Lift the budget in the spawn message.** Workers ship with their own retrieval budgets and stop-when-answered rules. Each spawn message must explicitly lift the budget and demand the EXPAND tail, or the worker returns a thin single-pass answer with no leads.
 - **One unique angle per worker.** No two workers in a wave share an angle. Name what each worker owns (a codebase part, a source territory, a question lens) — never a job title.
@@ -84,12 +85,15 @@ A worker with nothing to expand writes `## EXPAND` then `none — <one-line reas
 
 Decompose the query into 3+ orthogonal axes, classify the posture and tier (see the Postures section), and open the session directory `$OMT_DIR/ultraresearch/<slug>-<timestamp>/` as `$SESSION_DIR` (`<slug>` is a short kebab-case label derived from the query so the run is identifiable; the `<timestamp>` suffix keeps concurrent or repeated runs from colliding). You own the journal: you write every file in it; workers never do.
 
+  - **Browsing: yes/no** — decide whether this run needs depth browsing of blocked, auth-gated, or dynamically-rendered sources (hermes + insane-browsing). Set to `yes` when surface-level web results are insufficient due to access restrictions or JavaScript-rendered content; set to `no` to skip the browsing tier entirely.
+
 ## Phase 1 — Saturation wave
 
 Launch the entire first wave in one response — every Phase-0 axis at once, as foreground Agent workers. Sequential launches and "start with one and see" defeat the engine. Embed the relevant role protocol in each spawn message:
 
 - **Codebase (explore), per the tier floor.** Grep with 3+ keyword variations; structural/AST search; LSP definitions and references; file-name globs; `git log --all -S` and `--grep` for history including deleted code. Report absolute file paths, `file:line` patterns, and how findings connect.
 - **Web (librarian), per the tier floor.** At least 10 distinct websearch queries per worker, each with a different operator or angle; fetch the full page for every result that matters. Real-world usage via `gh search` and grep.app; official docs via sitemap discovery.
+- **Browsing (hermes, insane-browsing 로드), per the tier floor.** Full authenticated and JavaScript-rendered page access for sources blocked or insufficiently covered by surface-level web retrieval; only dispatched when Phase-0 Browsing gate is `yes`.
 
 ## Phase 2 — EXPAND until convergence (the wave loop)
 
@@ -160,13 +164,13 @@ CLEAR is the primary interactive pre-work path (a human answers the decisions vi
 
 The tier signal comes from: **the prometheus intent class + T1 risk modifiers + a caller-supplied override**. (This reuses the existing, validated intent classifier rather than inventing a bespoke complexity scorer. The classifier lives in the caller/prometheus; this engine owns only the tier→floor mapping below.)
 
-| Intent class (tier) | explore | librarian | floor | Notes |
-|---|---|---|---|---|
-| Trivial | 0 | 0 | 0 | short-circuit — no fan-out (see below) |
-| Scoped | 2 | 1 | 2-3 | the in-interview cap when deep-interview calls this engine |
-| Complex | 3 | 2 | ~5 + librarian | |
-| Architecture | 4 | 6 | full fan-out + oracle | the widest case |
-| explicit `/ultraresearch` | 4 | 6 | max | exhaustive |
+| Intent class (tier) | explore | librarian | browsing | floor | Notes |
+|---|---|---|---|---|---|
+| Trivial | 0 | 0 | 0 | 0 | short-circuit — no fan-out (see below) |
+| Scoped | 2 | 1 | 0 | 2-3 | the in-interview cap when deep-interview calls this engine |
+| Complex | 3 | 2 | 1 | ~5 + librarian | |
+| Architecture | 4 | 6 | 2 | full fan-out + oracle | the widest case |
+| explicit `/ultraresearch` | 4 | 6 | 2 | max | exhaustive |
 
 T1 risk modifiers raise the floor for high-risk dimensions; a caller-supplied override takes precedence over the intent-class default.
 

--- a/tools/lib/sync-directory.test.ts
+++ b/tools/lib/sync-directory.test.ts
@@ -128,6 +128,30 @@ describe("syncDirectory", () => {
       expect(await exists(path.join(tgt, "script.sh"))).toBe(true);
       expect(await exists(path.join(tgt, "readme.md"))).toBe(false);
     });
+
+    it("excludes python cache artifacts", async () => {
+      // A local pytest run leaves __pycache__/.pytest_cache + *.pyc on disk.
+      // sync copies directories verbatim (not from git), so .gitignore does not
+      // protect the walk — these must be pruned during the FS walk.
+      await writeFile(path.join(src, "mod.py"), "print('hi')");
+      await writeFile(path.join(src, "__pycache__/mod.cpython-312.pyc"), "bytecode");
+      await writeFile(path.join(src, ".pytest_cache/CACHEDIR.TAG"), "tag");
+      await writeFile(path.join(src, "pkg/sub.py"), "x = 1");
+      await writeFile(path.join(src, "pkg/__pycache__/sub.cpython-312.pyc"), "bytecode");
+
+      await syncDirectory(src, tgt);
+
+      // Legitimate .py source is still deployed (prune scoping).
+      expect(await exists(path.join(tgt, "mod.py"))).toBe(true);
+      expect(await exists(path.join(tgt, "pkg/sub.py"))).toBe(true);
+
+      // Cache directories and their *.pyc contents are pruned during the walk.
+      expect(await exists(path.join(tgt, "__pycache__"))).toBe(false);
+      expect(await exists(path.join(tgt, "__pycache__/mod.cpython-312.pyc"))).toBe(false);
+      expect(await exists(path.join(tgt, ".pytest_cache"))).toBe(false);
+      expect(await exists(path.join(tgt, "pkg/__pycache__"))).toBe(false);
+      expect(await exists(path.join(tgt, "pkg/__pycache__/sub.cpython-312.pyc"))).toBe(false);
+    });
   });
 
   describe("실행 권한 보존", () => {

--- a/tools/lib/sync-directory.test.ts
+++ b/tools/lib/sync-directory.test.ts
@@ -152,6 +152,36 @@ describe("syncDirectory", () => {
       expect(await exists(path.join(tgt, "pkg/__pycache__"))).toBe(false);
       expect(await exists(path.join(tgt, "pkg/__pycache__/sub.cpython-312.pyc"))).toBe(false);
     });
+
+    it("prunes python cache even when custom exclude is passed", async () => {
+      // Regression: callers like claude.ts pass { exclude: ["*.test.ts"] }.
+      // Under the old `?? DEFAULT_EXCLUDE` logic this REPLACES DEFAULT_EXCLUDE,
+      // so __pycache__/.pytest_cache/*.pyc are no longer excluded. The fix must
+      // always union PY_CACHE_EXCLUDE with the caller's list.
+      await writeFile(path.join(src, "script.sh"), "#!/bin/bash\necho hi");
+      await writeFile(path.join(src, "helper.ts"), "export const x = 1;");
+      await writeFile(path.join(src, "helper.test.ts"), "import './helper.ts'");
+      await writeFile(path.join(src, "__pycache__/mod.cpython-312.pyc"), "bytecode");
+      await writeFile(path.join(src, ".pytest_cache/CACHEDIR.TAG"), "Signature: 8a477f597d28d172789f06886806bc55");
+      await writeFile(path.join(src, "pkg/sub.py"), "x = 1");
+      await writeFile(path.join(src, "pkg/__pycache__/sub.cpython-312.pyc"), "bytecode");
+
+      // Custom exclude passed — currently replaces DEFAULT_EXCLUDE (bug).
+      await syncDirectory(src, tgt, { exclude: ["*.test.ts"] });
+
+      // Regular files are still copied.
+      expect(await exists(path.join(tgt, "script.sh"))).toBe(true);
+      expect(await exists(path.join(tgt, "helper.ts"))).toBe(true);
+      expect(await exists(path.join(tgt, "pkg/sub.py"))).toBe(true);
+
+      // Custom exclude still applies.
+      expect(await exists(path.join(tgt, "helper.test.ts"))).toBe(false);
+
+      // Python cache must be pruned regardless of custom exclude.
+      expect(await exists(path.join(tgt, "__pycache__/mod.cpython-312.pyc"))).toBe(false);
+      expect(await exists(path.join(tgt, ".pytest_cache/CACHEDIR.TAG"))).toBe(false);
+      expect(await exists(path.join(tgt, "pkg/__pycache__/sub.cpython-312.pyc"))).toBe(false);
+    });
   });
 
   describe("실행 권한 보존", () => {

--- a/tools/lib/sync-directory.ts
+++ b/tools/lib/sync-directory.ts
@@ -1,7 +1,10 @@
 import fs from "fs/promises";
 import path from "path";
 
-export const DEFAULT_EXCLUDE = ["*.test.ts", "__pycache__", ".pytest_cache", "*.pyc"];
+/** Python cache patterns that are always excluded, regardless of any caller-supplied list. */
+export const PY_CACHE_EXCLUDE = ["__pycache__", ".pytest_cache", "*.pyc"];
+
+export const DEFAULT_EXCLUDE = [...PY_CACHE_EXCLUDE, "*.test.ts"];
 
 /**
  * Checks if a filename matches any of the given glob-style exclude patterns.
@@ -139,7 +142,9 @@ export async function syncDirectory(
   target: string,
   options?: { exclude?: string[]; platformRoot?: string }
 ): Promise<void> {
-  const exclude = options?.exclude ?? DEFAULT_EXCLUDE;
+  // PY_CACHE_EXCLUDE is always prepended so callers that supply a custom list
+  // (e.g. { exclude: ["*.test.ts"] }) do not accidentally lose Python cache pruning.
+  const exclude = [...PY_CACHE_EXCLUDE, ...(options?.exclude ?? ["*.test.ts"])];
   const platformRoot = options?.platformRoot;
 
   // 1. Ensure target directory exists

--- a/tools/lib/sync-directory.ts
+++ b/tools/lib/sync-directory.ts
@@ -1,7 +1,7 @@
 import fs from "fs/promises";
 import path from "path";
 
-export const DEFAULT_EXCLUDE = ["*.test.ts"];
+export const DEFAULT_EXCLUDE = ["*.test.ts", "__pycache__", ".pytest_cache", "*.pyc"];
 
 /**
  * Checks if a filename matches any of the given glob-style exclude patterns.
@@ -22,14 +22,25 @@ export function isExcluded(filename: string, patterns: string[]): boolean {
 /**
  * Recursively collects all file paths under a directory.
  * Returns paths relative to the root dir.
+ *
+ * Excluded names are pruned DURING the walk: an excluded directory name (e.g.
+ * `__pycache__`, `.pytest_cache`) is never descended into, and excluded files
+ * (e.g. `*.pyc`) are skipped. Pruning at the walk — not only in the caller's
+ * post-filter — is what keeps the contents of a cache directory off the copy
+ * list, since the source tree is copied verbatim from disk, not from git.
  */
-export async function collectFiles(dir: string, rel = ""): Promise<string[]> {
+export async function collectFiles(
+  dir: string,
+  rel = "",
+  exclude: string[] = DEFAULT_EXCLUDE,
+): Promise<string[]> {
   const results: string[] = [];
   const entries = await fs.readdir(dir, { withFileTypes: true });
   for (const entry of entries) {
+    if (isExcluded(entry.name, exclude)) continue;
     const relPath = rel ? `${rel}/${entry.name}` : entry.name;
     if (entry.isDirectory()) {
-      const nested = await collectFiles(path.join(dir, entry.name), relPath);
+      const nested = await collectFiles(path.join(dir, entry.name), relPath, exclude);
       results.push(...nested);
     } else if (entry.isFile()) {
       results.push(relPath);
@@ -134,8 +145,8 @@ export async function syncDirectory(
   // 1. Ensure target directory exists
   await fs.mkdir(target, { recursive: true });
 
-  // 2. Collect source files
-  const sourceFiles = await collectFiles(source);
+  // 2. Collect source files (excluded dir names are pruned during the walk)
+  const sourceFiles = await collectFiles(source, "", exclude);
 
   // 3. Determine files to copy (respecting exclude patterns)
   const includedSourceFiles = sourceFiles.filter((relPath) => {
@@ -166,8 +177,10 @@ export async function syncDirectory(
     }
   }
 
-  // 5. Collect target files and delete orphans
-  const targetFiles = await collectFiles(target);
+  // 5. Collect target files and delete orphans. Walk the full target tree
+  //    (no prune) so orphan detection sees every deployed file; the per-file
+  //    isExcluded guard below preserves excluded target-only files.
+  const targetFiles = await collectFiles(target, "", []);
   const includedSourceSet = new Set(includedSourceFiles);
 
   for (const relPath of targetFiles) {


### PR DESCRIPTION
## 📌 Summary

OMT에 봇 탐지(WAF)를 우회하고 사용자 브라우저 쿠키로 인증을 재사용하는 브라우징 엔진 `insane-browsing`을 MIT OSS(`fivetaku/insane-search`)에서 verbatim 벤더링하고, 이를 구동하는 `hermes` 워커 에이전트와 `ultraresearch` 브라우징 티어 배선을 추가했습니다. 이후 코드리뷰 두 차례를 거쳐 SSRF·쿠키 인증 경계·WAF 오분류 등의 보안·정확성 결함을 하드닝했습니다.

---

## 🔧 Changes

### insane-browsing 엔진 벤더링

- `skills/insane-browsing/engine/` — curl_cffi TLS 임퍼소네이션 기반 fetch 체인 + Playwright 스텔스 fallback, WAF 탐지(`waf_detector.py`/`waf_profiles.yaml`), 검증·요약·결과 스키마
- `skills/insane-browsing/scripts/` — 사용자 브라우저 쿠키 추출·복호화·CDP 주입(`extract_cookies.py`/`cookie_crypto.py`/`cookie_domains.py`/`cookie_paths.py`)
- `skills/insane-browsing/engine/templates/` — 실제 Chrome / 모바일 Chrome Playwright 템플릿
- `skills/insane-browsing/references/` — 벤더 레퍼런스 문서(agent-reach, insane-search)
- `NOTICES`·`ATTRIBUTION.md` — MIT 라이선스·출처(`fivetaku/insane-search @ cac87e5`, OMO `ultimate-browsing` fork 경유) 명시

벤더 정책은 verbatim(원본 그대로 도입) 후 결함만 후속 커밋으로 하드닝하는 방식입니다. 엔진은 로컬에서 `uv` 격리 환경으로 실행되며 `requirements.txt`(curl_cffi/beautifulsoup4/PyYAML)를 동봉합니다.

**영향 범위**
- 신규 스킬 디렉터리 추가로 기존 컴포넌트에 영향 없음. 엔진은 로컬 `uv` 실행이라 런타임 의존성은 OMT 본체에 들어가지 않음.
- 쿠키 재사용은 사용자 로컬 브라우저 프로파일을 읽는 인증 경계(Security-T1) 동작.

### hermes 워커 에이전트

- `agents/hermes.md` — insane-browsing 엔진을 호출해 자율 브라우징을 수행하는 워커. attempt-then-fallback(curl 선시도 → 실패 시 Playwright) 흐름.

**영향 범위**
- 신규 에이전트. 임의 URL(프롬프트 인젝션 영향 가능)을 자율 브라우징하므로 SSRF·쿠키 경계가 실제 위협 표면.

### ultraresearch 브라우징 티어 배선

- `skills/ultraresearch/SKILL.md` — 리서치 파이프라인의 브라우징 티어를 insane-browsing/hermes로 연결.

**영향 범위**
- ultraresearch가 차단당하던 리서치 시나리오에서 브라우징 능력을 확보. 기존 단계 인터페이스 변경 없음.

### 배포 배선

- `projects/oh-my-toong/sync.yaml` — hermes·insane-browsing 등록
- `tools/lib/sync-directory.ts` — 동기화 시 Python 캐시(`__pycache__`/`.pytest_cache`/`*.pyc`)를 오버라이드 불가능한 베이스로 분리해 항상 제외(custom exclude를 넘기는 호출자에도 적용)

**영향 범위**
- `sync-directory.ts`는 OMT 자체 코드. 변경은 `syncDirectory` 내부에 한정되며 어댑터 호출부는 불변.

### 보안·정확성 하드닝

코드리뷰에서 CONFIRMED된 결함을 TDD(RED→GREEN)로 수정:

- **SSRF** — curl 최초 fetch URL 검증(`curl_probe.py`), Playwright fallback에 요청 인터셉터(`context.route`)와 executor final_url 재검사(`executor.py`/템플릿)
- **쿠키 인증 경계** — 도메인 필터 public-suffix·단일 라벨 거부(`cookie_domains.py`), CDP 주입 page-target 전환·전건 거부 시 실패(`extract_cookies.py`), CBC 복호화 PKCS7 패딩 검증(`cookie_crypto.py`), 빈 키링 `b""` 가드
- **WAF** — aws_waf 탐지에서 일반 인프라 헤더(`x-amzn-requestid`/`x-amzn-errortype`) 제거(`waf_profiles.yaml`)
- **문서** — 쿠키 명령 Python 3.11 핀(`SKILL.md`)
- (선행 커밋) verdict 분류·WAF 대소문자·Playwright JSON 엔벨로프·SSRF 리다이렉트·Referer 보안 수정

**영향 범위**
- 전부 벤더 코드 내 보안 가드 추가/교정. 정상 경로 동작 보존(엔진 32 passed, 스크립트 43 passed, 회귀 0).

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. Verbatim 벤더링 후 후속 하드닝 정책

**배경 및 문제 상황:**
insane-browsing은 OMO `ultimate-browsing` fork를 경유해 `fivetaku/insane-search`에서 들여온 외부 OSS입니다. 원본을 손대 들여오면 향후 upstream 변경 추적과 라이선스 감사가 어려워집니다. 반면 원본에는 SSRF·쿠키 처리 결함이 있었습니다.

**해결 방안:**
fork-point 커밋(`cac87e5`)에서 verbatim으로 벤더링하고, 결함은 별도 후속 커밋으로만 수정했습니다. 출처와 copy-chain(특히 Tier 3 스텔스 Chromium·Tier 2 쿠키 레이어가 fork-added라는 점)을 `ATTRIBUTION.md`에 기록해 후속 감사의 시작점을 명시했습니다.

**선택과 트레이드오프:**
- verbatim 유지로 upstream 대조가 가능하나, 보안 패치가 벤더 코드에 누적되면 재벤더링 시 재적용 부담이 생깁니다. 패치를 후속 커밋으로 격리해 어떤 변경이 OMT 고유 하드닝인지 추적 가능하게 했습니다.
- 미해결: upstream에 PR을 올릴지(역기여) 여부는 열려 있습니다.

### 2. SSRF 이중 경로 방어

**배경 및 문제 상황:**
hermes는 임의 URL(공격자/프롬프트 인젝션 영향 가능)을 자율 브라우징합니다. 초기 SSRF 가드가 curl 경로의 *리다이렉트 대상*에만 적용돼, ① curl 최초 fetch URL과 ② curl이 차단한 URL이 Playwright fallback으로 재투입되는 경로 두 곳이 무방비였습니다. 즉 보안 가드가 한 경로에만 있고 형제 경로엔 없었습니다.

**해결 방안:**
curl은 검사를 루프 최상단으로 올려 최초 URL과 리다이렉트 hop을 대칭으로 검사합니다. Playwright는 `context.route` 인터셉터로 *요청 발사 자체*를 차단(DNS 해석 후 private/loopback/link-local/metadata면 abort)하고, executor에서 final_url 호스트를 한 번 더 검사하는 이중 방어를 둡니다.

**구현 세부사항:**
Playwright는 post-hoc 검사만으로는 내부 요청이 이미 나간 뒤라 본문 반환만 막을 뿐입니다. 그래서 요청 단계 인터셉터가 1차 방어, executor final_url 재검사가 2차 방어입니다. 인터셉터는 IPv4-mapped-IPv6(`::ffff:169.254.169.254`) 같은 우회 표기까지 분류합니다.

**선택과 트레이드오프:**
- JS 인터셉터는 curl의 `_is_blocked_host`와 판정 로직이 중복됩니다(언어가 달라 공유 불가). 중복을 감수하고 각 런타임에서 발사 전 차단을 우선했습니다.

### 3. 쿠키 인증 경계 하드닝

**배경 및 문제 상황:**
쿠키 재사용은 사용자 인증을 그대로 빌리는 동작이라 스코핑·복호화·주입 각 단계가 신뢰 경계입니다. 도메인 필터가 public suffix를 거르지 못해 `--domain com`이 모든 `.com` 쿠키를 추출하고, CDP 주입이 browser-target에 page 전용 API를 보내 전면 무작동했으며, CBC 복호화가 패딩 검증 없이 잘못된 키에서 garbage를 조용히 반환했습니다.

**해결 방안:**
도메인 필터는 단일 라벨과 public suffix를 거부(정당 eTLD+1은 통과), CDP는 `/json/list`의 page-target에 연결, 복호화는 PKCS7 unpadder로 검증(잘못된 키는 ValueError), 빈 키링은 Linux 기본값 `peanuts` 대체·타 OS는 명시적 실패로 처리했습니다.

**선택과 트레이드오프:**
- public suffix 검사는 전체 PSL 의존성 대신 하드코딩 소목록으로 구현했습니다(소형 벤더 스킬에 무거운 의존성 회피). 목록 밖 ccTLD 2차 도메인은 통과할 수 있어 코드에 `lazy:` 주석으로 상한과 업그레이드 경로를 표시했습니다. 현재 위협 모델(단일 사용자 로컬 도구)에서는 충분하다고 판단했습니다.
- CDP는 page-target `Network.setCookie` 유지(최소 변경)와 browser-level `Storage.setCookies`(의미상 깔끔하나 페이로드 변경) 중 전자를 택했습니다.

### 4. Python 버전 플로어 분리

**배경 및 문제 상황:**
엔진은 Python 3.10에서 동작하지만 쿠키 스크립트는 `typing.NotRequired`/`assert_never`(3.11+)를 사용합니다. 문서가 쿠키 명령에 `--python`을 명시하지 않아 ambient Python 3.10 환경에서 ImportError로 즉사할 수 있었습니다.

**해결 방안:**
엔진 명령은 `--python 3.10`, 쿠키 명령은 `--python 3.11`로 의도적으로 다른 floor를 핀했습니다. 두 floor를 하나로 통합하지 않은 것은 엔진이 더 넓은 호환성을 유지하도록 두기 위함입니다.

**선택과 트레이드오프:**
- floor가 둘이라 문서가 약간 복잡해지지만, 엔진의 호환 범위를 쿠키 스크립트 때문에 좁히지 않는 편을 택했습니다.

---

## ✅ Checklist

### 엔진·배포
- [ ] 엔진 테스트가 Python 3.10에서 전부 통과
  - `skills/insane-browsing/engine/tests/`
- [ ] 쿠키 스크립트 테스트가 Python 3.11에서 전부 통과
  - `skills/insane-browsing/scripts/tests/`
- [ ] custom exclude를 넘겨도 동기화 시 `__pycache__`/`*.pyc`가 제외됨
  - `tools/lib/sync-directory.ts`
- [ ] `make validate`·`make test` 통과(회귀 없음)

### 보안 가드
- [ ] 내부/메타데이터 호스트가 최초 URL일 때 curl이 차단함
  - `skills/insane-browsing/engine/curl_probe.py`
- [ ] Playwright fallback이 내부 호스트 요청을 발사 전에 abort함
  - `skills/insane-browsing/engine/templates/playwright_real_chrome.js`
  - `skills/insane-browsing/engine/templates/playwright_mobile_chrome.js`
- [ ] `--domain com`/`co.uk` 등 bare TLD·public suffix 입력이 거부됨
  - `skills/insane-browsing/scripts/cookie_domains.py`
- [ ] 잘못된 키 복호화가 garbage 대신 ValueError로 실패함
  - `skills/insane-browsing/scripts/cookie_crypto.py`
- [ ] CDP 주입이 전건 거부(0/N)일 때 조용히 성공하지 않고 실패함
  - `skills/insane-browsing/scripts/extract_cookies.py`

---

## 📎 References
- [fivetaku/insane-search (벤더 원본, MIT @ cac87e5)](https://github.com/fivetaku/insane-search)
- 벤더 출처·copy-chain 상세: 리포 내 `NOTICES`·`skills/insane-browsing/ATTRIBUTION.md`