### PR TITLE
feat: QA·코드리뷰 표면 5종 강화 (요구사항 게이트 등)

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -413,7 +413,7 @@ Finders surface candidates; they do not judge them — and **you do not judge th
 This is a **report**. You surface verified findings, ranked by what matters most. You do NOT decide whether to merge and you do NOT decide whether to fix — that is the reader's call. Removing the merge verdict is deliberate: a reviewer that labels findings and shows the failure path is more trusted than one that issues a pass/fail an author then argues with.
 
 1. **Merge** verified findings that describe the same defect (same root cause, across chunks) — combine their evidence and note the corroborating angles. (Near-duplicates within a chunk were already deduped before verification.)
-2. **Class** each finding: **correctness** (the change behaves wrong) or **cleanup** (behaves correctly but is low quality), from the angle that found it.
+2. **Class** each finding: **correctness** (the change behaves wrong), **cleanup** (behaves correctly but is low quality), or **requirement-gap** (an AC or stated requirement is absent — the behavior is missing, not wrong), from the angle that found it.
 3. **Rank** most-significant first: **correctness before cleanup**; within a class, **CONFIRMED before PLAUSIBLE**.
 4. **Cap**: keep the most significant findings. If a review produced an unwieldy number, keep the top ~15 and state how many were dropped — never silently truncate.
 5. **Pre-existing**: a candidate on an unchanged context line is tagged `[Pre-existing]` and listed under Out of Scope — unless the change aggravates it (increases blast radius or frequency), in which case it stays in the main list.
@@ -432,7 +432,7 @@ This is a **report**. You surface verified findings, ranked by what matters most
 
 This is a **report**. It does not gate. There is no Assessment / "Ready to merge" section, and there is no HTML — the deliverable is the Phase 3 findings as terminal text.
 
-Emit the ranked findings directly: each finding carries its verdict (CONFIRMED / PLAUSIBLE), class (correctness / cleanup), `file:line`, and the verifier's enriched evidence (current code, what's wrong, failure scenario, fix, blast radius — the shape returned by `references/verifier-prompt.md`). Pre-existing findings go under Out of Scope. This findings text is also the handoff contract consumed by `review-report` when it dispatches a code-reviewer agent that runs this skill — do not invent a different format.
+Emit the ranked findings directly: each finding carries its verdict (CONFIRMED / PLAUSIBLE), class (correctness / cleanup / requirement-gap), `file:line`, and the verifier's enriched evidence (current code, what's wrong, failure scenario, fix, blast radius — the shape returned by `references/verifier-prompt.md`). Pre-existing findings go under Out of Scope. This findings text is also the handoff contract consumed by `review-report` when it dispatches a code-reviewer agent that runs this skill — do not invent a different format.
 
 ## Reference Files (on-demand)
 

--- a/skills/goal/SKILL.md
+++ b/skills/goal/SKILL.md
@@ -202,19 +202,19 @@ For each non-retired story, map the story's acceptance criteria and verification
 
 <!-- story-layer:end -->
 
-**Code-review lane (runs alongside the objective self-check).** After each sisyphus pass, an independent code-review lane runs alongside the objective lane. Dispatch a fresh **code-reviewer** agent independently of the builder (sisyphus); self-review by the builder is forbidden. This lane is the autonomous loop's one genuinely independent gate — a fresh instance, not the orchestrator — so it carries the structural anti-anchoring teeth the objective self-check no longer provides. The code-reviewer writes `$OMT_DIR/goal-codereview-{sid}.json` directly (it has file tools); the orchestrator passes only the session-derived path and never transcribes finding content. The artifact schema the code-reviewer must emit:
+**Code-review lane (runs alongside the objective self-check).** After each sisyphus pass, an independent code-review lane runs alongside the objective lane. Dispatch a fresh **code-reviewer** agent independently of the builder (sisyphus); self-review by the builder is forbidden. This lane is the autonomous loop's one genuinely independent gate — a fresh instance, not the orchestrator — so it carries the structural anti-anchoring teeth the objective self-check no longer provides. Before dispatching the code-reviewer, the orchestrator runs `bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts serialize-requirements` and feeds its stdout block into the reviewer's `{REQUIREMENTS}` input so the reviewer can detect requirement-gap findings (stories the diff does not satisfy). The code-reviewer writes `$OMT_DIR/goal-codereview-{sid}.json` directly (it has file tools); the orchestrator passes only the session-derived path and never transcribes finding content. The artifact schema the code-reviewer must emit:
 
 ```json
 {
   "findings": [
-    { "class": "correctness|cleanup", "verdict": "CONFIRMED|PLAUSIBLE", "ref": "<file:line>" }
+    { "class": "correctness|cleanup|requirement-gap", "verdict": "CONFIRMED|PLAUSIBLE", "ref": "<file:line>" }
   ],
   "reviewer": "<reviewer id>",
   "at": "<ISO timestamp>"
 }
 ```
 
-**Pass signal:** any finding where `verdict === "CONFIRMED"` blocks completion — whether `class` is `correctness` or `cleanup`. `PLAUSIBLE` findings are non-blocking; they are reported but do not prevent completion. `class` is an informational label the gate does not key on (the gate keys solely on `verdict === "CONFIRMED"`).
+**Pass signal:** any finding where `verdict === "CONFIRMED"` blocks completion — whether `class` is `correctness`, `cleanup`, or `requirement-gap`. `PLAUSIBLE` findings are non-blocking; they are reported but do not prevent completion. `class` is an informational label the gate does not key on (the gate keys solely on `verdict === "CONFIRMED"`).
 
 A blocking code-review finding (any CONFIRMED) routes back to sisyphus re-dispatch targeted at those specific findings — the same concrete-progress shape as an objective-lane REQUEST_CHANGES verdict.
 

--- a/skills/goal/scripts/goal-state.test.ts
+++ b/skills/goal/scripts/goal-state.test.ts
@@ -19,6 +19,7 @@ import {
   reviseStory,
   addStory,
   retireStory,
+  serializeRequirements,
   type GoalPhase,
   type Story,
 } from './goal-state.ts';
@@ -1904,6 +1905,102 @@ describe('story layer: code-review completion lane (TODO 1)', () => {
     setVerdict(S, 'APPROVE');
     expect(requestComplete(S)).toBe(false);
     expect(rawState().phase).not.toBe('complete');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TODO 6: requirement-gap class (Hop E) + serialize-requirements (Hop B)
+// ---------------------------------------------------------------------------
+
+describe('requirement-gap class: validator accepts and gate keys on verdict', () => {
+  // AC18: requirement-gap must be in BOTH the class union AND VALID_CLASSES.
+  // A PLAUSIBLE requirement-gap finding must NOT block completion — the gate
+  // keys only on verdict===CONFIRMED, class is informational.
+  // RED: currently VALID_CLASSES=['correctness','cleanup'] → artifact null → false (not true).
+  test('PLAUSIBLE requirement-gap finding does not block completion', () => {
+    const artifact = buildSatisfiedFixture(S);
+    writeVerdictArtifact(S, artifact);
+    writeCodeReviewArtifact(S, {
+      findings: [{ class: 'requirement-gap', verdict: 'PLAUSIBLE', ref: 'foo.ts:1' }],
+      reviewer: 'code-reviewer',
+      at: '2026-06-12T00:00:00',
+    });
+    expect(requestComplete(S)).toBe(true);
+    expect(rawState().phase).toBe('complete');
+  });
+
+  // A CONFIRMED requirement-gap finding must block completion (verdict gate).
+  // Currently also false (wrong reason: class unknown → artifact null).
+  // After fix: false for right reason (CONFIRMED verdict).
+  test('CONFIRMED requirement-gap finding blocks completion', () => {
+    const artifact = buildSatisfiedFixture(S);
+    writeVerdictArtifact(S, artifact);
+    writeCodeReviewArtifact(S, {
+      findings: [{ class: 'requirement-gap', verdict: 'CONFIRMED', ref: 'foo.ts:2' }],
+      reviewer: 'code-reviewer',
+      at: '2026-06-12T00:00:00',
+    });
+    expect(requestComplete(S)).toBe(false);
+    expect(rawState().phase).toBe('pursuing');
+  });
+});
+
+describe('serialize-requirements subcommand', () => {
+  // Exact format: [id] story — AC: a1; a2 — verify: surface, one line per story + trailing newline.
+  // RED: serializeRequirements does not exist yet.
+  test('exact output for a confirmed multi-AC story', () => {
+    setGoalState(S, { phase: 'planning', outcome: 'ship it' });
+    const story: Story = {
+      id: 'S1',
+      story: 'ship the feature',
+      acceptance_criteria: ['the UI renders', 'data persists'],
+      verification_surface: 'playwright e2e green',
+      status: 'unconfirmed',
+    };
+    setStories(S, [story]);
+    confirmStory(S, 'S1');
+    const out = serializeRequirements(S);
+    expect(out).toBe('[S1] ship the feature — AC: the UI renders; data persists — verify: playwright e2e green\n');
+  });
+
+  // Zero-confirmed / all-retired → empty string (empty block).
+  test('empty output when all stories are retired', () => {
+    setGoalState(S, { phase: 'planning', outcome: 'ship it' });
+    const s1: Story = {
+      id: 'S1',
+      story: 'old story',
+      acceptance_criteria: ['ac'],
+      verification_surface: 'v',
+      status: 'unconfirmed',
+    };
+    setStories(S, [s1]);
+    retireStory(S, 'S1');
+    const out = serializeRequirements(S);
+    expect(out).toBe('');
+  });
+
+  // Zero stories → empty string.
+  test('empty output when no stories exist', () => {
+    const out = serializeRequirements(S);
+    expect(out).toBe('');
+  });
+
+  // CLI dispatch: serialize-requirements subcommand prints the confirmed story block.
+  test('CLI dispatch prints confirmed story block', () => {
+    setGoalState(S, { phase: 'planning', outcome: 'ship it' });
+    const story: Story = {
+      id: 'S1',
+      story: 'ship the feature',
+      acceptance_criteria: ['green', 'deployed'],
+      verification_surface: 'smoke test',
+      status: 'unconfirmed',
+    };
+    setStories(S, [story]);
+    confirmStory(S, 'S1');
+    const out = runCli('serialize-requirements');
+    expect(out).toContain('[S1] ship the feature');
+    expect(out).toContain('AC: green; deployed');
+    expect(out).toContain('verify: smoke test');
   });
 });
 

--- a/skills/goal/scripts/goal-state.ts
+++ b/skills/goal/scripts/goal-state.ts
@@ -852,7 +852,7 @@ export function requestComplete(sessionId: string): boolean {
   // Code-review lane (D-3): the SECOND independent refusal lane, reached only after
   // every objective-lane gate above passes — so "both lanes clean" is the completion condition.
   // Absent/invalid artifact → block (never-false-complete: degrade toward block). The
-  // gate keys ONLY on verdict==='CONFIRMED' (any class — correctness OR cleanup); `class`
+  // gate keys ONLY on verdict==='CONFIRMED' (any class — correctness, cleanup, or requirement-gap); `class`
   // is informational and never branched on.
   const codeReview = readCodeReviewArtifact(sessionId);
   if (codeReview === null) {
@@ -867,7 +867,7 @@ export function requestComplete(sessionId: string): boolean {
 }
 
 /**
- * Formats all CONFIRMED (non-retired) stories as a requirements block:
+ * Formats all confirmed stories as a requirements block:
  * one line per story — `[id] story — AC: a1; a2 — verify: surface` — with a
  * trailing newline. Zero confirmed stories → empty string (empty block).
  * Feeds the code-review lane's `{REQUIREMENTS}` input (Hop B).

--- a/skills/goal/scripts/goal-state.ts
+++ b/skills/goal/scripts/goal-state.ts
@@ -652,7 +652,7 @@ interface VerdictArtifact {
 // ---------------------------------------------------------------------------
 
 interface CodeReviewFinding {
-  class: 'correctness' | 'cleanup';
+  class: 'correctness' | 'cleanup' | 'requirement-gap';
   verdict: 'CONFIRMED' | 'PLAUSIBLE';
   ref?: string;
 }
@@ -749,7 +749,7 @@ function readCodeReviewArtifact(sessionId: string): CodeReviewArtifact | null {
   if (typeof reviewer !== 'string' || reviewer.length === 0) return null;
   if (typeof a['at'] !== 'string') return null;
   // Validate each finding; any enum violation → whole artifact null
-  const VALID_CLASSES = ['correctness', 'cleanup'];
+  const VALID_CLASSES = ['correctness', 'cleanup', 'requirement-gap'];
   const VALID_FINDING_VERDICTS = ['CONFIRMED', 'PLAUSIBLE'];
   for (const entry of a['findings'] as unknown[]) {
     if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) return null;
@@ -864,6 +864,23 @@ export function requestComplete(sessionId: string): boolean {
 
   mergeWrite(sessionId, { phase: 'complete', active: false });
   return true;
+}
+
+/**
+ * Formats all CONFIRMED (non-retired) stories as a requirements block:
+ * one line per story — `[id] story — AC: a1; a2 — verify: surface` — with a
+ * trailing newline. Zero confirmed stories → empty string (empty block).
+ * Feeds the code-review lane's `{REQUIREMENTS}` input (Hop B).
+ */
+export function serializeRequirements(sessionId: string): string {
+  const state = readGoalState(sessionId);
+  const stories: Story[] = state?.stories ?? [];
+  const confirmed = stories.filter((s) => s.status === 'confirmed');
+  if (confirmed.length === 0) return '';
+  const lines = confirmed.map(
+    (s) => `[${s.id}] ${s.story} — AC: ${s.acceptance_criteria.join('; ')} — verify: ${s.verification_surface}`
+  );
+  return lines.join('\n') + '\n';
 }
 
 // ---------------------------------------------------------------------------
@@ -1064,9 +1081,11 @@ function main(): void {
         process.exit(1);
       }
       retireStory(sessionId, rawId);
+    } else if (subcommand === 'serialize-requirements') {
+      process.stdout.write(serializeRequirements(sessionId));
     } else {
       process.stderr.write(
-        'Usage: goal-state.ts <set|set-verdict|set-budget-limited|set-blocked|request-complete|get|status|list-others|adopt|set-stories|confirm-story|revise-story|add-story|retire-story> [options]\n'
+        'Usage: goal-state.ts <set|set-verdict|set-budget-limited|set-blocked|request-complete|get|status|list-others|adopt|set-stories|confirm-story|revise-story|add-story|retire-story|serialize-requirements> [options]\n'
       );
       process.exit(1);
     }

--- a/skills/orchestrate-review/SKILL.md
+++ b/skills/orchestrate-review/SKILL.md
@@ -183,6 +183,8 @@ Finders may fail due to CLI unavailability, timeout, or errors. This is NOT quor
 - removed-behavior: {…}
 - cross-file: {…}
 - cleanup: {…}
+- security: {…}
+- requirements-coverage: {…}
 ```
 
 No severity, no priority, no verdict, no merge assessment. If zero candidates survived across all angles, return the Angle Coverage block with an empty Candidate Findings list.

--- a/skills/orchestrate-review/orchestrate-review.config.yaml
+++ b/skills/orchestrate-review/orchestrate-review.config.yaml
@@ -17,7 +17,7 @@ chunk-review:
     # if codex rejects `gpt-5.5`, fall back to `gpt-5.4`.
     # Change one member's `model`/`command` to run that angle on a different model/CLI.
     #
-    # Angle set (single lean mode): 3 correctness lenses + 1 cleanup lens.
+    # Angle set: 3 correctness lenses + 1 cleanup lens + 1 security lens + 1 requirements-coverage lens.
     - name: line-scan
       command: codex exec
       model: gpt-5.5

--- a/skills/orchestrate-review/orchestrate-review.config.yaml
+++ b/skills/orchestrate-review/orchestrate-review.config.yaml
@@ -46,6 +46,20 @@ chunk-review:
       color: "YELLOW"
       effort_level: xhigh
       output_format: json
+    - name: security
+      command: codex exec
+      model: gpt-5.5
+      emoji: "\U0001F512"
+      color: "RED"
+      effort_level: xhigh
+      output_format: json
+    - name: requirements-coverage
+      command: codex exec
+      model: gpt-5.5
+      emoji: "\U0001F4CB"
+      color: "GREEN"
+      effort_level: xhigh
+      output_format: json
   settings:
     timeout: 1800
     # No-op with the angle members above (no `claude` member to exclude); kept

--- a/skills/orchestrate-review/prompts/default.md
+++ b/skills/orchestrate-review/prompts/default.md
@@ -40,6 +40,14 @@ Diff-only review is insufficient. The working directory reflects the post-change
 - **Reuse / Simplification / Efficiency / Altitude** — re-implemented helpers (name the existing one), unnecessary complexity (name the simpler form), wasted work (name the cheaper alternative), fragile special-cases on shared infrastructure (generalize instead).
 - **Speculative complexity** — unrequested features/abstractions/config, single-use abstractions, error handling for impossible states, backwards-compat shims with no removal date.
 
+**Security (the change introduces an exploitable weakness):**
+
+- **OWASP-aligned scan** — for each changed or touched function, ask whether an attacker can control an input that reaches an unsafe sink, bypass an authz check, recover a secret, or exploit weak crypto: injection (SQL/shell/prompt — unsanitized input concatenated into a query, command, or LLM prompt; eval of user-supplied data), broken authz/authn (missing or bypassable gate on a new route/handler, a check skipped for a subset of inputs, IDOR exposing another user's data), secret/credential/PII exposure (logged, returned in a response, or hardcoded), crypto misuse (weak/deprecated algorithm, hardcoded IV/salt, predictable RNG for a security-sensitive use).
+
+**Requirements coverage (an acceptance criterion is unmet):**
+
+- **Per-AC mapping** — only when your review context carries acceptance criteria / requirements. Enumerate each criterion and check whether the diff implements and/or tests it (new logic covering the stated behaviour, test assertions verifying it, required config/schema changes); surface any criterion with no clear supporting evidence, and do not silently drop partial coverage. If no acceptance criteria are present (the common standalone-review case), skip this angle and report nothing — do not invent criteria.
+
 ## Output Format
 
 ```

--- a/skills/orchestrate-review/prompts/default.md
+++ b/skills/orchestrate-review/prompts/default.md
@@ -49,7 +49,7 @@ Diff-only review is insufficient. The working directory reflects the post-change
 
 - **{file}:{line}** — {summary: one sentence on what is wrong, or for cleanup the better form}
   - failure_scenario: {concrete inputs/state → wrong output, crash, or lost effect (for a dropped side-effect, name the effect that no longer fires and what downstream depends on it — no crash or visible-output change required); for cleanup, the concrete cost — what is duplicated, wasted, or harder to maintain}
-  - found by: {line-scan | removed-behavior | cross-file | cleanup}
+  - found by: {line-scan | removed-behavior | cross-file | cleanup | security | requirements-coverage}
 
 ### Angle Coverage
 One line per angle: how many candidates it produced, or "found nothing".

--- a/skills/orchestrate-review/scripts/job.test.ts
+++ b/skills/orchestrate-review/scripts/job.test.ts
@@ -112,6 +112,14 @@ describe('parseChunkReviewConfig', () => {
     const result = await parseChunkReviewConfig(configPath);
     expect(result['chunk-review'].members[0].env).toEqual({ KIMI_API_KEY: 'test-key', KIMI_MODEL: 'kimi-k2' });
   });
+
+  test('real config registers security and requirements-coverage members', async () => {
+    const realPath = path.join(import.meta.dirname, '..', 'orchestrate-review.config.yaml');
+    const result = await parseChunkReviewConfig(realPath);
+    const names = result['chunk-review'].members.map((r: { name: string }) => r.name);
+    expect(names.includes('security')).toBeTruthy();
+    expect(names.includes('requirements-coverage')).toBeTruthy();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/skills/orchestrate-review/scripts/prompts/cleanup.md
+++ b/skills/orchestrate-review/scripts/prompts/cleanup.md
@@ -24,6 +24,7 @@ Locate `## Diff Command` in the REVIEW CONTENT and run it via Bash. If it fails 
 - **Simplification**: unnecessary complexity the change adds — redundant or derivable state, copy-paste with slight variation, deep nesting, dead code left behind. Name the simpler form that does the same job.
 - **Efficiency**: wasted work the change introduces — redundant computation or repeated I/O, independent operations run sequentially, blocking work added to startup or hot paths. Name the cheaper alternative.
 - **Altitude**: fragile bandaids — special cases layered on shared infrastructure are a sign the fix is not deep enough. Prefer generalizing the underlying mechanism over adding special cases.
+- **Conventions**: code that deviates from patterns or guidelines visible in the review context (`{REQUIREMENTS}`, `{PROJECT_CONTEXT}`) or the surrounding codebase — name the prevailing pattern the change diverges from.
 - **Speculative complexity** (this project values minimum code that solves the problem, nothing speculative): a feature/abstraction/config/option not asked for; an abstraction introduced for a path with exactly one caller; flexibility or configurability added for a hypothetical future; error handling for a state that cannot occur given the surrounding contract; a backwards-compatibility shim for an old format/API with no documented removal date.
 
 ## Scope

--- a/skills/orchestrate-review/scripts/prompts/requirements-coverage.md
+++ b/skills/orchestrate-review/scripts/prompts/requirements-coverage.md
@@ -46,7 +46,7 @@ A list of candidate findings, one per unmet or partially-met acceptance criterio
 For each candidate:
 
 - **ac**: the acceptance criterion text (quoted or paraphrased from `{REQUIREMENTS}`)
-- **file**: `path/to/file.ext` most relevant to the gap (omit if the gap is not file-specific)
+- **file**: `path/to/file.ext` most relevant to the gap — the file where the missing behaviour should live, or the closest existing file the criterion concerns. Always provide one: downstream verification builds `git diff {RANGE} -- {file}` from this field and cannot consume a fileless candidate.
 - **line**: line number (omit if not line-specific)
 - **summary**: one sentence stating which criterion is unmet and why the diff does not satisfy it
 - **failure_scenario**: the concrete user action, input, or runtime path that would expose the missing coverage → the wrong outcome or absent behaviour

--- a/skills/orchestrate-review/scripts/prompts/requirements-coverage.md
+++ b/skills/orchestrate-review/scripts/prompts/requirements-coverage.md
@@ -1,0 +1,54 @@
+CRITICAL: You MUST obey these rules. No exceptions.
+
+- READ-ONLY. Do NOT edit or write any files. You find candidates; you do not fix.
+- Execute the diff command from the REVIEW CONTENT FIRST, then read the actual files for context.
+- Surface candidates ONLY through your assigned angle. Other angles are covered by other finders — do not duplicate their work or pad your list with their concerns.
+- Do NOT assign severity, priority, P-levels, verdicts, or a merge recommendation. That is decided downstream.
+
+# Code-Review Finder — Requirements coverage
+
+You are one finder in a multi-angle code review. Your single lens is **acceptance-criterion coverage**: enumerate each AC in `{REQUIREMENTS}` and determine whether the diff satisfies it. Surface any criterion that is unmet or unaddressed as a candidate; an independent verifier judges each one later.
+
+## Premises (non-negotiable)
+
+- The working directory is the post-change state of the code under review. Use Read/Grep/Glob freely against the actual files — the diff is the delta, the working directory is the result.
+- Your job is mapping, not authoring. Do NOT write new acceptance criteria, reinterpret the intent of existing ones beyond what is stated, or assign a final class label (CONFIRMED / PLAUSIBLE / etc.) — the classifier decides that downstream.
+
+## Step 1 — Obtain the diff (MANDATORY)
+
+Locate `## Diff Command` in the REVIEW CONTENT and run it via Bash. If it fails or returns empty output, report that and stop — do not fabricate the diff.
+
+## Your angle
+
+### When `{REQUIREMENTS}` is empty or contains no acceptance criteria
+
+If `{REQUIREMENTS}` is blank, contains only whitespace, or lists no acceptance criteria, **report none and stop** — this is the common standalone-review case where no requirements were attached. Do not invent criteria or pad your output.
+
+### When acceptance criteria are present
+
+Work through each acceptance criterion in `{REQUIREMENTS}` one at a time (per-AC mapping):
+
+1. **Identify the criterion** — quote or paraphrase the AC precisely as stated.
+2. **Locate relevant diff hunks** — find the changed lines, added/removed logic, or new tests that would satisfy this criterion. Use Read/Grep/Glob on the working directory to confirm what the post-change code actually does.
+3. **Assess coverage** — does the diff clearly implement and/or test this criterion? Evidence that counts: new logic covering the stated behaviour, test assertions verifying it, or configuration/schema changes it requires.
+4. **Surface as a candidate if unmet** — if you cannot find clear evidence the criterion is satisfied, emit it as a candidate. Do NOT silently drop partial-coverage concerns.
+
+Do not duplicate findings already obvious to other angles (e.g. a logic bug is for the line-scan finder). Your scope is coverage gaps: ACs the diff simply does not address, or addresses incompletely relative to what the criterion requires.
+
+## Scope
+
+Surface candidates ONLY for files listed in `## Review Scope`. Files outside the list are reference material you read to understand the change — do not file candidates against them.
+
+## Output
+
+A list of candidate findings, one per unmet or partially-met acceptance criterion. If no AC is present or all criteria are clearly satisfied, say so explicitly rather than padding.
+
+For each candidate:
+
+- **ac**: the acceptance criterion text (quoted or paraphrased from `{REQUIREMENTS}`)
+- **file**: `path/to/file.ext` most relevant to the gap (omit if the gap is not file-specific)
+- **line**: line number (omit if not line-specific)
+- **summary**: one sentence stating which criterion is unmet and why the diff does not satisfy it
+- **failure_scenario**: the concrete user action, input, or runtime path that would expose the missing coverage → the wrong outcome or absent behaviour
+
+No severity, no priority, no verdict, no merge recommendation. If no requirements are present, write: "No AC — report none."

--- a/skills/orchestrate-review/scripts/prompts/security.md
+++ b/skills/orchestrate-review/scripts/prompts/security.md
@@ -1,0 +1,43 @@
+CRITICAL: You MUST obey these rules. No exceptions.
+
+- READ-ONLY. Do NOT edit or write any files. You find candidates; you do not fix.
+- Execute the diff command from the REVIEW CONTENT FIRST, then read the actual files for context.
+- Surface candidates ONLY through your assigned angle. The other finders hunt for correctness and code quality — you hunt for security vulnerabilities. Do not file correctness bugs or cleanup; do not pad.
+- Do NOT assign severity, priority, P-levels, verdicts, or a merge recommendation. That is decided downstream.
+
+# Code-Review Finder — Security
+
+You are one finder in a multi-angle code review. The other angles hunt for bugs and code quality; your single lens is **security** — code that a malicious actor could exploit or that leaks sensitive data. Surface candidate findings; an independent verifier judges each one later, so pass through every candidate with a nameable attack path — do not silently drop half-believed ones, and do not invent ones you cannot ground in the code.
+
+## Premises (non-negotiable)
+
+- The working directory is the post-change state of the code under review. Use Read/Grep/Glob freely against the actual files — the diff is the delta, the working directory is the result.
+- Diff-only review is insufficient. Trace how tainted input flows from entry points through the changed code; read the auth middleware, permission checks, and ORM/query layers the change touches.
+
+## Step 1 — Obtain the diff (MANDATORY)
+
+Locate `## Diff Command` in the REVIEW CONTENT and run it via Bash. If it fails or returns empty output, report that and stop — do not fabricate the diff.
+
+## Your angle
+
+Examine the diff and the surrounding context for OWASP-aligned vulnerabilities. For each changed or touched function ask: can an attacker control an input that reaches an unsafe sink, bypass an authorization check, recover a secret, or exploit a weak crypto primitive? Look for:
+
+- **Injection**: SQL, shell command, or prompt injection — unsanitized user input concatenated into a query, shell command, or LLM prompt string; parameterized queries replaced with string interpolation; eval of user-supplied data.
+- **Broken authz/authn**: missing or bypassable authentication gate on a new route or handler; authorization check skipped for a subset of inputs; privilege escalation path introduced by a role or scope change; insecure direct object reference exposing another user's data.
+- **Secret/credential exposure**: API keys, passwords, tokens, or PII logged, returned in a response, hardcoded in source, or written to a file with broad permissions; secrets passed through environment variables that are echoed or exposed.
+- **Crypto misuse**: weak or deprecated algorithm (MD5, SHA-1, DES, ECB mode); hardcoded IV or salt; predictable random number used for a security-sensitive purpose; incorrect use of encrypt-then-MAC vs MAC-then-encrypt.
+
+## Scope
+
+Surface candidates ONLY for files listed in `## Review Scope`. Files outside the list are reference material you read to understand the change — you do not file candidates against them.
+
+## Output
+
+A list of candidate findings. For each:
+
+- **file**: `path/to/file.ext`
+- **line**: line number (omit if the candidate is not line-specific)
+- **summary**: one sentence stating what the vulnerability is
+- **failure_scenario**: the concrete attacker-controlled input or action → the exploit or data exposure that results
+
+No severity, no priority, no verdict, no merge recommendation. If nothing qualifies through this angle, say so explicitly rather than padding.

--- a/skills/qa/stage3-handson.md
+++ b/skills/qa/stage3-handson.md
@@ -142,7 +142,11 @@ curl -s http://localhost:{port}/endpoint | jq .
    agent-browser get url              # current URL after navigation
    agent-browser get text @eN         # element text content
    ```
-6. Close the session:
+6. **Capture a screenshot** (mandatory — attach as visual evidence for the review):
+   ```bash
+   agent-browser screenshot
+   ```
+7. Close the session:
    ```bash
    agent-browser close
    ```
@@ -163,6 +167,9 @@ If any agent-browser step returns a non-zero exit code or the required assertion
 | Page loads | No console errors, expected elements visible |
 | Interaction | Click/input produces expected result |
 | Navigation | Routes resolve to correct pages |
+| Screenshot captured | At least one screenshot taken and referenced in evidence |
+| CJK / glyph rendering | CJK characters, emoji, and non-ASCII glyphs render without replacement boxes or mojibake |
+| Layout overflow | No element overflows its container; horizontal scroll width does not exceed viewport width |
 
 ---
 
@@ -311,13 +318,13 @@ If ANY verification fails:
 
 ## Adversarial Scenario Matrix
 
-Hands-on verification is not "run the happy path once." A change is only verified when it survives hostile probing. After the modality procedures above confirm the happy path, run the adversarial checks below. Each category names what a hostile check looks like so a verifier running hands-on knows what to probe — pick the rows that apply to the change under review and actually execute them, do not reason about them on paper.
+Hands-on verification is not "run the happy path once." A change is only verified when it survives hostile probing. When running these checks, adopt the mindset of a malicious or careless user: someone who ignores documentation, pastes garbage data, skips required fields, and actively tries to confuse or break the system. After the modality procedures above confirm the happy path, run the adversarial checks below. Each category names what a hostile check looks like so a verifier running hands-on knows what to probe — pick the rows that apply to the change under review and actually execute them, do not reason about them on paper.
 
 | # | Category | What the adversarial check probes |
 |---|----------|-----------------------------------|
 | 1 | **Error / failure paths** | Force the failure branch (unreachable dependency, denied permission, invalid auth, exhausted quota) and assert it fails *safely*: no partial writes, a clear error message, and the correct status/exit code. A failure that silently half-completes is a defect. |
-| 2 | **Boundary / malformed input** | Probe the `boundary\|malformed` surface: feed empty, oversized, wrong-type, encoding-edge (UTF-8 / null bytes / emoji), and off-by-one boundary values. Assert each is rejected or handled deterministically rather than crashing or coercing silently. |
+| 2 | **Boundary / malformed input** | Probe the `boundary\|malformed` surface: feed empty, zero, negative, oversized, wrong-type, encoding-edge (UTF-8 / null bytes / emoji), and off-by-one boundary values. Assert each is rejected or handled deterministically rather than crashing or coercing silently. |
 | 3 | **Injection** | Send SQL / command / prompt injection payloads through every user-controlled field (query params, body, headers, file names, LLM prompts). Assert the payload is neutralized, not interpreted. |
-| 4 | **Interruption–cancel–resume + dirty initial state** | Kill or cancel the operation mid-flight, then re-run it; also start it from a dirty/partial prior state (leftover lock file, half-written record, stale session). Assert it recovers to a consistent state rather than compounding corruption. |
+| 4 | **Interruption–cancel–resume + dirty initial state** | Kill or cancel the operation mid-flight, then re-run it; trigger concurrent executions, rapid repeated calls, and out-of-order sequencing; also start it from a dirty/partial prior state (leftover lock file, half-written record, stale session). Assert it recovers to a consistent state rather than compounding corruption. |
 | 5 | **Misleading success** (OWASP LLM09) | Distrust a green check / `200` / `"done"` that does not reflect real success. Verify the *actual effect* — the row was written, the file changed on disk, the message was delivered — not the success signal the system reports. An overconfident success claim is itself the bug. |
 | 6 | **Idempotency / re-run** | Run the operation twice with identical inputs and assert no duplicate records, double charges, or corruption. **By-design exception**: some operations are intentionally non-idempotent (append-only logs, "send another reminder", incrementing counters). When the spec marks an operation as intended to differ on re-run, repeated effects are an acceptable exception, not a defect — confirm against the intended behavior rather than flagging it. |


### PR DESCRIPTION
## 📌 Summary
OMT의 QA·코드리뷰 리뷰 표면을 5종 개선으로 강화합니다 — 적대적 시나리오 매트릭스 확장과 시각 QA 검증, 보안·요구사항커버리지 finder 추가, cleanup의 컨벤션 점검, 그리고 goal 자율 루프에 요구사항 게이트(승인된 AC를 리뷰어에 직렬화 + `requirement-gap` finding 클래스)를 연결합니다.

---

## 🔧 Changes

### qa — 적대적 시나리오 + 시각 검증 강화
- Adversarial Scenario Matrix에 malicious/careless 페르소나 프레이밍, 경계값(`zero`/`negative`), 인터럽션(`concurrent`/`rapid`/`out-of-order`) 시나리오를 **인라인 보강**
- Step 3.4 Frontend Verification에 필수 스크린샷 캡처 + CJK/glyph 렌더링 + 레이아웃 overflow 검증 추가

기존 6범주 매트릭스의 구조는 보존하고 범주 2·4와 인트로만 보강했습니다.

**영향 범위**
- `skills/qa/stage3-handson.md` prose만 변경. 런타임 코드 무변경, 하위 호환.

### orchestrate-review — 보안·요구사항커버리지 finder 추가
- `security` finder(읽기 전용, OWASP 정렬: injection/authz/secret/crypto)와 `requirements-coverage` finder(AC별 diff 매핑) 신규 프롬프트 2종
- config 멤버 등록 **4→6 angle**, attribution 양면 정합(`default.md` found-by + `SKILL.md` Angle Coverage)
- `cleanup` finder "Your angle"에 컨벤션 일탈 점검 1줄 추가 — **주입 없는 pull 방식**(컨벤션 목록/경로 하드코딩 없음)
- `job.test.ts`에 실제 config 멤버 파싱 회귀 테스트(fixture 아닌 실제 config 로드)

**영향 범위**
- 리뷰 fan-out이 4→6 angle로 증가. 두 finder는 상시 실행. `requirements-coverage`는 `{REQUIREMENTS}`가 비면 self-skip(none 보고).

### goal·code-review — 요구사항 게이트 연결
- `goal-state.ts`: `serialize-requirements` 서브커맨드(confirmed 스토리를 리뷰어 `{REQUIREMENTS}`로 직렬화) + `requirement-gap` finding 클래스(타입 union과 `VALID_CLASSES` **양 사이트**)
- `goal/SKILL.md`: code-review lane이 직렬화기를 호출해 리뷰어에 주입하되 기존 `goal-codereview-{sid}.json` output-path handoff는 보존
- `code-review/SKILL.md`: classify와 terminal 출력에 `requirement-gap` 열거

**영향 범위**
- goal 자율 루프의 완료 게이트. `requestComplete`의 게이트 판정 로직은 verdict-only로 **변경 없음**(`requirement-gap` 추가는 검증기가 클래스를 accept하게 할 뿐). 새 클래스는 배포(`make sync`) 이후 런타임에 발효.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. `requirement-gap`은 새 클래스, 보안은 `correctness`로 — class 귀속의 비대칭

**배경 및 문제 상황:**
보안 finder와 요구사항 미충족(requirement-gap) 둘 다 새로운 finding 유형입니다. 각각 새 클래스를 신설할지 기존 클래스에 접을지 결정해야 했고, enum 작업 중복 최소화와 표현력 사이의 트레이드오프가 있었습니다.

**해결 방안:**
보안은 `correctness`에 접고, requirement-gap은 새 클래스로 신설했습니다. 비대칭의 근거는 두 유형과 기존 클래스의 **분류학적 관계**입니다.

**구현 세부사항:**
보안 취약점은 "잘못 동작하는 것"이라 `correctness`의 **subset** — 접는 것이 분류학적으로 정직합니다. 반면 미충족 AC는 동작이 "**없는**" 상태로, `correctness`("wrong")도 `cleanup`("low quality")도 아닌 **disjoint** — 새 클래스를 받을 자격이 있습니다.

**선택과 트레이드오프:**
게이트는 `verdict`만 보고 `class`는 informational이라, "class는 리포트 형태만 산다"는 논거도 성립합니다. 그러나 이 논거는 *too much를 증명*합니다(그렇다면 requirement-gap도 죽여야 함). 따라서 subset/disjoint 관계가 load-bearing 근거이고, 비용-가시성 논거는 부차적입니다.

### 2. 두 finding-class taxonomy를 의도적으로 분리 — 결합하지 않음

**배경 및 문제 상황:**
`requirement-gap`을 `goal-state.ts`(TS const)와 `code-review/SKILL.md`(markdown prose) 양쪽에 추가했습니다. 단일 source로 묶고 싶은 유혹이 있습니다.

**해결 방안:**
두 독립 taxonomy로 유지했습니다(공유 source 없음). markdown prose가 TS const를 import할 수 없어, 매체 자체가 두 열거를 강제합니다 — 진짜 선택지는 "단일 source vs 두 source"가 아니라 "**가드된 parity vs 가드 없는 parity**"입니다.

**구현 세부사항:**
goal-lane artifact(`goal-state.ts`의 `CodeReviewFinding`)와 standalone `/code-review` 리포트는 별개 소비자입니다. 게이트 검증기는 union과 `VALID_CLASSES`가 불일치하면 artifact 전체를 거부해 false-block을 냅니다 — 단 **block 방향으로 degrade**라 저위험이고, 내부 parity는 테스트로 가드됩니다.

**선택과 트레이드오프:**
두 열거가 drift할 위험 vs 강제 결합의 복잡도. 상설 drift-guard 테스트는 설계 게이트에서 declined했습니다(두 enum은 독립 시스템). revisit 트리거: 실제 cross-taxonomy false-block이 현장에서 발생하면.

### 3. 두 finder 상시 실행(4→6 angle), 조건부 활성화 없음 — 비용 정직화

**배경 및 문제 상황:**
`requirements-coverage` finder는 `{REQUIREMENTS}`가 있을 때만 의미가 있습니다. AC 없는 standalone 리뷰에서 dispatch를 조건부로 스킵할 수 있습니다.

**해결 방안:**
사용자 결정으로 둘 다 상시 실행하고, coverage finder는 `{REQUIREMENTS}`가 비면 self-skip(none 보고)합니다.

**선택과 트레이드오프:**
self-skip은 **output 토큰만** 아끼고 invocation은 아끼지 못합니다 — AC 없는 standalone 리뷰마다 full `codex exec`(gpt-5.5/xhigh, 1800s)가 돌고 나서 self-skip합니다. 이는 `job.ts`에 조건부 dispatch 분기를 넣지 않으려는 **knowing trade**입니다(공짜 점심 아님). revisit 트리거: AC 없는 고볼륨 standalone 리뷰의 codex 비용/지연이 문제되면 조건부 dispatch로 전환.

---

## ✅ Checklist

### qa 표면
- [ ] Adversarial Scenario Matrix에 malicious/careless 페르소나 + cat-2 `zero`/`negative` + cat-4 `concurrent`/`rapid`/`out-of-order` 존재
  - `skills/qa/stage3-handson.md`
- [ ] Step 3.4에 screenshot 캡처 + CJK/glyph + overflow 검증 존재
  - `skills/qa/stage3-handson.md`

### orchestrate-review finder
- [ ] `parseChunkReviewConfig`가 실제 config에서 `security`·`requirements-coverage` 멤버를 반환
  - `skills/orchestrate-review/scripts/job.test.ts`
- [ ] `security.md`가 finder 스켈레톤 + injection/authz/secret/crypto 렌즈를 갖고 severity/verdict를 부여하지 않음
  - `skills/orchestrate-review/scripts/prompts/security.md`
- [ ] `requirements-coverage.md`가 AC별 매핑 + 빈 `{REQUIREMENTS}` self-skip 지침을 가짐
  - `skills/orchestrate-review/scripts/prompts/requirements-coverage.md`
- [ ] `cleanup` finder에 컨벤션 점검 1줄 존재, 하드코딩 경로 0
  - `skills/orchestrate-review/scripts/prompts/cleanup.md`
- [ ] 두 finder가 `default.md` found-by와 `SKILL.md` Angle Coverage 양면에 등재
  - `skills/orchestrate-review/prompts/default.md`
  - `skills/orchestrate-review/SKILL.md`

### goal·code-review 요구사항 게이트
- [ ] `serialize-requirements`가 confirmed 스토리를 `[id] story — AC: …— verify: …` 블록으로 출력, 0건이면 빈 블록
  - `skills/goal/scripts/goal-state.ts`
- [ ] `requirement-gap`이 union과 `VALID_CLASSES` 양 사이트에 존재해 검증기가 accept
  - `skills/goal/scripts/goal-state.ts`
- [ ] goal code-review lane이 `serialize-requirements`를 호출하고 `goal-codereview-{sid}.json` output-path를 보존
  - `skills/goal/SKILL.md`
- [ ] `/code-review` classify와 terminal 출력에 `requirement-gap` 열거
  - `skills/code-review/SKILL.md`
- [ ] `make validate` + `make test` green
