### PR TITLE
feat(craft-issue): 배포 후 관찰 섹션 추가

### DIFF
--- a/skills/craft-issue/references/issue-craft.md
+++ b/skills/craft-issue/references/issue-craft.md
@@ -79,7 +79,7 @@ Bug issues add three fields, placed between Problem and AC:
 | **Root Cause** | (promoted from standard, filled from Stage 3 code investigation output) |
 | **Evidence** | Logs, stack traces, error output, or metric anomalies that confirm the symptom. |
 
-For bug issues the ordering is: Problem → Reproduction → Root Cause → Evidence → Pre-Context → AC → Non-Goals → References.
+For bug issues the ordering is: Problem → Reproduction → Root Cause → Evidence → Pre-Context → AC → Post-Release Observation → Non-Goals → References. Post-Release Observation appears only when its escalation trigger holds — for a bug, the production symptom-rate floor (see the Post-Release Observation Section); omit it when the fix's value is fully delivered the moment the Reproduction re-run passes.
 
 ### Pre-Context Rules
 
@@ -108,6 +108,7 @@ After slicing, the relationship rule is: shared context lives in the parent ONCE
 | **User Value** | Conditional — user-facing work | What the user gains from the parent initiative as a whole. One to two sentences. |
 | **User Flow: current → after** | Conditional — transition genre (see Transition-Genre Additions below) | A compact before/after contrast of the user-visible or system-visible path, applied at the parent level when the initiative as a whole is a behavior change or migration. |
 | **Scope of Application** | Conditional — transition genre (see Transition-Genre Additions below) | Who or what converts to the new path and who or what intentionally stays on the old path. Must be explicit on both sides — "new registrations use the new path; existing users keep the old path, no forced migration" is the pattern. Omit neither side. |
+| **Post-Release Observation** | Conditional — the initiative as a whole moves a shared outcome, or has a shared predicted post-release state | The initiative-level observation (Form 1 and/or Form 2 per the Post-Release Observation Section), declared once in the parent like Core Concept; children reference it rather than each re-declaring, unless a child owns a distinct sub-outcome. Omit when no shared post-release observation applies. |
 | **Decisions Needed** | Required when open decisions exist | Open product or policy decisions that block or shape child work (see Decisions Needed definition below). Omit when no open decisions remain at the time of filing. |
 | **Notes** | Optional | Provenance, superseded prior attempts, and context that does not fit elsewhere. |
 | **References** | Required | Per the existing References rules in the Standard Body Shape. |

--- a/skills/craft-issue/references/issue-craft.md
+++ b/skills/craft-issue/references/issue-craft.md
@@ -25,6 +25,7 @@ Korean-working teams, use this canonical mapping:
 | AC | 완료 조건 |
 | (AC) Verification | 검증 |
 | Non-Goals | 범위 제외 |
+| Post-Release Observation | 배포 후 관찰 |
 | User Flow: current → after | 전환 방식 / 동선 변화 |
 | Decisions Needed | 결정 필요 |
 | References | References (그대로 둔다) |
@@ -48,6 +49,7 @@ it, never as a reflex:
 | **two-bucket** Confirmed-Facts / Needs-Verification grouping | the structured Pre-Context above is already in use AND a sub-item holds 3+ items. |
 | **Decisions Needed** | an open product/policy decision actually blocks or shapes the work. |
 | **Notes** | provenance (superseded attempts, deep-interview artifact path) that has no other home. |
+| **Post-Release Observation** | the issue moves a measurable outcome (adoption, conversion, adherence, latency, error rate — Form 1), OR the change implies a checkable expectation about logs / data / state to confirm after release (Form 2). Omit only when neither holds — a pure capability / readability refactor / infra issue whose value is fully delivered the moment its ACs pass. |
 
 The test before emitting any escalation section: *would a lean sibling issue in this epic carry it?*
 If the house siblings stay flat, match them — do not emit scaffolding the reader skims past. A
@@ -63,6 +65,7 @@ Needed + Notes is over-built; collapse it to the lean default.
 | **Root Cause** | The underlying mechanism that produces the problem. Must be grounded in code, logs, or a reproducible trace — not speculation. If unknown, write `TBD — needs validation via {method}`. |
 | **Pre-Context** | Background facts on scope and risk the reader needs before implementation begins — three sub-items (**Affected Areas**, **Premises**, **Blockers & Risks**). See Pre-Context Rules below. |
 | **AC** | Acceptance criteria (see Section 2 below). At least one AC per issue. |
+| **Post-Release Observation** | What is watched after release — an aspirational outcome metric and/or a falsifiable predicted post-release state (value, movement, invariant, or success log) — distinct from AC, which only confirms the change was built. Escalation section; see Post-Release Observation Section below. |
 | **Non-Goals** | What this issue explicitly does NOT address. Prevents scope creep. |
 | **References** | PRDs, design docs, Slack threads, incident records, code commits/PRs, and logs use markdown links. Related PM issues are linked through the native relation step, not by duplicating the relationship in the body. PM-issue mentions that must appear in the body without becoming related use a form your PM tool does not auto-link into a relation, with a one-sentence note explaining why they are context rather than related-issue links. |
 
@@ -129,6 +132,81 @@ Issues whose substance is a behavior or path change — migration, switchover, r
 The intent ban applies: this section records what changes from the user or system perspective, not how it will be built. "Before: new users are directed to onboarding screen A. After: new users are directed to onboarding screen B" is permitted. "Implement a redirect from screen A to screen B using router hook X" is not.
 
 For parent issues, the User Flow: current → after section captures the initiative-level path change. Child issues may carry their own User Flow section if their individual slice represents a distinct behavior change, or omit it if the parent's section covers their scope.
+
+### Post-Release Observation Section
+
+An AC confirms the change was **built** (acceptance-time: run the command, the state holds). It does **not**
+confirm what happens **after release** — an issue can pass every AC and still fail to move the outcome it
+exists for, or fail to shift production data the way the change predicts. That gap is filled by a
+**Post-Release Observation** section (KO header: 배포 후 관찰). This is a body section, **not an AC**: its
+observation happens after release, over a window, so it cannot gate acceptance and must not be forced into the
+§2 two-line AC shape.
+
+It takes one of **two forms**, and an issue may carry both:
+
+**Form 1 — Outcome metric (결과 지표, aspirational).** Used when the issue's purpose is to move a product or
+system value outcome. Records, all at the WHAT level:
+
+- **Outcome metric** — the observable signal whose movement proves the value materialized (e.g., "daily
+  adherence rate among targeted users", "checkout conversion", "p95 latency", "error-rate of the affected
+  endpoint").
+- **Target / direction** — a threshold or a direction-vs-baseline. Concrete figure when one is set; otherwise
+  `TBD — needs validation via {method}`. The §2 weasel-word prohibition applies — "improves" alone is not a
+  target; "increases vs. the pre-release baseline" is.
+- **Observation method + window** — how and when the metric is read after release (e.g., "Amplitude cohort
+  comparison vs. the prior 4 weeks, read 4 weeks post-rollout").
+
+**Form 2 — Predicted post-release state (예측된 배포 후 상태, falsifiable).** Used when the change implies a
+*checkable expectation about logs, data, or state* after release — the expectation is **derived from the
+change**, and a query or log read confirms it over a window. This is a correctness check, not a value
+judgment. It takes one or more of these shapes (usually a conjunction):
+
+- **reaches a value / state** — "field X becomes 'Balance'", "the legacy-row count becomes 0", "the daily
+  discrepancy count converges to ~0".
+- **moves by a derived magnitude** — "weekly trigger count rises by ≈ N (computed from a pre-deploy snapshot),
+  then returns to the prior baseline".
+- **holds an invariant (does not change)** — "rows that do not match the condition are left unchanged".
+- **executes / logs success** — "the nightly job logs a success completion on every scheduled run". This is
+  the *weakest* shape alone — it confirms the job ran, not that the data is right; when the data effect is
+  queryable, pair it with a value/invariant check rather than resting on the log. For a recurring job,
+  "keeps logging success across the window" is a real ongoing confirmation (it can silently stop in prod),
+  distinct from the one-time "it ran once" you check at acceptance.
+
+Records, whichever shapes apply:
+
+- **Expected condition** — the post-release state, derived from the change (value / magnitude / invariant /
+  success-log, usually combined).
+- **Confirmation query or log + window** — the concrete query or log read that confirms it after release, and
+  the window to read it over (e.g., "OpenSearch daily discrepancy-count over 7–14 days post-deploy"; "DB count
+  of legacy rows right after the migration job's success log").
+- **Falsification clause** — if the observed state does not match the expectation (beyond a stated tolerance
+  where a magnitude is involved), the change did **not** behave as designed → investigate. (Contrast Form 1,
+  where missing the target is a value disappointment, not a defect.)
+- **Pairs with an acceptance-time AC** when a baseline or expected value must be captured before deploy: make
+  "compute and record the expected value/delta from query Z before deploy" an AC (it is runnable now), and let
+  Form 2 assert the post-release state against it.
+
+Beware a **self-referential** Form-2 signal: when the change both produces and measures it (a job that
+corrects the very count it reports), convergence proves the mechanism ran, not that the value moved — pair it
+with a Form 1 outcome.
+
+Distinguish Form 2 from `TBD — needs validation via {method}`: a `TBD` marks a **fact missing at filing
+time**; a Form-2 prediction is a **stated expectation to confirm after release**. They are different states —
+do not collapse a prediction into a TBD.
+
+**Model-A boundary** (both forms). The section names the metric/prediction and how it will be observed — it
+does **not** specify instrumentation, event schemas, or dashboard construction ("add event E with property P",
+"build dashboard D" is HOW — Model-B work for `prometheus` / `sisyphus` downstream). And — **for Form 1
+only** — a "the code ran" count is not a value outcome: a sent push or a fired trigger proves the feature
+executed, not that adherence or conversion moved, so do not pass an execution count off as a Form-1 metric.
+(In Form 2 a success log is a legitimate confirmation shape — just the weakest, per its bullet above.)
+
+For a **bug-genre** issue, the observation is the production symptom rate falling to its expected floor (e.g.,
+"the stack-trace count for this error drops to ~0 in OpenSearch over 7 days post-deploy"), distinct from the
+acceptance-time AC (the Reproduction re-run now passes).
+
+For a **sliced initiative**, the initiative-level observation lives once in the parent (like Core Concept);
+children reference it rather than each re-declaring it, unless a child owns a distinct sub-outcome.
 
 ### Decisions Needed
 


### PR DESCRIPTION
## 📌 Summary

craft-issue 스킬에 **배포 후 관찰(Post-Release Observation)** 섹션을 추가했습니다. 인수조건(AC)은 "변경이 만들어졌는가"까지만 보증하는데, 배포 후 의도한 결과나 데이터가 실제로 움직였는지를 따로 적지 않으면 "AC는 다 통과했지만 정작 목적은 달성 못 한" 이슈가 그대로 빠져나갑니다. 이를 Form 1(결과 지표)과 Form 2(예측된 배포 후 상태)로 나눠 기술하도록 했습니다.

---

## 🔧 Changes

### craft-issue 스킬 — issue-craft.md (이슈 본문 형태·AC·슬라이스 루브릭 레퍼런스)

- **배포 후 관찰 섹션 신설.** AC와 구분되는 배포 후 관찰을 두 form으로 정의합니다.
  - **Form 1 — 결과 지표(지향):** 움직여야 할 가치 지표, 목표 방향, 관찰 방법과 윈도우.
  - **Form 2 — 예측된 배포 후 상태(반증 가능):** 변경 자체에서 파생되는, 쿼리나 로그로 확인 가능한 기대. 값 도달·델타·불변·로그 성공 같은 여러 shape를 보통 조합으로 가지며, 확인 쿼리와 윈도우, 반증절, 인수시점 AC와의 페어링을 함께 적습니다.
- **지원 편집 3곳:** 로컬라이제이션 표(배포 후 관찰 KO 헤더), Escalation 표(언제 포함하고 언제 생략하는지), Standard Body Shape 메뉴 행.

AC만 있으면 "배포 후 한 주간 구독량이 트리거 변경분만큼 움직여야 한다" 같은 사후 확인이 이슈에서 누락됩니다. 이 섹션이 그 확인을 1급 슬롯으로 끌어올립니다.

**영향 범위**
- craft-issue 스킬이 생성하는 PM 이슈 본문의 형태에만 영향. 런타임 코드나 sync 파이프라인과 무관합니다.
- 단일 파일 +78줄. SKILL.md는 본문 형태 정의를 이 레퍼런스에 위임하므로 손대지 않았습니다.
- Escalation 규칙이라 순수 capability 추가나 가독성 리팩토링, 인프라 이슈에서는 섹션이 통째로 생략됩니다.
- 기존 섹션(AC 루브릭, INVEST 슬라이스 게이트, Model-A purity)은 그대로 두는 additive 변경이라 하위 호환됩니다.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. Form 2를 정량 델타에서 다중 shape로 추상화

**배경 및 문제 상황:**
처음 Form 2는 "구독 트리거를 바꾸면 첫 주 트리거 수가 N만큼 증가한다" 같은 정량 델타에 맞춰 썼습니다. 그런데 실제 배포 후 기대는 케이스가 더 넓습니다. 스케줄러 로그가 성공으로 찍힌다, 마이그레이션 후 특정 카운트가 0이 된다, 조건에 안 맞는 행은 그대로 유지된다(불변) 등. 델타 중심 문구로는 이들이 Form 2로 인식되지 못하고 전부 AC로 밀려났습니다.

**해결 방안:**
Form 2의 정의를 "데이터 시계열의 정량적 이동"에서 "로그·데이터·상태에 대한 확인 가능한 기대"로 넓히고, 네 가지 shape(값 도달, 파생된 델타, 불변, 로그 성공)를 명시했습니다. 보통 이들은 조합으로 나타납니다(예: 야간 잡이 매일 성공 로그를 남기고 + 불일치 건수가 0으로 수렴).

**관련 코드:**
```
// Before (델타 한정)
**Form 2 — Predicted data movement (예측된 데이터 이동, falsifiable).** Used when the change has a
*quantitatively predictable* effect on a data series — the expected magnitude is **derived from the
change itself**, not hoped for.

// After (다중 shape)
**Form 2 — Predicted post-release state (예측된 배포 후 상태, falsifiable).** Used when the change
implies a *checkable expectation about logs, data, or state* after release ... takes one or more of
these shapes (usually a conjunction):
- reaches a value/state · moves by a derived magnitude · holds an invariant · executes/logs success
```

**선택과 트레이드오프:**
케이스마다 새 항목을 깎는 대신 shape의 집합으로 추상화하는 쪽을 택했습니다. 너무 잘게 나누면 이 스킬을 쓰는 에이전트가 자기 케이스를 어디에 넣을지 헷갈리고, 너무 추상적이면 빈 슬롯이 됩니다. 검증에서 6개 시나리오(마이그레이션, reconciliation, 구독 델타, 가독성 리팩토링)가 자기 shape를 정확히 골랐습니다.

### 2. "code ran ≠ outcome" 주의를 Form 1에만 적용

**배경 및 문제 상황:**
원래 본문에는 "푸시를 보냈다, 트리거가 발동했다 같은 '코드가 실행됐다' 카운트는 결과가 아니다"라는 주의가 양쪽 form 공통으로 걸려 있었습니다. 문제는 이 주의가 Form 2의 정당한 관측인 로그 성공까지 "그건 결과 아님"으로 기각시킨다는 점입니다. 검증에서 야간 reconciliation 잡의 "매일 성공 로그"가 이 주의를 근거로 AC나 운영 모니터링으로 강등됐습니다.

**해결 방안:**
이 주의를 Form 1 한정으로 좁혔습니다. Form 1(가치 지표)에서는 실행 카운트를 지표로 위장하면 안 되는 게 맞지만, Form 2에서는 로그 성공이 정당한(가장 약한) 확인 shape입니다. 더해서 "한 번 돌았다"(인수시점 AC)와 "관찰 윈도우 내내 매일 성공 로그를 남긴다"(Form 2)를 구분하도록 명시했습니다. 후자는 prod에서 잡이 조용히 멈출 수 있어 별도 확인 대상입니다.

**관련 코드:**
```
// Before (양쪽 공통)
And **a "the code ran" count is not an outcome**: a sent push, or a fired trigger, proves the feature
executed — not that the value moved (Form 1) or that the predicted population actually shifted (Form 2).

// After (Form 1 한정 + Form 2는 로그 성공 허용)
And — **for Form 1 only** — a "the code ran" count is not a value outcome ...
(In Form 2 a success log is a legitimate confirmation shape — just the weakest.)
```

**선택과 트레이드오프:**
로그 성공이 가장 약한 shape라는 단서를 남겨, 데이터 효과를 쿼리할 수 있으면 로그에만 기대지 말고 값·불변 확인과 같이 쓰라고 했습니다. 함께 자기참조 신호 주의(잡이 스스로 보정하고 산출하는 지표의 수렴은 메커니즘이 돌았다는 증거일 뿐 가치 이동의 증거는 아니므로 Form 1을 동반)를 추가했습니다.

### 3. (열린 질문) AC와 Form 2의 경계 — 1회성 마이그레이션

**배경 및 문제 상황:**
1회성 백필 같은 변경은 데이터 상태(미설정 수 0, 기설정 불변)를 스테이징에서 인수시점에 검증할 수도, prod에서 배포 후에 확인할 수도 있습니다. 검증 reps에서 같은 데이터 상태가 어떤 경우는 AC로, 어떤 경우는 Form 2로 갈렸습니다.

**선택과 트레이드오프:**
결함이 아니라 정당한 판단 차이로 봤습니다(스테이징 인수 체크포인트와 prod 확인 체크포인트는 서로 다른 시점). 그래서 강제 규칙을 더 넣지 않고 그대로 뒀습니다. 다만 "1회성 변경의 데이터 상태를 AC와 Form 2 양쪽에 적는 게 중복인지"는 리뷰에서 의견을 듣고 싶은 지점입니다.

---

## ✅ Checklist

### craft-issue 배포 후 관찰
- [ ] `make validate`가 통과한다 (schema / component / lib-import / AC-SSOT)
  - `skills/craft-issue/references/issue-craft.md`
- [ ] 배포 후 관찰 섹션이 AC와 구분되는 Form 1·Form 2를 정의하고, Form 2가 값 도달·델타·불변·로그 성공 shape를 포함한다
  - `skills/craft-issue/references/issue-craft.md`
- [ ] 로그 성공이 Form 2의 확인 shape로 인식된다(AC로 강등되지 않는다) — reconciliation·마이그레이션 시나리오에서 확인
  - `skills/craft-issue/references/issue-craft.md`
- [ ] 순수 가독성 리팩토링 이슈에서는 배포 후 관찰 섹션이 생략된다(과잉 발동 없음)
  - `skills/craft-issue/references/issue-craft.md`
- [ ] 델타형 변경(구독 트리거)에서 Form 2와 짝 AC가 함께 유지된다
  - `skills/craft-issue/references/issue-craft.md`
