### PR TITLE
chore: council GLM 교체 + react 룰 drift 정합

### DIFF
--- a/projects/loop-pack-fe-l2-vol1/rules/component-design.md
+++ b/projects/loop-pack-fe-l2-vol1/rules/component-design.md
@@ -8,12 +8,16 @@ paths: ["**/*.tsx", "**/*.jsx"]
 
 핵심:
 
+- **경계 = 변경 이유**: 변경 이유가 다르면 자른다. 성급한 공통화보단 중복이 낫다(rule of three) — 판단 기준·Before/After는 docs "경계 — 어디서 자를까".
+- **구현 vs 조합 분리**: 한 컴포넌트는 구현이거나 조합이거나 — 같은 추상화 고도. 조합하다 내부를 인라인 구현하지 마라(조합=목차, 구현=본문).
+- **무관한 상태 = 추출 신호**: 서로 무관한 state가 한 컴포넌트에 쌓이면 그 state를 쓰는 UI와 함께 떼어낸다. 상태를 '어디 둘지'의 판단은 react.md.
 - **Props 수**: 6개 이상이면 재설계 신호 — 표시 토글·boolean을 늘리지 말고 `children` 합성이나 컴포넌트 분리로. 4~5개는 관련 Props를 객체로 묶을지 검토. 진짜 문제는 개수 자체가 아니라 "서로 무관한 제어 손잡이가 흩어져 유효 조합을 못 읽는" 상태다.
 - **boolean Props**: 긍정형 + `is` 접두로 통일(`isOpen`·`disabled`). 부정형(`notDisabled` → 이중 부정)·모호한 이름(`show`) 금지.
 - **값의 주인 먼저**: 부모가 쥐면 Controlled(`value`+`onChange`), 자신이 쥐면 Uncontrolled(`defaultValue`+`ref`). 이 선택이 Props 모양을 결정한다. 공통 컴포넌트는 `value !== undefined`로 분기해 둘 다 지원.
 - **Drilling vs Context**: 2단계 전달은 유지(흐름 추적 가능). 3단계+인데 중간이 그 Props를 안 쓰거나, 여러 트리가 같은 상태를 공유하면 Context. Context는 서브트리 단위 한정 — 전역 스토어 대용이 아니다.
 - **Context 분리**: 자주 바뀌는 값과 드물게 바뀌는 값을 한 Context에 넣지 않는다(구독 하위 전체가 리렌더). 변경 빈도로 쪼갠다.
-- **공통 컴포넌트**: ①비즈니스 로직 미포함(판단은 사용처에서) ②도메인 용어 미사용(`Button`✅ `ProductButton`❌) ③`variant`/`size`로 외양 제어 + JSDoc 주석. 도입은 같은 UI가 3곳 이상 반복될 때 — "나중에 쓸 듯"은 만들 이유가 아니다(YAGNI).
+- **공통 컴포넌트**: ①비즈니스 로직 미포함(판단은 사용처에서) ②도메인 용어 미사용(`Button`✅ `ProductButton`❌) ③`variant`/`size`로 외양 제어 + JSDoc 주석. 도입은 같은 UI가 3곳 이상 반복될 때 — "나중에 쓸 듯"은 만들 이유가 아니다(YAGNI). 스타일 미세조정 요청이 반복되면 prop 늘리지 말고 `className` 위임 — docs "스타일 확장은 prop 말고 className 위임".
+- **children vs slot**: 채울 구멍이 하나면 `children`, 이름 붙은 자리가 여럿+순서 고정이면 slot(`title`/`footer` element props) — docs "children vs slot".
 - **조건부 Props**: 조합에 규칙이 있으면 전부 optional 대신 discriminated union(`{ variant: 'text'; label } | { variant: 'icon'; icon }`). HTML 속성을 그대로 넘길 땐 손으로 나열 말고 `ComponentPropsWithoutRef<'button'>` 확장.
 
 네이밍(`onX`/`handleX`)·props→state 미러링 금지·추출 기준은 `react.md`, discriminated union 기본기는 `typescript.md`에 있다 — 여기서 중복하지 않는다.

--- a/projects/loop-pack-fe-l2-vol1/rules/react.md
+++ b/projects/loop-pack-fe-l2-vol1/rules/react.md
@@ -8,6 +8,7 @@ paths: ["**/*.tsx", "**/*.jsx", "**/use*.ts"]
 
 - **상태 구조**: 동시에 참이면 안 되는 boolean들 대신 `status` 유니온(`'idle' | 'loading' | 'error' | 'success'`). 파생값은 state가 아니라 렌더 중 계산. 컬렉션의 선택은 객체 복사 말고 **id 저장** 후 find. props를 state로 미러링 금지(첫 값만 쓰면 `initialX`로 명명).
 - **상태 위치**: 쓰는 컴포넌트에 가깝게 둔다. "나중에 공유할지도"는 끌어올릴 이유가 아니다.
+- **상태 분류**: 서버 데이터 → 서버 상태(추후 TanStack Query) · UI 전용(모달 열림·탭 선택) → 로컬 `useState` · URL에 남아야 하는 것(필터·페이지·검색어) → URL 상태 · 여러 컴포넌트 공유 → Context/전역.
 - **effect가 틀린 도구인 경우**: 사용자 액션의 부수효과(요청 전송 등)는 effect 말고 **이벤트 핸들러**에. prop이 바뀔 때 상태 리셋은 effect 말고 **`key`**.
 - **데이터 패칭은 4상태**: `pending · error · empty · data`를 다 그린다(성공 경로만 그리지 않는다). `useEffect` fetch엔 `ignore` 플래그나 `AbortController` cleanup으로 race를 막는다.
 - **추출은 이득이 있을 때만**: 실재 재사용·테스트 격리·성능 중 트리거가 있을 때. 한 번 쓰는 pass-through 래퍼는 인라인. 옵션이 늘면 boolean prop 대신 **`children` 합성**.

--- a/projects/loop-pack-fe-l2-vol1/rules/typescript.md
+++ b/projects/loop-pack-fe-l2-vol1/rules/typescript.md
@@ -9,6 +9,7 @@ paths: ["**/*.ts", "**/*.tsx"]
 - **불가능한 상태를 표현 불가능하게**: optional 자루(`{ status; data?; error? }`) 대신 discriminated union(`{ status: 'ok'; data } | { status: 'err'; error }`). 이런 union을 `switch`할 땐 `default`에서 `never`로 빠짐 없이.
 - **데이터 모양**: 필드는 기본 required, _진짜_ 없을 수 있을 때만 `?`. nullable은 경계(API·입력)에서 좁히고 내부 타입으로 퍼뜨리지 않는다.
 - **`as` 대신**: 객체 모양 검증은 `satisfies`, 좁히기는 타입 가드.
+- **`!` 대신**: 빗나갈 수 있는 조회(`find(...)`·`arr[i]`)는 early return·`?? fallback`·"못 찾으면 throw하는 헬퍼"로 좁힌다.
 - **상수**: `enum` 대신 `as const` 객체나 문자열 리터럴 유니온.
 - **async**: 서로 독립인 호출은 `Promise.all`로 병렬. floating promise 금지(`await`·`void`·`return` 중 하나).
 - **네이밍**: 타입은 단수 PascalCase(`Route`, `Routes` 아님), `I`/`T` 접두사 금지.

--- a/skills/agent-council/SKILL.md
+++ b/skills/agent-council/SKILL.md
@@ -186,11 +186,11 @@ When synthesizing, weight each model's opinion based on the question domain:
 |--------|-------------------|-------------------|
 | claude | Nuanced trade-off reasoning, instruction coherence across long context, risk/impact assessment | Architecture decisions, requirement ambiguity resolution, risk evaluation |
 | codex | Code-level feasibility analysis, implementation cost/complexity estimation, API contract design | "Is this buildable?" questions, implementation approach choices, technical debt evaluation |
-| gemini | Broad factual grounding, alternative solution discovery, edge case identification | Technology comparisons, "what are we missing?" questions, assumption challenges |
+| glm | Independent reasoning from a different model lineage, alternative solution discovery, assumption challenges | Technology comparisons, "what are we missing?" questions, cross-checking consensus |
 
 **Application rules:**
 - On **consensus**: model strengths are irrelevant — report agreement as-is
-- On **divergence**: reference the table above. If the question is about implementation feasibility and codex disagrees with claude and gemini, state: "Codex's position carries additional weight here as an implementation feasibility question (see Model Characteristics)"
+- On **divergence**: reference the table above. If the question is about implementation feasibility and codex disagrees with claude and glm, state: "Codex's position carries additional weight here as an implementation feasibility question (see Model Characteristics)"
 - On **contradiction with table**: if a model gives a strong argument outside its listed strengths, the argument's quality overrides the table. Strengths are tie-breakers, not vetoes
 - **Never discard** a model's opinion solely because the domain doesn't match its listed strengths
 

--- a/skills/agent-council/council.config.yaml
+++ b/skills/agent-council/council.config.yaml
@@ -30,11 +30,12 @@ council:
       effort_level: "xhigh"
       output_format: json
 
-    - name: gemini
-      command: "gemini"
-      emoji: "💎"
-      color: "GREEN"
-      model: "gemini-3.1-pro-preview"
+    - name: glm
+      command: "opencode run"
+      emoji: "🟣"
+      color: "YELLOW"
+      model: "opencode-go/glm-5.2"
+      output_format: json
 
   # Execution settings
   settings:

--- a/skills/agent-council/prompts/glm.md
+++ b/skills/agent-council/prompts/glm.md
@@ -1,9 +1,10 @@
 You are an advisory council member providing independent analysis on software engineering decisions.
 
-Strengths you bring: broad factual grounding, alternative framing, edge case discovery.
+Strengths you bring: independent reasoning from a different model lineage, alternative solution discovery, assumption challenges.
 
 Constraints:
+- Provide your independent opinion — give a single position. Do NOT synthesize multiple viewpoints or anticipate what other members will say.
 - Challenge assumptions the others might accept at face value
 - Propose at least one alternative approach not mentioned in the question
-- Identify edge cases and failure modes others might miss
+- Support every recommendation with specific reasoning
 - Structure your response with clear sections: Position, Reasoning, Risks, Recommendation


### PR DESCRIPTION
## 📌 Summary

agent-council의 죽은 gemini 멤버를 GLM-5.2(opencode go)로 교체하고, loop-pack react 룰의 소스↔배포본 drift(상태 분류 불릿)를 OMT 소스에 반영해 정합화한다.

---

## 🔧 Changes

### agent-council — 자문 멤버 교체

- gemini 멤버 제거, glm 멤버 추가 (`opencode run` / `opencode-go/glm-5.2` / `output_format: json`)

gemini CLI(0.42.0)의 개인 무료 Code Assist 티어가 Google에 의해 sunset되어(`IneligibleTierError`), 인증이 통과해도 티어 거부로 gemini 멤버가 항상 실패하는 상태였다. opencode의 "OpenCode Go" credential로 접근되는 GLM-5.2로 대체한다.

**영향 범위**
- council 자문 구성이 `claude·gpt·gemini` → `claude·gpt·glm`으로 변경. 전역 배포(`~/.claude/skills/agent-council/`). gemini API/키 의존 제거, opencode go credential에 의존.

### loop-pack-fe-l2-vol1 — react 룰 상태 분류 불릿

- OMT 소스 `projects/loop-pack-fe-l2-vol1/rules/react.md`에 "상태 분류" 불릿 추가

이 불릿은 배포본(`loop-pack/.claude/rules/react.md`)엔 직접 커밋돼 있었으나 OMT 소스(SSOT)엔 없었다. react는 sync 등록 룰이라, 이대로면 다음 sync가 소스로 배포본을 덮어 불릿이 삭제된다. 소스에 동일 문구·위치로 추가해 두 계보를 일치시킨다.

**영향 범위**
- loop-pack-fe-l2-vol1로 sync되는 react 룰 내용. 추가 후 소스==배포본 byte-identical. 다른 프로젝트 무관.

---

## 💬 Review Points

### 1. GLM-5.2 라우팅을 opencode 경유로 선택

**배경 및 문제 상황:**
gemini 무료 티어 sunset으로 멤버 교체가 필요했다. GLM을 붙이는 길은 두 가지였다 — (a) Anthropic 호환 엔드포인트를 `claude` CLI에 env(base URL + auth token)로 주입, (b) opencode의 GLM 모델 사용.

**해결 방안:**
(b) `opencode run -m opencode-go/glm-5.2`를 멤버로 추가. council 프레임워크가 `detectCliType`으로 opencode를 1급 지원하므로 별도 배선 없이 붙는다.

**구현 세부사항:**
(a)도 멤버별 `env` 주입 경로가 살아있어 가능하지만, `council.config.yaml`은 git-tracked라 토큰을 박으면 시크릿 유출이고 값 보간(`${VAR}`)도 없다. 게다가 전역 export한 `ANTHROPIC_AUTH_TOKEN`은 진짜 `claude` 멤버와 같은 변수를 공유해 그 멤버를 깨뜨린다. opencode는 자체 credential로 인증을 떠안아 이 문제들을 전부 우회한다.

**선택과 트레이드오프:**
opencode 멤버는 `output_format: json`이 필수다 — 드라이버가 `--format json`의 NDJSON을 파싱해 텍스트·종료상태를 뽑기 때문. config에 명시했다. `effort_level`은 의도적으로 미설정(opencode 분기가 붙이는 `--variant`를 `opencode run`이 받지 않음). 트레이드오프: opencode가 호출 시 레포 컨텍스트를 로드해 input 토큰이 크다(프로브 기준 ~62k). 비용 민감하면 `--pure` 검토 여지.

### 2. drift를 소스에 반영 (배포본 손편집 → SSOT 정합)

**배경 및 문제 상황:**
상태 분류 불릿이 loop-pack 레포의 배포본에 직접 커밋돼 있었으나 OMT 소스엔 없었다. sync 관리 대상 파일을 산출물 쪽에서 편집하면 다음 sync가 도로 덮어쓴다.

**해결 방안:**
불릿을 OMT 소스에 동일 문구·위치로 추가해 소스를 SSOT로 끌어올렸다.

**선택과 트레이드오프:**
반대 방향(배포본에서 불릿 제거)도 가능했으나, 불릿이 의도된 규칙 내용이라 소스에 반영하는 쪽을 택했다. 결과적으로 소스==배포본 byte-identical, 향후 sync 클로버 없음.

---

## ✅ Checklist

### agent-council
- [ ] council 자문이 claude·gpt·glm 3인으로 구성되고 gemini가 없다
  - `skills/agent-council/council.config.yaml`
- [ ] glm 멤버가 `opencode run -m opencode-go/glm-5.2 --format json` + stdin 프롬프트로 응답을 반환한다
  - `skills/agent-council/council.config.yaml`

### loop-pack react 룰
- [ ] OMT 소스 react.md에 상태 분류 불릿이 존재하고 배포본과 byte-identical하다
  - `projects/loop-pack-fe-l2-vol1/rules/react.md`
- [ ] `make validate`가 통과한다
