### PR TITLE
feat(code-review): 검증 단계 인라인 판정 전환 + find 토큰 계측 게이트

### DIFF
--- a/lib/agent-drivers/codex.test.ts
+++ b/lib/agent-drivers/codex.test.ts
@@ -104,6 +104,16 @@ describe('codex AgentDriver', () => {
     expect(result!.terminal).toBe('stop');
   });
 
+  test('`parseStdout` - turn.completed의 usage가 배열이면 ParseResult.usage는 undefined (배열 가드)', () => {
+    const lines = [
+      JSON.stringify({ type: 'thread.started', thread_id: 'aaaaaaaa-0000-0000-0000-000000000001' }),
+      JSON.stringify({ type: 'turn.completed', usage: [1000, 500] }),
+    ].join('\n');
+    const result = codexDriver.parseStdout(lines);
+    expect(result).not.toBeNull();
+    expect(result!.usage).toBeUndefined();
+  });
+
   test('`parseStdout` - 완전히 잘못된 입력은 null 반환', () => {
     const result = codexDriver.parseStdout('garbage\nnot json at all\n{}broken');
     expect(result).toBeNull();

--- a/lib/agent-drivers/codex.test.ts
+++ b/lib/agent-drivers/codex.test.ts
@@ -49,6 +49,22 @@ describe('codex AgentDriver', () => {
     expect(result!.terminal).toBe('error');
   });
 
+  // F1: usage extraction
+  test('`parseStdout` - turn.completed의 usage가 ParseResult.usage로 반환됨', () => {
+    const stdout = readFixture('codex-trivial.ndjson');
+    const result = codexDriver.parseStdout(stdout);
+    expect(result).not.toBeNull();
+    expect(result!.usage).toBeDefined();
+    expect(result!.usage!.input_tokens).toBe(46369);
+  });
+
+  test('`parseStdout` - turn.completed 없을 때 usage는 undefined (turn.failed)', () => {
+    const stdout = readFixture('codex-turn-failed.ndjson');
+    const result = codexDriver.parseStdout(stdout);
+    expect(result).not.toBeNull();
+    expect(result!.usage).toBeUndefined();
+  });
+
   // -------------------------------------------------------------------------
   // parseStdout — synthesized NDJSON
   // -------------------------------------------------------------------------

--- a/lib/agent-drivers/codex.ts
+++ b/lib/agent-drivers/codex.ts
@@ -52,7 +52,7 @@ export const codexDriver: AgentDriver = {
 
       if (ev.type === 'turn.completed') {
         hasTurnCompleted = true;
-        if (ev.usage && typeof ev.usage === 'object') {
+        if (ev.usage && typeof ev.usage === 'object' && !Array.isArray(ev.usage)) {
           usage = ev.usage as Record<string, number>;
         }
       }

--- a/lib/agent-drivers/codex.ts
+++ b/lib/agent-drivers/codex.ts
@@ -40,6 +40,7 @@ export const codexDriver: AgentDriver = {
     let hasTurnCompleted = false;
     let hasTurnFailed = false;
     let hasItemCompleted = false;
+    let usage: Record<string, number> | undefined;
 
     for (const event of rawEvents) {
       if (!event || typeof event !== 'object') continue;
@@ -51,6 +52,9 @@ export const codexDriver: AgentDriver = {
 
       if (ev.type === 'turn.completed') {
         hasTurnCompleted = true;
+        if (ev.usage && typeof ev.usage === 'object') {
+          usage = ev.usage as Record<string, number>;
+        }
       }
 
       if (ev.type === 'turn.failed') {
@@ -82,6 +86,7 @@ export const codexDriver: AgentDriver = {
       terminal,
       text: textParts.join(''),
       rawEvents,
+      usage,
     };
   },
 

--- a/lib/agent-drivers/types.ts
+++ b/lib/agent-drivers/types.ts
@@ -21,6 +21,7 @@ export interface ParseResult {
   terminal: TerminalSignal;
   text: string;            // concatenated agent_message/text events only (NDJSON noise stripped)
   rawEvents: unknown[];    // for events-turn-N.jsonl audit log
+  usage?: Record<string, number>; // token counts from turn.completed; undefined when no turn.completed seen
 }
 
 export interface InitialCommandOpts {

--- a/lib/worker-utils.test.ts
+++ b/lib/worker-utils.test.ts
@@ -937,6 +937,46 @@ describe('executeOneTurn state/message/workerEnv regression', () => {
     // JSON.parse of null gives null, undefined key gives undefined — must be null
     expect(status.message).toBe(null);
   });
+
+  // F2: usage from ParseResult is written into status.json
+  test('usage field from ParseResult is written into status.json', async () => {
+    const memberDir = join(tmpDir, 'f2-usage');
+    mkdirSync(memberDir, { recursive: true });
+
+    const mockDriver = makeOneTurnMockDriver({
+      sessionID: 'ses_f2', terminal: 'stop', text: 'body', rawEvents: [],
+      usage: { input_tokens: 12345, output_tokens: 42 },
+    });
+    const mockRunOnce = makeFlexibleMockRunOnce('body', { state: 'done', exitCode: 0 });
+
+    await runOneTurn(makeOneTurnOpts(memberDir, {
+      driverFactory: () => mockDriver,
+      runOnceFn: mockRunOnce,
+    }));
+
+    const status = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    expect(status.usage.input_tokens).toBe(12345);
+  });
+
+  // F2: usage is null (not {}) when driver returns no usage
+  test('usage is null in status.json when driver returns no usage', async () => {
+    const memberDir = join(tmpDir, 'f2-no-usage');
+    mkdirSync(memberDir, { recursive: true });
+
+    const mockDriver = makeOneTurnMockDriver({
+      sessionID: 'ses_f2b', terminal: 'stop', text: 'body', rawEvents: [],
+      // no usage field
+    });
+    const mockRunOnce = makeFlexibleMockRunOnce('body', { state: 'done', exitCode: 0 });
+
+    await runOneTurn(makeOneTurnOpts(memberDir, {
+      driverFactory: () => mockDriver,
+      runOnceFn: mockRunOnce,
+    }));
+
+    const status = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    expect(status.usage).toBe(null);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/lib/worker-utils.test.ts
+++ b/lib/worker-utils.test.ts
@@ -939,7 +939,7 @@ describe('executeOneTurn state/message/workerEnv regression', () => {
   });
 
   // F2: usage from ParseResult is written into status.json
-  test('usage field from ParseResult is written into status.json', async () => {
+  test('`ParseResult`의 usage 필드가 status.json에 기록됨', async () => {
     const memberDir = join(tmpDir, 'f2-usage');
     mkdirSync(memberDir, { recursive: true });
 
@@ -959,7 +959,7 @@ describe('executeOneTurn state/message/workerEnv regression', () => {
   });
 
   // F2: usage is null (not {}) when driver returns no usage
-  test('usage is null in status.json when driver returns no usage', async () => {
+  test('driver가 usage를 반환하지 않을 때 status.json의 usage가 null임', async () => {
     const memberDir = join(tmpDir, 'f2-no-usage');
     mkdirSync(memberDir, { recursive: true });
 

--- a/lib/worker-utils.test.ts
+++ b/lib/worker-utils.test.ts
@@ -994,6 +994,138 @@ function makeNullParseDriver(): AgentDriver {
   };
 }
 
+// ---------------------------------------------------------------------------
+// P2 regression: resume turns must accumulate usage across turns
+// ---------------------------------------------------------------------------
+
+describe('resumeOneTurn usage 누적', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'usage-accum-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // P2-main: two-turn flow — final status.json usage is the per-key sum of both turns
+  test('두 턴에 걸친 usage가 최종 status.json에 합산됨', async () => {
+    const memberDir = join(tmpDir, 'two-turns');
+    mkdirSync(memberDir, { recursive: true });
+
+    // Turn 1: initial runOneTurn with output_tokens=100, input_tokens=1000
+    const turn1Driver = makeOneTurnMockDriver({
+      sessionID: 'ses_accum', terminal: 'stop', text: 'turn1', rawEvents: [],
+      usage: { output_tokens: 100, input_tokens: 1000 },
+    });
+    const turn1RunOnce = makeFlexibleMockRunOnce('turn1', { state: 'done', exitCode: 0 });
+
+    await runOneTurn(makeOneTurnOpts(memberDir, {
+      driverFactory: () => turn1Driver,
+      runOnceFn: turn1RunOnce,
+    }));
+
+    // Verify turn 1 wrote usage correctly
+    const statusAfterTurn1 = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    expect(statusAfterTurn1.usage.output_tokens).toBe(100);
+
+    // Simulate cmdResumeMember: increment resume_count before calling resumeOneTurn
+    writeFileSync(
+      join(memberDir, 'status.json'),
+      JSON.stringify({ ...statusAfterTurn1, resume_count: 1 }),
+    );
+
+    // Turn 2: resumeOneTurn with output_tokens=50, input_tokens=2000
+    const turn2Driver = makeOneTurnMockDriver({
+      sessionID: 'ses_accum', terminal: 'stop', text: 'turn2', rawEvents: [],
+      usage: { output_tokens: 50, input_tokens: 2000 },
+    });
+    const turn2RunOnce = makeFlexibleMockRunOnce('turn2', { state: 'done', exitCode: 0 });
+
+    await resumeOneTurn('ses_accum', makeOneTurnOpts(memberDir, {
+      driverFactory: () => turn2Driver,
+      runOnceFn: turn2RunOnce,
+    }));
+
+    const finalStatus = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    // Must be sum of both turns
+    expect(finalStatus.usage.output_tokens).toBe(150);
+    expect(finalStatus.usage.input_tokens).toBe(3000);
+  });
+
+  // P2-carry: resume turn whose current usage is undefined carries prior usage forward
+  test('현재 턴의 usage가 없을 때 이전 usage를 유지함 (null로 초기화 금지)', async () => {
+    const memberDir = join(tmpDir, 'carry-forward');
+    mkdirSync(memberDir, { recursive: true });
+
+    // Turn 1: initial runOneTurn with usage
+    const turn1Driver = makeOneTurnMockDriver({
+      sessionID: 'ses_carry', terminal: 'stop', text: 'turn1', rawEvents: [],
+      usage: { output_tokens: 77, input_tokens: 500 },
+    });
+    const turn1RunOnce = makeFlexibleMockRunOnce('turn1', { state: 'done', exitCode: 0 });
+
+    await runOneTurn(makeOneTurnOpts(memberDir, {
+      driverFactory: () => turn1Driver,
+      runOnceFn: turn1RunOnce,
+    }));
+
+    const statusAfterTurn1 = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    // Simulate cmdResumeMember increment
+    writeFileSync(
+      join(memberDir, 'status.json'),
+      JSON.stringify({ ...statusAfterTurn1, resume_count: 1 }),
+    );
+
+    // Turn 2: resume turn with NO usage (e.g. turn.failed with no turn.completed)
+    const turn2Driver = makeOneTurnMockDriver({
+      sessionID: 'ses_carry', terminal: 'stop', text: 'turn2', rawEvents: [],
+      // no usage field
+    });
+    const turn2RunOnce = makeFlexibleMockRunOnce('turn2', { state: 'done', exitCode: 0 });
+
+    await resumeOneTurn('ses_carry', makeOneTurnOpts(memberDir, {
+      driverFactory: () => turn2Driver,
+      runOnceFn: turn2RunOnce,
+    }));
+
+    const finalStatus = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    // Prior usage must be preserved, not replaced with null
+    expect(finalStatus.usage).not.toBe(null);
+    expect(finalStatus.usage.output_tokens).toBe(77);
+  });
+
+  // P2-initial: initial (non-resume) turn still uses last-write-wins — no accumulation
+  test('초기 턴(비재개)은 기존 status.json의 usage를 누적하지 않음', async () => {
+    const memberDir = join(tmpDir, 'initial-no-accum');
+    mkdirSync(memberDir, { recursive: true });
+
+    // Pre-populate status.json with some usage from a completely different unrelated run
+    writeFileSync(join(memberDir, 'status.json'), JSON.stringify({
+      member: 'x', state: 'done', resume_count: 0,
+      usage: { output_tokens: 9999, input_tokens: 9999 },
+    }));
+
+    const mockDriver = makeOneTurnMockDriver({
+      sessionID: 'ses_init', terminal: 'stop', text: 'body', rawEvents: [],
+      usage: { output_tokens: 10, input_tokens: 20 },
+    });
+    const mockRunOnce = makeFlexibleMockRunOnce('body', { state: 'done', exitCode: 0 });
+
+    // runOneTurn = initial turn: must NOT add 9999 to 10
+    await runOneTurn(makeOneTurnOpts(memberDir, {
+      driverFactory: () => mockDriver,
+      runOnceFn: mockRunOnce,
+    }));
+
+    const status = JSON.parse(readFileSync(join(memberDir, 'status.json'), 'utf8'));
+    // Must be exactly the current turn's usage — no 9999 double-count
+    expect(status.usage.output_tokens).toBe(10);
+    expect(status.usage.input_tokens).toBe(20);
+  });
+});
+
 describe('executeOneTurn parsed===null with driver — process state preservation (P1-1)', () => {
   let tmpDir: string;
 

--- a/lib/worker-utils.ts
+++ b/lib/worker-utils.ts
@@ -467,6 +467,7 @@ async function executeOneTurn(
     message: runResultRecord.message ?? null,
     finishedAt: runResultRecord.finishedAt ?? new Date().toISOString(),
     workerEnv: builtCmd.env,
+    usage: parsed?.usage ?? null,
   });
 
   return { state, sessionID, text, exitCode };

--- a/lib/worker-utils.ts
+++ b/lib/worker-utils.ts
@@ -384,10 +384,21 @@ async function executeOneTurn(
   try { fs.writeFileSync(path.join(memberDir, 'error.txt'), '', 'utf8'); } catch { /* ignore absent */ }
 
   // Read existing status.json to preserve resume_count (legacy files may not have it)
+  // and to accumulate usage across resume turns (per-key sum when resume_count > 0).
   let existingResumeCount = 0;
+  let priorUsage: Record<string, number> | null = null;
   try {
     const existing = JSON.parse(fs.readFileSync(path.join(memberDir, 'status.json'), 'utf8')) as Record<string, unknown>;
     existingResumeCount = typeof existing.resume_count === 'number' ? existing.resume_count : 0;
+    if (existingResumeCount > 0) {
+      const u = existing.usage;
+      if (u && typeof u === 'object' && !Array.isArray(u)) {
+        priorUsage = Object.create(null) as Record<string, number>;
+        for (const [k, v] of Object.entries(u as Record<string, unknown>)) {
+          if (typeof v === 'number') priorUsage[k] = v;
+        }
+      }
+    }
   } catch { /* absent or invalid → default 0 */ }
 
   const runResult = await runOnceFn({
@@ -456,6 +467,26 @@ async function executeOneTurn(
     text = rawStdout;
   }
 
+  // Accumulate usage across resume turns. On the initial turn (priorUsage===null)
+  // this is last-write-wins. On resume turns, per-key sum of prior + current.
+  // input_tokens over-counts re-fed context on resume but is not read by any gate;
+  // output_tokens is exactly correct under summation (each turn's new output).
+  const currentUsage = parsed?.usage;
+  let accumulatedUsage: Record<string, number> | null;
+  if (priorUsage === null) {
+    // Initial turn: no accumulation
+    accumulatedUsage = currentUsage ?? null;
+  } else if (currentUsage === undefined) {
+    // Resume turn with no usage reported (e.g. turn.failed): carry prior forward unchanged
+    accumulatedUsage = priorUsage;
+  } else {
+    // Resume turn with usage: per-key sum
+    const merged = Object.create(null) as Record<string, number>;
+    for (const [k, v] of Object.entries(priorUsage)) merged[k] = v;
+    for (const [k, v] of Object.entries(currentUsage)) merged[k] = (merged[k] ?? 0) + v;
+    accumulatedUsage = merged;
+  }
+
   const runResultRecord = runResult as Record<string, unknown>;
   atomicWriteJson(path.join(memberDir, 'status.json'), {
     member,
@@ -467,7 +498,7 @@ async function executeOneTurn(
     message: runResultRecord.message ?? null,
     finishedAt: runResultRecord.finishedAt ?? new Date().toISOString(),
     workerEnv: builtCmd.env,
-    usage: parsed?.usage ?? null,
+    usage: accumulatedUsage,
   });
 
   return { state, sessionID, text, exitCode };

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -416,9 +416,9 @@ Omit the last argument when `findTokenUsage` is unavailable. A D=0 review (zero 
 **Find-inclusion rule:**
 
 Read `[$CLAUDE_CONFIG_DIR|~/.claude]/settings.json` and `./.claude/settings.json` (project overrides user):
-- Resolve `omt.codeReview.findInclusionThreshold` into `<findInclusionThreshold>`; if undefined, use `0.5`
+- Resolve `omt.codeReview.findInclusionThreshold` into `<findInclusionThreshold>`; if undefined, use `50000` (output tokens)
 
-After writing the sink, if `findTokenUsage` is available, compute `findShare = findTokenUsage.usage.output_tokens / totalReviewOutputTokens`. If `findShare >= omt.codeReview.findInclusionThreshold`, append a note to the Phase 3 report: "Find token share `{findShare}` >= threshold `{findInclusionThreshold}` — find-phase redesign is in scope as a follow-up (Story 2)." This rule is measurement-only in v1 — it does not block the review or change any verdict.
+After writing the sink, if `findTokenUsage` is available, compare `findTokenUsage.usage.output_tokens` directly against `findInclusionThreshold` as an absolute output-token count. (v1 note: verify/synthesis tokens are not measured in v1, so a true share-of-total-review-tokens ratio is not computable; this threshold is an absolute cost signal instead.) If `findTokenUsage.usage.output_tokens >= findInclusionThreshold`, append a note to the Phase 3 report: "Find output tokens `{findTokenUsage.usage.output_tokens}` >= threshold `{findInclusionThreshold}` tokens — find-phase redesign is in scope as a follow-up (Story 2)." This rule is measurement-only in v1 — it does not block the review or change any verdict.
 
 ## Step 6: Verification + Synthesis
 
@@ -433,7 +433,7 @@ Finders surface candidates; they do not judge them. You judge each deduped candi
 Read `[$CLAUDE_CONFIG_DIR|~/.claude]/settings.json` and `./.claude/settings.json` (project overrides user):
 - Resolve `omt.codeReview.escalationConfidenceThreshold` into `<threshold>`; if undefined, use `0.35`
 - Resolve `omt.codeReview.escalationKCap` into `<k>`; if undefined, use `3`
-- Resolve `omt.codeReview.findInclusionThreshold` into `<findInclusionThreshold>`; if undefined, use `0.5` (also resolved in the Find Phase Sink above)
+- Resolve `omt.codeReview.findInclusionThreshold` into `<findInclusionThreshold>`; if undefined, use `50000` (output tokens; also resolved in the Find Phase Sink above)
 
 **Inline judgment steps:**
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -41,11 +41,12 @@ These premises must be reflected in the chunk-reviewer dispatch prompt — see S
 | Evidence Verification (build/test/lint) | Yes | - |
 | Chunking decision | Yes | - |
 | Findings synthesis (rank/class verified findings) | Yes | - |
-| Individual candidate verification (Phase 2) | NEVER | verifier subagent (one per candidate) |
+| Individual candidate judgment inline (Phase 2) | Yes | - |
+| Escalation verification (candidates below confidence threshold) | - | verifier subagent (one per escalated candidate) |
 | Individual chunk review | NEVER | chunk-reviewer |
 | Code modification | NEVER | (forbidden entirely) |
 
-**RULE**: Orchestration, synthesis, and decisions = Do directly. Per-candidate verification = DELEGATE to verifier subagents (one per candidate). Multi-angle finding = DELEGATE to chunk-reviewer. Code modification = FORBIDDEN.
+**RULE**: Orchestration, synthesis, and decisions = Do directly. Per-candidate inline judgment = Do directly in Phase 2 (reasoning → confidence → verdict + enrichment). Escalated candidates (confidence below threshold) = DELEGATE to verifier subagents (one per candidate). Multi-angle finding = DELEGATE to chunk-reviewer. Code modification = FORBIDDEN.
 
 ### Role Separation
 
@@ -58,22 +59,23 @@ digraph role_separation {
     "Codebase" [shape=cylinder];
     "Orchestrator" -> "chunk-reviewer" [label="dispatch with {DIFF_COMMAND}"];
     "chunk-reviewer" -> "Orchestrator" [label="candidate findings"];
-    "Orchestrator" -> "verifier" [label="dispatch one per candidate"];
+    "Orchestrator" -> "Codebase" [label="Read/Grep inline (Phase 2)"];
+    "Orchestrator" -> "verifier" [label="dispatch per escalated candidate"];
     "verifier" -> "Codebase" [label="Read/Grep to verify"];
-    "verifier" -> "Orchestrator" [label="verdict + enriched finding"];
+    "verifier" -> "Orchestrator" [label="verdict (supersedes inline)"];
 }
 ```
 
 **Your role as orchestrator:**
 - Dispatch chunk-reviewer agents with diff command strings (each fans out the angle finders)
-- Dispatch one verifier subagent per candidate; collect their verdicts and drop REFUTED
+- Judge each deduped candidate inline in Phase 2 (reasoning → confidence → verdict + enrichment); enrich kept findings directly
+- Escalate only candidates below the confidence threshold to verifier subagents; collect their final verdicts; supersede inline tentative verdicts with verifier verdicts in Phase 3
 - Synthesize the kept findings into a ranked findings report (text only)
 - Make chunking decisions and rank the verified findings (no merge verdict — this review reports, it does not gate)
 
 **NOT your role:**
 - Modifying any source files
-- Running the raw `git diff` command (chunk-reviewers and verifiers execute the diff)
-- Judging candidates in your own context — each candidate goes to its own verifier subagent
+- Running the raw `git diff` command (chunk-reviewers execute the diff)
 
 ### Context Budget
 
@@ -84,17 +86,18 @@ digraph role_separation {
 - CLAUDE.md file content
 - Step 3 evidence summary (structured table — build/test/lint status + test coverage mapping, truncated to summary on success / last 30 lines on failure)
 - chunk-reviewer results (candidate findings)
-- Verifier subagent verdicts + enriched findings (Phase 2)
+- Phase 2 inline judgment output (reasoning, verdicts, enriched findings for non-escalated candidates)
+- Escalated verifier subagent verdicts + enriched findings (Phase 2, candidates below confidence threshold)
+- Code reading via Read/Grep for Phase 2 inline candidate judgment
 
 **Forbidden in orchestrator context:**
-- Running the raw `git diff` command (chunk-reviewers and verifiers execute the diff, not you)
-- Reading code to verify candidates in your own context (each candidate goes to its own verifier subagent)
+- Running the raw `git diff` command (chunk-reviewers execute the diff, not you)
 - Modifying any source files
 
 **Context management:**
-- Per-candidate code reading happens inside verifier subagents, not your context — see Phase 2 cap & batching
+- Phase 2 inline judgment reads candidate code directly in your context (non-escalated candidates); only escalated candidates' code reading moves into verifier subagent contexts
 
-**RULE**: Per-candidate verification is delegated to verifier subagents. You CANNOT run the raw diff command or modify files.
+**RULE**: Inline judgment for non-escalated candidates runs in your context. Only escalated candidates are delegated to verifier subagents. You CANNOT run the raw diff command or modify files.
 
 ## Step 0: Intent and Context Acquisition
 
@@ -385,28 +388,59 @@ After all re-dispatches complete, merge all chunk results (original + re-dispatc
 
 ## Step 6: Verification + Synthesis
 
-After all chunk-reviewers return, produce the final findings in two phases: per-candidate verification via a verifier fan-out (Phase 2), and findings synthesis (Phase 3). The terminal deliverable is the **Phase 3 findings text** — no walkthrough, no diagrams, no HTML.
+After all chunk-reviewers return, produce the final findings in two phases: per-candidate inline judgment with selective escalation (Phase 2), and findings synthesis (Phase 3). The terminal deliverable is the **Phase 3 findings text** — no walkthrough, no diagrams, no HTML.
 
 ### Phase 2: Candidate Verification (MANDATORY)
 
-Finders surface candidates; they do not judge them — and **you do not judge them in your own context either**. You dispatch **one verifier subagent per candidate**. Each verifier reads the actual code in isolation and returns exactly one verdict. Per-candidate isolation is deliberate: it keeps each judgment free of the other candidates' framing (no anchoring) and gives each verifier a clean context to read deeply. This is the precision gate — finders ran wide for recall; verification narrows to what is real. A candidate is real or it is not, at a stated confidence.
+Finders surface candidates; they do not judge them. You judge each deduped candidate **inline** — reasoning through the evidence, reading the relevant code in your context, and issuing a confidence score and verdict. Inline judgment eliminates the multi-candidate batch-output parse hazard, and the orchestrator's context (already holding chunk-reviewer results and diff stat) is a clean enough frame for accurate triage: no anchoring from the authoring context, because this is already a separate review session.
 
-**Dispatch:**
+**Config resolution:**
 
-1. **Dedup near-duplicates first** (same defect, same location, same reason → keep one, merging the `found by` angles and keeping the most concrete failure scenario). Verifying duplicates wastes verifier slots.
-2. **MANDATORY READ: `references/verifier-prompt.md`** — the per-candidate verifier contract. Read it now before dispatching.
-3. For each remaining candidate, interpolate the placeholders:
-   - {RANGE} ← the review range from Step 1
-   - {CANDIDATE_FILE} / {CANDIDATE_LINE} / {CANDIDATE_SUMMARY} / {CANDIDATE_FAILURE_SCENARIO} / {CANDIDATE_FOUND_BY} ← the candidate's fields
-   - {INTENT} ← Step 0 intent/requirements (or "N/A — code-quality-only review")
-4. Dispatch a `general-purpose` subagent per candidate via the Task tool (`subagent_type: "general-purpose"`) with the interpolated prompt. **All candidates in ONE response** — parallel, foreground.
-5. **Collect** each verifier's verdict. **Keep CONFIRMED and PLAUSIBLE; drop REFUTED.** You do not re-judge a verdict — the verifier read the code; you collect.
+Read `[$CLAUDE_CONFIG_DIR|~/.claude]/settings.json` and `./.claude/settings.json` (project overrides user):
+- Resolve `omt.codeReview.escalationConfidenceThreshold` into `<threshold>`; if undefined, use `0.35`
+- Resolve `omt.codeReview.escalationKCap` into `<k>`; if undefined, use `3`
 
-**Cap & batching:** verify at most **25 candidates per batch**. If more survive dedup, batch by file proximity, **correctness candidates first**, and state how many were deferred — never silently drop.
+**Inline judgment steps:**
 
-**The verdict ladder, the verification method, and the read-only constraint all live in `references/verifier-prompt.md`** — that is the contract each verifier applies. Keep it as the single source; do not restate the ladder here.
+1. **Dedup near-duplicates first** (same defect, same location, same reason → keep one, merging the `found by` angles and keeping the most concrete failure scenario). Deduplication reduces the judgment workload before it starts.
+2. **MANDATORY READ: `references/verifier-prompt.md`** — read it before beginning judgment. The verdict ladder (CONFIRMED / PLAUSIBLE / REFUTED), verification method, and 9-field output contract all live there. Escalated candidates reuse this file as their dispatch prompt.
+3. For each remaining candidate, in order:
 
-**Enrichment arrives with the verdict.** Each kept verifier returns the enriched finding (current code, what's wrong, failure scenario, fix, blast radius) because it had to read the code to decide. Phase 3 assembles these directly — there is no separate enrichment pass.
+   **REASONING** — read the code at the issue location (Read/Grep on the candidate file), trace the call chain from the entry point, and check the execution context (threading, dispatch model, runtime configuration). Apply the verdict ladder from `references/verifier-prompt.md`. Reason explicitly before issuing a score.
+
+   **CONFIDENCE** — assign a numeric value in **0.0–1.0** reflecting certainty that the finding is real (1.0 = no doubt, 0.0 = clearly not a bug). This value is **internal only**: it drives the escalation comparison and candidate ranking but is **never serialized into any artifact**.
+
+   **VERDICT** — exactly one of CONFIRMED / PLAUSIBLE / REFUTED (ladder in `references/verifier-prompt.md`).
+
+   For **CONFIRMED** or **PLAUSIBLE** (kept findings), emit the full 9-field enrichment inline:
+
+   ```
+   VERDICT: <CONFIRMED | PLAUSIBLE>
+   TITLE: <short finding title>
+   LOCATION: <file>:<line> — <section / function name>
+   CURRENT CODE:
+   <5-15 lines centered on the issue>
+   WHAT'S WRONG: <the problem, grounded in the quoted line>
+   FAILURE SCENARIO: <concrete inputs/state -> wrong output, crash, or lost effect; for a cleanup finding, the concrete cost>
+   FIX: <concrete diff, or design direction if structural>
+   BLAST RADIUS: <grep/reference evidence — what else references this, or "This location only">
+   FOUND BY: <angle(s)>
+   ```
+
+   For **REFUTED**, emit a one-line note:
+
+   ```
+   VERDICT: REFUTED — <one line quoting the line/guard/invariant that proves it is not a bug>
+   ```
+
+4. **Escalation** — after all inline judgments complete, collect candidates where `confidence < omt.codeReview.escalationConfidenceThreshold`:
+   - If the count exceeds `omt.codeReview.escalationKCap`, take the `<k>` lowest-confidence candidates for escalation; the overflow candidates **keep their inline verdict** and are **surfaced in Phase 3** — never silently dropped.
+   - For each escalated candidate, interpolate `references/verifier-prompt.md` with the candidate's fields and dispatch a `general-purpose` subagent via the Task tool (`subagent_type: "general-purpose"`). **All escalated candidates in ONE response** — parallel, foreground.
+   - The escalated verifier's verdict is **FINAL** and **supersedes** the inline tentative verdict in Phase 3.
+
+**Cap & batching:** judge at most **25 candidates per batch** inline. If more survive dedup, batch by file proximity, **correctness candidates first**, and state how many were deferred — never silently drop.
+
+**The verdict ladder, verification method, and 9-field output contract all live in `references/verifier-prompt.md`** — that is the single source; the inline judgment mirrors this contract directly.
 
 ### Phase 3: Findings Synthesis (report-only)
 
@@ -432,7 +466,7 @@ This is a **report**. You surface verified findings, ranked by what matters most
 
 This is a **report**. It does not gate. There is no Assessment / "Ready to merge" section, and there is no HTML — the deliverable is the Phase 3 findings as terminal text.
 
-Emit the ranked findings directly: each finding carries its verdict (CONFIRMED / PLAUSIBLE), class (correctness / cleanup), `file:line`, and the verifier's enriched evidence (current code, what's wrong, failure scenario, fix, blast radius — the shape returned by `references/verifier-prompt.md`). Pre-existing findings go under Out of Scope. This findings text is also the handoff contract consumed by `review-report` when it dispatches a code-reviewer agent that runs this skill — do not invent a different format.
+Emit the ranked findings directly: each finding carries its verdict (CONFIRMED / PLAUSIBLE), class (correctness / cleanup), `file:line`, and enriched evidence (current code, what's wrong, failure scenario, fix, blast radius — the 9-field shape from `references/verifier-prompt.md`, produced inline for non-escalated findings or by the escalated verifier for superseded ones). Pre-existing findings go under Out of Scope. This findings text is also the handoff contract consumed by `review-report` when it dispatches a code-reviewer agent that runs this skill — do not invent a different format.
 
 ## Reference Files (on-demand)
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -384,7 +384,41 @@ Each chunk-reviewer scans its whole assigned diff through every angle and report
 
 Re-dispatch a chunk-reviewer for its chunk only when its response signals an infrastructure failure: a "Partial review"/"Limited review" degradation notice, an Angle Coverage entry marked `Unavailable`, or a reported diff-command failure.
 Cap: maximum 1 re-dispatch per original chunk; if the re-dispatch also fails, accept partial coverage.
-After all re-dispatches complete, merge all chunk results (original + re-dispatched) before proceeding to Step 6.
+After all re-dispatches complete, merge all chunk results (original + re-dispatched) before proceeding to the Find Phase Sink.
+
+## Find Phase Sink
+
+**Establish `runId` before dispatching chunk-reviewers (Step 5):**
+
+- Running under `/goal` (a `goal-codereview-{sid}.json` artifact path is active for the current session): `runId = {sid}`
+- Otherwise: `runId = crypto.randomUUID()` (Tier-0 builtin — no dependency required)
+
+**After all chunk-reviewers return and before Phase 2 begins, write the durable sink:**
+
+Parse the conductor's returned text for:
+- `found` — sum of per-angle counts from the Angle Coverage block (each angle's `K candidates` value)
+- `deduped` — the N in `### Candidate Findings ({N}/from M angles)` header
+- `findTokenUsage` — raw JSON object from the `### Find Token Usage` block (omit when unavailable — do not block the sink write)
+
+Compute `dispatched`:
+- v1: `dispatched = deduped` — no inline cap exists; the field records verify load for the find-inclusion gate and diverges only if a later inline cap or pre-filter is added
+
+Invoke the sink helper:
+
+```bash
+bun "${CLAUDE_SKILL_DIR}/scripts/durable-sink.ts" \
+  "<runId>" <found> <deduped> <dispatched> \
+  '<findTokenUsageJson>'
+```
+
+Omit the last argument when `findTokenUsage` is unavailable. A D=0 review (zero candidates) still invokes the sink — `candidates.json` is written with zeros.
+
+**Find-inclusion rule:**
+
+Read `[$CLAUDE_CONFIG_DIR|~/.claude]/settings.json` and `./.claude/settings.json` (project overrides user):
+- Resolve `omt.codeReview.findInclusionThreshold` into `<findInclusionThreshold>`; if undefined, use `0.5`
+
+After writing the sink, if `findTokenUsage` is available, compute `findShare = findTokenUsage.usage.output_tokens / totalReviewOutputTokens`. If `findShare >= omt.codeReview.findInclusionThreshold`, append a note to the Phase 3 report: "Find token share `{findShare}` >= threshold `{findInclusionThreshold}` — find-phase redesign is in scope as a follow-up (Story 2)." This rule is measurement-only in v1 — it does not block the review or change any verdict.
 
 ## Step 6: Verification + Synthesis
 
@@ -399,6 +433,7 @@ Finders surface candidates; they do not judge them. You judge each deduped candi
 Read `[$CLAUDE_CONFIG_DIR|~/.claude]/settings.json` and `./.claude/settings.json` (project overrides user):
 - Resolve `omt.codeReview.escalationConfidenceThreshold` into `<threshold>`; if undefined, use `0.35`
 - Resolve `omt.codeReview.escalationKCap` into `<k>`; if undefined, use `3`
+- Resolve `omt.codeReview.findInclusionThreshold` into `<findInclusionThreshold>`; if undefined, use `0.5` (also resolved in the Find Phase Sink above)
 
 **Inline judgment steps:**
 

--- a/skills/code-review/scripts/durable-sink.test.ts
+++ b/skills/code-review/scripts/durable-sink.test.ts
@@ -1,0 +1,162 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { writeDurableSink } from './durable-sink';
+
+// ---------------------------------------------------------------------------
+// F4: durable sink — candidates.json + usage-summary.json per runId
+//
+// Guards three properties:
+//   1. Path determinism: sink writes to EXACTLY ${OMT_DIR}/code-review/<runId>/
+//   2. Field completeness: candidates.json has `found`, `deduped`, `dispatched`
+//      as separate assertable fields
+//   3. D=0 invariant: a zero-dispatch run still writes candidates.json (zeros)
+//
+// runId is injected (never generated inside writeDurableSink) so tests are
+// deterministic without crypto.randomUUID() variance.
+// getOmtDir() reads OMT_DIR at call-time, so the hermetic temp-dir env setup
+// routes writes to the test fixture dir.
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+const originalOmtDir = process.env.OMT_DIR;
+
+/** Stable run id for path-determinism tests. */
+const KNOWN_RUN_ID = 'test-run-abc123';
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'durable-sink-test-'));
+  process.env.OMT_DIR = tmpDir;
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  if (originalOmtDir !== undefined) {
+    process.env.OMT_DIR = originalOmtDir;
+  } else {
+    delete process.env.OMT_DIR;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// AC 1: path determinism — sink writes to ${OMT_DIR}/code-review/<runId>/
+// ---------------------------------------------------------------------------
+describe('F4: durable sink path determinism', () => {
+  test('candidates.json path resolves to ${OMT_DIR}/code-review/<runId>/candidates.json', () => {
+    writeDurableSink({ runId: KNOWN_RUN_ID, found: 5, deduped: 3, dispatched: 3 });
+
+    const expectedPath = join(tmpDir, 'code-review', KNOWN_RUN_ID, 'candidates.json');
+    expect(existsSync(expectedPath)).toBe(true);
+  });
+
+  test('usage-summary.json path resolves to ${OMT_DIR}/code-review/<runId>/usage-summary.json', () => {
+    writeDurableSink({ runId: KNOWN_RUN_ID, found: 5, deduped: 3, dispatched: 3 });
+
+    const expectedPath = join(tmpDir, 'code-review', KNOWN_RUN_ID, 'usage-summary.json');
+    expect(existsSync(expectedPath)).toBe(true);
+  });
+
+  test('different runIds write to different subdirectories (no cross-run collision)', () => {
+    writeDurableSink({ runId: 'run-alpha', found: 2, deduped: 1, dispatched: 1 });
+    writeDurableSink({ runId: 'run-beta', found: 3, deduped: 2, dispatched: 2 });
+
+    expect(existsSync(join(tmpDir, 'code-review', 'run-alpha', 'candidates.json'))).toBe(true);
+    expect(existsSync(join(tmpDir, 'code-review', 'run-beta', 'candidates.json'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC 2: candidates.json field completeness — found, deduped, dispatched
+//        each asserted SEPARATELY (catching a partial-write)
+// ---------------------------------------------------------------------------
+describe('F4: candidates.json field completeness', () => {
+  test('candidates.json contains `found` field', () => {
+    writeDurableSink({ runId: KNOWN_RUN_ID, found: 7, deduped: 4, dispatched: 4 });
+
+    const raw = readFileSync(join(tmpDir, 'code-review', KNOWN_RUN_ID, 'candidates.json'), 'utf8');
+    const parsed = JSON.parse(raw);
+    expect(parsed.found).toBe(7);
+  });
+
+  test('candidates.json contains `deduped` field', () => {
+    writeDurableSink({ runId: KNOWN_RUN_ID, found: 7, deduped: 4, dispatched: 4 });
+
+    const raw = readFileSync(join(tmpDir, 'code-review', KNOWN_RUN_ID, 'candidates.json'), 'utf8');
+    const parsed = JSON.parse(raw);
+    expect(parsed.deduped).toBe(4);
+  });
+
+  test('candidates.json contains `dispatched` field', () => {
+    writeDurableSink({ runId: KNOWN_RUN_ID, found: 7, deduped: 4, dispatched: 4 });
+
+    const raw = readFileSync(join(tmpDir, 'code-review', KNOWN_RUN_ID, 'candidates.json'), 'utf8');
+    const parsed = JSON.parse(raw);
+    expect(parsed.dispatched).toBe(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC 3: D=0 invariant — a zero-dispatch run still writes candidates.json
+//        (a review that found nothing still needs the measurement artifact)
+// ---------------------------------------------------------------------------
+describe('F4: D=0 invariant', () => {
+  test('D=0: candidates.json is written with found=0', () => {
+    writeDurableSink({ runId: KNOWN_RUN_ID, found: 0, deduped: 0, dispatched: 0 });
+
+    const expectedPath = join(tmpDir, 'code-review', KNOWN_RUN_ID, 'candidates.json');
+    expect(existsSync(expectedPath)).toBe(true);
+
+    const parsed = JSON.parse(readFileSync(expectedPath, 'utf8'));
+    expect(parsed.found).toBe(0);
+  });
+
+  test('D=0: candidates.json deduped field is zero', () => {
+    writeDurableSink({ runId: KNOWN_RUN_ID, found: 0, deduped: 0, dispatched: 0 });
+
+    const parsed = JSON.parse(
+      readFileSync(join(tmpDir, 'code-review', KNOWN_RUN_ID, 'candidates.json'), 'utf8')
+    );
+    expect(parsed.deduped).toBe(0);
+  });
+
+  test('D=0: candidates.json dispatched field is zero', () => {
+    writeDurableSink({ runId: KNOWN_RUN_ID, found: 0, deduped: 0, dispatched: 0 });
+
+    const parsed = JSON.parse(
+      readFileSync(join(tmpDir, 'code-review', KNOWN_RUN_ID, 'candidates.json'), 'utf8')
+    );
+    expect(parsed.dispatched).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC 4: findTokenUsage is persisted in usage-summary.json (optional field)
+//        Missing findTokenUsage does NOT block the sink write.
+// ---------------------------------------------------------------------------
+describe('F4: usage-summary.json', () => {
+  test('findTokenUsage is written to usage-summary.json when provided', () => {
+    const tokenData = { memberCount: 4, usage: { input_tokens: 1200, output_tokens: 800 } };
+    writeDurableSink({ runId: KNOWN_RUN_ID, found: 3, deduped: 2, dispatched: 2, findTokenUsage: tokenData });
+
+    const raw = readFileSync(join(tmpDir, 'code-review', KNOWN_RUN_ID, 'usage-summary.json'), 'utf8');
+    const parsed = JSON.parse(raw);
+    expect(parsed.findTokenUsage).toEqual(tokenData);
+  });
+
+  test('missing findTokenUsage does not block sink write (usage-summary.json still created)', () => {
+    writeDurableSink({ runId: KNOWN_RUN_ID, found: 2, deduped: 1, dispatched: 1 });
+
+    const expectedPath = join(tmpDir, 'code-review', KNOWN_RUN_ID, 'usage-summary.json');
+    expect(existsSync(expectedPath)).toBe(true);
+  });
+
+  test('missing findTokenUsage writes null in usage-summary.json', () => {
+    writeDurableSink({ runId: KNOWN_RUN_ID, found: 2, deduped: 1, dispatched: 1 });
+
+    const parsed = JSON.parse(
+      readFileSync(join(tmpDir, 'code-review', KNOWN_RUN_ID, 'usage-summary.json'), 'utf8')
+    );
+    expect(parsed.findTokenUsage).toBeNull();
+  });
+});

--- a/skills/code-review/scripts/durable-sink.test.ts
+++ b/skills/code-review/scripts/durable-sink.test.ts
@@ -5,25 +5,39 @@ import { join } from 'path';
 import { writeDurableSink } from './durable-sink';
 
 // ---------------------------------------------------------------------------
-// F4: durable sink — candidates.json + usage-summary.json per runId
+// 듀러블 싱크 테스트 — CLI/파싱 경계 및 파일 기록 검증
 //
-// Guards three properties:
-//   1. Path determinism: sink writes to EXACTLY ${OMT_DIR}/code-review/<runId>/
-//   2. Field completeness: candidates.json has `found`, `deduped`, `dispatched`
-//      as separate assertable fields
-//   3. D=0 invariant: a zero-dispatch run still writes candidates.json (zeros)
+// 세 가지 속성을 보장한다:
+//   1. 경로 결정성: 싱크가 정확히 ${OMT_DIR}/code-review/<runId>/ 에 기록
+//   2. 필드 완전성: candidates.json에 `found`, `deduped`, `dispatched` 각각 검증
+//   3. D=0 불변 조건: 토출 수가 0인 리뷰에도 candidates.json 기록
 //
-// runId is injected (never generated inside writeDurableSink) so tests are
-// deterministic without crypto.randomUUID() variance.
-// getOmtDir() reads OMT_DIR at call-time, so the hermetic temp-dir env setup
-// routes writes to the test fixture dir.
+// runId는 외부 주입(`writeDurableSink` 내부에서 생성 금지)으로 테스트 결정성 보장.
+// `getOmtDir()`는 호출 시점에 OMT_DIR을 읽으므로, 헤르메틱 임시 디렉터리로 라우팅.
 // ---------------------------------------------------------------------------
+
+/** CLI 서브프로세스 테스트용 스크립트 경로 */
+const SCRIPT_PATH = join(import.meta.dir, 'durable-sink.ts');
 
 let tmpDir: string;
 const originalOmtDir = process.env.OMT_DIR;
 
-/** Stable run id for path-determinism tests. */
+/** 경로 결정성 테스트용 고정 runId */
 const KNOWN_RUN_ID = 'test-run-abc123';
+
+/** CLI를 서브프로세스로 실행하고 `exitCode`, `stdout`, `stderr`를 반환한다 */
+function runCLI(args: string[]) {
+  const result = Bun.spawnSync(['bun', SCRIPT_PATH, ...args], {
+    env: { ...process.env, OMT_DIR: tmpDir },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  return {
+    exitCode: result.exitCode,
+    stderr: result.stderr.toString(),
+    stdout: result.stdout.toString(),
+  };
+}
 
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), 'durable-sink-test-'));
@@ -40,24 +54,24 @@ afterEach(() => {
 });
 
 // ---------------------------------------------------------------------------
-// AC 1: path determinism — sink writes to ${OMT_DIR}/code-review/<runId>/
+// AC 1: 경로 결정성 — ${OMT_DIR}/code-review/<runId>/ 에 기록
 // ---------------------------------------------------------------------------
-describe('F4: durable sink path determinism', () => {
-  test('candidates.json path resolves to ${OMT_DIR}/code-review/<runId>/candidates.json', () => {
+describe('F4: 싱크 경로 결정성', () => {
+  test('`candidates.json` 경로가 ${OMT_DIR}/code-review/<runId>/candidates.json으로 결정된다', () => {
     writeDurableSink({ runId: KNOWN_RUN_ID, found: 5, deduped: 3, dispatched: 3 });
 
     const expectedPath = join(tmpDir, 'code-review', KNOWN_RUN_ID, 'candidates.json');
     expect(existsSync(expectedPath)).toBe(true);
   });
 
-  test('usage-summary.json path resolves to ${OMT_DIR}/code-review/<runId>/usage-summary.json', () => {
+  test('`usage-summary.json` 경로가 ${OMT_DIR}/code-review/<runId>/usage-summary.json으로 결정된다', () => {
     writeDurableSink({ runId: KNOWN_RUN_ID, found: 5, deduped: 3, dispatched: 3 });
 
     const expectedPath = join(tmpDir, 'code-review', KNOWN_RUN_ID, 'usage-summary.json');
     expect(existsSync(expectedPath)).toBe(true);
   });
 
-  test('different runIds write to different subdirectories (no cross-run collision)', () => {
+  test('runId가 다르면 서로 다른 하위 디렉터리에 기록된다 (크로스-런 충돌 없음)', () => {
     writeDurableSink({ runId: 'run-alpha', found: 2, deduped: 1, dispatched: 1 });
     writeDurableSink({ runId: 'run-beta', found: 3, deduped: 2, dispatched: 2 });
 
@@ -67,11 +81,11 @@ describe('F4: durable sink path determinism', () => {
 });
 
 // ---------------------------------------------------------------------------
-// AC 2: candidates.json field completeness — found, deduped, dispatched
-//        each asserted SEPARATELY (catching a partial-write)
+// AC 2: candidates.json 필드 완전성 — found, deduped, dispatched 각각 검증
+//        (부분 쓰기 감지)
 // ---------------------------------------------------------------------------
-describe('F4: candidates.json field completeness', () => {
-  test('candidates.json contains `found` field', () => {
+describe('F4: `candidates.json` 필드 완전성', () => {
+  test('`candidates.json`에 `found` 필드가 존재한다', () => {
     writeDurableSink({ runId: KNOWN_RUN_ID, found: 7, deduped: 4, dispatched: 4 });
 
     const raw = readFileSync(join(tmpDir, 'code-review', KNOWN_RUN_ID, 'candidates.json'), 'utf8');
@@ -79,7 +93,7 @@ describe('F4: candidates.json field completeness', () => {
     expect(parsed.found).toBe(7);
   });
 
-  test('candidates.json contains `deduped` field', () => {
+  test('`candidates.json`에 `deduped` 필드가 존재한다', () => {
     writeDurableSink({ runId: KNOWN_RUN_ID, found: 7, deduped: 4, dispatched: 4 });
 
     const raw = readFileSync(join(tmpDir, 'code-review', KNOWN_RUN_ID, 'candidates.json'), 'utf8');
@@ -87,7 +101,7 @@ describe('F4: candidates.json field completeness', () => {
     expect(parsed.deduped).toBe(4);
   });
 
-  test('candidates.json contains `dispatched` field', () => {
+  test('`candidates.json`에 `dispatched` 필드가 존재한다', () => {
     writeDurableSink({ runId: KNOWN_RUN_ID, found: 7, deduped: 4, dispatched: 4 });
 
     const raw = readFileSync(join(tmpDir, 'code-review', KNOWN_RUN_ID, 'candidates.json'), 'utf8');
@@ -97,11 +111,11 @@ describe('F4: candidates.json field completeness', () => {
 });
 
 // ---------------------------------------------------------------------------
-// AC 3: D=0 invariant — a zero-dispatch run still writes candidates.json
-//        (a review that found nothing still needs the measurement artifact)
+// AC 3: D=0 불변 조건 — 토출 수가 0인 리뷰에도 candidates.json 기록
+//        (결과가 없는 리뷰에도 측정 아티팩트 필요)
 // ---------------------------------------------------------------------------
-describe('F4: D=0 invariant', () => {
-  test('D=0: candidates.json is written with found=0', () => {
+describe('F4: D=0 불변 조건', () => {
+  test('D=0: `candidates.json`이 found=0으로 기록된다', () => {
     writeDurableSink({ runId: KNOWN_RUN_ID, found: 0, deduped: 0, dispatched: 0 });
 
     const expectedPath = join(tmpDir, 'code-review', KNOWN_RUN_ID, 'candidates.json');
@@ -111,7 +125,7 @@ describe('F4: D=0 invariant', () => {
     expect(parsed.found).toBe(0);
   });
 
-  test('D=0: candidates.json deduped field is zero', () => {
+  test('D=0: `candidates.json`의 `deduped` 필드가 0이다', () => {
     writeDurableSink({ runId: KNOWN_RUN_ID, found: 0, deduped: 0, dispatched: 0 });
 
     const parsed = JSON.parse(
@@ -120,7 +134,7 @@ describe('F4: D=0 invariant', () => {
     expect(parsed.deduped).toBe(0);
   });
 
-  test('D=0: candidates.json dispatched field is zero', () => {
+  test('D=0: `candidates.json`의 `dispatched` 필드가 0이다', () => {
     writeDurableSink({ runId: KNOWN_RUN_ID, found: 0, deduped: 0, dispatched: 0 });
 
     const parsed = JSON.parse(
@@ -131,11 +145,11 @@ describe('F4: D=0 invariant', () => {
 });
 
 // ---------------------------------------------------------------------------
-// AC 4: findTokenUsage is persisted in usage-summary.json (optional field)
-//        Missing findTokenUsage does NOT block the sink write.
+// AC 4: usage-summary.json — findTokenUsage 기록 (선택 필드)
+//        findTokenUsage가 없어도 싱크 쓰기를 차단하지 않는다.
 // ---------------------------------------------------------------------------
-describe('F4: usage-summary.json', () => {
-  test('findTokenUsage is written to usage-summary.json when provided', () => {
+describe('F4: `usage-summary.json`', () => {
+  test('`findTokenUsage`가 제공되면 `usage-summary.json`에 기록된다', () => {
     const tokenData = { memberCount: 4, usage: { input_tokens: 1200, output_tokens: 800 } };
     writeDurableSink({ runId: KNOWN_RUN_ID, found: 3, deduped: 2, dispatched: 2, findTokenUsage: tokenData });
 
@@ -144,19 +158,86 @@ describe('F4: usage-summary.json', () => {
     expect(parsed.findTokenUsage).toEqual(tokenData);
   });
 
-  test('missing findTokenUsage does not block sink write (usage-summary.json still created)', () => {
+  test('`findTokenUsage`가 없어도 싱크 쓰기를 차단하지 않는다', () => {
     writeDurableSink({ runId: KNOWN_RUN_ID, found: 2, deduped: 1, dispatched: 1 });
 
     const expectedPath = join(tmpDir, 'code-review', KNOWN_RUN_ID, 'usage-summary.json');
     expect(existsSync(expectedPath)).toBe(true);
   });
 
-  test('missing findTokenUsage writes null in usage-summary.json', () => {
+  test('`findTokenUsage`가 없으면 `usage-summary.json`에 null로 기록된다', () => {
     writeDurableSink({ runId: KNOWN_RUN_ID, found: 2, deduped: 1, dispatched: 1 });
 
     const parsed = JSON.parse(
       readFileSync(join(tmpDir, 'code-review', KNOWN_RUN_ID, 'usage-summary.json'), 'utf8')
     );
     expect(parsed.findTokenUsage).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C-4: writeDurableSink에 빈 runId 전달 시 에러를 던진다
+// ---------------------------------------------------------------------------
+describe('C-4: `writeDurableSink` 빈 runId 검증', () => {
+  test('runId가 빈 문자열이면 에러를 던진다', () => {
+    expect(() => {
+      writeDurableSink({ runId: '', found: 0, deduped: 0, dispatched: 0 });
+    }).toThrow('writeDurableSink: runId must be non-empty');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C-2: CLI 숫자 인자 검증 — 빈 문자열과 비정수 소수점은 exit 1
+// ---------------------------------------------------------------------------
+describe('C-2: CLI 숫자 인자 검증', () => {
+  test('빈 문자열 `found` 인자는 exit 1을 반환한다', () => {
+    const { exitCode } = runCLI(['run-id', '', '3', '3']);
+    expect(exitCode).toBe(1);
+  });
+
+  test('소수점 `found` 인자는 exit 1을 반환한다', () => {
+    const { exitCode } = runCLI(['run-id', '2.5', '3', '3']);
+    expect(exitCode).toBe(1);
+  });
+
+  test('빈 문자열 `deduped` 인자는 exit 1을 반환한다', () => {
+    const { exitCode } = runCLI(['run-id', '5', '', '3']);
+    expect(exitCode).toBe(1);
+  });
+
+  test('빈 문자열 `dispatched` 인자는 exit 1을 반환한다', () => {
+    const { exitCode } = runCLI(['run-id', '5', '3', '']);
+    expect(exitCode).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C-3: findTokenUsageJson이 유효한 JSON이지만 객체가 아닐 때 null로 기록
+// ---------------------------------------------------------------------------
+describe('C-3: 비객체 JSON은 `findTokenUsage`를 null로 기록한다', () => {
+  test('숫자 JSON은 `findTokenUsage`를 null로 기록하고 exit 0을 반환한다', () => {
+    const r = runCLI(['run-id', '5', '3', '3', '42']);
+    expect(r.exitCode).toBe(0);
+    const usagePath = join(tmpDir, 'code-review', 'run-id', 'usage-summary.json');
+    const parsed = JSON.parse(readFileSync(usagePath, 'utf8'));
+    expect(parsed.findTokenUsage).toBeNull();
+  });
+
+  test('배열 JSON은 `findTokenUsage`를 null로 기록하고 exit 0을 반환한다', () => {
+    const r = runCLI(['run-id', '5', '3', '3', '[1,2,3]']);
+    expect(r.exitCode).toBe(0);
+    const usagePath = join(tmpDir, 'code-review', 'run-id', 'usage-summary.json');
+    const parsed = JSON.parse(readFileSync(usagePath, 'utf8'));
+    expect(parsed.findTokenUsage).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C-5: 잘못된 JSON 파싱 시 exit 2
+// ---------------------------------------------------------------------------
+describe('C-5: 잘못된 JSON 파싱 시 exit 2를 반환한다', () => {
+  test('malformed JSON은 exit 2를 반환한다', () => {
+    const { exitCode } = runCLI(['run-id', '5', '3', '3', '{bad json}']);
+    expect(exitCode).toBe(2);
   });
 });

--- a/skills/code-review/scripts/durable-sink.test.ts
+++ b/skills/code-review/scripts/durable-sink.test.ts
@@ -233,11 +233,52 @@ describe('C-3: 비객체 JSON은 `findTokenUsage`를 null로 기록한다', () =
 });
 
 // ---------------------------------------------------------------------------
-// C-5: 잘못된 JSON 파싱 시 exit 2
+// C-5: 잘못된 JSON — exit 0으로 fall-through, null 기록, stderr 경고
+//   (round-2 exit(2)는 plan TODO-7 "persist what is available" 위반이었으므로 제거)
 // ---------------------------------------------------------------------------
-describe('C-5: 잘못된 JSON 파싱 시 exit 2를 반환한다', () => {
-  test('malformed JSON은 exit 2를 반환한다', () => {
+describe('C-5: malformed findTokenUsageJson은 null로 기록하고 exit 0을 반환한다', () => {
+  test('malformed JSON은 exit 0을 반환한다', () => {
     const { exitCode } = runCLI(['run-id', '5', '3', '3', '{bad json}']);
-    expect(exitCode).toBe(2);
+    expect(exitCode).toBe(0);
+  });
+
+  test('malformed JSON이어도 candidates.json이 기록된다', () => {
+    runCLI(['run-id', '5', '3', '3', '{bad json}']);
+    const candidatesPath = join(tmpDir, 'code-review', 'run-id', 'candidates.json');
+    expect(existsSync(candidatesPath)).toBe(true);
+  });
+
+  test('malformed JSON이면 usage-summary.json의 findTokenUsage가 null로 기록된다', () => {
+    runCLI(['run-id', '5', '3', '3', '{bad json}']);
+    const usagePath = join(tmpDir, 'code-review', 'run-id', 'usage-summary.json');
+    const parsed = JSON.parse(readFileSync(usagePath, 'utf8'));
+    expect(parsed.findTokenUsage).toBeNull();
+  });
+
+  test('malformed JSON은 stderr에 경고 메시지를 출력한다', () => {
+    const { stderr } = runCLI(['run-id', '5', '3', '3', '{bad json}']);
+    expect(stderr).toContain('invalid findTokenUsageJson');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C-2b: 음수 인자 — exit 1 (non-negative 보장)
+// ---------------------------------------------------------------------------
+describe('C-2b: 음수 인자는 exit 1을 반환한다', () => {
+  test('음수 `found` 인자는 exit 1을 반환하고 파일을 기록하지 않는다', () => {
+    const { exitCode } = runCLI(['run-id', '-3', '3', '3']);
+    expect(exitCode).toBe(1);
+    const candidatesPath = join(tmpDir, 'code-review', 'run-id', 'candidates.json');
+    expect(existsSync(candidatesPath)).toBe(false);
+  });
+
+  test('음수 `deduped` 인자는 exit 1을 반환한다', () => {
+    const { exitCode } = runCLI(['run-id', '5', '-1', '3']);
+    expect(exitCode).toBe(1);
+  });
+
+  test('음수 `dispatched` 인자는 exit 1을 반환한다', () => {
+    const { exitCode } = runCLI(['run-id', '5', '3', '-2']);
+    expect(exitCode).toBe(1);
   });
 });

--- a/skills/code-review/scripts/durable-sink.ts
+++ b/skills/code-review/scripts/durable-sink.ts
@@ -103,8 +103,11 @@ if (import.meta.main) {
   const deduped = Number(dedupedStr);
   const dispatched = Number(dispatchedStr);
 
-  if (!Number.isInteger(found) || !Number.isInteger(deduped) || !Number.isInteger(dispatched)) {
-    process.stderr.write('durable-sink: found/deduped/dispatched must be integers\n');
+  if (
+    !Number.isInteger(found) || !Number.isInteger(deduped) || !Number.isInteger(dispatched) ||
+    found < 0 || deduped < 0 || dispatched < 0
+  ) {
+    process.stderr.write('durable-sink: found/deduped/dispatched must be non-negative integers\n');
     process.exit(1);
   }
 
@@ -118,8 +121,8 @@ if (import.meta.main) {
         process.stderr.write(`durable-sink: findTokenUsageJson is not a JSON object — writing null\n`);
       }
     } catch {
-      process.stderr.write(`durable-sink: invalid findTokenUsageJson — writing null\n`);
-      process.exit(2);
+      process.stderr.write(`durable-sink: invalid findTokenUsageJson — recording usage as null\n`);
+      // fall through: leave findTokenUsage undefined → writeDurableSink records null
     }
   }
 

--- a/skills/code-review/scripts/durable-sink.ts
+++ b/skills/code-review/scripts/durable-sink.ts
@@ -48,9 +48,14 @@ export interface DurableSinkParams {
 /**
  * Writes candidates.json and usage-summary.json to
  * ${OMT_DIR}/code-review/${runId}/.
+ *
+ * Returns the absolute path to the sink directory so callers can log it
+ * without re-deriving the path independently (K-3).
  */
-export function writeDurableSink(params: DurableSinkParams): void {
+export function writeDurableSink(params: DurableSinkParams): string {
   const { runId, found, deduped, dispatched, findTokenUsage } = params;
+
+  if (!runId) throw new Error('writeDurableSink: runId must be non-empty');
 
   const sinkDir = join(getOmtDir(), 'code-review', runId);
   mkdirSync(sinkDir, { recursive: true });
@@ -66,6 +71,8 @@ export function writeDurableSink(params: DurableSinkParams): void {
     JSON.stringify({ findTokenUsage: findTokenUsage ?? null }, null, 2),
     'utf8'
   );
+
+  return sinkDir;
 }
 
 // ---------------------------------------------------------------------------
@@ -80,7 +87,12 @@ export function writeDurableSink(params: DurableSinkParams): void {
 if (import.meta.main) {
   const [, , runId, foundStr, dedupedStr, dispatchedStr, findTokenUsageJson] = process.argv;
 
-  if (!runId || foundStr === undefined || dedupedStr === undefined || dispatchedStr === undefined) {
+  if (
+    !runId ||
+    foundStr === undefined || foundStr === '' ||
+    dedupedStr === undefined || dedupedStr === '' ||
+    dispatchedStr === undefined || dispatchedStr === ''
+  ) {
     process.stderr.write(
       'usage: durable-sink.ts <runId> <found> <deduped> <dispatched> [<findTokenUsageJson>]\n'
     );
@@ -91,7 +103,7 @@ if (import.meta.main) {
   const deduped = Number(dedupedStr);
   const dispatched = Number(dispatchedStr);
 
-  if (!Number.isFinite(found) || !Number.isFinite(deduped) || !Number.isFinite(dispatched)) {
+  if (!Number.isInteger(found) || !Number.isInteger(deduped) || !Number.isInteger(dispatched)) {
     process.stderr.write('durable-sink: found/deduped/dispatched must be integers\n');
     process.exit(1);
   }
@@ -99,12 +111,18 @@ if (import.meta.main) {
   let findTokenUsage: object | undefined;
   if (findTokenUsageJson && findTokenUsageJson.trim() !== '') {
     try {
-      findTokenUsage = JSON.parse(findTokenUsageJson) as object;
+      const parsed: unknown = JSON.parse(findTokenUsageJson);
+      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+        findTokenUsage = parsed as object;
+      } else {
+        process.stderr.write(`durable-sink: findTokenUsageJson is not a JSON object — writing null\n`);
+      }
     } catch {
       process.stderr.write(`durable-sink: invalid findTokenUsageJson — writing null\n`);
+      process.exit(2);
     }
   }
 
-  writeDurableSink({ runId, found, deduped, dispatched, findTokenUsage });
-  process.stdout.write(`durable-sink: wrote ${join(getOmtDir(), 'code-review', runId)}/\n`);
+  const sinkDir = writeDurableSink({ runId, found, deduped, dispatched, findTokenUsage });
+  process.stdout.write(`durable-sink: wrote ${sinkDir}/\n`);
 }

--- a/skills/code-review/scripts/durable-sink.ts
+++ b/skills/code-review/scripts/durable-sink.ts
@@ -1,0 +1,110 @@
+/**
+ * Durable sink for code-review run metrics.
+ *
+ * Writes two measurement artifacts to ${OMT_DIR}/code-review/${runId}/:
+ *   - candidates.json  — {found, deduped, dispatched} counts
+ *   - usage-summary.json — {findTokenUsage} (null when aggregate unavailable)
+ *
+ * The directory is created on first write (mkdirSync recursive).
+ * A D=0 review STILL writes candidates.json with zeros.
+ * Missing findTokenUsage does NOT block the write — usage-summary.json is
+ * written with findTokenUsage: null in that case.
+ *
+ * runId is always injected by the caller:
+ *   - Under /goal: pass the goal session id {sid} so the sink correlates with
+ *     goal-codereview-{sid}.json (goal-state.ts resolveCodeReviewArtifactPath)
+ *   - Otherwise: pass crypto.randomUUID() (Tier-0 builtin, no extra dep)
+ *
+ * getOmtDir() reads $OMT_DIR at call time, enabling hermetic test injection
+ * via process.env.OMT_DIR = tmpDir.
+ */
+
+import { mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { getOmtDir } from '@lib/omt-dir';
+
+export interface DurableSinkParams {
+  /** Injected by caller — never generated inside this function. */
+  runId: string;
+  /** Total candidates surfaced across all angles (sum of per-angle counts). */
+  found: number;
+  /** Candidates surviving deduplication (total-surviving header). */
+  deduped: number;
+  /**
+   * Candidates entering inline verification.
+   * v1: dispatched === deduped (no inline cap exists yet).
+   * The field records verify load for the find-inclusion gate and diverges
+   * only if a later inline cap or pre-filter is added.
+   */
+  dispatched: number;
+  /**
+   * Raw JSON object from the `### Find Token Usage` block in the conductor's
+   * returned text (T4, commit 84d67d02). Omit or pass undefined when the
+   * aggregate is unavailable — the write proceeds without blocking.
+   */
+  findTokenUsage?: object;
+}
+
+/**
+ * Writes candidates.json and usage-summary.json to
+ * ${OMT_DIR}/code-review/${runId}/.
+ */
+export function writeDurableSink(params: DurableSinkParams): void {
+  const { runId, found, deduped, dispatched, findTokenUsage } = params;
+
+  const sinkDir = join(getOmtDir(), 'code-review', runId);
+  mkdirSync(sinkDir, { recursive: true });
+
+  writeFileSync(
+    join(sinkDir, 'candidates.json'),
+    JSON.stringify({ found, deduped, dispatched }, null, 2),
+    'utf8'
+  );
+
+  writeFileSync(
+    join(sinkDir, 'usage-summary.json'),
+    JSON.stringify({ findTokenUsage: findTokenUsage ?? null }, null, 2),
+    'utf8'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point — mirrors usage-summary.ts convention
+//
+// Usage:
+//   bun durable-sink.ts <runId> <found> <deduped> <dispatched> [<findTokenUsageJson>]
+//
+// <findTokenUsageJson>: raw JSON string from the `### Find Token Usage` block.
+//   Omit or pass '' when the aggregate is unavailable.
+// ---------------------------------------------------------------------------
+if (import.meta.main) {
+  const [, , runId, foundStr, dedupedStr, dispatchedStr, findTokenUsageJson] = process.argv;
+
+  if (!runId || foundStr === undefined || dedupedStr === undefined || dispatchedStr === undefined) {
+    process.stderr.write(
+      'usage: durable-sink.ts <runId> <found> <deduped> <dispatched> [<findTokenUsageJson>]\n'
+    );
+    process.exit(1);
+  }
+
+  const found = Number(foundStr);
+  const deduped = Number(dedupedStr);
+  const dispatched = Number(dispatchedStr);
+
+  if (!Number.isFinite(found) || !Number.isFinite(deduped) || !Number.isFinite(dispatched)) {
+    process.stderr.write('durable-sink: found/deduped/dispatched must be integers\n');
+    process.exit(1);
+  }
+
+  let findTokenUsage: object | undefined;
+  if (findTokenUsageJson && findTokenUsageJson.trim() !== '') {
+    try {
+      findTokenUsage = JSON.parse(findTokenUsageJson) as object;
+    } catch {
+      process.stderr.write(`durable-sink: invalid findTokenUsageJson — writing null\n`);
+    }
+  }
+
+  writeDurableSink({ runId, found, deduped, dispatched, findTokenUsage });
+  process.stdout.write(`durable-sink: wrote ${join(getOmtDir(), 'code-review', runId)}/\n`);
+}

--- a/skills/goal/scripts/goal-state-codereview-contract.test.ts
+++ b/skills/goal/scripts/goal-state-codereview-contract.test.ts
@@ -1,0 +1,170 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { readCodeReviewArtifact } from './goal-state';
+
+// ---------------------------------------------------------------------------
+// V8: code-review artifact enum-contract preservation (redesign path)
+//
+// Guards the T1 EXTERNAL contract for the code-review completion lane:
+//   - every verdict in {CONFIRMED, PLAUSIBLE}  (readCodeReviewArtifact rejects
+//     the whole artifact on any enum violation — never-false-complete)
+//   - every class in {correctness, cleanup}
+//   - zero serialized `confidence` in any finding  (readCodeReviewArtifact
+//     ignores extra keys so it will NOT reject a leaked confidence; only this
+//     raw-string scan catches that — ADR D-3, risk R1)
+//
+// T5 (44c7ae4f) pins `confidence` as inline-internal numeric 0.0-1.0, never
+// serialized into the artifact.  This test enforces that property: if the
+// redesign path ever leaks `confidence` into a finding's JSON, the raw-scan
+// assertion fails.
+//
+// The REAL readCodeReviewArtifact is called directly (goal-state.ts:735);
+// the non-null assertion proves the real reader ACCEPTS the redesign-path
+// artifact (R1 fail-closed gate).  readCodeReviewArtifact reads from
+// resolveCodeReviewArtifactPath(sid) = ${getOmtDir()}/goal-codereview-${sid}.json;
+// getOmtDir() reads OMT_DIR at call time, so the hermetic temp-dir env setup
+// makes the real reader read the fixture.
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+const originalOmtDir = process.env.OMT_DIR;
+
+/** Session id for tests in this file — isolated from the main goal-state session. */
+const SID = 'v8-contract-test';
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'goal-codereview-contract-test-'));
+  process.env.OMT_DIR = tmpDir;
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  if (originalOmtDir !== undefined) {
+    process.env.OMT_DIR = originalOmtDir;
+  } else {
+    delete process.env.OMT_DIR;
+  }
+});
+
+/**
+ * Conventional artifact path — mirrors resolveCodeReviewArtifactPath (goal-state.ts:720-722).
+ * No path argument accepted: D-11 (a path arg would be a steerable gate input).
+ */
+function codeReviewArtifactPath(sid: string): string {
+  return `${process.env.OMT_DIR}/goal-codereview-${sid}.json`;
+}
+
+function writeArtifact(sid: string, obj: object): void {
+  writeFileSync(codeReviewArtifactPath(sid), JSON.stringify(obj), 'utf8');
+}
+
+// Representative redesign-path finding set: inline + escalated, kept under the
+// {CONFIRMED, PLAUSIBLE} enum.  REFUTED findings are dropped before serialization
+// (they never appear in the artifact), so the set is a mix of both kept verdicts
+// across both classes.
+const REDESIGN_FINDINGS: Array<{ class: string; verdict: string; ref: string }> = [
+  // inline correctness judgment, high certainty -> CONFIRMED
+  { class: 'correctness', verdict: 'CONFIRMED', ref: 'skills/code-review/SKILL.md:Phase2:inline' },
+  // escalated correctness finding, uncertain -> PLAUSIBLE
+  { class: 'correctness', verdict: 'PLAUSIBLE',  ref: 'tools/sync.ts:42' },
+  // inline cleanup judgment, low severity -> PLAUSIBLE
+  { class: 'cleanup',     verdict: 'PLAUSIBLE',  ref: 'skills/code-review/SKILL.md:Phase2:escalated' },
+  // escalated cleanup finding, architecture concern -> CONFIRMED
+  { class: 'cleanup',     verdict: 'CONFIRMED',  ref: 'tools/adapters/claude.ts:88' },
+];
+
+describe('V8: code-review artifact enum-contract preservation (redesign path)', () => {
+  // -------------------------------------------------------------------------
+  // AC 1: real readCodeReviewArtifact returns non-null — R1 fail-closed gate
+  // -------------------------------------------------------------------------
+  test(
+    'valid schema: readCodeReviewArtifact returns non-null for redesign-path artifact (R1 fail-closed)',
+    () => {
+      writeArtifact(SID, {
+        findings: REDESIGN_FINDINGS,
+        reviewer: 'code-reviewer',
+        at: '2026-06-26T10:00:00',
+      });
+
+      const artifact = readCodeReviewArtifact(SID);
+      expect(artifact).not.toBeNull();
+    }
+  );
+
+  // -------------------------------------------------------------------------
+  // AC 2: every finding verdict in {CONFIRMED, PLAUSIBLE}
+  // -------------------------------------------------------------------------
+  test(
+    'every finding verdict in {CONFIRMED, PLAUSIBLE} — enum contract preserved across redesign path',
+    () => {
+      writeArtifact(SID, {
+        findings: REDESIGN_FINDINGS,
+        reviewer: 'code-reviewer',
+        at: '2026-06-26T10:00:00',
+      });
+
+      const artifact = readCodeReviewArtifact(SID)!;
+      const VALID_VERDICTS = new Set(['CONFIRMED', 'PLAUSIBLE']);
+      for (const finding of artifact.findings) {
+        expect(VALID_VERDICTS.has(finding.verdict)).toBe(true);
+      }
+    }
+  );
+
+  // -------------------------------------------------------------------------
+  // AC 3: every finding class in {correctness, cleanup}
+  // -------------------------------------------------------------------------
+  test(
+    'every finding class in {correctness, cleanup} — enum contract preserved across redesign path',
+    () => {
+      writeArtifact(SID, {
+        findings: REDESIGN_FINDINGS,
+        reviewer: 'code-reviewer',
+        at: '2026-06-26T10:00:00',
+      });
+
+      const artifact = readCodeReviewArtifact(SID)!;
+      const VALID_CLASSES = new Set(['correctness', 'cleanup']);
+      for (const finding of artifact.findings) {
+        expect(VALID_CLASSES.has(finding.class)).toBe(true);
+      }
+    }
+  );
+
+  // -------------------------------------------------------------------------
+  // AC 4 (CRITICAL): zero confidence in raw serialized finding strings
+  //
+  // readCodeReviewArtifact IGNORES extra keys (goal-state.ts:754-759) so it
+  // will NOT reject a leaked `confidence` field — the raw-string scan is the
+  // ONLY guard.  T5 (44c7ae4f) pins confidence as inline-internal; this test
+  // enforces that property: a confidence leak would brick every goal completion
+  // silently if it collided with verdict/class enum validation downstream.
+  //
+  // readCodeReviewArtifact casts the full parsed object (TypeScript casts are
+  // erased at runtime), so artifact.findings retains all original JSON keys —
+  // serializing each finding catches a leaked `confidence` key exactly as the
+  // raw-file scan did.
+  // -------------------------------------------------------------------------
+  test(
+    'CRITICAL: zero confidence in raw serialized finding strings ' +
+    '(readCodeReviewArtifact ignores extra keys — raw scan is the only guard, T5/ADR-D3/R1)',
+    () => {
+      writeArtifact(SID, {
+        findings: REDESIGN_FINDINGS,
+        reviewer: 'code-reviewer',
+        at: '2026-06-26T10:00:00',
+      });
+
+      const artifact = readCodeReviewArtifact(SID)!;
+
+      // Scan each finding's own serialization independently — not just the top-level
+      // JSON string — because a leaked confidence may appear only in a finding key.
+      for (const finding of artifact.findings) {
+        const serialized = JSON.stringify(finding);
+        expect(serialized).not.toContain('confidence');
+      }
+    }
+  );
+});

--- a/skills/goal/scripts/goal-state-codereview-contract.test.ts
+++ b/skills/goal/scripts/goal-state-codereview-contract.test.ts
@@ -75,12 +75,12 @@ const REDESIGN_FINDINGS: Array<{ class: string; verdict: string; ref: string }> 
   { class: 'cleanup',     verdict: 'CONFIRMED',  ref: 'tools/adapters/claude.ts:88' },
 ];
 
-describe('V8: code-review artifact enum-contract preservation (redesign path)', () => {
+describe('V8: code-review 아티팩트 열거형 계약 보존 (redesign 경로)', () => {
   // -------------------------------------------------------------------------
   // AC 1: real readCodeReviewArtifact returns non-null — R1 fail-closed gate
   // -------------------------------------------------------------------------
   test(
-    'valid schema: readCodeReviewArtifact returns non-null for redesign-path artifact (R1 fail-closed)',
+    '유효한 스키마: `readCodeReviewArtifact`가 redesign 경로 아티팩트에 대해 null이 아닌 값 반환 (R1 fail-closed)',
     () => {
       writeArtifact(SID, {
         findings: REDESIGN_FINDINGS,
@@ -97,7 +97,7 @@ describe('V8: code-review artifact enum-contract preservation (redesign path)', 
   // AC 2: every finding verdict in {CONFIRMED, PLAUSIBLE}
   // -------------------------------------------------------------------------
   test(
-    'every finding verdict in {CONFIRMED, PLAUSIBLE} — enum contract preserved across redesign path',
+    '모든 finding verdict가 {CONFIRMED, PLAUSIBLE}에 속함 — redesign 경로에서 열거형 계약 보존',
     () => {
       writeArtifact(SID, {
         findings: REDESIGN_FINDINGS,
@@ -117,7 +117,7 @@ describe('V8: code-review artifact enum-contract preservation (redesign path)', 
   // AC 3: every finding class in {correctness, cleanup}
   // -------------------------------------------------------------------------
   test(
-    'every finding class in {correctness, cleanup} — enum contract preserved across redesign path',
+    '모든 finding class가 {correctness, cleanup}에 속함 — redesign 경로에서 열거형 계약 보존',
     () => {
       writeArtifact(SID, {
         findings: REDESIGN_FINDINGS,
@@ -148,8 +148,7 @@ describe('V8: code-review artifact enum-contract preservation (redesign path)', 
   // raw-file scan did.
   // -------------------------------------------------------------------------
   test(
-    'CRITICAL: zero confidence in raw serialized finding strings ' +
-    '(readCodeReviewArtifact ignores extra keys — raw scan is the only guard, T5/ADR-D3/R1)',
+    'CRITICAL: 직렬화된 finding 문자열에 confidence 없음 (`readCodeReviewArtifact`는 추가 키 무시 — raw 스캔이 유일한 보호, T5/ADR-D3/R1)',
     () => {
       writeArtifact(SID, {
         findings: REDESIGN_FINDINGS,

--- a/skills/goal/scripts/goal-state.ts
+++ b/skills/goal/scripts/goal-state.ts
@@ -732,7 +732,7 @@ function resolveCodeReviewArtifactPath(sessionId: string): string {
  * artifact (never-false-complete: a broken reviewer output must degrade toward
  * block, never mask a CONFIRMED finding). `findings: []` is valid and clean.
  */
-function readCodeReviewArtifact(sessionId: string): CodeReviewArtifact | null {
+export function readCodeReviewArtifact(sessionId: string): CodeReviewArtifact | null {
   const content = readFileOrNull(resolveCodeReviewArtifactPath(sessionId));
   if (!content) return null;
   let obj: unknown;

--- a/skills/orchestrate-review/SKILL.md
+++ b/skills/orchestrate-review/SKILL.md
@@ -23,8 +23,8 @@ When finders cannot deliver — none configured/available after filtering, or al
 4. Read each finder's output file via the Read tool.
 5. Merge candidates using the Aggregation rules.
 6. Run `bun "${CLAUDE_SKILL_DIR}/scripts/usage-summary.ts" "$JOB_DIR"` and append the result as a `### Find Token Usage` block to the merged candidate text. This step **MUST** run before `clean` — the job dir is deleted in the next teardown step and the per-member token data is gone.
-7. Return the merged candidate list (including the `### Find Token Usage` block).
-8. Run teardown: `bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" clean "$JOB_DIR"` (deletes the job dir; `usage-summary.ts` was already run in step 6). Then **STOP** — do not run any further tools.
+7. Run teardown: `bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" clean "$JOB_DIR"` (deletes the job dir; `usage-summary.ts` was already run in step 6).
+8. Return the merged candidate list (including the `### Find Token Usage` block) as the final response, then **STOP** — do not run any further tools.
 
 **If a finder fails (outputFilePath is null in the manifest): apply Degradation Policy. Do NOT re-start the job.**
 
@@ -92,7 +92,7 @@ Response JSON (not done — re-run this step):
 Use the Read tool to read each finder's `outputFilePath` from the manifest.
 
 ### Step 4 — Merge, Teardown & Return
-Merge all finder candidate lists per the Aggregation rules. Run `usage-summary.ts "$JOB_DIR"` and append the `### Find Token Usage` block to the merged text. Return the merged candidate list (including the `### Find Token Usage` block), then run teardown: `clean "$JOB_DIR"`, then STOP.
+Merge all finder candidate lists per the Aggregation rules. Run `usage-summary.ts "$JOB_DIR"` and append the `### Find Token Usage` block to the merged text. Run teardown: `clean "$JOB_DIR"`. Then return the merged candidate list (including the `### Find Token Usage` block) as the final response, then STOP.
 
 ## Worker Output Contract
 
@@ -196,4 +196,4 @@ No severity, no priority, no verdict, no merge assessment. If zero candidates su
 
 ## Termination
 
-After outputting the merged candidate list (including the `### Find Token Usage` block), run teardown: (1) `usage-summary.ts "$JOB_DIR"` — already run in step 6, already included in returned text; (2) `clean "$JOB_DIR"` — deletes the job dir. Once teardown is complete, your task is **COMPLETE** — do NOT read source files, do NOT explore the codebase, do not run any further tools.
+Run teardown before returning: (1) `usage-summary.ts "$JOB_DIR"` — harvest and append `### Find Token Usage` to the merged text (step 6); (2) `clean "$JOB_DIR"` — deletes the job dir. Once teardown is complete, return the merged candidate list (including the `### Find Token Usage` block) as the final response — your task is **COMPLETE** — do NOT read source files, do NOT explore the codebase, do not run any further tools.

--- a/skills/orchestrate-review/SKILL.md
+++ b/skills/orchestrate-review/SKILL.md
@@ -22,8 +22,9 @@ When finders cannot deliver — none configured/available after filtering, or al
 3. Collect: `bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" collect "$JOB_DIR"` — repeat until `overallState` is `"done"`.
 4. Read each finder's output file via the Read tool.
 5. Merge candidates using the Aggregation rules.
-6. Return the merged candidate list.
-7. **STOP.** Do not run any further tools beyond the prescribed teardown (`clean`).
+6. Run `bun "${CLAUDE_SKILL_DIR}/scripts/usage-summary.ts" "$JOB_DIR"` and append the result as a `### Find Token Usage` block to the merged candidate text. This step **MUST** run before `clean` — the job dir is deleted in the next teardown step and the per-member token data is gone.
+7. Return the merged candidate list (including the `### Find Token Usage` block).
+8. **STOP.** Then run teardown: `bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" clean "$JOB_DIR"`. Do not run any further tools.
 
 **If a finder fails (outputFilePath is null in the manifest): apply Degradation Policy. Do NOT re-start the job.**
 
@@ -35,7 +36,8 @@ You may ONLY execute these commands via Bash:
 - `bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" start --prompt-file "$PROMPT_FILE"` — start a review job
 - `bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" collect "$JOB_DIR"` — collect results (polls internally every 5s, 150s default timeout). No external sleep needed.
 - `bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" resume-member --job "$JOB_DIR" --member <member> --prompt "..."` — drive an incomplete finder to a complete answer (see Member Resume Policy; cap 3 attempts)
-- `bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" clean "$JOB_DIR"` — remove the job dir; teardown step, run only after everything is complete
+- `bun "${CLAUDE_SKILL_DIR}/scripts/usage-summary.ts" "$JOB_DIR"` — harvest per-member token usage; **run BEFORE `clean`** (job dir is deleted by clean)
+- `bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" clean "$JOB_DIR"` — remove the job dir; teardown step, run only after usage-summary and everything else is complete
 
 **CRITICAL**: Always set `timeout: 180000` on every Bash tool call.
 
@@ -125,7 +127,7 @@ These constraints govern the orchestration path — while dispatched finders are
 
 **Member Resume Policy (`resume-member`):**
 
-Collect results. If any finder's answer is incomplete (still running, or a non-answer: plan/framing/waiting/partial), use `resume-member` to drive it to a complete answer (cap: 3 attempts). If a finder outright fails (`missing_cli`/`error`/`timed_out`/`canceled`/`non_retryable`), fall back to in-session per the trigger logic below. Once every finder is finished, run `clean`.
+Collect results. If any finder's answer is incomplete (still running, or a non-answer: plan/framing/waiting/partial), use `resume-member` to drive it to a complete answer (cap: 3 attempts). If a finder outright fails (`missing_cli`/`error`/`timed_out`/`canceled`/`non_retryable`), fall back to in-session per the trigger logic below. Once every finder is finished, run `usage-summary.ts` (harvest token counts), then run `clean`.
 
 ```
 bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" resume-member --job "$JOB_DIR" --member <member> --prompt "Please complete your candidate list."
@@ -133,7 +135,7 @@ bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" resume-member --job "$JOB_DIR" --member
 
 The prompt is written by the Conductor to fit the situation. The above is a reference example only.
 
-`clean` deletes the job dir (needed by `resume-member`), so it is the last step — only after everything is complete.
+`usage-summary.ts` harvests token counts from `members/*/status.json` (see step 6 above). `clean` deletes the job dir (needed by `resume-member`), so it is the last step — only after `usage-summary.ts` and everything else is complete.
 
 ## Aggregation
 
@@ -183,10 +185,15 @@ Finders may fail due to CLI unavailability, timeout, or errors. This is NOT quor
 - removed-behavior: {…}
 - cross-file: {…}
 - cleanup: {…}
+
+### Find Token Usage
+```json
+{ "memberCount": N, "usage": { "input_tokens": N, "output_tokens": N, … } }
+```
 ```
 
-No severity, no priority, no verdict, no merge assessment. If zero candidates survived across all angles, return the Angle Coverage block with an empty Candidate Findings list.
+No severity, no priority, no verdict, no merge assessment. If zero candidates survived across all angles, return the Angle Coverage block with an empty Candidate Findings list. Always include the `### Find Token Usage` block (append the JSON output of `usage-summary.ts` verbatim).
 
 ## Termination
 
-After outputting the merged candidate list, your task is **COMPLETE**. Do NOT run any additional tools beyond the prescribed teardown (`clean`). Do NOT read source files. Do NOT explore the codebase. Return the candidate list and stop.
+After outputting the merged candidate list (including the `### Find Token Usage` block), your task is **COMPLETE**. Teardown sequence: (1) `usage-summary.ts "$JOB_DIR"` — already run in step 6, included in returned text; (2) `clean "$JOB_DIR"` — deletes the job dir. Do NOT read source files. Do NOT explore the codebase. Return the candidate list and stop.

--- a/skills/orchestrate-review/SKILL.md
+++ b/skills/orchestrate-review/SKILL.md
@@ -91,8 +91,8 @@ Response JSON (not done — re-run this step):
 ### Step 3 — Read Outputs
 Use the Read tool to read each finder's `outputFilePath` from the manifest.
 
-### Step 4 — Merge & Return
-Merge all finder candidate lists per the Aggregation rules, return the merged candidate list, then STOP.
+### Step 4 — Merge, Teardown & Return
+Merge all finder candidate lists per the Aggregation rules. Run `usage-summary.ts "$JOB_DIR"` and append the `### Find Token Usage` block to the merged text. Return the merged candidate list (including the `### Find Token Usage` block), then run teardown: `clean "$JOB_DIR"`, then STOP.
 
 ## Worker Output Contract
 

--- a/skills/orchestrate-review/SKILL.md
+++ b/skills/orchestrate-review/SKILL.md
@@ -24,7 +24,7 @@ When finders cannot deliver — none configured/available after filtering, or al
 5. Merge candidates using the Aggregation rules.
 6. Run `bun "${CLAUDE_SKILL_DIR}/scripts/usage-summary.ts" "$JOB_DIR"` and append the result as a `### Find Token Usage` block to the merged candidate text. This step **MUST** run before `clean` — the job dir is deleted in the next teardown step and the per-member token data is gone.
 7. Return the merged candidate list (including the `### Find Token Usage` block).
-8. **STOP.** Then run teardown: `bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" clean "$JOB_DIR"`. Do not run any further tools.
+8. Run teardown: `bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" clean "$JOB_DIR"` (deletes the job dir; `usage-summary.ts` was already run in step 6). Then **STOP** — do not run any further tools.
 
 **If a finder fails (outputFilePath is null in the manifest): apply Degradation Policy. Do NOT re-start the job.**
 
@@ -196,4 +196,4 @@ No severity, no priority, no verdict, no merge assessment. If zero candidates su
 
 ## Termination
 
-After outputting the merged candidate list (including the `### Find Token Usage` block), your task is **COMPLETE**. Teardown sequence: (1) `usage-summary.ts "$JOB_DIR"` — already run in step 6, included in returned text; (2) `clean "$JOB_DIR"` — deletes the job dir. Do NOT read source files. Do NOT explore the codebase. Return the candidate list and stop.
+After outputting the merged candidate list (including the `### Find Token Usage` block), run teardown: (1) `usage-summary.ts "$JOB_DIR"` — already run in step 6, already included in returned text; (2) `clean "$JOB_DIR"` — deletes the job dir. Once teardown is complete, your task is **COMPLETE** — do NOT read source files, do NOT explore the codebase, do not run any further tools.

--- a/skills/orchestrate-review/scripts/f3-flow.test.ts
+++ b/skills/orchestrate-review/scripts/f3-flow.test.ts
@@ -1,0 +1,105 @@
+#!/usr/bin/env bun
+/**
+ * F3-flow: proves the usage-summary harvest must precede clean.
+ *
+ * Three tests together establish the ordering constraint:
+ *   1. summarizeUsage on a fixture job dir returns a known non-zero aggregate (harvest works).
+ *   2. summarizeUsage on the SAME fixture after members/ is deleted returns 0
+ *      (harvest is impossible post-clean — proves the window closes).
+ *   3. SKILL.md conductor execution steps mention "Find Token Usage" (the label appended
+ *      to the returned text) BEFORE the `clean` teardown reference — enforcing the prose
+ *      correctly sequences harvest → return → clean.
+ *
+ * Tests 1 & 2 are green from the start (summarizeUsage already implemented in T3).
+ * Test 3 is the RED gate: it fails until SKILL.md wires usage-summary before clean.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { summarizeUsage } from './usage-summary.ts';
+
+const SKILL_MD_PATH = path.resolve(path.dirname(import.meta.path), '../SKILL.md');
+
+// Known fixture token totals (alice + bob)
+const FIXTURE_INPUT_TOKENS = 300; // 100 + 200
+const FIXTURE_OUTPUT_TOKENS = 130; // 50 + 80
+const FIXTURE_CACHED_TOKENS = 20; // alice only
+
+function makeJobFixture(dir: string): void {
+  const membersDir = path.join(dir, 'members');
+  const members = [
+    {
+      name: 'alice',
+      usage: { input_tokens: 100, output_tokens: 50, cached_input_tokens: 20 },
+    },
+    {
+      name: 'bob',
+      usage: { input_tokens: 200, output_tokens: 80 },
+    },
+  ];
+  for (const m of members) {
+    fs.mkdirSync(path.join(membersDir, m.name), { recursive: true });
+    fs.writeFileSync(
+      path.join(membersDir, m.name, 'status.json'),
+      JSON.stringify({ member: m.name, state: 'done', usage: m.usage }),
+    );
+  }
+}
+
+describe('F3-flow: usage-summary harvest must precede clean', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'f3-flow-test-'));
+    makeJobFixture(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('summarizeUsage returns known non-zero aggregate BEFORE members/ is deleted', () => {
+    const result = summarizeUsage(tmpDir);
+
+    expect(result.memberCount).toBe(2);
+    expect(result.usage.input_tokens).toBe(FIXTURE_INPUT_TOKENS);
+    expect(result.usage.output_tokens).toBe(FIXTURE_OUTPUT_TOKENS);
+    expect(result.usage.cached_input_tokens).toBe(FIXTURE_CACHED_TOKENS);
+  });
+
+  test('summarizeUsage returns zero aggregate AFTER members/ is deleted (simulates clean)', () => {
+    // Mirror generic-job.ts:867 — rmSync on the members subdir simulates what clean does
+    // to the data summarizeUsage reads. The job dir shell survives; only member data is gone.
+    fs.rmSync(path.join(tmpDir, 'members'), { recursive: true, force: true });
+
+    const result = summarizeUsage(tmpDir);
+
+    expect(result.memberCount).toBe(0);
+    expect(result.usage).toEqual({});
+  });
+
+  test('SKILL.md conductor steps include "Find Token Usage" before the clean teardown reference', () => {
+    const skill = fs.readFileSync(SKILL_MD_PATH, 'utf8');
+
+    // "Find Token Usage" is the labelled block the conductor appends to returned text.
+    // It must appear inside the CRITICAL: Execution Constraint section, before the STOP/clean step.
+    const execConstraintStart = skill.indexOf('## CRITICAL: Execution Constraint');
+    expect(execConstraintStart).toBeGreaterThan(-1);
+
+    // Search only within the execution-constraint block (up to the next ## heading)
+    const nextHeadingPos = skill.indexOf('\n## ', execConstraintStart + 1);
+    const execSection = nextHeadingPos > -1
+      ? skill.slice(execConstraintStart, nextHeadingPos)
+      : skill.slice(execConstraintStart);
+
+    const findTokenUsagePos = execSection.indexOf('Find Token Usage');
+    expect(findTokenUsagePos).toBeGreaterThan(-1); // RED until SKILL.md is updated
+
+    // clean must also appear in this section, AFTER the Find Token Usage step
+    const cleanAfterPos = execSection.indexOf('`clean`', findTokenUsagePos);
+    expect(cleanAfterPos).toBeGreaterThan(-1);
+    expect(findTokenUsagePos).toBeLessThan(cleanAfterPos);
+  });
+});

--- a/skills/orchestrate-review/scripts/f3-flow.test.ts
+++ b/skills/orchestrate-review/scripts/f3-flow.test.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * F3-flow: proves the usage-summary harvest must precede clean.
+ * F3-flow: proves the usage-summary harvest must precede clean, and clean must precede return.
  *
  * Three tests together establish the ordering constraint:
  *   1. summarizeUsage on a fixture job dir returns a known non-zero aggregate (harvest works).
@@ -8,10 +8,10 @@
  *      (harvest is impossible post-clean — proves the window closes).
  *   3. SKILL.md conductor execution steps mention "Find Token Usage" (the label appended
  *      to the returned text) BEFORE the `clean` teardown reference — enforcing the prose
- *      correctly sequences harvest → return → clean.
+ *      correctly sequences harvest → clean → return (final response).
  *
  * Tests 1 & 2 are green from the start (summarizeUsage already implemented in T3).
- * Test 3 is the RED gate: it fails until SKILL.md wires usage-summary before clean.
+ * Test 3 is the RED gate: it fails until SKILL.md wires usage-summary before clean before return.
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
@@ -80,11 +80,11 @@ describe('F3-flow: usage-summary 하베스트는 clean보다 먼저 실행돼야
     expect(result.usage).toEqual({});
   });
 
-  test('SKILL.md 지휘자 단계에서 "Find Token Usage"는 clean 정리 참조보다 앞에 위치한다', () => {
+  test('SKILL.md 지휘자 단계에서 "Find Token Usage"는 `clean` 앞에, `clean`은 최종 return 앞에 위치한다', () => {
     const skill = fs.readFileSync(SKILL_MD_PATH, 'utf8');
 
     // "Find Token Usage" is the labelled block the conductor appends to returned text.
-    // It must appear inside the CRITICAL: Execution Constraint section, before the STOP/clean step.
+    // It must appear inside the CRITICAL: Execution Constraint section, before the clean step.
     const execConstraintStart = skill.indexOf('## CRITICAL: Execution Constraint');
     expect(execConstraintStart).toBeGreaterThan(-1);
 
@@ -95,11 +95,16 @@ describe('F3-flow: usage-summary 하베스트는 clean보다 먼저 실행돼야
       : skill.slice(execConstraintStart);
 
     const findTokenUsagePos = execSection.indexOf('Find Token Usage');
-    expect(findTokenUsagePos).toBeGreaterThan(-1); // RED until SKILL.md is updated
+    expect(findTokenUsagePos).toBeGreaterThan(-1);
 
-    // clean must also appear in this section, AFTER the Find Token Usage step
+    // clean must appear in this section, AFTER the Find Token Usage step
     const cleanAfterPos = execSection.indexOf('`clean`', findTokenUsagePos);
     expect(cleanAfterPos).toBeGreaterThan(-1);
     expect(findTokenUsagePos).toBeLessThan(cleanAfterPos);
+
+    // The final "Return" step must appear AFTER the clean step — teardown before return
+    const returnAfterCleanPos = execSection.indexOf('Return', cleanAfterPos);
+    expect(returnAfterCleanPos).toBeGreaterThan(-1);
+    expect(cleanAfterPos).toBeLessThan(returnAfterCleanPos);
   });
 });

--- a/skills/orchestrate-review/scripts/f3-flow.test.ts
+++ b/skills/orchestrate-review/scripts/f3-flow.test.ts
@@ -48,7 +48,7 @@ function makeJobFixture(dir: string): void {
   }
 }
 
-describe('F3-flow: usage-summary harvest must precede clean', () => {
+describe('F3-flow: usage-summary 하베스트는 clean보다 먼저 실행돼야 한다', () => {
   let tmpDir: string;
 
   beforeEach(() => {
@@ -60,7 +60,7 @@ describe('F3-flow: usage-summary harvest must precede clean', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('summarizeUsage returns known non-zero aggregate BEFORE members/ is deleted', () => {
+  test('`summarizeUsage`는 members/ 삭제 전에 알려진 비-0 합산값을 반환한다', () => {
     const result = summarizeUsage(tmpDir);
 
     expect(result.memberCount).toBe(2);
@@ -69,7 +69,7 @@ describe('F3-flow: usage-summary harvest must precede clean', () => {
     expect(result.usage.cached_input_tokens).toBe(FIXTURE_CACHED_TOKENS);
   });
 
-  test('summarizeUsage returns zero aggregate AFTER members/ is deleted (simulates clean)', () => {
+  test('`summarizeUsage`는 members/ 삭제 후 빈 합산값을 반환한다 (clean 시뮬레이션)', () => {
     // Mirror generic-job.ts:867 — rmSync on the members subdir simulates what clean does
     // to the data summarizeUsage reads. The job dir shell survives; only member data is gone.
     fs.rmSync(path.join(tmpDir, 'members'), { recursive: true, force: true });
@@ -80,7 +80,7 @@ describe('F3-flow: usage-summary harvest must precede clean', () => {
     expect(result.usage).toEqual({});
   });
 
-  test('SKILL.md conductor steps include "Find Token Usage" before the clean teardown reference', () => {
+  test('SKILL.md 지휘자 단계에서 "Find Token Usage"는 clean 정리 참조보다 앞에 위치한다', () => {
     const skill = fs.readFileSync(SKILL_MD_PATH, 'utf8');
 
     // "Find Token Usage" is the labelled block the conductor appends to returned text.

--- a/skills/orchestrate-review/scripts/usage-summary.test.ts
+++ b/skills/orchestrate-review/scripts/usage-summary.test.ts
@@ -32,7 +32,7 @@ function makeFixture(
 // F3-unit: summarizeUsage
 // ---------------------------------------------------------------------------
 
-describe('summarizeUsage (F3-unit)', () => {
+describe('`summarizeUsage` (F3-unit)', () => {
   let tmpDir: string;
 
   beforeEach(() => {
@@ -43,7 +43,7 @@ describe('summarizeUsage (F3-unit)', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('sums usage across two members with known fixture', () => {
+  test('알려진 픽스처로 두 멤버의 `usage`를 합산한다', () => {
     makeFixture(tmpDir, [
       { name: 'alice', status: { member: 'alice', state: 'done', usage: { input_tokens: 100, output_tokens: 50 } } },
       { name: 'bob',   status: { member: 'bob',   state: 'done', usage: { input_tokens: 200, output_tokens: 80 } } },
@@ -56,7 +56,7 @@ describe('summarizeUsage (F3-unit)', () => {
     expect(result.usage.output_tokens).toBe(130);
   });
 
-  test('member missing usage field contributes 0 (no throw)', () => {
+  test('`usage` 필드가 없는 멤버는 0으로 기여하며 예외를 던지지 않는다', () => {
     makeFixture(tmpDir, [
       { name: 'charlie', status: { member: 'charlie', state: 'error' } },
     ]);
@@ -67,7 +67,7 @@ describe('summarizeUsage (F3-unit)', () => {
     expect(result.usage).toEqual({});
   });
 
-  test('null usage contributes 0 (no throw)', () => {
+  test('`null` `usage`는 0으로 기여하며 예외를 던지지 않는다', () => {
     makeFixture(tmpDir, [
       { name: 'dana', status: { member: 'dana', state: 'error', usage: null } },
     ]);
@@ -78,7 +78,7 @@ describe('summarizeUsage (F3-unit)', () => {
     expect(result.usage).toEqual({});
   });
 
-  test('missing members dir does not throw, returns zero aggregate', () => {
+  test('`members` 디렉터리가 없어도 예외를 던지지 않고 빈 집계를 반환한다', () => {
     // tmpDir exists but members/ subdir does not
     const result = summarizeUsage(tmpDir);
 
@@ -86,7 +86,7 @@ describe('summarizeUsage (F3-unit)', () => {
     expect(result.usage).toEqual({});
   });
 
-  test('empty members dir produces zero aggregate', () => {
+  test('`members` 디렉터리가 비어 있으면 빈 집계를 반환한다', () => {
     fs.mkdirSync(path.join(tmpDir, 'members'));
 
     const result = summarizeUsage(tmpDir);
@@ -95,7 +95,7 @@ describe('summarizeUsage (F3-unit)', () => {
     expect(result.usage).toEqual({});
   });
 
-  test('mixed members — some with usage, some without — sums only present numeric fields', () => {
+  test('`usage`가 있는 멤버와 없는 멤버가 섞여 있을 때 숫자 필드만 합산한다', () => {
     makeFixture(tmpDir, [
       { name: 'alice', status: { member: 'alice', state: 'done', usage: { input_tokens: 100, output_tokens: 50, cached_input_tokens: 20 } } },
       { name: 'bob',   status: { member: 'bob',   state: 'done', usage: { input_tokens: 200 } } },
@@ -110,7 +110,7 @@ describe('summarizeUsage (F3-unit)', () => {
     expect(result.usage.cached_input_tokens).toBe(20);
   });
 
-  test('member dir lacking status.json is skipped silently, does not increment memberCount', () => {
+  test('`status.json`이 없는 멤버 디렉터리는 조용히 건너뛰고 `memberCount`를 증가시키지 않는다', () => {
     const membersDir = path.join(tmpDir, 'members');
     fs.mkdirSync(path.join(membersDir, 'ghost'), { recursive: true });
     // no status.json written

--- a/skills/orchestrate-review/scripts/usage-summary.test.ts
+++ b/skills/orchestrate-review/scripts/usage-summary.test.ts
@@ -120,4 +120,29 @@ describe('`summarizeUsage` (F3-unit)', () => {
     expect(result.memberCount).toBe(0);
     expect(result.usage).toEqual({});
   });
+
+  // C-1: array-valued status.json must not inflate memberCount
+  test('`status.json`이 JSON 배열이면 `memberCount`를 증가시키지 않고 usage에 기여하지 않는다', () => {
+    const membersDir = path.join(tmpDir, 'members');
+    fs.mkdirSync(path.join(membersDir, 'bad-array'), { recursive: true });
+    fs.writeFileSync(path.join(membersDir, 'bad-array', 'status.json'), '[]');
+
+    const result = summarizeUsage(tmpDir);
+
+    expect(result.memberCount).toBe(0);
+    expect(result.usage).toEqual({});
+  });
+
+  // C-5: prototype-key "constructor" in usage must sum to a number
+  test('`usage` 키가 "constructor"인 경우 숫자로 올바르게 합산된다', () => {
+    makeFixture(tmpDir, [
+      { name: 'eve', status: { member: 'eve', state: 'done', usage: { constructor: 5 } } },
+    ]);
+
+    const result = summarizeUsage(tmpDir);
+
+    expect(result.memberCount).toBe(1);
+    expect(typeof result.usage['constructor']).toBe('number');
+    expect(result.usage['constructor']).toBe(5);
+  });
 });

--- a/skills/orchestrate-review/scripts/usage-summary.test.ts
+++ b/skills/orchestrate-review/scripts/usage-summary.test.ts
@@ -1,0 +1,123 @@
+#!/usr/bin/env bun
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { summarizeUsage } from './usage-summary.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'usage-summary-test-'));
+}
+
+function makeFixture(
+  tmpDir: string,
+  members: Array<{ name: string; status: Record<string, unknown> }>,
+): void {
+  const membersDir = path.join(tmpDir, 'members');
+  for (const m of members) {
+    fs.mkdirSync(path.join(membersDir, m.name), { recursive: true });
+    fs.writeFileSync(
+      path.join(membersDir, m.name, 'status.json'),
+      JSON.stringify(m.status),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// F3-unit: summarizeUsage
+// ---------------------------------------------------------------------------
+
+describe('summarizeUsage (F3-unit)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('sums usage across two members with known fixture', () => {
+    makeFixture(tmpDir, [
+      { name: 'alice', status: { member: 'alice', state: 'done', usage: { input_tokens: 100, output_tokens: 50 } } },
+      { name: 'bob',   status: { member: 'bob',   state: 'done', usage: { input_tokens: 200, output_tokens: 80 } } },
+    ]);
+
+    const result = summarizeUsage(tmpDir);
+
+    expect(result.memberCount).toBe(2);
+    expect(result.usage.input_tokens).toBe(300);
+    expect(result.usage.output_tokens).toBe(130);
+  });
+
+  test('member missing usage field contributes 0 (no throw)', () => {
+    makeFixture(tmpDir, [
+      { name: 'charlie', status: { member: 'charlie', state: 'error' } },
+    ]);
+
+    const result = summarizeUsage(tmpDir);
+
+    expect(result.memberCount).toBe(1);
+    expect(result.usage).toEqual({});
+  });
+
+  test('null usage contributes 0 (no throw)', () => {
+    makeFixture(tmpDir, [
+      { name: 'dana', status: { member: 'dana', state: 'error', usage: null } },
+    ]);
+
+    const result = summarizeUsage(tmpDir);
+
+    expect(result.memberCount).toBe(1);
+    expect(result.usage).toEqual({});
+  });
+
+  test('missing members dir does not throw, returns zero aggregate', () => {
+    // tmpDir exists but members/ subdir does not
+    const result = summarizeUsage(tmpDir);
+
+    expect(result.memberCount).toBe(0);
+    expect(result.usage).toEqual({});
+  });
+
+  test('empty members dir produces zero aggregate', () => {
+    fs.mkdirSync(path.join(tmpDir, 'members'));
+
+    const result = summarizeUsage(tmpDir);
+
+    expect(result.memberCount).toBe(0);
+    expect(result.usage).toEqual({});
+  });
+
+  test('mixed members — some with usage, some without — sums only present numeric fields', () => {
+    makeFixture(tmpDir, [
+      { name: 'alice', status: { member: 'alice', state: 'done', usage: { input_tokens: 100, output_tokens: 50, cached_input_tokens: 20 } } },
+      { name: 'bob',   status: { member: 'bob',   state: 'done', usage: { input_tokens: 200 } } },
+      { name: 'charlie', status: { member: 'charlie', state: 'done' } },
+    ]);
+
+    const result = summarizeUsage(tmpDir);
+
+    expect(result.memberCount).toBe(3);
+    expect(result.usage.input_tokens).toBe(300);
+    expect(result.usage.output_tokens).toBe(50);
+    expect(result.usage.cached_input_tokens).toBe(20);
+  });
+
+  test('member dir lacking status.json is skipped silently, does not increment memberCount', () => {
+    const membersDir = path.join(tmpDir, 'members');
+    fs.mkdirSync(path.join(membersDir, 'ghost'), { recursive: true });
+    // no status.json written
+
+    const result = summarizeUsage(tmpDir);
+
+    expect(result.memberCount).toBe(0);
+    expect(result.usage).toEqual({});
+  });
+});

--- a/skills/orchestrate-review/scripts/usage-summary.ts
+++ b/skills/orchestrate-review/scripts/usage-summary.ts
@@ -34,15 +34,18 @@ export interface UsageSummary {
  * Cross-runtime safe: uses only fs + path (Node built-ins).
  */
 export function summarizeUsage(jobDir: string): UsageSummary {
-  const membersDir = path.join(path.resolve(jobDir), 'members');
+  const membersDir = path.resolve(jobDir, 'members');
   const aggregate: Record<string, number> = {};
   let memberCount = 0;
 
-  if (!fs.existsSync(membersDir)) {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(membersDir);
+  } catch {
     return { memberCount: 0, usage: {} };
   }
 
-  for (const entry of fs.readdirSync(membersDir)) {
+  for (const entry of entries) {
     const statusPath = path.join(membersDir, entry, 'status.json');
     let status: unknown;
     try {

--- a/skills/orchestrate-review/scripts/usage-summary.ts
+++ b/skills/orchestrate-review/scripts/usage-summary.ts
@@ -35,7 +35,7 @@ export interface UsageSummary {
  */
 export function summarizeUsage(jobDir: string): UsageSummary {
   const membersDir = path.resolve(jobDir, 'members');
-  const aggregate: Record<string, number> = {};
+  const aggregate = Object.create(null) as Record<string, number>;
   let memberCount = 0;
 
   let entries: string[];
@@ -53,7 +53,7 @@ export function summarizeUsage(jobDir: string): UsageSummary {
     } catch {
       continue;
     }
-    if (!status || typeof status !== 'object') continue;
+    if (!status || typeof status !== 'object' || Array.isArray(status)) continue;
 
     memberCount++;
 

--- a/skills/orchestrate-review/scripts/usage-summary.ts
+++ b/skills/orchestrate-review/scripts/usage-summary.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env bun
+/**
+ * usage-summary — generic token-usage harvest for a job dir.
+ *
+ * Reads members/[*]/status.json from the given job directory, sums each
+ * member's `usage` object (token counts written by the worker, T2), and
+ * prints a JSON aggregate to stdout.
+ *
+ * Design invariants:
+ *   - Pure read; never mutates any file.
+ *   - Members whose status.json lacks a `usage` field (or has null/non-object)
+ *     contribute 0 to every key — never throws.
+ *   - memberCount counts entries that have a readable status.json, regardless
+ *     of whether they carried usage data.
+ *
+ * Usage:
+ *   bun usage-summary.ts <jobDir>
+ *
+ * Stdout (JSON):
+ *   { "memberCount": N, "usage": { "input_tokens": N, "output_tokens": N, … } }
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+export interface UsageSummary {
+  memberCount: number;
+  /** Aggregate token counts across all members. Keys mirror ParseResult.usage keys. */
+  usage: Record<string, number>;
+}
+
+/**
+ * Traverse members/<entry>/status.json files under jobDir and aggregate usage.
+ * Cross-runtime safe: uses only fs + path (Node built-ins).
+ */
+export function summarizeUsage(jobDir: string): UsageSummary {
+  const membersDir = path.join(path.resolve(jobDir), 'members');
+  const aggregate: Record<string, number> = {};
+  let memberCount = 0;
+
+  if (!fs.existsSync(membersDir)) {
+    return { memberCount: 0, usage: {} };
+  }
+
+  for (const entry of fs.readdirSync(membersDir)) {
+    const statusPath = path.join(membersDir, entry, 'status.json');
+    let status: unknown;
+    try {
+      status = JSON.parse(fs.readFileSync(statusPath, 'utf8'));
+    } catch {
+      continue;
+    }
+    if (!status || typeof status !== 'object') continue;
+
+    memberCount++;
+
+    const usage = (status as Record<string, unknown>).usage;
+    if (usage && typeof usage === 'object' && !Array.isArray(usage)) {
+      for (const [key, val] of Object.entries(usage as Record<string, unknown>)) {
+        if (typeof val === 'number') {
+          aggregate[key] = (aggregate[key] ?? 0) + val;
+        }
+      }
+    }
+  }
+
+  return { memberCount, usage: aggregate };
+}
+
+if (import.meta.main) {
+  const jobDir = process.argv[2];
+  if (!jobDir) {
+    process.stderr.write('usage-summary: missing jobDir argument\n');
+    process.exit(1);
+  }
+  process.stdout.write(JSON.stringify(summarizeUsage(jobDir), null, 2) + '\n');
+}


### PR DESCRIPTION
## 📌 Summary

`code-review` 스킬의 검증 단계를 "후보 1건당 verifier 서브에이전트 1개"(`O(D)`) 팬아웃에서 메인 세션 인라인 판정(`O(0+k)`)으로 전환하고, find 단계 토큰 사용량을 계측해 향후 find 재설계 여부를 데이터로 판단하는 측정 게이트를 추가합니다. 리뷰 품질(verdict 어휘·계약)은 그대로 유지합니다.

---

## 🔧 Changes

### code-review 검증 단계 (Story 1: verify-redesign)

- Phase 2를 후보별 verifier 팬아웃에서 메인 세션 인라인 판정으로 재작성: 후보마다 `REASONING → CONFIDENCE(0.0–1.0) → VERDICT` + 9필드 enrichment를 인라인 산출
- confidence가 임계값(`escalationConfidenceThreshold`, 기본 0.35) 미만인 후보만, 최대 k개(`escalationKCap`, 기본 3개)까지 `general-purpose` verifier로 에스컬레이션. 에스컬레이션 verdict가 인라인 잠정 verdict를 supersede
- k 초과분은 인라인 verdict를 유지한 채 Phase 3에 노출(조용히 드롭 금지)
- Role Separation·Context Budget·Phase 3 합성 지침을 인라인 경로와 모순 없게 전파

기존 설계의 후보별 격리는 "다른 후보 프레이밍에 휩쓸리는 anchoring 방지"가 명분이었으나, 메인 세션은 이미 chunk-reviewer 결과만 들고 있는 별도 리뷰 컨텍스트라 anchoring이 없고, 인라인 판정은 다중 후보 batch-output 파싱 위험을 제거합니다.

**영향 범위**
- `code-review` 스킬의 검증 단계 동작 변경. verifier 호출 수가 후보 수 D개 → 통상 0개, 불확실 후보가 있어도 최대 3개로 감소
- verdict 어휘 `{CONFIRMED, PLAUSIBLE, REFUTED}`·class `{correctness, cleanup}`·`references/verifier-prompt.md` 계약 불변
- `code-review` 산출물을 소비하는 `review-report`·goal 완료 게이트와의 핸드오프 포맷 불변

### find 토큰 계측 게이트 (Story 2: find-measurement-gate)

- `ParseResult.usage?`(optional) 추가, codex 드라이버가 `turn.completed`에서 토큰 추출
- 워커가 `status.json`에 `usage` 1개 필드 기록(기존 9개 필드 불변)
- 신규 `usage-summary.ts`: job 디렉터리의 `members/*/status.json` usage 합산. orchestrate-review conductor가 `clean`(디렉터리 삭제) **전**에 수확하도록 teardown 순서 고정
- 신규 `durable-sink.ts`: 1회 실행마다 후보 D-count(`found`/`deduped`/`dispatched`)와 find 토큰을 `$OMT_DIR/code-review/{runId}/`에 영속화
- find-inclusion 규칙: find 출력 토큰이 `findInclusionThreshold`(기본 50000) 이상이면 "find 재설계가 후속 범위" 노트만 첨부

**영향 범위**
- 측정 전용 — find 단계 동작·verdict를 바꾸지 않음. 리뷰를 막지 않음
- `ParseResult.usage`가 optional이라 claude/opencode 드라이버는 무변경으로 컴파일
- find 토큰 미측정 시(usage 없음) sink는 null로 기록하고 계속 진행(차단 안 함)

### 계약 보증

- `goal-state.ts`의 `readCodeReviewArtifact`에 `export` 추가(V8 테스트가 복사본이 아닌 실제 게이트 함수를 호출하도록)
- 테스트 6종 추가(codex·worker·usage-summary·durable-sink·f3-flow·goal-codereview 계약). 특히 계약 테스트는 confidence가 직렬화 산출물에 새지 않음을 raw-scan으로 검증

**영향 범위**
- 신규 .ts 스크립트는 Tier-0 builtin / `@lib/*` / 선언 의존성만 사용(`make validate` bare-import 가드 통과)

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.

### 1. 검증 비용 O(D) → O(0+k) 전환과 recall-hold 검증 책임

**배경 및 문제 상황:**
`code-review` 한 번에 후보가 D개면 verifier 서브에이전트가 D개 떠올랐습니다(Phase 2 캡 25 → 최악 25개). 서브에이전트는 각자 시스템 프롬프트 로드·파일 읽기·추론 비용을 지불하므로, 리뷰 토큰 비용의 주범이었습니다.

**해결 방안:**
메인 세션이 후보를 인라인 판정하고, confidence가 임계값 미만인 소수만 격리 verifier로 에스컬레이션합니다. 즉 "격리 비용"을 전체 후보가 아니라 불확실한 소수(최대 3개)에만 지불합니다.

**구현 세부사항:**
confidence(0.0–1.0)는 에스컬레이션 라우팅과 후보 랭킹에만 쓰이는 **내부 신호**이며, 어떤 아티팩트에도 직렬화되지 않습니다. 산출물에는 verdict/class만 남습니다. 이 불변식은 계약 테스트의 raw-string scan으로 강제됩니다(confidence 키 0건).

**선택과 트레이드오프:**
이 PR의 핵심 논점은 "인라인 판정이 팬아웃만큼 CONFIRMED를 잡아내느냐(recall-hold)"입니다. 이건 출력이 비결정적이라 CI 단위테스트로 증명할 수 없습니다. **recall-hold는 커밋된 테스트가 아니라 사용자 소유의 out-of-band shadow A/B로 검증합니다** — 두 방식(인라인 vs 팬아웃)을 동일 리뷰에 나란히 돌려 비교하는 것은 이 PR 범위 밖이며, CI는 "동작·계약 무손상"까지만 보증합니다. 리뷰어는 이 점(품질 동등성은 CI가 아닌 A/B로 검증)을 전제로 봐주시면 됩니다.

### 2. find 계측을 차단 게이트가 아닌 관찰 노트로 둔 이유

**배경 및 문제 상황:**
"find 단계도 토큰 비용이 큰가?"를 감이 아니라 데이터로 판단하고 싶었지만, v1에서는 verify/synthesis 단계 토큰을 측정하지 않습니다.

**해결 방안:**
전체 리뷰 대비 find 비율(분수)은 분모를 모르니 계산 불가 → 절대 출력토큰 임계(50000)라는 단순 신호로 후퇴했습니다. 임계 초과 시 "find 재설계가 후속 범위"라는 노트만 남기고, 리뷰를 막거나 verdict를 바꾸지 않습니다.

**선택과 트레이드오프:**
측정만 켜두고 판단은 사람에게 남기는 가역적 첫 삽입입니다. 차단 게이트로 만들면 잘못된 임계가 정상 리뷰를 막을 위험이 있어 의도적으로 관찰 전용으로 두었습니다. find 단계 자체는 v1에서 재설계하지 않습니다.

### 3. teardown 순서 불변식 (usage-summary → clean → STOP)

**배경 및 문제 상황:**
usage 데이터는 `members/*/status.json`에 있는데, conductor의 `clean`이 그 디렉터리를 삭제합니다. STOP/clean이 usage 수확보다 먼저 오면 데이터가 영구 손실됩니다.

**해결 방안:**
orchestrate-review SKILL.md의 모든 종료 경로(Execution Constraint·Conductor Step 4·Termination)에서 `usage-summary` → `clean` → STOP 순서를 고정했습니다.

**선택과 트레이드오프:**
프롬프트 산문이라 결정적 테스트가 어렵습니다. f3-flow 테스트가 "삭제 전 비-0 / 삭제 후 0"으로 수확 윈도우의 존재는 코드로 증명하지만, SKILL.md 순서 자체는 grep 단언이라 회귀 방어가 약합니다(리뷰 과정에서 이 한계를 인지하고 PLAUSIBLE로 기록함). 결정적 로직은 .ts로 내려 단위테스트하고 산문은 최소 강제하는 분업을 따랐습니다.

---

## ✅ Checklist

### code-review 검증 단계 인라인 전환
- [ ] confidence가 어떤 아티팩트에도 직렬화되지 않는다 (raw-scan 0건)
  - `skills/goal/scripts/goal-state-codereview-contract.test.ts`
- [ ] verdict·class 어휘가 기존과 동일하게 유지된다
  - `skills/code-review/SKILL.md`
- [ ] confidence 미만 후보만 에스컬레이션되고 k 초과분은 인라인 verdict로 surface된다
  - `skills/code-review/SKILL.md`

### find 토큰 계측
- [ ] codex `turn.completed`에서 `usage.input_tokens`를 추출하고, turn-failed면 throw 없이 undefined를 반환한다
  - `lib/agent-drivers/codex.test.ts`
- [ ] 워커 `status.json`에 usage가 기록되고, 드라이버가 usage를 안 주면 null이 된다
  - `lib/worker-utils.test.ts`
- [ ] usage-summary가 clean 전엔 비-0 합산, members 삭제 후엔 0을 반환한다
  - `skills/orchestrate-review/scripts/f3-flow.test.ts`
- [ ] durable sink가 found/deduped/dispatched를 각각 기록하고, 음수·소수·빈 인자를 거부하며, 깨진 find-usage JSON은 null로 기록하고 차단하지 않는다
  - `skills/code-review/scripts/durable-sink.test.ts`

### 무손상 보증
- [ ] `make typecheck`·`make validate`가 exit 0 (claude/opencode 드라이버 무변경 컴파일 + bare-import 가드 통과)