### PR TITLE
fix(keyword-detector): deep-interview 평문 트리거 제거

### DIFF
--- a/hooks/keyword-detector.sh
+++ b/hooks/keyword-detector.sh
@@ -80,7 +80,6 @@ strip_mode_tags() {
   perl -0pe 's/<analyze-mode>.*?<\/analyze-mode>//gs' |
   perl -0pe 's/<think-mode>.*?<\/think-mode>//gs' |
   perl -0pe 's/<ultrawork-mode>.*?<\/ultrawork-mode>//gs' |
-  perl -0pe 's/<deep-interview-mode>.*?<\/deep-interview-mode>//gs' |
   perl -0pe 's/<deep-interview-continuation>.*?<\/deep-interview-continuation>//gs' |
   perl -0pe 's/<system-reminder>.*?<\/system-reminder>//gs'
 }
@@ -111,14 +110,6 @@ PROMPT_LOWER=$(echo "$PROMPT_NO_CODE" | tr '[:upper:]' '[:lower:]')
 if echo "$PROMPT_LOWER" | grep -qE '\b(ultrawork|ulw)\b'; then
   cat << 'EOF'
 {"continue": true, "hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": "<ultrawork-mode>\n\n**MANDATORY**: You MUST say \"ULTRAWORK MODE ENABLED!\" to the user as your first response when this mode activates. This is non-negotiable.\n\n[CODE RED] Maximum precision required. Ultrathink before acting.\n\nYOU MUST LEVERAGE ALL AVAILABLE AGENTS TO THEIR FULLEST POTENTIAL.\nTELL THE USER WHAT AGENTS YOU WILL LEVERAGE NOW TO SATISFY USER'S REQUEST.\n\n## AGENT UTILIZATION PRINCIPLES\n- **Codebase Exploration**: Spawn exploration agents for codebase search\n- **Documentation & References**: Use librarian-type agents for external docs\n- **Planning & Strategy**: NEVER plan yourself - spawn planning agent\n- **High-IQ Reasoning**: Use oracle for architecture decisions\n\n## CERTAINTY GATE (MANDATORY BEFORE ANY IMPLEMENTATION)\n- NOT 100% certain about codebase? → spawn explore agent FIRST\n- NOT 100% certain about architecture? → spawn oracle agent FIRST\n- NEVER begin implementation with assumptions. Assumptions = bugs.\n\n## EXECUTION RULES\n- **TODO**: Track EVERY step. Mark complete IMMEDIATELY.\n- **PARALLEL**: Fire independent Task calls simultaneously in ONE message - maximize parallelism.\n- **DELEGATE**: Orchestrate specialized agents aggressively. Never solo complex work.\n- **VERIFY**: Check ALL requirements met before done.\n\n## ZERO TOLERANCE\n- NO Scope Reduction - deliver FULL implementation\n- NO Partial Completion - finish 100%\n- NO Premature Stopping - ALL TODOs must be complete\n- NO TEST DELETION - fix code, not tests\n\n## BLOCKED EXCUSES (catch yourself saying these → STOP and FIX)\n| Excuse Pattern | Required Action |\n|----------------|------------------|\n| \"I couldn't find/access...\" | Spawn explore agent, try harder |\n| \"Here's a simplified version...\" | Deliver the FULL version |\n| \"This should work but I can't verify...\" | Spawn argus for verification |\n| \"I'll leave this for the user to...\" | YOU complete it |\n| \"Due to complexity, I only...\" | Continue until 100% done |\n\nTHE USER ASKED FOR X. DELIVER EXACTLY X.\n\n</ultrawork-mode>\n\n---\n"}}
-EOF
-  exit 0
-fi
-
-# Check for deep-interview keywords (third priority)
-if echo "$PROMPT_LOWER" | grep -qiE '\b(deep[- ]?interview|ouroboros)\b|딥인터뷰'; then
-  cat << 'EOF'
-{"continue": true, "hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": "<deep-interview-mode>\n\n**DEEP INTERVIEW REQUESTED** — you MUST invoke `Skill(deep-interview)` before responding. Do NOT conduct the interview directly. The skill invocation activates state tracking and stop protection.\n\n</deep-interview-mode>\n\n---\n"}}
 EOF
   exit 0
 fi

--- a/hooks/keyword-detector_test.sh
+++ b/hooks/keyword-detector_test.sh
@@ -472,103 +472,6 @@ test_keyword_detector_uses_project_root_variable() {
 }
 
 # =============================================================================
-# Tests: Deep Interview Keyword Detection
-# =============================================================================
-
-test_deep_interview_english_keyword_activates_mode() {
-    mkdir -p "$TEST_TMP_DIR/.git"
-
-    local session_id="di-test-english"
-    local output
-    output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$session_id"'", "prompt": "deep interview about auth"}' | "$SCRIPT_DIR/keyword-detector.sh" 2>&1) || true
-
-    assert_output_contains "$output" "DEEP INTERVIEW REQUESTED" "Should say REQUESTED, not ACTIVATED" || return 1
-    assert_output_contains "$output" "Skill(deep-interview)" "Should mandate calling Skill(deep-interview)" || return 1
-    assert_output_contains "$output" "deep-interview-mode" "Output should contain deep-interview-mode tag" || return 1
-    assert_output_not_contains "$output" "You are now in deep interview mode" "Should NOT instruct model to conduct the interview directly" || return 1
-    # State file is NOT created by keyword-detector — creation moved to pre-tool-enforcer seed
-    assert_file_not_exists "$TEST_TMP_DIR/.omt/deep-interview-active-state-${session_id}.json" "keyword-detector must NOT create state file (creation moved to seed)" || return 1
-}
-
-test_deep_interview_ouroboros_keyword() {
-    mkdir -p "$TEST_TMP_DIR/.git"
-
-    local session_id="di-test-ouroboros"
-    local output
-    output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$session_id"'", "prompt": "ouroboros this conversation"}' | "$SCRIPT_DIR/keyword-detector.sh" 2>&1) || true
-
-    assert_output_contains "$output" "DEEP INTERVIEW REQUESTED" "Should say REQUESTED for ouroboros keyword" || return 1
-    assert_output_contains "$output" "Skill(deep-interview)" "Should mandate calling Skill(deep-interview) for ouroboros" || return 1
-    assert_output_contains "$output" "deep-interview-mode" "Output should contain deep-interview-mode tag" || return 1
-    # State file is NOT created by keyword-detector
-    assert_file_not_exists "$TEST_TMP_DIR/.omt/deep-interview-active-state-${session_id}.json" "keyword-detector must NOT create state file for ouroboros" || return 1
-}
-
-test_deep_interview_korean_keyword() {
-    mkdir -p "$TEST_TMP_DIR/.git"
-
-    local session_id="di-test-korean"
-    local output
-    output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$session_id"'", "prompt": "딥인터뷰 시작해줘"}' | "$SCRIPT_DIR/keyword-detector.sh" 2>&1) || true
-
-    assert_output_contains "$output" "DEEP INTERVIEW REQUESTED" "Should say REQUESTED for Korean keyword 딥인터뷰" || return 1
-    assert_output_contains "$output" "Skill(deep-interview)" "Should mandate calling Skill(deep-interview) for Korean keyword" || return 1
-    assert_output_contains "$output" "deep-interview-mode" "Output should contain deep-interview-mode tag" || return 1
-    # State file is NOT created by keyword-detector
-    assert_file_not_exists "$TEST_TMP_DIR/.omt/deep-interview-active-state-${session_id}.json" "keyword-detector must NOT create state file for Korean keyword" || return 1
-}
-
-test_deep_interview_nested_loop_prevention() {
-    mkdir -p "$TEST_TMP_DIR/.git"
-
-    # Simulate a prompt that contains only a prior assistant deep-interview-mode block (no new keyword)
-    local nested_prompt="<deep-interview-mode>
-**DEEP INTERVIEW REQUESTED** — you MUST invoke Skill(deep-interview) before responding.
-
-Do NOT conduct the interview directly. The skill invocation activates state tracking and stop protection.
-
-</deep-interview-mode>"
-
-    local session_id="di-test-nested"
-    local output
-    output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$session_id"'", "prompt": "'"$(printf '%s' "$nested_prompt" | sed 's/"/\\"/g' | tr '\n' ' ')"'"}' | "$SCRIPT_DIR/keyword-detector.sh" 2>&1) || true
-
-    # Should NOT re-trigger deep-interview injection (tag is stripped before keyword check)
-    assert_output_not_contains "$output" "DEEP INTERVIEW REQUESTED" "Nested deep-interview-mode tag should NOT re-trigger injection" || return 1
-
-    # State file should NOT be created (no incidental creation path remains)
-    assert_file_not_exists "$TEST_TMP_DIR/.omt/deep-interview-active-state-${session_id}.json" "Deep interview state file should NOT be created for nested loop" || return 1
-}
-
-# =============================================================================
-# A1 — incidental mention of deep-interview keywords creates no state file
-# =============================================================================
-
-test_a1_incidental_mention_creates_no_state_file() {
-    mkdir -p "$TEST_TMP_DIR/.git"
-
-    local session_id="di-test-mention"
-    # Mentions (including negation) — none should trigger state file creation
-    local prompts=(
-        "we are NOT doing a deep-interview today"
-        "the ouroboros pattern is interesting"
-        "딥인터뷰에 대해 들어봤어요?"
-    )
-
-    local p
-    for p in "${prompts[@]}"; do
-        echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$session_id"'", "prompt": "'"$p"'"}' \
-            | "$SCRIPT_DIR/keyword-detector.sh" > /dev/null 2>&1 || true
-    done
-
-    # No state file should exist from keyword-detector
-    local found
-    found=$(ls "$OMT_DIR"/deep-interview-active-state-*.json 2>/dev/null | wc -l | tr -d ' ')
-    [[ "$found" -eq 0 ]] \
-        || { echo "ASSERTION FAILED: incidental mention must not create state file (found=$found files)"; return 1; }
-}
-
-# =============================================================================
 # Tests: Deep Interview seed started_at/last_touched_at parser compatibility (TODO 5)
 # Survivor tests re-pointed: invoke pre-tool-enforcer.sh Skill(deep-interview) seed
 # =============================================================================
@@ -661,23 +564,14 @@ main() {
     run_test test_get_project_root_function_exists_in_keyword_detector
     run_test test_keyword_detector_uses_project_root_variable
 
+    # Deep Interview seed timestamp parser compatibility
+    run_test test_deep_interview_seed_has_parser_compatible_timestamps
+
     # JSON output format validation - hookSpecificOutput (from hooks/test/)
     run_test test_ultrawork_output_uses_hook_specific_output_format
     run_test test_think_output_uses_hook_specific_output_format
     run_test test_search_output_uses_hook_specific_output_format
     run_test test_analyze_output_uses_hook_specific_output_format
-
-    # Deep Interview Keyword Detection (mode activation; no state file from keyword-detector)
-    run_test test_deep_interview_english_keyword_activates_mode
-    run_test test_deep_interview_ouroboros_keyword
-    run_test test_deep_interview_korean_keyword
-    run_test test_deep_interview_nested_loop_prevention
-
-    # A1 — incidental mention creates no state file
-    run_test test_a1_incidental_mention_creates_no_state_file
-
-    # Deep Interview seed timestamps (TODO 5: survivor tests re-pointed to pre-tool-enforcer seed)
-    run_test test_deep_interview_seed_has_parser_compatible_timestamps
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"


### PR DESCRIPTION
## 📌 Summary

평문에 "deep-interview"(또는 `ouroboros`, `딥인터뷰`)를 *언급만* 해도 UserPromptSubmit 키워드 디텍터가 `<deep-interview-mode>` 블록을 주입해 "state tracking과 stop protection이 활성화됐다"고 — 실제로는 아닌데 — 주장하며 `Skill(deep-interview)` 호출을 압박하던 false-positive를 제거한다. 이제 평문 언급은 `{"continue": true}`만 반환한다.

---

## 🔧 Changes

### keyword-detector 훅 (`hooks/keyword-detector.sh`)

- deep-interview 키워드 분기를 삭제. 평문 "deep-interview"/"ouroboros"/"딥인터뷰"가 더 이상 `<deep-interview-mode>`를 주입하지 않는다.
- `<deep-interview-mode>` strip은 제거(주입처가 사라져 orphan). `<deep-interview-continuation>` strip은 **유지** — persistent-mode Stop 훅(`decision.ts`)이 deep-interview 스킬 state가 active일 때 여전히 주입하는 live 태그이기 때문.

**영향 범위**
UserPromptSubmit 평문 경로 한정. 실제 `Skill(deep-interview)` state seed(`pre-tool-enforcer.sh`, 무변경)·세션 복원·stop protection 모두 무영향. deep-interview 스킬 자체는 그대로 동작한다.

### 테스트 (`hooks/keyword-detector_test.sh`)

- 삭제된 키워드 분기의 테스트(영문/ouroboros/한국어/중첩) 4개 + incidental-mention 테스트를 제거.
- `pre-tool-enforcer.sh` seed의 타임스탬프 파서 호환성을 검증하는 survivor 테스트는 유지(여전히 live 동작).

**영향 범위**
26/26 green.

---

## 💬 Review Points

### 1. 평문 키워드 트리거가 deep-interview에만 있던 anomaly

**배경 및 문제 상황:**
keyword-detector의 다른 키워드(ultrawork/think/search/analyze)는 *의도-동사*라 평문 매칭이 정당하다. 그런데 deep-interview만 *스킬 이름*을 매칭해서, 주제로 한 번 언급했을 뿐인데 스킬 호출을 강요했다. 더구나 주입 메시지가 "state tracking이 활성화됐다"고 했지만 — 평문 경로는 state 파일을 전혀 만들지 않는다(생성은 `pre-tool-enforcer.sh`가 실제 `Skill()` 호출 시에만 수행). 즉 주입 텍스트가 실제 상태를 오기재했다.

**해결 방안:**
그 분기만 외과적으로 제거. prometheus·sisyphus·goal엔 평문 키워드 트리거가 애초에 없어(검증) 추가 작업이 없다. 스킬 자체와 실제 `Skill()` seed 경로는 보존.

**선택과 트레이드오프:**
평문 "deep interview me"가 더는 자동 리마인더를 띄우지 않는다 — 다만 `/deep-interview`나 명시적 스킬 호출로 충분하고, 주제-언급 false-positive(특히 이 변경을 *논의*할 때마다 트리거되는)의 비용이 그 편의를 압도한다고 판단했다.

---

## ✅ Checklist

- [ ] 평문 "deep-interview"/"ouroboros"/"딥인터뷰"가 `<deep-interview-mode>`를 주입하지 않는다 (`{"continue": true}`만 반환)
  - `hooks/keyword-detector.sh`
- [ ] 실제 `Skill(deep-interview)` state seed는 그대로 동작한다 (`pre-tool-enforcer.sh` 무변경)
- [ ] `<deep-interview-continuation>` strip이 유지된다 (persistent-mode가 주입하는 live 태그)
  - `hooks/keyword-detector.sh`
- [ ] 키워드 디텍터 테스트 26/26 green
  - `hooks/keyword-detector_test.sh`
