### PR TITLE
feat(goal): 완료 강제 양방향 강화 (2-레인 관문 + continuation)

### DIFF
--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -8,8 +8,11 @@ skills: code-review
 
 You are the code-reviewer agent. Follow the code-review skill exactly.
 
-**Identity**: Orchestrator of the full code review pipeline. You acquire intent, gather context, verify evidence, chunk the diff, dispatch chunk-reviewer agents, fan out per-candidate verifier subagents, and produce the ranked findings. You do NOT render HTML or produce a user-facing walkthrough presentation; your sole deliverable is the render-time markdown findings text.
+**Identity**: Orchestrator of the full code review pipeline. You acquire intent, gather context, verify evidence, chunk the diff, dispatch chunk-reviewer agents, fan out per-candidate verifier subagents, and produce the ranked findings. You do NOT render HTML or produce a user-facing walkthrough presentation. Your default deliverable is the render-time markdown findings text; when a caller specifies a structured-output target (an output path plus a schema), you instead write the findings to that path directly rather than returning them for the caller to transcribe (see Output).
 
 **Input**: A code review invocation — PR number/URL, branch comparison, or auto-detect — plus any intent/requirements context provided by the caller.
 
-**Output**: The render-time markdown findings text per the code-review skill's Phase 3 synthesis contract — verified findings ranked correctness-before-cleanup and CONFIRMED-before-PLAUSIBLE (verdict-labeled finding cards, split into Correctness and Cleanup). Do NOT produce HTML output. Do NOT open a browser. Do NOT print a terminal pointer. Return the assembled markdown findings text directly so the caller can consume it.
+**Output**: Two delivery modes selected by the invocation. The findings content is identical in both — verified findings ranked correctness-before-cleanup and CONFIRMED-before-PLAUSIBLE (verdict-labeled finding cards, split into Correctness and Cleanup) per the code-review skill's Phase 3 synthesis contract — only the channel differs.
+
+- **Default (markdown return)**: Return the assembled render-time markdown findings text directly so the caller can consume it. Do NOT produce HTML output. Do NOT open a browser. Do NOT print a terminal pointer.
+- **Structured artifact (when the caller provides an output path and schema)**: Write the findings to that path in the caller-specified schema directly (you have file tools); the written artifact is the deliverable and the caller will not transcribe returned text. Do NOT substitute a markdown return for the file write in this mode.

--- a/hooks/persistent-mode/decision.test.ts
+++ b/hooks/persistent-mode/decision.test.ts
@@ -565,13 +565,94 @@ describe('makeDecision', () => {
 
       expect(result.decision).toBe('block');
       const reason = result.reason!;
-      // behavioral steering: next concrete action + proxy-signal refusal + when-uncertain-keep-going
+      // behavioral steering: next concrete action + proxy-signal refusal
       expect(reason.toLowerCase()).toContain('next');
       expect(reason.toLowerCase()).toContain('proxy');
-      expect(reason.toLowerCase()).toContain('uncertain');
       // NO audit rubric leaked into the continuation (ADR-5: rubric lives in argus)
       expect(reason.toLowerCase()).not.toContain('prompt-to-artifact');
       expect(reason.toLowerCase()).not.toContain('verify-the-verifier');
+    });
+
+    it('continuation branch-A: next concrete action toward objective; proxy-signal completion rejected', async () => {
+      await writeGoal({
+        active: true,
+        phase: 'pursuing',
+        objective_verdict: '',
+        iteration: 1,
+        max_iterations: 10,
+        outcome: 'goal objective text',
+      });
+
+      const result = makeDecision(createContext());
+
+      expect(result.decision).toBe('block');
+      const reason = result.reason!;
+      // Branch A: asserts next concrete action
+      expect(reason.toLowerCase()).toContain('next concrete action');
+      // Branch A: proxy-signal refusal — named explicitly
+      expect(reason).toContain('proxy signals');
+      expect(reason).toContain('NOT objective completion');
+    });
+
+    it('continuation branch-B: claim-to-disprove framing for done belief', async () => {
+      await writeGoal({
+        active: true,
+        phase: 'pursuing',
+        objective_verdict: '',
+        iteration: 1,
+        max_iterations: 10,
+        outcome: 'goal objective text',
+      });
+
+      const result = makeDecision(createContext());
+
+      expect(result.decision).toBe('block');
+      const reason = result.reason!;
+      // Branch B: claim-to-disprove framing
+      expect(reason).toMatch(/claim to disprove|not trusted until verified/i);
+    });
+
+    it('continuation branch-B: names both completion-gate lanes (argus + code-review) and request-complete', async () => {
+      await writeGoal({
+        active: true,
+        phase: 'pursuing',
+        objective_verdict: '',
+        iteration: 1,
+        max_iterations: 10,
+        outcome: 'goal objective text',
+      });
+
+      const result = makeDecision(createContext());
+
+      expect(result.decision).toBe('block');
+      const reason = result.reason!;
+      // Branch B: redirects to completion gate naming BOTH lanes
+      expect(reason.toLowerCase()).toContain('argus');
+      expect(reason.toLowerCase()).toContain('code-review');
+      // Branch B: names request-complete
+      expect(reason).toContain('request-complete');
+    });
+
+    it('continuation envelope is unchanged: GOAL-ITERATION header and untrusted_objective block preserved', async () => {
+      await writeGoal({
+        active: true,
+        phase: 'pursuing',
+        objective_verdict: '',
+        iteration: 2,
+        max_iterations: 10,
+        outcome: 'SENTINEL_OBJECTIVE_TEXT',
+      });
+
+      const result = makeDecision(createContext());
+
+      expect(result.decision).toBe('block');
+      const reason = result.reason!;
+      // Envelope: iteration header unchanged
+      expect(reason).toContain('[GOAL - ITERATION 3/10]');
+      // Envelope: untrusted_objective wrap unchanged
+      expect(reason).toContain('<untrusted_objective>');
+      expect(reason).toContain('</untrusted_objective>');
+      expect(reason).toContain('SENTINEL_OBJECTIVE_TEXT');
     });
 
     it('continuation has complete-blocked gate', async () => {

--- a/hooks/persistent-mode/decision.ts
+++ b/hooks/persistent-mode/decision.ts
@@ -119,12 +119,13 @@ ${truncatedObjective}
 
 Tokens consumed: not measured (this loop is bounded by iterations, not tokens).
 
-INSTRUCTIONS (behavioral steering):
-1. Take the next concrete action that moves the objective forward.
-2. Do NOT call request-complete on proxy signals (e.g. tests-green, build-passing); those are NOT objective completion.
-3. When uncertain whether the objective is met, keep pursuing — do not stop early.
+INSTRUCTIONS (behavioral steering) — match your state to ONE branch:
 
-Gate: only complete once the objective is genuinely achieved; if you are truly blocked with no actionable next step, report the blocker and stop.
+A) Work remains → take the next concrete action toward the objective. Do NOT call request-complete on proxy signals (e.g. tests-green, build-passing); those are NOT objective completion.
+
+B) You believe the objective is MET → do NOT stop here. Your 'done' is a claim to disprove — not trusted until verified. Completion is never self-declared and never happens by stopping. Run the completion gate defined in the goal skill — the objective-level argus lane AND the independent code-review lane — then run the request-complete sequence. If either lane is non-clean, that is remaining work → branch A.
+
+Completion fires ONLY through request-complete. Stopping without it does NOT complete the objective. If you are truly blocked with no actionable next step, report the blocker and stop.
 
 </goal-continuation>
 

--- a/skills/goal/SKILL.md
+++ b/skills/goal/SKILL.md
@@ -172,7 +172,7 @@ Re-plan (`set --phase planning`) preserves `stories[]` including per-story statu
 
 After a sisyphus pass, completion is NOT self-declared. Invoke an objective-level **argus** (a fresh instance, with no prior-verdict context), presenting the **verification surface as PROSE requirements** — a completeness Spec. This is the objective-scope completeness check: argus verifies that every prose-stated requirement in the verification surface is reflected in the deliverable, and renders an APPROVE / REQUEST_CHANGES / COMMENT verdict.
 
-**Inject the completion-audit rubric INTO the argus invocation** (it lives in the argus prompt, never in any continuation prompt). The rubric forces an evidence-based verdict and asserts each element independently:
+**Inject the completion-audit rubric, project conventions, and project-specific scenarios INTO the argus invocation** (they live in the argus prompt, never in any continuation prompt). Argus (= the qa skill) runs its **full battery**: automated checks (build / test / lint) AND the hands-on adversarial matrix — not the completeness-audit rubric alone. The rubric forces an evidence-based verdict and asserts each element independently:
 
 - **prompt-to-artifact mapping** — argus must map every explicit requirement, numbered item, named file, command, test, gate, and deliverable in the verification surface to concrete evidence; an unmapped requirement is incomplete.
 - **proxy-signal refusal** — argus must refuse proxy signals as completion by themselves: passing tests, a green build, a complete manifest, or substantial effort count only insofar as they cover every requirement in the verification surface.
@@ -196,9 +196,25 @@ After a sisyphus pass, completion is NOT self-declared. Invoke an objective-leve
 
 For each non-retired story, argus maps the story's acceptance criteria and verification surface to concrete evidence and renders an `APPROVE` or `REQUEST_CHANGES` per-story verdict. A single non-APPROVE per-story entry blocks completion regardless of the `objective_verdict` field — `objective_verdict === 'APPROVE'` alone is never sufficient.
 
-`request-complete` reads the artifact from the conventional path internally (no path argument). It refuses if: the artifact is absent or schema-invalid; any non-retired story entry is non-APPROVE; any non-retired story is `unconfirmed`; an entry is missing for any non-retired story; zero non-retired stories exist; or the existing dual gate is unmet (`objective_verdict !== 'APPROVE'` in state, or empty `completion_evidence_paths`). When all checks pass, `request-complete` writes `phase=complete` and `active=false`.
+`request-complete` reads the artifact from the conventional path internally (no path argument). It refuses if: the artifact is absent or schema-invalid; any non-retired story entry is non-APPROVE; any non-retired story is `unconfirmed`; an entry is missing for any non-retired story; zero non-retired stories exist; or the existing dual gate is unmet (`objective_verdict !== 'APPROVE'` in state, or empty `completion_evidence_paths`). As a second structural refusal lane, `request-complete` also reads the code-review artifact (`goal-codereview-{sid}.json`) from its conventional path internally (no path argument) and refuses if that artifact is absent, schema-invalid, or contains any `CONFIRMED` finding (see code-review lane below); this refusal is structural — it runs inside `request-complete` itself independent of the orchestrator loop, so completion is blocked even if the loop misbehaves. When all checks pass, `request-complete` writes `phase=complete` and `active=false`.
 
 <!-- story-layer:end -->
+
+**Code-review lane (runs alongside argus).** After each sisyphus pass, an independent code-review lane runs alongside the argus lane. Dispatch a fresh **code-reviewer** agent independently of the builder (sisyphus); self-review by the builder is forbidden. The code-reviewer writes `$OMT_DIR/goal-codereview-{sid}.json` directly (it has file tools); the orchestrator passes only the session-derived path and never transcribes finding content. The artifact schema the code-reviewer must emit:
+
+```json
+{
+  "findings": [
+    { "class": "correctness|cleanup", "verdict": "CONFIRMED|PLAUSIBLE", "ref": "<file:line>" }
+  ],
+  "reviewer": "<reviewer id>",
+  "at": "<ISO timestamp>"
+}
+```
+
+**Pass signal:** any finding where `verdict === "CONFIRMED"` blocks completion — whether `class` is `correctness` or `cleanup`. `PLAUSIBLE` findings are non-blocking; they are reported but do not prevent completion. `class` is an informational label the gate does not key on (the gate keys solely on `verdict === "CONFIRMED"`).
+
+A blocking code-review finding (any CONFIRMED) routes back to sisyphus re-dispatch targeted at those specific findings — the same concrete-progress shape as an argus REQUEST_CHANGES verdict.
 
 **Completion fires ONLY on argus APPROVE AND an objective-scope Evidence Audit pass.** A **COMMENT verdict is NOT sufficient** for completion — COMMENT means MEDIUM gaps remain. The Evidence Audit reuses the verify-the-verifier shape: confirm argus's verdict HOLDS UP by reading the evidence argus saved (does it demonstrate the verification surface was met?) — auditing, never re-running a command and never rendering your own verdict. If the evidence is missing or does not demonstrate the verification surface, it is an Evidence Gap → re-invoke argus, do not complete.
 
@@ -216,7 +232,7 @@ bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts request-complete
 
 APPROVE alone does NOT leave the goal pursuing/active — the `request-complete` handoff is what transitions to terminal `complete` (and it is structurally gated on completion-evidence, so a write that never reached the gate cannot false-complete).
 
-**No design/architecture lane gates completion.** The only gate on the completion path is this objective-level argus — which also re-derives per-WHAT-slice verdicts and authors the verdict artifact at `$OMT_DIR/goal-verdict-{sid}.json`. There is no design-review or daedalus pass between pursuit and completion — design is plan-time advisory only.
+**Two lanes gate completion: argus and code-review.** The completion path runs both the objective-level argus lane (correctness, completeness, and evidence audit) and the independent code-review lane (static quality and conventions) — both must be clean for `request-complete` to pass. No design or architecture lane gates completion: daedalus and design-review are plan-time advisory only, not completion gates. Code-review is a completion-time quality lane and is distinct from design-review — the two must not be conflated.
 
 ### Concrete progress action per non-APPROVE verdict
 
@@ -225,6 +241,7 @@ Every non-APPROVE verdict drives a concrete progress action — never action-les
 - **REQUEST_CHANGES naming incomplete work items** (tactical — the work is unfinished, the plan is sound) → re-dispatch `Skill(skill: "sisyphus")` on the named incomplete TODOs. This stays inside sisyphus's junior loop; phase remains `pursuing`.
 - **Strategic plan inadequacy** (the plan itself cannot reach the objective — the decomposition is wrong, not merely unfinished) → re-plan via `Skill(skill: "prometheus")`: run `set --phase planning` first (which clears the verdict), let prometheus's human design gates run un-wrapped, then `set --phase pursuing` after the fresh sisyphus dispatch.
 - **COMMENT (MEDIUM gaps only)** → re-dispatch `Skill(skill: "sisyphus")` to fix the argus-named MEDIUM gaps; do NOT `request-complete` on a COMMENT.
+- **Code-review lane: any CONFIRMED finding** → re-dispatch `Skill(skill: "sisyphus")` on the specific findings in `goal-codereview-{sid}.json`. Phase remains `pursuing`; run a fresh code-review dispatch after sisyphus resolves the findings.
 
 ### Blocked-stop
 

--- a/skills/goal/scripts/goal-state.test.ts
+++ b/skills/goal/scripts/goal-state.test.ts
@@ -200,6 +200,7 @@ describe('goal state', () => {
       JSON.stringify({ objective_verdict: 'APPROVE', stories: [{ id: 'S1', verdict: 'APPROVE', evidence_refs: ['proof.txt'] }], verifier: 'argus', at: '2026-06-12T00:00:00' }),
       'utf8'
     );
+    writeCodeReviewArtifact(S2, { findings: [], reviewer: 'code-reviewer', at: '2026-06-12T00:00:00' });
     expect(requestComplete(S2)).toBe(true);
     // complete is terminal (active:false) so readGoalState returns null; assert on raw
     expect(rawStateOf(S2).phase).toBe('complete');
@@ -236,6 +237,7 @@ describe('goal state', () => {
     expect(rawState().phase).toBe('budget_limited');
 
     // APPROVE-backed request-complete must win over the prior budget_limited
+    writeCodeReviewArtifact(S, { findings: [], reviewer: 'code-reviewer', at: '2026-06-12T00:00:00' });
     expect(requestComplete(S)).toBe(true);
     expect(rawState().phase).toBe('complete');
     expect(rawState().active).toBe(false);
@@ -291,6 +293,7 @@ describe('goal state', () => {
       JSON.stringify({ objective_verdict: 'APPROVE', stories: [{ id: 'S1', verdict: 'APPROVE', evidence_refs: ['p'] }], verifier: 'argus', at: '2026-06-12T00:00:00' }),
       'utf8'
     );
+    writeCodeReviewArtifact(Sc, { findings: [], reviewer: 'code-reviewer', at: '2026-06-12T00:00:00' });
     requestComplete(Sc);
     expect(rawStateOf(Sc).active).toBe(false);
 
@@ -374,6 +377,7 @@ describe('goal state', () => {
       JSON.stringify({ objective_verdict: 'APPROVE', stories: [{ id: 'S1', verdict: 'APPROVE', evidence_refs: ['a.md'] }], verifier: 'argus', at: '2026-06-12T00:00:00' }),
       'utf8'
     );
+    writeCodeReviewArtifact(S, { findings: [], reviewer: 'code-reviewer', at: '2026-06-12T00:00:00' });
     expect(requestComplete(S)).toBe(true);
     expect(rawState().phase).toBe('complete');
     expect(rawState().active).toBe(false);
@@ -439,6 +443,7 @@ describe('goal state', () => {
       JSON.stringify({ objective_verdict: 'APPROVE', stories: [{ id: 'S1', verdict: 'APPROVE', evidence_refs: [p1] }], verifier: 'argus', at: '2026-06-12T00:00:00' }),
       'utf8'
     );
+    writeCodeReviewArtifact(S, { findings: [], reviewer: 'code-reviewer', at: '2026-06-12T00:00:00' });
 
     // request-complete must exit 0 (no throw) now that evidence + story artifact present
     run('request-complete');
@@ -1512,6 +1517,15 @@ function writeVerdictArtifact(sid: string, obj: object): void {
   writeFileSync(verdictArtifactPath(sid), JSON.stringify(obj), 'utf8');
 }
 
+/** Code-review lane artifact path: $OMT_DIR/goal-codereview-{sid}.json (mirrors verdict path). */
+function codeReviewArtifactPath(sid: string): string {
+  return `${process.env.OMT_DIR}/goal-codereview-${sid}.json`;
+}
+
+function writeCodeReviewArtifact(sid: string, obj: object): void {
+  writeFileSync(codeReviewArtifactPath(sid), JSON.stringify(obj), 'utf8');
+}
+
 /** Build a fully-satisfied gate fixture for one session:
  *  - 2 confirmed stories (S1, S2)
  *  - evidence paths set
@@ -1527,6 +1541,9 @@ function buildSatisfiedFixture(sid: string): object {
   confirmStory(sid, 'S2');
   setGoalState(sid, { phase: 'pursuing', completion_evidence_paths: [`${process.env.OMT_DIR}/evidence.md`] });
   setVerdict(sid, 'APPROVE');
+  // Code-review lane: a clean (no-findings) artifact so the second completion lane passes
+  // by default. Callers asserting a BLOCK overwrite this with a CONFIRMED/invalid one.
+  writeCodeReviewArtifact(sid, { findings: [], reviewer: 'code-reviewer', at: '2026-06-12T00:00:00' });
 
   // Valid artifact
   return {
@@ -1676,6 +1693,7 @@ describe('story layer: request-complete verdict gate (T4)', () => {
       verifier: 'argus',
       at: '2026-06-12T00:00:00',
     });
+    writeCodeReviewArtifact(S2, { findings: [], reviewer: 'code-reviewer', at: '2026-06-12T00:00:00' });
     expect(requestComplete(S2)).toBe(true);
     expect(rawStateOf(S2).phase).toBe('complete');
   });
@@ -1771,6 +1789,119 @@ describe('story layer: request-complete verdict gate (T4)', () => {
       verifier: 'argus',
       at: '2026-06-12T00:00:00',
     });
+    expect(requestComplete(S)).toBe(false);
+    expect(rawState().phase).not.toBe('complete');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TODO 1: code-review 완료 레인 (두 번째 독립 거부 레인)
+// ---------------------------------------------------------------------------
+
+describe('story layer: code-review completion lane (TODO 1)', () => {
+  // AC1: a CONFIRMED finding (correctness OR cleanup) blocks completion even when
+  // the argus lane is fully green. The gate keys ONLY on verdict===CONFIRMED.
+  test('code-review CONFIRMED blocks completion (cleanup class)', () => {
+    const artifact = buildSatisfiedFixture(S);
+    writeVerdictArtifact(S, artifact); // argus lane fully green
+    writeCodeReviewArtifact(S, {
+      findings: [{ class: 'cleanup', verdict: 'CONFIRMED', ref: 'foo.ts:1' }],
+      reviewer: 'code-reviewer',
+      at: '2026-06-12T00:00:00',
+    });
+    expect(requestComplete(S)).toBe(false);
+    expect(rawState().phase).toBe('pursuing');
+  });
+
+  test('code-review CONFIRMED blocks completion (correctness class)', () => {
+    const artifact = buildSatisfiedFixture(S);
+    writeVerdictArtifact(S, artifact);
+    writeCodeReviewArtifact(S, {
+      findings: [{ class: 'correctness', verdict: 'CONFIRMED', ref: 'foo.ts:2' }],
+      reviewer: 'code-reviewer',
+      at: '2026-06-12T00:00:00',
+    });
+    expect(requestComplete(S)).toBe(false);
+    expect(rawState().phase).toBe('pursuing');
+  });
+
+  // AC2: a clean code-review (no findings / PLAUSIBLE-only) permits completion.
+  test('code-review clean permits completion (empty findings)', () => {
+    const artifact = buildSatisfiedFixture(S);
+    writeVerdictArtifact(S, artifact);
+    writeCodeReviewArtifact(S, { findings: [], reviewer: 'code-reviewer', at: '2026-06-12T00:00:00' });
+    expect(requestComplete(S)).toBe(true);
+    expect(rawState().phase).toBe('complete');
+  });
+
+  test('code-review clean permits completion (PLAUSIBLE only)', () => {
+    const artifact = buildSatisfiedFixture(S);
+    writeVerdictArtifact(S, artifact);
+    writeCodeReviewArtifact(S, {
+      findings: [{ class: 'cleanup', verdict: 'PLAUSIBLE', ref: 'foo.ts:3' }],
+      reviewer: 'code-reviewer',
+      at: '2026-06-12T00:00:00',
+    });
+    expect(requestComplete(S)).toBe(true);
+    expect(rawState().phase).toBe('complete');
+  });
+
+  // AC3: absent / corrupt / unknown-verdict / empty-reviewer each refuses (no throw),
+  // phase unchanged (never-false-complete: degrade toward block).
+  test('code-review invalid artifact refuses (absent)', () => {
+    const artifact = buildSatisfiedFixture(S);
+    writeVerdictArtifact(S, artifact);
+    rmSync(codeReviewArtifactPath(S), { force: true }); // ensure the code-review artifact is absent
+    expect(requestComplete(S)).toBe(false);
+    expect(rawState().phase).toBe('pursuing');
+  });
+
+  test('code-review invalid artifact refuses (corrupt json)', () => {
+    const artifact = buildSatisfiedFixture(S);
+    writeVerdictArtifact(S, artifact);
+    writeFileSync(codeReviewArtifactPath(S), '{not json', 'utf8');
+    expect(requestComplete(S)).toBe(false);
+    expect(rawState().phase).toBe('pursuing');
+  });
+
+  test('code-review invalid artifact refuses (unknown verdict)', () => {
+    const artifact = buildSatisfiedFixture(S);
+    writeVerdictArtifact(S, artifact);
+    writeCodeReviewArtifact(S, {
+      findings: [{ class: 'correctness', verdict: 'BOGUS', ref: 'foo.ts:4' }],
+      reviewer: 'code-reviewer',
+      at: '2026-06-12T00:00:00',
+    });
+    expect(requestComplete(S)).toBe(false);
+    expect(rawState().phase).toBe('pursuing');
+  });
+
+  test('code-review invalid artifact refuses (empty reviewer)', () => {
+    const artifact = buildSatisfiedFixture(S);
+    writeVerdictArtifact(S, artifact);
+    writeCodeReviewArtifact(S, { findings: [], reviewer: '', at: '2026-06-12T00:00:00' });
+    expect(requestComplete(S)).toBe(false);
+    expect(rawState().phase).toBe('pursuing');
+  });
+
+  // AC8: re-plan unlinks the code-review artifact (ADR-3 stale-vector); a fresh objective
+  // cannot false-complete on a prior objective's clean code-review.
+  test('re-plan unlinks code-review artifact', () => {
+    const artifact = buildSatisfiedFixture(S);
+    writeVerdictArtifact(S, artifact);
+    writeCodeReviewArtifact(S, { findings: [], reviewer: 'code-reviewer', at: '2026-06-12T00:00:00' });
+    expect(existsSync(codeReviewArtifactPath(S))).toBe(true);
+
+    // Re-plan (planning transition) must invalidate the code-review artifact.
+    setGoalState(S, { phase: 'planning', outcome: '새 목표' });
+    expect(existsSync(codeReviewArtifactPath(S))).toBe(false);
+
+    // New pursuit, all argus-side gates re-satisfied, but no fresh code-review artifact.
+    const s1: Story = { id: 'S1', story: 'new', acceptance_criteria: ['ac1'], verification_surface: 'v1', status: 'unconfirmed' };
+    setStories(S, [s1]);
+    confirmStory(S, 'S1');
+    setGoalState(S, { phase: 'pursuing', completion_evidence_paths: [`${process.env.OMT_DIR}/evidence.md`] });
+    setVerdict(S, 'APPROVE');
     expect(requestComplete(S)).toBe(false);
     expect(rawState().phase).not.toBe('complete');
   });

--- a/skills/goal/scripts/goal-state.ts
+++ b/skills/goal/scripts/goal-state.ts
@@ -357,6 +357,14 @@ export function setGoalState(sessionId: string, opts: SetGoalOpts): void {
     } catch {
       // ignore — ENOENT (no artifact) and other transient I/O errors are both safe to skip
     }
+    // D-4: the code-review lane artifact must not survive a re-plan either (same ADR-3
+    // stale-vector — a prior objective's clean code-review must not false-complete a new
+    // objective). Error policy mirrors the goal-verdict unlink above exactly.
+    try {
+      unlinkSync(resolveCodeReviewArtifactPath(sessionId));
+    } catch {
+      // ignore — ENOENT (no artifact) and other transient I/O errors are both safe to skip
+    }
     // A FRESH goal (no active prior) must not inherit the dead goal's consumed iteration
     // budget; a re-plan loop-back of the SAME active goal MUST (budget accumulates across
     // re-plans). readGoalState returns non-null ONLY for an active prior → re-plan.
@@ -636,6 +644,25 @@ interface VerdictArtifact {
   at: string;
 }
 
+// ---------------------------------------------------------------------------
+// Code-review artifact types — the SECOND independent completion lane.
+// Mirrors the verdict artifact: read/validate only, authored by a fresh
+// code-reviewer agent. The gate keys ONLY on verdict==='CONFIRMED'; `class`
+// is a reader-validated, gate-unused informational label.
+// ---------------------------------------------------------------------------
+
+interface CodeReviewFinding {
+  class: 'correctness' | 'cleanup';
+  verdict: 'CONFIRMED' | 'PLAUSIBLE';
+  ref?: string;
+}
+
+interface CodeReviewArtifact {
+  findings: CodeReviewFinding[];
+  reviewer: string;
+  at: string;
+}
+
 /**
  * Derives the verdict artifact path from the session id — mirrors the state
  * path convention (`goal-state-${sid}.json` → `goal-verdict-${sid}.json`).
@@ -683,6 +710,54 @@ function readVerdictArtifact(sessionId: string): VerdictArtifact | null {
     if (!Array.isArray(e['evidence_refs'])) return null;
   }
   return obj as VerdictArtifact;
+}
+
+/**
+ * Derives the code-review artifact path from the session id — mirrors the
+ * verdict path convention (`goal-verdict-${sid}.json` → `goal-codereview-${sid}.json`).
+ * NO path argument accepted (D-11: a path argument would be a steerable gate input).
+ */
+function resolveCodeReviewArtifactPath(sessionId: string): string {
+  return `${getOmtDir()}/goal-codereview-${sessionId}.json`;
+}
+
+/**
+ * Reads and validates the code-review artifact. Returns the parsed artifact on
+ * success, or null when the file is absent or the schema is invalid (never throws).
+ * Schema: { findings: [{class, verdict, ref?}], reviewer, at } — NO `lane` field
+ * (the path already identifies the lane).
+ * `reviewer` must be a NON-EMPTY string — one notch stricter than the verdict
+ * artifact's verifier string-check, because self-review bias is maximal at the
+ * convention boundary (D-5/D-6). Any per-finding enum violation rejects the WHOLE
+ * artifact (never-false-complete: a broken reviewer output must degrade toward
+ * block, never mask a CONFIRMED finding). `findings: []` is valid and clean.
+ */
+function readCodeReviewArtifact(sessionId: string): CodeReviewArtifact | null {
+  const content = readFileOrNull(resolveCodeReviewArtifactPath(sessionId));
+  if (!content) return null;
+  let obj: unknown;
+  try {
+    obj = JSON.parse(content);
+  } catch {
+    return null;
+  }
+  if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) return null;
+  const a = obj as Record<string, unknown>;
+  // Required top-level fields
+  if (!Array.isArray(a['findings'])) return null;
+  const reviewer = a['reviewer'];
+  if (typeof reviewer !== 'string' || reviewer.length === 0) return null;
+  if (typeof a['at'] !== 'string') return null;
+  // Validate each finding; any enum violation → whole artifact null
+  const VALID_CLASSES = ['correctness', 'cleanup'];
+  const VALID_FINDING_VERDICTS = ['CONFIRMED', 'PLAUSIBLE'];
+  for (const entry of a['findings'] as unknown[]) {
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) return null;
+    const e = entry as Record<string, unknown>;
+    if (!VALID_CLASSES.includes(e['class'] as string)) return null;
+    if (!VALID_FINDING_VERDICTS.includes(e['verdict'] as string)) return null;
+  }
+  return obj as CodeReviewArtifact;
 }
 
 /**
@@ -772,6 +847,19 @@ export function requestComplete(sessionId: string): boolean {
     if (entry.verdict !== 'APPROVE') {
       return false;
     }
+  }
+
+  // Code-review lane (D-3): the SECOND independent refusal lane, reached only after
+  // every argus gate above passes — so "both lanes clean" is the completion condition.
+  // Absent/invalid artifact → block (never-false-complete: degrade toward block). The
+  // gate keys ONLY on verdict==='CONFIRMED' (any class — correctness OR cleanup); `class`
+  // is informational and never branched on.
+  const codeReview = readCodeReviewArtifact(sessionId);
+  if (codeReview === null) {
+    return false;
+  }
+  if (codeReview.findings.some((f) => f.verdict === 'CONFIRMED')) {
+    return false;
   }
 
   mergeWrite(sessionId, { phase: 'complete', active: false });


### PR DESCRIPTION
## 📌 Summary

goal 스킬의 핵심 불변식(완료를 절대 거짓 선언하지 않는다)을 **양방향으로 구조 강화**한다. ① 완료 관문에 argus와 독립된 code-review 레인을 추가해 두 레인 모두 clean일 때만 `request-complete`가 통과하도록 하고(false-complete 방어), ② 미완료 상태에서 멈추려 할 때 주입되는 Stop 훅 메시지를 2-분기 redirect로 바꿔 "완료라 판단되면 멈추지 말고 완료 관문을 돌려라"로 유도한다(premature-stop 방어).

---

## 🔧 Changes

### goal 완료 관문 (`goal-state.ts`)

- `readCodeReviewArtifact` 신규: `goal-codereview-{sid}.json`을 conventional path에서 내부적으로 읽고, null-on-invalid(throw 안 함), enum 위반 시 아티팩트 전체 거부, 빈 reviewer 거부.
- `requestComplete`에 code-review 레인 게이트 추가: 아티팩트가 부재/손상이거나 CONFIRMED finding(correctness 또는 cleanup)이 하나라도 있으면 완료 거부. 기존 argus 게이트(verdict=APPROVE + completion-evidence)는 선행 그대로 유지 — 즉 **두 레인 AND**.
- 재계획(`set --phase planning`) 시 code-review 아티팩트를 goal-verdict와 나란히 언링크(stale 아티팩트 심층 방어).

**영향 범위**
`request-complete` 통과 조건이 좁아진다(argus APPROVE + code-review clean 둘 다 필요). GoalState 스키마 무변경, 신규 CLI 서브커맨드 없음 → 기존 CLI 하위호환(goal-state.test.ts 89개 green). 소스 수정이라 `make sync` 배포 전까지 런타임 goal CLI(`~/.claude/...`)는 무영향.

### goal 스킬 prose (`SKILL.md`)

- 완료 관문 섹션에 2-레인 prose 추가: code-review 레인이 argus와 나란히 돌고, CONFIRMED 차단·PLAUSIBLE 비차단, 빌더와 독립된 fresh reviewer(자기리뷰 금지), 차단 시 sisyphus 재투입을 기술.
- argus 호출을 qa full-battery(자동검사 + hands-on 적대적 매트릭스)로 강화하고 프로젝트 컨벤션/시나리오 주입을 명문화.
- daedalus는 계획 시점 어드바이저리로 남는다는 점을 2-레인과 정합.

**영향 범위**
prose 한정. code-review/qa/argus/daedalus 스킬·에이전트 파일 무수정.

### persistent-mode Stop 훅 (`decision.ts`)

- `buildGoalContinuationMessage`를 generic 3항목 "keep pursuing"에서 **2-분기 redirect**로 재작성: (A) 작업 잔존 → 다음 구체 행동, proxy 신호로 완료 금지 / (B) 완료 판단 → 멈추지 말고, 'done'을 반증 대상으로 취급, goal 스킬 완료 관문(argus 레인 + code-review 레인)을 돌린 뒤 `request-complete`. 한 레인이라도 non-clean이면 분기 A로.
- 메시지 envelope(iteration 헤더·untrusted_objective 래퍼)는 무변경.

**영향 범위**
Stop 훅이 goal pursuing을 차단할 때 주입하는 메시지 한정. 훅은 경량 회로차단기로 유지 — verifier 디스패치는 넣지 않고 SKILL 완료 관문으로 위임. iteration/cap/block 결정 로직 무변경(persistent-mode 161개 green).

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.

### 1. 완료 검증을 prose 규율이 아닌 `request-complete` 내부 구조 게이트로

**배경 및 문제 상황:**
goal의 단일 load-bearing 불변식은 "루프가 절대 false-complete하지 않는다"이다. code-review가 통과 조건이려면, 그 강제가 오케스트레이터의 성실함(prose 지침)에 의존해선 안 된다 — verdict-write나 아티팩트-read가 실패해도 결과가 *완료*로 degrade되면 안 되고 *차단*으로 degrade돼야 한다.

**해결 방안:**
code-review 게이트를 `request-complete` 함수 내부에 둔다. 아티팩트를 conventional path에서 직접 읽고(경로 인자 없음), 부재·손상·CONFIRMED 중 하나라도면 `mergeWrite(phase=complete)` 도달 자체를 막는다. 작성(code-reviewer 에이전트)과 판정(requestComplete)을 분리해, 신뢰 입력은 reviewer가 쓰고 게이트만 소비한다.

**선택과 트레이드오프:**
- `readCodeReviewArtifact`는 **null-on-invalid, never-throw**: 손상 아티팩트가 예외로 루프를 깨는 대신 조용히 차단으로 degrade(fail-closed).
- **구조적 provenance 게이트(reviewer≠builder)는 의도적으로 채택하지 않음**: 레퍼런스(oh-my-codex ultragoal)의 독립-리뷰어 검사도 실측 결과 self-reported role 문자열 비교라 위조 가능했고, 진짜 teeth는 하네스 attestation(ralplan consensus-gate)급 대공사가 필요. 현 위협(lazy/drift)엔 defense-in-depth로 충분하다고 판단해 게이트는 아티팩트 존재·스키마·CONFIRMED만 강제한다. 리뷰어 의견 환영.

### 2. continuation을 경량 redirect로 — verifier 디스패치를 훅에 넣지 않음

**배경 및 문제 상황:**
다른 실패 방향은 premature-stop이다(목표 미달인데 AI가 "다 됐다" 판단하고 멈춤). Stop 훅이 이걸 잡아야 하는데, 훅 메시지에 "argus와 code-reviewer를 디스패치하라"는 오케스트레이션을 인라인하면 훅이 무거운 조율 레이어가 된다.

**해결 방안:**
레퍼런스 실측(oh-my-codex 네이티브 goal 훅 = generic "continue and gather evidence" redirect / lazycodex ulw-loop = per-step inline self-QA + final gate에서만 delegate)에 맞춰, 훅은 회로차단기로 유지한다. 메시지는 2-분기로 갈리되 done-branch는 "goal 스킬에 정의된 완료 관문을 돌려라"로 **위임**할 뿐, 디스패치를 인라인하지 않는다. 디스패치 오케스트레이션은 #1에서 이미 SKILL 완료 관문이 소유.

**선택과 트레이드오프:**
- lazycodex의 claim-to-disprove 톤 차용("네 'done'은 반증 대상, 검증 전까지 불신") — 단순 "계속 진행"보다 멈춤 시도를 더 의도적인 행위로 만든다.
- 훅 메시지는 self-reported 신호라 강제력은 verdict-게이트(#1)에 있고 이 메시지는 *유도*다. 더 강한 evidence-gate(lazycodex의 `EVIDENCE_RECORDED` 차단)는 과하다고 판단해 보류.

---

## ✅ Checklist

### 2-레인 완료 관문
- [ ] code-review 레인에 CONFIRMED(correctness 또는 cleanup) finding이 있으면 argus가 전부 APPROVE여도 `request-complete`가 거부한다
  - `skills/goal/scripts/goal-state.ts`
- [ ] PLAUSIBLE-only finding은 완료를 차단하지 않는다(보고만)
  - `skills/goal/scripts/goal-state.ts`
- [ ] code-review 아티팩트 부재/손상JSON/unknown-verdict/빈 reviewer는 각각 거부되며 throw하지 않는다
  - `skills/goal/scripts/goal-state.ts`
- [ ] 재계획 시 code-review 아티팩트가 언링크된다
  - `skills/goal/scripts/goal-state.ts`

### continuation redirect
- [ ] continuation 메시지가 2-분기(work-remains / done)이며, done-branch가 완료 관문(argus + code-review 레인)과 `request-complete`로 redirect한다
  - `hooks/persistent-mode/decision.ts`
- [ ] 메시지 envelope(iteration 헤더·untrusted_objective 래퍼)가 보존된다
  - `hooks/persistent-mode/decision.ts`

### 회귀 없음
- [ ] 기존 테스트 전부 green: goal-state 89, persistent-mode 161, 그리고 typecheck exit 0
