### PR TITLE
refactor(sisyphus): junior opus 에스컬레이션 금지

### DIFF
--- a/skills/sisyphus/delegation.md
+++ b/skills/sisyphus/delegation.md
@@ -100,7 +100,7 @@ When delegating to sisyphus-junior, refer to the Load Skills table in the `<skil
 
 ### Model: Junior always runs Sonnet
 
-sisyphus-junior runs on Sonnet — always. Do NOT pass `model="opus"` to junior. Junior is the generation agent, and generation errors are caught downstream by verification (argus, tests). If an implementation seems to need more capability, strengthen the verification, not the generator — never escalate the generator to Opus.
+sisyphus-junior runs on Sonnet — always. Do NOT pass `model="opus"` to junior. Junior is the generation agent; its output is checked by junior's own mandatory tests, and by argus only when the orchestrator creates an explicit verify task — implement tasks get no automatic argus pass. If an implementation seems to need more capability, tighten junior's required tests or add an explicit verify task — never escalate the generator to Opus.
 
 ---
 

--- a/skills/sisyphus/delegation.md
+++ b/skills/sisyphus/delegation.md
@@ -98,9 +98,9 @@ Rate limit: 100 requests per minute per IP. Return 429 Too Many Requests when ex
 
 When delegating to sisyphus-junior, refer to the Load Skills table in the `<skill-catalog>` block and include situation-matching skills in Section 7.
 
-### Model Override (opus escalation)
+### Model: Junior always runs Sonnet
 
-For complex implementation, request sisyphus-junior with opus: `Agent(subagent_type="sisyphus-junior", model="opus", prompt=...)`. The inline `model` argument overrides the agent's sonnet default.
+sisyphus-junior runs on Sonnet — always. Do NOT pass `model="opus"` to junior. Junior is the generation agent, and generation errors are caught downstream by verification (argus, tests). If an implementation seems to need more capability, strengthen the verification, not the generator — never escalate the generator to Opus.
 
 ---
 


### PR DESCRIPTION
## 📌 Summary
sisyphus-junior를 항상 Sonnet으로 고정한다. delegation.md에서 junior를 Opus로 올리도록 권하던 에스컬레이션 지침을 명시적 금지문으로 교체해, 토큰 분석에서 드러난 불필요한 Opus 소비(junior 디스패치의 21%가 Opus 오버라이드)를 차단한다.

---

## 🔧 Changes

### sisyphus 스킬 — delegation.md
- `### Model Override (opus escalation)`(junior를 `model="opus"`로 디스패치하도록 권하던 섹션)을 `### Model: Junior always runs Sonnet` 금지문으로 교체
- "junior는 항상 Sonnet · `model="opus"` 금지 · 능력이 부족해 보이면 생성기가 아니라 검증을 강화" 원칙을 명문화
- librarian의 `### Research Depth (opus escalation)` 섹션은 변경 없이 유지

**영향 범위**
- sisyphus 오케스트레이션의 junior 위임 동작에만 영향. 산문(가이던스) 변경으로 실행 로직 무변경.
- `make sync` 배포 후 다음 세션부터 반영. 다른 스킬/에이전트 정의 무영향.
- librarian opus 에스컬레이션은 유지 → 리서치 경로 변화 없음.

---

## 💬 Review Points

### 1. "절제" 가이드가 아니라 "금지"로 둔 이유
**배경 및 문제 상황:**
최근 7일 트랜스크립트 분석에서 sisyphus-junior 디스패치 413건 중 87건(21%)이 오케스트레이터의 `model="opus"` 오버라이드로 실행돼 약 5,400 Opus 턴을 소비했다. 메인 Opus가 "이 구현은 복잡하다"고 판단할 때마다 junior를 Opus로 올린 패턴이다.

**해결 방안:**
"꼭 필요할 때만 Opus" 식 절제 가이드는 오케스트레이터가 매번 "이건 복잡하니까"로 재합리화하기 쉽다. escalation 지침 자체를 제거하고 "junior는 항상 Sonnet" 명시 금지문으로 대체했다.

**구현 세부사항:**
해당 섹션을 금지문으로 교체하면서, 근거 원칙("생성 오류는 하류 검증(argus/test)이 잡으므로 능력이 부족해 보이면 생성기가 아니라 검증을 강화하라")을 함께 박아 규칙을 자기설명적으로 만들었다.

**선택과 트레이드오프:**
- 채택: 명시적 금지 — 재합리화 차단, enforceable
- 기각: 절제 가이드 — 판단 여지가 남아 누수 재발 가능
- 트레이드오프: 진짜 어려운 구현을 Sonnet으로 강제하면 재작업이 늘 수 있으나, 재작업은 test/argus가 잡는 범위다. 생성기를 비싸게 하기보다 검증층을 두껍게 하는 방향을 택했다.
- librarian 에스컬레이션을 남긴 이유: 리서치는 가끔 깊은 추론이 필요하고 누수량(약 150턴)이 무시 가능해 일관성보다 실용을 우선했다.

---

## ✅ Checklist
### junior 모델 고정
- [ ] delegation.md에 junior를 `model="opus"`로 디스패치하라는 지침이 남아있지 않다
  - `skills/sisyphus/delegation.md`
- [ ] librarian의 Research Depth (opus escalation) 섹션이 그대로 유지된다
  - `skills/sisyphus/delegation.md`
- [ ] `make validate` 통과