### PR TITLE
feat(loop-pack-fe-l2-vol1): OMT 룰 동기화 등록

### DIFF
--- a/projects/loop-pack-fe-l2-vol1/rules/component-design.md
+++ b/projects/loop-pack-fe-l2-vol1/rules/component-design.md
@@ -1,0 +1,19 @@
+---
+paths: ["**/*.tsx", "**/*.jsx"]
+---
+
+# 컴포넌트 설계 판단 규칙
+
+> 컴포넌트·Props를 설계하기 전에 **`docs/react/component-design.md`를 읽고** 상황에 맞게 적용하라(판단 기준 표·Before/After 카탈로그).
+
+핵심:
+
+- **Props 수**: 6개 이상이면 재설계 신호 — 표시 토글·boolean을 늘리지 말고 `children` 합성이나 컴포넌트 분리로. 4~5개는 관련 Props를 객체로 묶을지 검토. 진짜 문제는 개수 자체가 아니라 "서로 무관한 제어 손잡이가 흩어져 유효 조합을 못 읽는" 상태다.
+- **boolean Props**: 긍정형 + `is` 접두로 통일(`isOpen`·`disabled`). 부정형(`notDisabled` → 이중 부정)·모호한 이름(`show`) 금지.
+- **값의 주인 먼저**: 부모가 쥐면 Controlled(`value`+`onChange`), 자신이 쥐면 Uncontrolled(`defaultValue`+`ref`). 이 선택이 Props 모양을 결정한다. 공통 컴포넌트는 `value !== undefined`로 분기해 둘 다 지원.
+- **Drilling vs Context**: 2단계 전달은 유지(흐름 추적 가능). 3단계+인데 중간이 그 Props를 안 쓰거나, 여러 트리가 같은 상태를 공유하면 Context. Context는 서브트리 단위 한정 — 전역 스토어 대용이 아니다.
+- **Context 분리**: 자주 바뀌는 값과 드물게 바뀌는 값을 한 Context에 넣지 않는다(구독 하위 전체가 리렌더). 변경 빈도로 쪼갠다.
+- **공통 컴포넌트**: ①비즈니스 로직 미포함(판단은 사용처에서) ②도메인 용어 미사용(`Button`✅ `ProductButton`❌) ③`variant`/`size`로 외양 제어 + JSDoc 주석. 도입은 같은 UI가 3곳 이상 반복될 때 — "나중에 쓸 듯"은 만들 이유가 아니다(YAGNI).
+- **조건부 Props**: 조합에 규칙이 있으면 전부 optional 대신 discriminated union(`{ variant: 'text'; label } | { variant: 'icon'; icon }`). HTML 속성을 그대로 넘길 땐 손으로 나열 말고 `ComponentPropsWithoutRef<'button'>` 확장.
+
+네이밍(`onX`/`handleX`)·props→state 미러링 금지·추출 기준은 `react.md`, discriminated union 기본기는 `typescript.md`에 있다 — 여기서 중복하지 않는다.

--- a/projects/loop-pack-fe-l2-vol1/rules/react.md
+++ b/projects/loop-pack-fe-l2-vol1/rules/react.md
@@ -1,0 +1,14 @@
+---
+paths: ["**/*.tsx", "**/*.jsx"]
+---
+
+# React 판단 규칙
+
+훅 순서·exhaustive-deps·useEffect 상태동기화·렌더 순수성은 **ESLint(react-hooks)가 강제**한다. 여기엔 기계가 못 잡는 판단만.
+
+- **상태 구조**: 동시에 참이면 안 되는 boolean들 대신 `status` 유니온(`'idle' | 'loading' | 'error' | 'success'`). 파생값은 state가 아니라 렌더 중 계산. 컬렉션의 선택은 객체 복사 말고 **id 저장** 후 find. props를 state로 미러링 금지(첫 값만 쓰면 `initialX`로 명명).
+- **상태 위치**: 쓰는 컴포넌트에 가깝게 둔다. "나중에 공유할지도"는 끌어올릴 이유가 아니다.
+- **effect가 틀린 도구인 경우**: 사용자 액션의 부수효과(요청 전송 등)는 effect 말고 **이벤트 핸들러**에. prop이 바뀔 때 상태 리셋은 effect 말고 **`key`**.
+- **데이터 패칭은 4상태**: `pending · error · empty · data`를 다 그린다(성공 경로만 그리지 않는다). `useEffect` fetch엔 `ignore` 플래그나 `AbortController` cleanup으로 race를 막는다.
+- **추출은 이득이 있을 때만**: 실재 재사용·테스트 격리·성능 중 트리거가 있을 때. 한 번 쓰는 pass-through 래퍼는 인라인. 옵션이 늘면 boolean prop 대신 **`children` 합성**.
+- **네이밍**: 이벤트 prop은 `onX`, 핸들러 구현은 `handleX`. 컴포넌트는 명사(`UserList`), 훅은 도메인(`useUser`) — `useFetchData`처럼 메커니즘이 이름에 보이면 추상화가 얕다. 이름에 "and"가 있으면 책임 분리 후보.

--- a/projects/loop-pack-fe-l2-vol1/rules/react.md
+++ b/projects/loop-pack-fe-l2-vol1/rules/react.md
@@ -1,5 +1,5 @@
 ---
-paths: ["**/*.tsx", "**/*.jsx"]
+paths: ["**/*.tsx", "**/*.jsx", "**/use*.ts"]
 ---
 
 # React 판단 규칙

--- a/projects/loop-pack-fe-l2-vol1/rules/testing.md
+++ b/projects/loop-pack-fe-l2-vol1/rules/testing.md
@@ -1,0 +1,14 @@
+---
+paths: ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"]
+---
+
+# 테스트 판단 규칙
+
+> 테스트를 만지기 전에 **`docs/testing/conventions.md`를 읽고** 상황에 맞게 적용하라(전체 규칙·안티패턴 표).
+
+핵심:
+
+- **사용자가 쓰는 방식을 닮게**: 구현 세부(state 이름·내부 메서드·CSS 클래스) 말고, 보고 조작하는 동작을 검증.
+- **쿼리**: `getByRole` > `getByLabelText` > `getByText`. `getByTestId`·`container.querySelector` 금지.
+- **상호작용**: `userEvent.setup()` + `await`. 비동기 등장은 `findBy`. `waitFor` 콜백엔 assertion 하나만, side-effect 금지.
+- **모킹**: 네트워크만 MSW. 내 코드의 내부 모듈을 `vi.mock`하지 않는다(false green).

--- a/projects/loop-pack-fe-l2-vol1/rules/typescript.md
+++ b/projects/loop-pack-fe-l2-vol1/rules/typescript.md
@@ -1,0 +1,14 @@
+---
+paths: ["**/*.ts", "**/*.tsx"]
+---
+
+# TypeScript 판단 규칙
+
+`any`·`@ts-ignore`·`as`·미사용·strict는 **ESLint·tsc가 강제**한다. 여기엔 모양·시퀀싱 판단만.
+
+- **불가능한 상태를 표현 불가능하게**: optional 자루(`{ status; data?; error? }`) 대신 discriminated union(`{ status: 'ok'; data } | { status: 'err'; error }`). 이런 union을 `switch`할 땐 `default`에서 `never`로 빠짐 없이.
+- **데이터 모양**: 필드는 기본 required, _진짜_ 없을 수 있을 때만 `?`. nullable은 경계(API·입력)에서 좁히고 내부 타입으로 퍼뜨리지 않는다.
+- **`as` 대신**: 객체 모양 검증은 `satisfies`, 좁히기는 타입 가드.
+- **상수**: `enum` 대신 `as const` 객체나 문자열 리터럴 유니온.
+- **async**: 서로 독립인 호출은 `Promise.all`로 병렬. floating promise 금지(`await`·`void`·`return` 중 하나).
+- **네이밍**: 타입은 단수 PascalCase(`Route`, `Routes` 아님), `I`/`T` 접두사 금지.

--- a/projects/loop-pack-fe-l2-vol1/sync.yaml
+++ b/projects/loop-pack-fe-l2-vol1/sync.yaml
@@ -1,0 +1,9 @@
+name: loop-pack-fe-l2-vol1
+path: ~/repos/loop-pack-fe-l2-vol1/main
+
+rules:
+  items:
+    - react
+    - component-design
+    - testing
+    - typescript


### PR DESCRIPTION
## 📌 Summary
신규 프로젝트 `loop-pack-fe-l2-vol1`을 OMT 룰 동기화 대상으로 등록한다. 프로젝트 전용 FE 컨벤션 룰 4종(component-design, react, testing, typescript)과 이를 배포하는 `sync.yaml`을 추가해, 해당 프로젝트가 OMT 선언적 sync로 룰을 일괄 배포받도록 온보딩한다.

---

## 🔧 Changes

### loop-pack-fe-l2-vol1 프로젝트 등록
- `projects/loop-pack-fe-l2-vol1/sync.yaml` 추가 — 프로젝트 경로 + 룰 컴포넌트 배포 정의
- `projects/loop-pack-fe-l2-vol1/rules/` FE 룰 4종 추가: `component-design.md`, `react.md`, `testing.md`, `typescript.md`

OMT의 `projects/<name>/` 프로젝트별 오버라이드 패턴(projects/*/sync.yaml이 루트보다 먼저 처리됨)을 따라 이 프로젝트만의 FE 컨벤션을 sync 대상으로 선언한다.

**영향 범위**
- 순수 추가(additive). 기존 프로젝트·글로벌 컴포넌트 무영향.
- `loop-pack-fe-l2-vol1` 타겟에만 룰 배포(`make sync` 시). 글로벌 `rules/`를 덮지 않는 프로젝트 스코프.

---

## 💬 Review Points

### 1. 프로젝트 스코프 등록 (표준 온보딩) + 룰 분량 확인 요망
**배경 및 문제 상황:**
loop-pack-fe-l2-vol1은 FE 프로젝트로 React/TS/testing/component-design 컨벤션이 프로젝트 특화다. 글로벌 `rules/`에 넣으면 모든 프로젝트로 퍼지므로 부적절하다.

**해결 방안:**
OMT의 `projects/<name>/sync.yaml` + `projects/<name>/rules/` 오버라이드 메커니즘으로 이 프로젝트에만 룰을 스코프했다. 새로운 설계 결정은 없고 표준 온보딩 패턴을 따른다.

**선택과 트레이드오프:**
- 룰 4종이 각 14~19줄로 간결하다. 의도된 최소 컨벤션인지, 추후 보강 예정인지 리뷰어 확인을 요청한다. (열린 질문)

---

## ✅ Checklist
### loop-pack-fe-l2-vol1 등록
- [ ] `make validate` 통과 (sync.yaml 스키마 + 참조 컴포넌트 존재)
  - `projects/loop-pack-fe-l2-vol1/sync.yaml`
- [ ] `make sync-dry`에서 loop-pack-fe-l2-vol1 타겟에 룰 4종이 배포 예정으로 잡힌다
  - `projects/loop-pack-fe-l2-vol1/rules/`
- [ ] 기존 프로젝트·글로벌 컴포넌트 배포 결과 무변경 (additive 확인)