### PR TITLE
refactor: 프롬프트 캐시 안전 컨텍스트 주입 전환

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,36 @@ Read("skills/prometheus/SKILL.md")  // Wrong
 
 `sync.yaml:path` contains absolute paths to target projects. These are local to each developer's machine — do not commit personal paths in PRs.
 
+### Cache-Safe Context Injection
+
+Hook and skill authors who emit injected context (SessionStart stdout, keyword-detector payloads, skill `` !`command` `` macro output) MUST follow these constraints. The goal: bytes that land in the PREFIX segment of the conversation must be session-invariant so the KV cache is not evicted on every new session. A single varying byte anywhere in the prefix evicts the entire downstream cache.
+
+- **No per-request volatile values in PREFIX-position injected context.** Timestamps, PIDs, ephemeral counters, or any value that changes between requests must not appear in context injected into the conversation prefix.
+
+- **Sort collections (deterministic ordering) before emitting.** Any list, set, or map serialized into injected context must be sorted before output. Insertion-order or filesystem-order enumerations are non-deterministic across sessions and defeat caching.
+
+- **Session-varying values: coarsen OR use a static state-file pointer.** If a value legitimately varies by session but must appear in injected context, either coarsen it to a stable category (e.g., a count bucket rather than an exact count), or emit a static shell read command — `cat "$OMT_DIR/<state>-$OMT_SESSION_ID.json"` — with a run-now imperative. The pointer string itself is static; the actual read happens in TAIL position, not PREFIX.
+
+- **SessionStart stdout = static; route dynamic/volatile data to stderr or on-demand reads.** The SessionStart hook's stdout is injected directly into the conversation prefix. Keep it fully static. Emit diagnostic or session-varying information to stderr (logged, not injected) or defer it to an on-demand read instruction executed later in the conversation body.
+
+- **Skill-body `` !`command` `` macro output must be deterministic + session-invariant.** Command substitutions embedded in SKILL.md via the `` !`...` `` macro are evaluated at skill-load time and injected into the prefix. Their output must be bit-for-bit identical across sessions; any path, timestamp, or environment-specific value disqualifies a command from macro use.
+
+#### Accepted unavoidable
+
+These items deviate from the constraints above but are retained because fixing them would break correctness or routing:
+
+- **(i) Small-handoff payload** — Compaction already cold-starts the prefix, so marginal cache loss at the handoff boundary is zero. The size threshold governing this payload is a capacity axis (the `additionalContext` field cap), not a cache axis. Accepted as-is.
+
+- **(ii) rules-injector `targetRelativePath` / post-compact paths** — Codex resolves tool paths per-tool and per-compact; the path values are data-driven and must reflect the actual runtime location. Static-izing them would break routing. Accepted as session-specific by necessity.
+
+- **(iii) Pin count/location** — Pin data is determined by actual filesystem state at session start. The values are data-driven and deterministic given identical pin state, not per-request volatile. Accepted as data-driven deterministic.
+
+- **(iv) `decision.ts` Stop-reason numbers** — These values appear in TAIL-position (the Stop hook output), not in the conversation prefix. Tail-position content has zero cache impact. Retained for behavioral signal.
+
+#### Harness assumption
+
+`CLAUDE_ENV_FILE` exports (`OMT_DIR`, `OMT_SESSION_ID`) reach the agent's Bash-tool environment at runtime. Hook round-trip acceptance criteria verify hook write/emit consistency only — the "Claude Code sources the env file so agent Bash tools see these variables" leg is a documented assumption, not something the OMT test suite verifies.
+
 ## Language Conventions
 
 - **Commit messages**: Korean (한국어) with 명사형 종결

--- a/hooks/cache-safe-guard_test.sh
+++ b/hooks/cache-safe-guard_test.sh
@@ -1,0 +1,309 @@
+#!/bin/bash
+# =============================================================================
+# Cache-Safe Guard Tests (TODO 5)
+# Regression net for PREFIX-position context emitters.
+#
+# Guards that the combined stdout of three emitters matches NONE of the five
+# volatile-value patterns that would break prompt-cache determinism:
+#   1. /(Users|home)/[^"]*     — expanded abs path (AUXILIARY)
+#   2. <SESSION_ID value>      — raw session ID (LOAD-BEARING)
+#   3. Iteration:? *\d+/\d+   — digit/digit progress
+#   4. resume-forge-[^"]*\.json — resume-forge filename
+#   5. \b\d+ incomplete tasks\b — task count
+#
+# Emitters under guard:
+#   - hooks/session-start.sh         (prometheus restore + pending + large-handoff pointer)
+#   - hooks/resume-forge-start.sh    (restore block)
+#   - skills/sisyphus/hooks/skill-catalog/index.ts  (static macro)
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# =============================================================================
+# Test harness — mirrors session-start_test.sh / resume-forge-start_test.sh
+# =============================================================================
+
+setup_test_env() {
+    TEST_TMP_DIR=$(mktemp -d)
+    mkdir -p "$TEST_TMP_DIR/.omt"
+    mkdir -p "$TEST_TMP_DIR/.git"
+
+    ORIGINAL_HOME="$HOME"
+    TEST_HOME=$(mktemp -d)
+    mkdir -p "$TEST_HOME/.claude"
+    export HOME="$TEST_HOME"
+    unset OMT_DIR
+    unset OMT_PROJECT
+
+    # Pre-compute TEST_OMT_DIR: mirrors hooks' OMT_DIR derivation.
+    # TEST_TMP_DIR has no real git repo, so PROJECT_NAME = basename(TEST_TMP_DIR).
+    TEST_PROJECT_NAME=$(basename "$TEST_TMP_DIR")
+    TEST_OMT_DIR="$TEST_HOME/.omt/$TEST_PROJECT_NAME"
+    mkdir -p "$TEST_OMT_DIR"
+    mkdir -p "$TEST_OMT_DIR/state"
+}
+
+teardown_test_env() {
+    export HOME="$ORIGINAL_HOME"
+    [ -d "${TEST_TMP_DIR:-}" ] && rm -rf "$TEST_TMP_DIR"
+    [ -d "${TEST_HOME:-}" ] && rm -rf "$TEST_HOME"
+}
+
+run_test() {
+    local test_name="$1"
+    setup_test_env
+    if "$test_name"; then
+        echo "[PASS] $test_name"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "[FAIL] $test_name"
+        ((TESTS_FAILED++)) || true
+    fi
+    teardown_test_env
+}
+
+# =============================================================================
+# Core guard: assert combined stdout matches NONE of the 5 patterns
+# Returns 0 if all patterns ABSENT (clean), non-zero if any pattern FOUND (leak)
+# =============================================================================
+assert_no_volatile_patterns() {
+    local combined="$1"
+    local sid="$2"
+    local label="${3:-}"
+    local found=0
+
+    # Pattern 1 (AUXILIARY): no expanded abs path under /Users or /home
+    if printf '%s' "$combined" | grep -qE '/(Users|home)/[^"]*'; then
+        local match
+        match=$(printf '%s' "$combined" | grep -oE '/(Users|home)/[^"]*' | head -1)
+        echo "  LEAK${label} Pattern 1 (abs path): $match"
+        found=1
+    fi
+
+    # Pattern 2 (LOAD-BEARING): raw session ID must NEVER appear in stdout
+    # The unexpanded-pointer design emits literal \$OMT_SESSION_ID, so the
+    # actual sid value zzqqxx must not appear anywhere.
+    if printf '%s' "$combined" | grep -qF "$sid"; then
+        echo "  LEAK${label} Pattern 2 (raw SESSION_ID '$sid' found in stdout)"
+        found=1
+    fi
+
+    # Pattern 3: no Iteration N/M progress ratio
+    if printf '%s' "$combined" | grep -qE 'Iteration:? *[0-9]+/[0-9]+'; then
+        local match
+        match=$(printf '%s' "$combined" | grep -oE 'Iteration:? *[0-9]+/[0-9]+' | head -1)
+        echo "  LEAK${label} Pattern 3 (digit/digit iteration): $match"
+        found=1
+    fi
+
+    # Pattern 4: no resume-forge-*.json filename in stdout
+    if printf '%s' "$combined" | grep -qE 'resume-forge-[^"]*\.json'; then
+        local match
+        match=$(printf '%s' "$combined" | grep -oE 'resume-forge-[^"]*\.json' | head -1)
+        echo "  LEAK${label} Pattern 4 (resume-forge filename): $match"
+        found=1
+    fi
+
+    # Pattern 5: no 'N incomplete tasks' count in stdout
+    if printf '%s' "$combined" | grep -qE '\b[0-9]+ incomplete tasks\b'; then
+        local match
+        match=$(printf '%s' "$combined" | grep -oE '\b[0-9]+ incomplete tasks\b' | head -1)
+        echo "  LEAK${label} Pattern 5 (incomplete task count): $match"
+        found=1
+    fi
+
+    return $found
+}
+
+# =============================================================================
+# Helper: create a >7000-char handoff file to trigger the large-handoff POINTER
+# (session-start.sh branches: <=7000 = inline+delete; >7000 = pointer+keep)
+# =============================================================================
+_write_large_handoff() {
+    local path="$1"
+    yes 'LARGE_HANDOFF_FILLER_LINE_1234567890_ABCDEFGHIJ' 2>/dev/null \
+        | head -c 7200 > "$path" 2>/dev/null || true
+    if [ ! -s "$path" ] || [ "$(wc -c < "$path" 2>/dev/null || echo 0)" -lt 7001 ]; then
+        python3 -c "print('X' * 7200)" > "$path" 2>/dev/null || true
+    fi
+}
+
+# =============================================================================
+# RED demonstration: guard catches a session-ID leak in a throwaway emitter
+#
+# Creates a scratch shell script (never touches the real emitters) that
+# regresses by embedding the raw SESSION_ID in its output.  Verifies that
+# assert_no_volatile_patterns correctly REJECTS the poisoned output.
+# =============================================================================
+test_guard_red_demo_session_id_leak() {
+    local sid="zzqqxx"
+    local scratch
+    scratch=$(mktemp "$TEST_TMP_DIR/scratch_emitter_XXXXXX.sh")
+
+    # Throwaway emitter that embeds the raw SESSION_ID — the regression we are guarding against
+    cat > "$scratch" << 'SCRATCH_EOF'
+#!/bin/bash
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | jq -r '.sessionId // ""')
+# REGRESSION BUG: raw session ID embedded in output — breaks prompt-cache prefix determinism
+echo "{\"continue\": true, \"hookSpecificOutput\": {\"additionalContext\": \"Restoring session context for ${SESSION_ID} -- continuing previous work\"}}"
+SCRATCH_EOF
+    chmod +x "$scratch"
+
+    local poisoned_out
+    poisoned_out=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid"'"}' \
+        | bash "$scratch" 2>/dev/null) || true
+    rm -f "$scratch"
+
+    # Guard must DETECT the leak (assert_no_volatile_patterns must return non-zero)
+    if assert_no_volatile_patterns "$poisoned_out" "$sid" " [RED-demo]"; then
+        echo "ASSERTION FAILED [RED demo]: guard should have caught the SESSION_ID leak but passed"
+        return 1
+    fi
+    # Guard correctly rejected the poisoned output — RED confirmed
+    return 0
+}
+
+# =============================================================================
+# AC12 GREEN: combined stdout of all three real emitters matches NONE of 5 patterns
+#
+# Emitter setup:
+#   session-start.sh  — active prometheus state (restore block)
+#                     + pending todos (pending-tasks block)
+#                     + >7000-char handoff + source=compact (large-handoff POINTER)
+#   resume-forge-start.sh — active resume-forge state file (restore block)
+#   skill-catalog/index.ts — static macro (no fixture needed)
+# =============================================================================
+test_cache_safe_guard_ac12_green() {
+    local sid="zzqqxx"
+    local now_ts
+    now_ts=$(date "+%Y-%m-%dT%H:%M:%S")
+
+    # --- session-start.sh fixture 1: active prometheus state ---
+    # Triggers the PROMETHEUS RESTORED block with UNEXPANDED cat pointer.
+    cat > "$TEST_OMT_DIR/prometheus-state-${sid}.json" << EOF
+{
+  "active": true,
+  "phase": "STAGE_B",
+  "plan_path": "",
+  "resume_summary": "Guard-test checkpoint — cache-safe TODO 5.",
+  "started_at": "${now_ts}",
+  "last_touched_at": "${now_ts}"
+}
+EOF
+
+    # --- session-start.sh fixture 2: pending todos ---
+    # Triggers the PENDING TASKS DETECTED block (no count embedded in output).
+    mkdir -p "$TEST_HOME/.claude/todos"
+    printf '[{"id":"1","status":"pending"},{"id":"2","status":"pending"}]' \
+        > "$TEST_HOME/.claude/todos/guard-todos.json"
+
+    # --- session-start.sh fixture 3: large handoff file (>7000 chars) ---
+    # With source=compact, the >7000-char branch emits an UNEXPANDED pointer
+    # (cat "$OMT_DIR/handoff-$OMT_SESSION_ID.md") instead of inlining the content.
+    _write_large_handoff "$TEST_OMT_DIR/handoff-${sid}.md"
+    if [ ! -s "$TEST_OMT_DIR/handoff-${sid}.md" ]; then
+        echo "ASSERTION FAILED: large handoff file could not be created"
+        return 1
+    fi
+
+    # Capture session-start.sh stdout (all three blocks: prometheus + pending + large-handoff pointer)
+    local ss_out
+    ss_out=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid"'", "source": "compact"}' \
+        | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
+
+    # Sanity: verify all three blocks fired before checking patterns
+    if ! printf '%s' "$ss_out" | grep -qF 'PROMETHEUS RESTORED'; then
+        echo "ASSERTION FAILED: session-start.sh must emit PROMETHEUS RESTORED block"
+        echo "  ss_out: ${ss_out:0:400}"
+        return 1
+    fi
+    if ! printf '%s' "$ss_out" | grep -qF 'PENDING TASKS DETECTED'; then
+        echo "ASSERTION FAILED: session-start.sh must emit PENDING TASKS DETECTED block"
+        echo "  ss_out: ${ss_out:0:400}"
+        return 1
+    fi
+    if ! printf '%s' "$ss_out" | grep -qF 'COMPACTION HANDOFF'; then
+        echo "ASSERTION FAILED: session-start.sh must emit COMPACTION HANDOFF block"
+        echo "  ss_out: ${ss_out:0:400}"
+        return 1
+    fi
+
+    # --- resume-forge-start.sh fixture: active resume-forge state ---
+    # The restore block emits qualitative phrase ("in progress"), not filename or digit/digit.
+    cat > "$TEST_OMT_DIR/state/resume-forge-guard-test.json" << 'EOF'
+{
+  "session_id": "guard-test",
+  "created_at": "2026-06-30T12:00:00",
+  "target_count": 3,
+  "scenarios": [
+    {"id": "c1", "loop1": {"status": "passed"}, "loop2": {"status": "passed"}},
+    {"id": "c2", "loop1": {"status": "passed"}, "loop2": {"status": "pending"}},
+    {"id": "c3", "loop1": {"status": "pending"}, "loop2": {"status": "pending"}}
+  ]
+}
+EOF
+
+    local rf_out
+    rf_out=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid"'"}' \
+        | "$SCRIPT_DIR/resume-forge-start.sh" 2>/dev/null) || true
+
+    # Sanity: resume-forge restore block fired
+    if ! printf '%s' "$rf_out" | grep -qF 'RESUME FORGE SESSION DETECTED'; then
+        echo "ASSERTION FAILED: resume-forge-start.sh must emit RESUME FORGE SESSION DETECTED"
+        echo "  rf_out: ${rf_out:0:400}"
+        return 1
+    fi
+
+    # --- skill-catalog macro ---
+    # Static output: no session IDs, no abs paths, no digit/digit, no filenames.
+    # HOME=TEST_HOME means no user skills dir → deterministic minimal output.
+    local sc_out
+    sc_out=$(bun run "$REPO_DIR/skills/sisyphus/hooks/skill-catalog/index.ts" 2>/dev/null) || {
+        echo "ASSERTION FAILED: skill-catalog invocation failed (bun available?)"
+        return 1
+    }
+
+    # Combine all three emitters' stdout
+    local combined
+    combined="${ss_out}${rf_out}${sc_out}"
+
+    # Core assertion: combined stdout must match NONE of the 5 volatile-value patterns
+    if ! assert_no_volatile_patterns "$combined" "$sid" ""; then
+        echo "ASSERTION FAILED: one or more volatile-value patterns found in combined emitter stdout"
+        return 1
+    fi
+
+    return 0
+}
+
+# =============================================================================
+# Main runner
+# =============================================================================
+
+main() {
+    echo "=========================================="
+    echo "Cache-Safe Guard Tests"
+    echo "=========================================="
+
+    # RED demonstration first: prove the guard can catch a leak
+    run_test test_guard_red_demo_session_id_leak
+
+    # AC12 GREEN: real emitters pass all 5 pattern checks
+    run_test test_cache_safe_guard_ac12_green
+
+    echo "=========================================="
+    echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"
+    echo "=========================================="
+
+    if [[ $TESTS_FAILED -gt 0 ]]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/hooks/resume-forge-start.sh
+++ b/hooks/resume-forge-start.sh
@@ -89,13 +89,21 @@ MESSAGES=""
 
 if [ -n "$MOST_RECENT_FILE" ] && [ -f "$MOST_RECENT_FILE" ]; then
   STATE_CONTENT=$(cat "$MOST_RECENT_FILE")
-  STATE_FILENAME=$(basename "$MOST_RECENT_FILE")
 
   # Count total scenarios and passed (loop2.status == "passed")
   TOTAL=$(echo "$STATE_CONTENT" | jq '.scenarios | length' 2>/dev/null || echo "0")
   PASSED=$(echo "$STATE_CONTENT" | jq '[.scenarios[] | select(.loop2.status == "passed")] | length' 2>/dev/null || echo "0")
 
-  MESSAGES="<session-restore>\n\n[RESUME FORGE SESSION DETECTED]\nState file: ${STATE_FILENAME}\nScenarios: ${PASSED}/${TOTAL} completed\nResume with resume-forge skill to continue.\n\n</session-restore>"
+  # Coarsen to qualitative phrase — avoids session-varying digit bytes in prompt-cache prefix
+  if [ "$PASSED" -eq 0 ]; then
+    PROGRESS_PHRASE="not started"
+  elif [ "$PASSED" -ge "$TOTAL" ]; then
+    PROGRESS_PHRASE="complete"
+  else
+    PROGRESS_PHRASE="in progress"
+  fi
+
+  MESSAGES="<session-restore>\n\n[RESUME FORGE SESSION DETECTED]\nScenarios: ${PROGRESS_PHRASE}\nResume with resume-forge skill to continue.\n\n</session-restore>"
 fi
 
 # Output result

--- a/hooks/resume-forge-start_test.sh
+++ b/hooks/resume-forge-start_test.sh
@@ -136,7 +136,7 @@ EOF
 }
 
 test_one_state_file_shows_scenario_summary() {
-    # State with 1 passed out of 3 total → shows 1/3
+    # State with 1 passed out of 3 total → shows qualitative "in progress"
     cat > "$TEST_OMT_DIR/state/resume-forge-abc123.json" << 'EOF'
 {
   "session_id": "abc123",
@@ -154,8 +154,8 @@ EOF
     output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "test-session"}' \
         | "$SCRIPT_DIR/resume-forge-start.sh" 2>&1) || true
 
-    assert_output_contains "$output" "1/3" \
-        "Should show 1 passed out of 3 total" || return 1
+    assert_output_contains "$output" "in progress" \
+        "Should show 'in progress' when some (not all) scenarios passed" || return 1
 }
 
 # =============================================================================
@@ -191,10 +191,11 @@ EOF
     output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "test-session"}' \
         | "$SCRIPT_DIR/resume-forge-start.sh" 2>&1) || true
 
-    # The newer file has 0/1 passed (loop2 pending), older has 2/2 passed
-    # So checking for 0/1 confirms we picked the newer file
-    assert_output_contains "$output" "0/1" \
-        "Should pick the most recent state file (0/1 passed)" || return 1
+    # The newer file has 0/1 passed (loop2 pending) → "not started"
+    # The older file has 2/2 passed → "complete"
+    # So checking for "not started" confirms we picked the newer file
+    assert_output_contains "$output" "not started" \
+        "Should pick the most recent state file (0/1 passed = not started)" || return 1
 }
 
 # =============================================================================
@@ -221,8 +222,8 @@ EOF
     output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "test-session"}' \
         | "$SCRIPT_DIR/resume-forge-start.sh" 2>&1) || true
 
-    assert_output_contains "$output" "4/4" \
-        "Should show 4/4 when all scenarios passed" || return 1
+    assert_output_contains "$output" "complete" \
+        "Should show 'complete' when all scenarios passed" || return 1
 }
 
 # =============================================================================
@@ -248,8 +249,93 @@ EOF
     output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "test-session"}' \
         | "$SCRIPT_DIR/resume-forge-start.sh" 2>&1) || true
 
-    assert_output_contains "$output" "2/3" \
-        "Should show 2/3 for mixed status" || return 1
+    assert_output_contains "$output" "in progress" \
+        "Should show 'in progress' for mixed status (2 of 3 passed)" || return 1
+}
+
+# =============================================================================
+# AC10: Session-invariant restore block (no filename, no digit/digit)
+# =============================================================================
+
+test_ac10_no_filename_no_digits_byte_invariant() {
+    # Part 1: restore block must contain no resume-forge filename and no digit/digit progress
+    cat > "$TEST_OMT_DIR/state/resume-forge-session-xyz.json" << 'EOF'
+{
+  "session_id": "xyz",
+  "created_at": "2026-04-10T12:00:00",
+  "scenarios": [
+    {"id": "c1", "loop1": {"status": "passed"}, "loop2": {"status": "passed"}},
+    {"id": "c2", "loop1": {"status": "passed"}, "loop2": {"status": "pending"}},
+    {"id": "c3", "loop1": {"status": "pending"}, "loop2": {"status": "pending"}}
+  ]
+}
+EOF
+
+    local output
+    output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "test-session"}' \
+        | "$SCRIPT_DIR/resume-forge-start.sh" 2>&1) || true
+
+    assert_output_not_contains "$output" "resume-forge-" \
+        "restore block must not contain resume-forge filename" || return 1
+
+    if echo "$output" | grep -qE "[0-9]+/[0-9]+"; then
+        echo "ASSERTION FAILED: restore block must not contain digit/digit progress"
+        echo "  Output: $output"
+        return 1
+    fi
+
+    assert_output_contains "$output" "resume-forge skill" \
+        "restore block must retain resume-forge skill instruction" || return 1
+
+    # Part 2: two in-progress files (different names + counts) must produce byte-identical output
+    for f in "$TEST_OMT_DIR/state"/resume-forge-*.json; do
+        [ -f "$f" ] && rm -f "$f"
+    done
+
+    # File A: 1/3 passed (in progress)
+    cat > "$TEST_OMT_DIR/state/resume-forge-sess-a.json" << 'EOF'
+{
+  "session_id": "sess-a",
+  "created_at": "2026-04-10T12:00:00",
+  "scenarios": [
+    {"id": "c1", "loop1": {"status": "passed"}, "loop2": {"status": "passed"}},
+    {"id": "c2", "loop1": {"status": "passed"}, "loop2": {"status": "pending"}},
+    {"id": "c3", "loop1": {"status": "pending"}, "loop2": {"status": "pending"}}
+  ]
+}
+EOF
+    local output_a
+    output_a=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "test-session"}' \
+        | "$SCRIPT_DIR/resume-forge-start.sh" 2>&1) || true
+
+    for f in "$TEST_OMT_DIR/state"/resume-forge-*.json; do
+        [ -f "$f" ] && rm -f "$f"
+    done
+
+    # File B: 2/5 passed (in progress — different name, different count, same bucket)
+    cat > "$TEST_OMT_DIR/state/resume-forge-sess-b.json" << 'EOF'
+{
+  "session_id": "sess-b",
+  "created_at": "2026-04-10T12:00:00",
+  "scenarios": [
+    {"id": "c1", "loop1": {"status": "passed"}, "loop2": {"status": "passed"}},
+    {"id": "c2", "loop1": {"status": "passed"}, "loop2": {"status": "passed"}},
+    {"id": "c3", "loop1": {"status": "pending"}, "loop2": {"status": "pending"}},
+    {"id": "c4", "loop1": {"status": "pending"}, "loop2": {"status": "pending"}},
+    {"id": "c5", "loop1": {"status": "pending"}, "loop2": {"status": "pending"}}
+  ]
+}
+EOF
+    local output_b
+    output_b=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "test-session"}' \
+        | "$SCRIPT_DIR/resume-forge-start.sh" 2>&1) || true
+
+    if [ "$output_a" != "$output_b" ]; then
+        echo "ASSERTION FAILED: same-bucket files with different names+counts must produce byte-identical output"
+        echo "  Output A (sess-a, 1/3): $output_a"
+        echo "  Output B (sess-b, 2/5): $output_b"
+        return 1
+    fi
 }
 
 # =============================================================================
@@ -316,6 +402,9 @@ main() {
 
     # Mixed status
     run_test test_mixed_status_shows_correct_ratio
+
+    # AC10: Session-invariant restore block
+    run_test test_ac10_no_filename_no_digits_byte_invariant
 
     # CLAUDE_ENV_FILE exports
     run_test test_exports_omt_dir_via_claude_env_file

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -178,6 +178,8 @@ if [ -f "$OMT_DIR/goal-state-${SESSION_ID}.json" ]; then
           # Planning-resume: guide the AI to continue co-designing the plan
           if [ "$GOAL_PLAN_AVAILABLE" = "true" ]; then
             GOAL_INSTRUCTION="\nRe-read the current plan from disk and continue the planning process where you left off.\n"
+          else
+            GOAL_INSTRUCTION="\nPlan file not available on disk yet. Continue planning from the beginning.\n"
           fi
         else
           # Pursuing-resume: guide the AI to continue autonomous pursuit

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -127,11 +127,6 @@ if [ -f "$OMT_DIR/prometheus-state-${SESSION_ID}.json" ]; then
     if [ "$PROM_ACTIVE" = "true" ]; then
       PROM_PHASE=$(echo "$PROMETHEUS_STATE" | jq -r '.phase // ""' 2>/dev/null)
       PROM_PLAN_PATH=$(echo "$PROMETHEUS_STATE" | jq -r '.plan_path // ""' 2>/dev/null)
-      PROM_RESUME=$(echo "$PROMETHEUS_STATE" | jq -r '.resume_summary // ""' 2>/dev/null)
-      # Escape backslashes so the value is safe to embed in a hand-built JSON string.
-      # Must happen here (data field only) — not at the final sed — to avoid doubling
-      # the intentional \n newline markers already present in the MESSAGES template.
-      PROM_RESUME=$(printf '%s' "$PROM_RESUME" | sed 's/\\/\\\\/g')
 
       # Determine whether the plan file is available on disk.
       # Unavailable means: plan_path empty/null, OR plan_path set but file missing.
@@ -140,19 +135,12 @@ if [ -f "$OMT_DIR/prometheus-state-${SESSION_ID}.json" ]; then
         PROM_PLAN_AVAILABLE=true
       fi
 
-      PROM_PLAN_NOTE=""
       PROM_INSTRUCTION=""
       if [ "$PROM_PLAN_AVAILABLE" = "true" ]; then
         PROM_INSTRUCTION="\nRe-read the current plan from disk and distrust stored verdicts -- re-run all gates on the current artifact.\n"
-      else
-        if [ -n "$PROM_RESUME" ] && [ "$PROM_RESUME" != "null" ]; then
-          PROM_PLAN_NOTE="\nPlan file not available on disk. Resume from this bookmark: ${PROM_RESUME}\n"
-        else
-          PROM_PLAN_NOTE="\nPlan file not available on disk yet.\n"
-        fi
       fi
 
-      MESSAGES="$MESSAGES<session-restore>\n\n[PROMETHEUS RESTORED]\n\nYou have an active prometheus session.\nPhase: $PROM_PHASE\nPlan path: $PROM_PLAN_PATH\n$PROM_PLAN_NOTE$PROM_INSTRUCTION\n</session-restore>\n\n---\n\n"
+      MESSAGES="$MESSAGES<session-restore>\n\n[PROMETHEUS RESTORED]\n\nYou have an active prometheus session.\nPhase: $PROM_PHASE\n\nRun this command NOW, before any other action:\n  cat \"\$OMT_DIR/prometheus-state-\$OMT_SESSION_ID.json\"\n(\$OMT_DIR and \$OMT_SESSION_ID are set in CLAUDE_ENV_FILE exported by this hook.)\n$PROM_INSTRUCTION\n</session-restore>\n\n---\n\n"
     fi
   fi
 fi
@@ -178,10 +166,6 @@ if [ -f "$OMT_DIR/goal-state-${SESSION_ID}.json" ]; then
 
       if [ "$GOAL_IS_PRISTINE" = "false" ]; then
         GOAL_PLAN_PATH=$(echo "$GOAL_STATE" | jq -r '.plan_path // ""' 2>/dev/null)
-        GOAL_RESUME=$(echo "$GOAL_STATE" | jq -r '.resume_summary // ""' 2>/dev/null)
-        GOAL_RESUME=$(printf '%s' "$GOAL_RESUME" | sed 's/\\/\\\\/g')
-        GOAL_ITERATION=$(echo "$GOAL_STATE" | jq -r '.iteration // 0' 2>/dev/null)
-        GOAL_MAX_ITER=$(echo "$GOAL_STATE" | jq -r '.max_iterations // 10' 2>/dev/null)
 
         # Determine whether the plan file is available on disk.
         GOAL_PLAN_AVAILABLE=false
@@ -189,36 +173,21 @@ if [ -f "$OMT_DIR/goal-state-${SESSION_ID}.json" ]; then
           GOAL_PLAN_AVAILABLE=true
         fi
 
-        # Escape backslashes so the value is safe to embed in a hand-built JSON string.
-        # Must happen after the -f existence check (which needs the raw path) and before
-        # $GOAL_PLAN_PATH is interpolated into MESSAGES.
-        GOAL_PLAN_PATH=$(printf '%s' "$GOAL_PLAN_PATH" | sed 's/\\/\\\\/g')
-
-        GOAL_PLAN_NOTE=""
         GOAL_INSTRUCTION=""
         if [ "$GOAL_PHASE" = "planning" ]; then
           # Planning-resume: guide the AI to continue co-designing the plan
           if [ "$GOAL_PLAN_AVAILABLE" = "true" ]; then
             GOAL_INSTRUCTION="\nRe-read the current plan from disk and continue the planning process where you left off.\n"
-          else
-            if [ -n "$GOAL_RESUME" ] && [ "$GOAL_RESUME" != "null" ]; then
-              GOAL_PLAN_NOTE="\nPlan file not available on disk. Resume from this bookmark: ${GOAL_RESUME}\n"
-            else
-              GOAL_PLAN_NOTE="\nPlan file not available on disk yet. Continue planning from the beginning.\n"
-            fi
           fi
         else
           # Pursuing-resume: guide the AI to continue autonomous pursuit
-          GOAL_INSTRUCTION="\nIteration: $GOAL_ITERATION/$GOAL_MAX_ITER. Continue pursuing the objective autonomously.\n"
+          GOAL_INSTRUCTION="\nContinue pursuing the objective autonomously.\n"
           if [ "$GOAL_PLAN_AVAILABLE" = "true" ]; then
             GOAL_INSTRUCTION="${GOAL_INSTRUCTION}Re-read the current plan from disk before continuing.\n"
           fi
-          if [ -n "$GOAL_RESUME" ] && [ "$GOAL_RESUME" != "null" ]; then
-            GOAL_PLAN_NOTE="\nLast checkpoint: ${GOAL_RESUME}\n"
-          fi
         fi
 
-        MESSAGES="$MESSAGES<session-restore>\n\n[GOAL RESTORED]\n\nYou have an active goal session (phase: $GOAL_PHASE).\nPlan path: $GOAL_PLAN_PATH\n$GOAL_PLAN_NOTE$GOAL_INSTRUCTION\nIMPORTANT: Invoking the goal skill again while a goal is already active is refused. Continue the existing goal, do not start a new one.\n\n</session-restore>\n\n---\n\n"
+        MESSAGES="$MESSAGES<session-restore>\n\n[GOAL RESTORED]\n\nYou have an active goal session (phase: $GOAL_PHASE).\n\nRun this command NOW, before any other action:\n  cat \"\$OMT_DIR/goal-state-\$OMT_SESSION_ID.json\"\n(\$OMT_DIR and \$OMT_SESSION_ID are set in CLAUDE_ENV_FILE exported by this hook.)\n$GOAL_INSTRUCTION\nIMPORTANT: Invoking the goal skill again while a goal is already active is refused. Continue the existing goal, do not start a new one.\n\n</session-restore>\n\n---\n\n"
       fi
     fi
   fi
@@ -244,9 +213,10 @@ if command -v jq &> /dev/null && [ "$SOURCE" = "compact" ]; then
     else
       HANDOFF="[COMPACTION HANDOFF -- full continuation record on disk]
 
-Your context was just compacted. The COMPLETE session handoff (original request verbatim, the full arc of decisions/rejections/Q&A, exact stopping point, and all user messages) is saved at:
-  $HANDOFF_FILE
-READ THAT FILE IN FULL NOW, BEFORE ANY OTHER ACTION. It is your only memory of this session -- do not trust your recollection of prior turns. Reconstructing it from memory is NOT reading it."
+Your context was just compacted. The COMPLETE session handoff (original request verbatim, the full arc of decisions/rejections/Q&A, exact stopping point, and all user messages) is on disk. Run this command NOW, BEFORE ANY OTHER ACTION:
+  cat \"\$OMT_DIR/handoff-\$OMT_SESSION_ID.md\"
+(\$OMT_DIR and \$OMT_SESSION_ID are set in CLAUDE_ENV_FILE exported by this hook.)
+It is your only memory of this session -- do not trust your recollection of prior turns. Reconstructing it from memory is NOT reading it."
     fi
   fi
 fi
@@ -276,7 +246,7 @@ for todo_path in "$OMT_DIR/todos.json" "$DIRECTORY/.claude/todos.json"; do
 done
 
 if [ "$INCOMPLETE_COUNT" -gt 0 ]; then
-  MESSAGES="$MESSAGES<session-restore>\n\n[PENDING TASKS DETECTED]\n\nYou have $INCOMPLETE_COUNT incomplete tasks from a previous session.\nPlease continue working on these tasks.\n\n</session-restore>\n\n---\n\n"
+  MESSAGES="$MESSAGES<session-restore>\n\n[PENDING TASKS DETECTED]\n\nYou have incomplete tasks from a previous session.\nPlease continue working on these tasks.\n\n</session-restore>\n\n---\n\n"
 fi
 
 # Output message if we have any restore content OR a consumed handoff.

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -179,7 +179,7 @@ if [ -f "$OMT_DIR/goal-state-${SESSION_ID}.json" ]; then
           if [ "$GOAL_PLAN_AVAILABLE" = "true" ]; then
             GOAL_INSTRUCTION="\nRe-read the current plan from disk and continue the planning process where you left off.\n"
           else
-            GOAL_INSTRUCTION="\nPlan file not available on disk yet. Continue planning from the beginning.\n"
+            GOAL_INSTRUCTION="\nNo plan file on disk yet. Continue planning from the state you just read above — resume from its resume_summary checkpoint if present, otherwise begin planning afresh.\n"
           fi
         else
           # Pursuing-resume: guide the AI to continue autonomous pursuit

--- a/hooks/session-start_test.sh
+++ b/hooks/session-start_test.sh
@@ -263,9 +263,18 @@ EOF
         return 1
     fi
 
-    # additionalContext must contain the bookmark text
-    assert_output_contains "$output" "Working on feature X" "additionalContext should contain resume_summary text" || return 1
-    assert_output_contains "$output" "Resume from this bookmark" "additionalContext should contain bookmark label" || return 1
+    # resume_summary is NO LONGER embedded directly — it is recoverable via the cat pointer.
+    assert_output_not_contains "$output" "Working on feature X" "resume_summary text must NOT be embedded directly (now via cat pointer)" || return 1
+    assert_output_not_contains "$output" "Resume from this bookmark" "PROM_PLAN_NOTE bookmark must NOT appear (orphan removed)" || return 1
+
+    # cat pointer must be present in additionalContext
+    local ctx
+    ctx=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
+    if ! echo "$ctx" | grep -qF 'cat "$OMT_DIR/prometheus-state-$OMT_SESSION_ID.json"'; then
+        echo "ASSERTION FAILED: additionalContext must contain UNEXPANDED cat pointer"
+        echo "  ctx: ${ctx:0:500}"
+        return 1
+    fi
 }
 
 test_session_start_prometheus_resume_summary_backslash_produces_valid_json() {
@@ -291,25 +300,23 @@ EOF
         return 1
     fi
 
-    # (b) the parsed additionalContext must contain backslashes intact
+    # (b) resume_summary is NOT embedded directly — recoverable via cat pointer
     local ctx
     ctx=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
 
     if echo "$ctx" | grep -qF 'C:\tmp\plan'; then
-        : # good
-    else
-        echo "ASSERTION FAILED: additionalContext should preserve backslash path C:\\tmp\\plan"
+        echo "ASSERTION FAILED: backslash resume_summary must NOT be embedded directly (now via cat pointer)"
         echo "  additionalContext: ${ctx:0:500}"
         return 1
     fi
 
-    if echo "$ctx" | grep -qF '\d+'; then
-        : # good
-    else
-        echo "ASSERTION FAILED: additionalContext should preserve backslash regex \\d+"
+    # (c) cat pointer must be present
+    if ! echo "$ctx" | grep -qF 'cat "$OMT_DIR/prometheus-state-$OMT_SESSION_ID.json"'; then
+        echo "ASSERTION FAILED: additionalContext must contain UNEXPANDED cat pointer"
         echo "  additionalContext: ${ctx:0:500}"
         return 1
     fi
+    return 0
 }
 
 # =============================================================================
@@ -1070,11 +1077,12 @@ test_session_start_encoder_invariants_in_source() {
         return 1
     fi
 
-    # Exactly 3 per-field backslash escapers (PROM_RESUME, GOAL_RESUME, GOAL_PLAN_PATH)
+    # Exactly 0 per-field backslash escapers: PROM_RESUME, GOAL_RESUME, GOAL_PLAN_PATH
+    # are no longer embedded in MESSAGES — all 3 escapers have been removed (cache-safe TODO 3).
     local escaper_count
-    escaper_count=$(grep -cF "sed 's/\\\\/\\\\\\\\/g'" "$SCRIPT_DIR/session-start.sh" 2>/dev/null || echo 0)
-    if [ "$escaper_count" -ne 3 ]; then
-        echo "ASSERTION FAILED: expected exactly 3 per-field backslash escapers, found $escaper_count"
+    escaper_count=$(grep -cF "sed 's/\\\\/\\\\\\\\/g'" "$SCRIPT_DIR/session-start.sh" 2>/dev/null || true)
+    if [ "$escaper_count" -ne 0 ]; then
+        echo "ASSERTION FAILED: expected 0 per-field backslash escapers after cache-safe refactor, found $escaper_count"
         grep -n "sed 's/\\\\" "$SCRIPT_DIR/session-start.sh"
         return 1
     fi
@@ -1266,6 +1274,486 @@ EOF
 }
 
 # =============================================================================
+# Tests: Cache-safe restore — TODO 3 (AC2a–AC6)
+# session-start.sh must emit UNEXPANDED literal cat pointers so the SessionStart
+# additionalContext block is session-invariant and cache-safe.
+# =============================================================================
+
+# Shared sentinel state helpers — use fresh timestamps so GC does not reap other-session files
+_write_prom_sentinel_state() {
+    local sid="$1"
+    local ts
+    ts=$(date "+%Y-%m-%dT%H:%M:%S")
+    cat > "$TEST_OMT_DIR/prometheus-state-${sid}.json" << EOF
+{
+  "active": true,
+  "phase": "S3",
+  "plan_path": "/SENTINEL_PP_zzqqxx/plan.md",
+  "resume_summary": "SENTINEL_RS_zzqqxx",
+  "started_at": "${ts}",
+  "last_touched_at": "${ts}",
+  "steps": {"acceptance_criteria": {"done": false, "content": [], "recorded_at": ""}, "design_decisions": {"done": false, "ref": ""}, "plan": {"done": false}}
+}
+EOF
+}
+
+_write_goal_sentinel_state() {
+    local sid="$1"
+    local ts
+    ts=$(date "+%Y-%m-%dT%H:%M:%S")
+    cat > "$TEST_OMT_DIR/goal-state-${sid}.json" << EOF
+{
+  "active": true,
+  "phase": "pursuing",
+  "plan_path": "/SENTINEL_PP_zzqqxx/plan.md",
+  "resume_summary": "SENTINEL_RS_zzqqxx",
+  "outcome": "Test objective",
+  "iteration": 3,
+  "max_iterations": 10,
+  "started_at": "${ts}",
+  "last_touched_at": "${ts}"
+}
+EOF
+}
+
+# AC2a: plan_path and resume_summary sentinels must NOT appear in prometheus stdout
+test_cache_safe_prom_sentinel_not_in_stdout() {
+    local sid="prom-sentinel-zzqqxx"
+    _write_prom_sentinel_state "$sid"
+
+    local output
+    output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid"'"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
+
+    local pp_count rs_count
+    pp_count=$(echo "$output" | grep -c "SENTINEL_PP_zzqqxx" 2>/dev/null || true)
+    rs_count=$(echo "$output" | grep -c "SENTINEL_RS_zzqqxx" 2>/dev/null || true)
+
+    if [ "${pp_count:-0}" -ne 0 ]; then
+        echo "ASSERTION FAILED (AC2a): plan_path sentinel must not appear in stdout (count=$pp_count)"
+        return 1
+    fi
+    if [ "${rs_count:-0}" -ne 0 ]; then
+        echo "ASSERTION FAILED (AC2a): resume_summary sentinel must not appear in stdout (count=$rs_count)"
+        return 1
+    fi
+}
+
+# AC2b: prometheus stdout contains UNEXPANDED cat pointer + run-now imperative;
+#        static instruction and PROM_PLAN_AVAILABLE branch retained;
+#        orphan PROM_PLAN_NOTE removed from source.
+test_cache_safe_prom_pointer_and_imperative() {
+    local sid="prom-ptr-zzqqxx"
+    _write_prom_sentinel_state "$sid"
+
+    local output
+    output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid"'"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
+
+    if ! echo "$output" | jq -e . > /dev/null 2>&1; then
+        echo "ASSERTION FAILED (AC2b): hook stdout must be valid JSON"
+        echo "  output: ${output:0:500}"
+        return 1
+    fi
+
+    local ctx
+    ctx=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
+
+    # Exactly 1 UNEXPANDED cat pointer
+    local ptr_count
+    ptr_count=$(echo "$ctx" | grep -cF 'cat "$OMT_DIR/prometheus-state-$OMT_SESSION_ID.json"' 2>/dev/null || true)
+    if [ "${ptr_count:-0}" -ne 1 ]; then
+        echo "ASSERTION FAILED (AC2b): additionalContext should contain exactly 1 cat pointer (found ${ptr_count:-0})"
+        echo "  ctx: ${ctx:0:600}"
+        return 1
+    fi
+
+    # run-now imperative
+    if ! echo "$ctx" | grep -qiE 'now, before any other action|run .*now|before resuming'; then
+        echo "ASSERTION FAILED (AC2b): additionalContext should contain run-now imperative"
+        return 1
+    fi
+
+    # Static instruction retained
+    if ! echo "$ctx" | grep -q "PROMETHEUS RESTORED"; then
+        echo "ASSERTION FAILED (AC2b): PROMETHEUS RESTORED header must be retained"
+        return 1
+    fi
+
+    # PROM_PLAN_AVAILABLE=true branch works: create a real plan file and verify instruction fires
+    local plan_file="$TEST_OMT_DIR/test-prom-plan.md"
+    echo "# Plan" > "$plan_file"
+    local sid2="prom-ptr-planok"
+    local ts2
+    ts2=$(date "+%Y-%m-%dT%H:%M:%S")
+    cat > "$TEST_OMT_DIR/prometheus-state-${sid2}.json" << EOF
+{
+  "active": true,
+  "phase": "S4",
+  "plan_path": "${plan_file}",
+  "resume_summary": "checkpoint",
+  "started_at": "${ts2}",
+  "last_touched_at": "${ts2}",
+  "steps": {"acceptance_criteria": {"done": false, "content": [], "recorded_at": ""}, "design_decisions": {"done": false, "ref": ""}, "plan": {"done": false}}
+}
+EOF
+    local out2
+    out2=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid2"'"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
+    local ctx2
+    ctx2=$(echo "$out2" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
+    if ! echo "$ctx2" | grep -q "Re-read the current plan from disk and distrust stored verdicts"; then
+        echo "ASSERTION FAILED (AC2b): PROM_PLAN_AVAILABLE=true branch must emit re-read instruction"
+        echo "  ctx2: ${ctx2:0:600}"
+        return 1
+    fi
+
+    # PROM_PLAN_NOTE orphan removed from source
+    if grep -q 'PROM_PLAN_NOTE' "$SCRIPT_DIR/session-start.sh"; then
+        echo "ASSERTION FAILED (AC2b): PROM_PLAN_NOTE must be removed from session-start.sh source"
+        return 1
+    fi
+}
+
+# AC2c: round-trip — source hook-produced CLAUDE_ENV_FILE, execute emitted cat, recover fields
+test_cache_safe_prom_round_trip() {
+    local sid="prom-rt-zzqqxx"
+    _write_prom_sentinel_state "$sid"
+
+    # (pre) stdout must be valid JSON
+    local output
+    output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid"'"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
+    if ! echo "$output" | jq -e . > /dev/null 2>&1; then
+        echo "ASSERTION FAILED (AC2c-pre): hook stdout must be valid JSON"
+        return 1
+    fi
+
+    # Run with TEMP CLAUDE_ENV_FILE (hook-produced, NOT a test self-export)
+    local tmp_env
+    tmp_env=$(mktemp)
+    echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid"'"}' \
+        | CLAUDE_ENV_FILE="$tmp_env" "$SCRIPT_DIR/session-start.sh" > /dev/null 2>&1 || true
+
+    # Source hook-produced file (not a test self-export)
+    # shellcheck source=/dev/null
+    source "$tmp_env"
+    rm -f "$tmp_env"
+
+    # Execute the emitted cat and verify fields are recoverable
+    local state_out
+    state_out=$(cat "$OMT_DIR/prometheus-state-$OMT_SESSION_ID.json" 2>/dev/null) || true
+    if ! echo "$state_out" | jq -e '.plan_path,.resume_summary' > /dev/null 2>&1; then
+        echo "ASSERTION FAILED (AC2c): round-trip cat must recover plan_path and resume_summary (non-empty)"
+        echo "  state_out: ${state_out:0:300}"
+        return 1
+    fi
+}
+
+# AC3a: goal plan_path, resume_summary, iteration sentinels must NOT appear in stdout
+test_cache_safe_goal_sentinel_not_in_stdout() {
+    local sid="goal-sentinel-zzqqxx"
+    _write_goal_sentinel_state "$sid"
+
+    local output
+    output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid"'"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
+
+    local pp_count rs_count
+    pp_count=$(echo "$output" | grep -c "SENTINEL_PP_zzqqxx" 2>/dev/null || true)
+    rs_count=$(echo "$output" | grep -c "SENTINEL_RS_zzqqxx" 2>/dev/null || true)
+
+    if [ "${pp_count:-0}" -ne 0 ]; then
+        echo "ASSERTION FAILED (AC3a): goal plan_path sentinel must not appear in stdout (count=$pp_count)"
+        return 1
+    fi
+    if [ "${rs_count:-0}" -ne 0 ]; then
+        echo "ASSERTION FAILED (AC3a): goal resume_summary sentinel must not appear in stdout (count=$rs_count)"
+        return 1
+    fi
+
+    # No iteration digit pattern
+    local ctx
+    ctx=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
+    if echo "$ctx" | grep -qE 'Iteration:? *[0-9]+/[0-9]+'; then
+        echo "ASSERTION FAILED (AC3a): iteration digit pattern must not appear in stdout"
+        return 1
+    fi
+}
+
+# AC3b: goal cat pointer + run-now; retained sentences; GOAL_PLAN_AVAILABLE branch.
+#        Must NOT introduce new "Invoke the goal skill" imperative.
+test_cache_safe_goal_pointer_and_imperative() {
+    local sid="goal-ptr-zzqqxx"
+    _write_goal_sentinel_state "$sid"
+
+    local output
+    output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid"'"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
+
+    if ! echo "$output" | jq -e . > /dev/null 2>&1; then
+        echo "ASSERTION FAILED (AC3b): hook stdout must be valid JSON"
+        return 1
+    fi
+
+    local ctx
+    ctx=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
+
+    # Exactly 1 UNEXPANDED cat pointer
+    local ptr_count
+    ptr_count=$(echo "$ctx" | grep -cF 'cat "$OMT_DIR/goal-state-$OMT_SESSION_ID.json"' 2>/dev/null || true)
+    if [ "${ptr_count:-0}" -ne 1 ]; then
+        echo "ASSERTION FAILED (AC3b): additionalContext should contain exactly 1 goal cat pointer (found ${ptr_count:-0})"
+        echo "  ctx: ${ctx:0:600}"
+        return 1
+    fi
+
+    # run-now imperative
+    if ! echo "$ctx" | grep -qiE 'now, before any other action|run .*now|before resuming'; then
+        echo "ASSERTION FAILED (AC3b): additionalContext should contain run-now imperative"
+        return 1
+    fi
+
+    # "Continue pursuing the objective autonomously" retained
+    if ! echo "$ctx" | grep -q "Continue pursuing the objective autonomously"; then
+        echo "ASSERTION FAILED (AC3b): 'Continue pursuing the objective autonomously' must be retained"
+        return 1
+    fi
+
+    # "refused" sentence retained (distinct substring)
+    if ! echo "$ctx" | grep -q "refused"; then
+        echo "ASSERTION FAILED (AC3b): re-invocation refused sentence must be retained"
+        return 1
+    fi
+
+    # GOAL RESTORED retained
+    if ! echo "$ctx" | grep -q "GOAL RESTORED"; then
+        echo "ASSERTION FAILED (AC3b): GOAL RESTORED header must be retained"
+        return 1
+    fi
+
+    # No new "Invoke the goal skill" imperative (D-4)
+    if echo "$ctx" | grep -qiE 'invoke the goal skill|run the goal skill|restart.*goal'; then
+        echo "ASSERTION FAILED (AC3b/D-4): must NOT introduce a new 'Invoke the goal skill' imperative"
+        return 1
+    fi
+
+    # GOAL_PLAN_AVAILABLE=true branch works
+    local plan_file="$TEST_OMT_DIR/test-goal-plan.md"
+    echo "# Plan" > "$plan_file"
+    local sid2="goal-ptr-planok"
+    local now_ts
+    now_ts=$(date "+%Y-%m-%dT%H:%M:%S")
+    cat > "$TEST_OMT_DIR/goal-state-${sid2}.json" << EOF
+{
+  "active": true,
+  "phase": "pursuing",
+  "plan_path": "${plan_file}",
+  "resume_summary": "checkpoint",
+  "outcome": "Test objective",
+  "iteration": 2,
+  "max_iterations": 10,
+  "started_at": "${now_ts}"
+}
+EOF
+    local out2
+    out2=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid2"'"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
+    local ctx2
+    ctx2=$(echo "$out2" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
+    if ! echo "$ctx2" | grep -q "Re-read the current plan from disk before continuing"; then
+        echo "ASSERTION FAILED (AC3b): GOAL_PLAN_AVAILABLE=true branch must emit re-read instruction"
+        echo "  ctx2: ${ctx2:0:600}"
+        return 1
+    fi
+}
+
+# AC3c: goal round-trip via sourced CLAUDE_ENV_FILE
+test_cache_safe_goal_round_trip() {
+    local sid="goal-rt-zzqqxx"
+    _write_goal_sentinel_state "$sid"
+
+    local output
+    output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid"'"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
+    if ! echo "$output" | jq -e . > /dev/null 2>&1; then
+        echo "ASSERTION FAILED (AC3c-pre): hook stdout must be valid JSON"
+        return 1
+    fi
+
+    local tmp_env
+    tmp_env=$(mktemp)
+    echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid"'"}' \
+        | CLAUDE_ENV_FILE="$tmp_env" "$SCRIPT_DIR/session-start.sh" > /dev/null 2>&1 || true
+
+    # shellcheck source=/dev/null
+    source "$tmp_env"
+    rm -f "$tmp_env"
+
+    local state_out
+    state_out=$(cat "$OMT_DIR/goal-state-$OMT_SESSION_ID.json" 2>/dev/null) || true
+    if ! echo "$state_out" | jq -e '.plan_path,.resume_summary,.iteration' > /dev/null 2>&1; then
+        echo "ASSERTION FAILED (AC3c): round-trip cat must recover plan_path, resume_summary, iteration"
+        echo "  state_out: ${state_out:0:300}"
+        return 1
+    fi
+}
+
+# AC4: INCOMPLETE_COUNT 7 vs 3 → pending block byte-identical, no digit
+test_cache_safe_incomplete_count_existence_only() {
+    local todos_dir="$TEST_HOME/.claude/todos"
+    mkdir -p "$todos_dir"
+
+    # 7 incomplete tasks
+    printf '[{"id":"1","status":"pending"},{"id":"2","status":"pending"},{"id":"3","status":"pending"},{"id":"4","status":"pending"},{"id":"5","status":"pending"},{"id":"6","status":"pending"},{"id":"7","status":"pending"}]' \
+        > "$todos_dir/test-todos.json"
+
+    local out_7
+    out_7=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "count-test"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
+
+    # 3 incomplete tasks (same file, different count)
+    printf '[{"id":"1","status":"pending"},{"id":"2","status":"pending"},{"id":"3","status":"pending"}]' \
+        > "$todos_dir/test-todos.json"
+
+    local out_3
+    out_3=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "count-test"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
+
+    # Byte-identical outputs
+    if [ "$out_7" != "$out_3" ]; then
+        echo "ASSERTION FAILED (AC4): incomplete task count should produce byte-identical output for 7 vs 3"
+        echo "  out_7: ${out_7:0:300}"
+        echo "  out_3: ${out_3:0:300}"
+        return 1
+    fi
+
+    # Pending block is present
+    local ctx
+    ctx=$(echo "$out_7" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
+    if ! echo "$ctx" | grep -q "PENDING TASKS DETECTED"; then
+        echo "ASSERTION FAILED (AC4): PENDING TASKS DETECTED block must be present"
+        return 1
+    fi
+
+    # No digit in the message
+    if echo "$ctx" | grep -qE 'have [0-9]+ incomplete'; then
+        echo "ASSERTION FAILED (AC4): pending message must not contain a digit count"
+        return 1
+    fi
+}
+
+# AC5: large handoff (>7000 chars) emits UNEXPANDED cat pointer; no expanded abs path;
+#      run-now retained; large-handoff file PRESERVED; round-trip cat returns non-empty.
+test_cache_safe_handoff_large_pointer() {
+    local sid="handoff-large-ptr"
+    local handoff_file="$TEST_OMT_DIR/handoff-${sid}.md"
+
+    # Create >7000-char handoff file
+    yes 'LARGE_HANDOFF_FILLER_LINE_1234567890_ABCDEFGHIJ' 2>/dev/null | head -c 7200 > "$handoff_file" 2>/dev/null || true
+    # Fallback if yes/head -c not available
+    if [ ! -s "$handoff_file" ] || [ "$(wc -c < "$handoff_file" 2>/dev/null || echo 0)" -lt 7001 ]; then
+        python3 -c "print('X' * 7200)" > "$handoff_file" 2>/dev/null || true
+    fi
+
+    local output
+    output=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid"'", "source": "compact"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
+
+    # (i) stdout valid JSON
+    if ! echo "$output" | jq -e . > /dev/null 2>&1; then
+        echo "ASSERTION FAILED (AC5): hook stdout must be valid JSON"
+        echo "  output: ${output:0:500}"
+        return 1
+    fi
+
+    local ctx
+    ctx=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
+
+    # (i) UNEXPANDED cat pointer for handoff
+    if ! echo "$ctx" | grep -qF 'cat "$OMT_DIR/handoff-$OMT_SESSION_ID.md"'; then
+        echo "ASSERTION FAILED (AC5-i): additionalContext must contain UNEXPANDED handoff cat pointer"
+        echo "  ctx: ${ctx:0:600}"
+        return 1
+    fi
+
+    # (i) NO expanded absolute path — check for the actual handoff_file path
+    if echo "$ctx" | grep -qF "${handoff_file}"; then
+        echo "ASSERTION FAILED (AC5-i): large-handoff must NOT emit expanded absolute path"
+        echo "  ctx: ${ctx:0:600}"
+        return 1
+    fi
+
+    # (ii) run-now imperative retained
+    if ! echo "$ctx" | grep -qiE 'now, before any other action'; then
+        echo "ASSERTION FAILED (AC5-ii): run-now imperative must be retained beside pointer"
+        return 1
+    fi
+
+    # (iii) large-handoff file PRESERVED (not deleted)
+    if [ ! -f "$handoff_file" ]; then
+        echo "ASSERTION FAILED (AC5-iii): large handoff file must be preserved (delete fires only on <=7000 path)"
+        return 1
+    fi
+
+    # (iii) round-trip: source env file and execute cat
+    local tmp_env
+    tmp_env=$(mktemp)
+    echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid"'", "source": "compact"}' \
+        | CLAUDE_ENV_FILE="$tmp_env" "$SCRIPT_DIR/session-start.sh" > /dev/null 2>&1 || true
+
+    # shellcheck source=/dev/null
+    source "$tmp_env"
+    rm -f "$tmp_env"
+
+    local cat_result
+    cat_result=$(cat "$OMT_DIR/handoff-$OMT_SESSION_ID.md" 2>/dev/null) || true
+    if [ -z "$cat_result" ]; then
+        echo "ASSERTION FAILED (AC5-iii): round-trip cat of large handoff must return non-empty"
+        return 1
+    fi
+}
+
+# AC6: prometheus restore output is byte-identical across two different session IDs
+test_cache_safe_prom_session_invariant() {
+    local ts
+    ts=$(date "+%Y-%m-%dT%H:%M:%S")
+    local state_body
+    state_body='{"active":true,"phase":"S3","plan_path":"/SENTINEL_PP_zzqqxx/plan.md","resume_summary":"SENTINEL_RS_variant_A","started_at":"'"$ts"'","last_touched_at":"'"$ts"'","steps":{"acceptance_criteria":{"done":false,"content":[],"recorded_at":""},"design_decisions":{"done":false,"ref":""},"plan":{"done":false}}}'
+
+    local sid_a="aaaa-session-inv"
+    local sid_b="zzqqxx-session-inv"
+
+    echo "$state_body" > "$TEST_OMT_DIR/prometheus-state-${sid_a}.json"
+    echo "$state_body" > "$TEST_OMT_DIR/prometheus-state-${sid_b}.json"
+
+    local out_a out_b
+    out_a=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid_a"'"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
+    out_b=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid_b"'"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
+
+    if [ "$out_a" != "$out_b" ]; then
+        echo "ASSERTION FAILED (AC6-prom): prometheus restore output must be byte-identical across session IDs"
+        echo "  out_a: ${out_a:0:500}"
+        echo "  out_b: ${out_b:0:500}"
+        return 1
+    fi
+}
+
+# AC6: goal restore output is byte-identical across two different session IDs
+test_cache_safe_goal_session_invariant() {
+    local ts
+    ts=$(date "+%Y-%m-%dT%H:%M:%S")
+    local state_body
+    state_body='{"active":true,"phase":"pursuing","plan_path":"/SENTINEL_PP_zzqqxx/plan.md","resume_summary":"SENTINEL_RS_variant_B","outcome":"Test objective","iteration":3,"max_iterations":10,"started_at":"'"$ts"'","last_touched_at":"'"$ts"'"}'
+
+    local sid_a="aaaa-goal-inv"
+    local sid_b="zzqqxx-goal-inv"
+
+    echo "$state_body" > "$TEST_OMT_DIR/goal-state-${sid_a}.json"
+    echo "$state_body" > "$TEST_OMT_DIR/goal-state-${sid_b}.json"
+
+    local out_a out_b
+    out_a=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid_a"'"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
+    out_b=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid_b"'"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
+
+    if [ "$out_a" != "$out_b" ]; then
+        echo "ASSERTION FAILED (AC6-goal): goal restore output must be byte-identical across session IDs"
+        echo "  out_a: ${out_a:0:500}"
+        echo "  out_b: ${out_b:0:500}"
+        return 1
+    fi
+}
+
+# =============================================================================
 # Main Test Runner
 # =============================================================================
 
@@ -1345,6 +1833,18 @@ main() {
     run_test test_gc_handoff_dash_sid_matched_exactly
     run_test test_gc_handoff_arm_does_not_call_is_current_session
     run_test test_gc_handoff_arm_does_not_disturb_json_state_gc
+
+    # Cache-safe restore — TODO 3 (AC2a–AC6)
+    run_test test_cache_safe_prom_sentinel_not_in_stdout
+    run_test test_cache_safe_prom_pointer_and_imperative
+    run_test test_cache_safe_prom_round_trip
+    run_test test_cache_safe_goal_sentinel_not_in_stdout
+    run_test test_cache_safe_goal_pointer_and_imperative
+    run_test test_cache_safe_goal_round_trip
+    run_test test_cache_safe_incomplete_count_existence_only
+    run_test test_cache_safe_handoff_large_pointer
+    run_test test_cache_safe_prom_session_invariant
+    run_test test_cache_safe_goal_session_invariant
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/session-start_test.sh
+++ b/hooks/session-start_test.sh
@@ -237,7 +237,7 @@ test_session_start_uses_project_root_variable() {
 }
 
 # =============================================================================
-# Tests: Prometheus restore — resume_summary surfaced when plan file unavailable
+# Tests: Prometheus restore — resume_summary omitted (cat pointer emitted) when plan file unavailable
 # =============================================================================
 
 test_session_start_prometheus_omits_resume_summary_and_emits_pointer_when_plan_unavailable() {

--- a/hooks/session-start_test.sh
+++ b/hooks/session-start_test.sh
@@ -240,7 +240,7 @@ test_session_start_uses_project_root_variable() {
 # Tests: Prometheus restore — resume_summary surfaced when plan file unavailable
 # =============================================================================
 
-test_session_start_prometheus_surfaces_resume_summary_when_plan_unavailable() {
+test_session_start_prometheus_omits_resume_summary_and_emits_pointer_when_plan_unavailable() {
     local sid="test-prometheus-resume"
 
     # Active prometheus state: resume_summary set, plan_path empty (never written)
@@ -486,6 +486,63 @@ EOF
     assert_output_not_contains "$output" "Re-read the current plan from disk" "pursuing without plan file: must NOT inject re-read instruction" || return 1
     # Must still surface iteration info
     assert_output_contains "$output" "GOAL RESTORED" "pursuing without plan file: should still inject GOAL RESTORED" || return 1
+}
+
+# Fix B: planning + no plan file → session-invariant guidance text emitted
+test_session_start_goal_planning_no_plan_emits_guidance_and_is_invariant() {
+    local ts
+    ts=$(date "+%Y-%m-%dT%H:%M:%S")
+    local sid_a="plan-nofile-sid-alpha"
+    local sid_b="plan-nofile-sid-beta"
+
+    # Non-pristine planning states (outcome set) with empty plan_path — no plan file on disk.
+    # resume_summary differs between the two sids to prove it is NOT visible in output.
+    cat > "$TEST_OMT_DIR/goal-state-${sid_a}.json" << EOF
+{
+  "active": true,
+  "phase": "planning",
+  "plan_path": "",
+  "resume_summary": "Alpha planning summary - should not appear in output.",
+  "outcome": "Build feature X",
+  "iteration": 1,
+  "started_at": "${ts}",
+  "last_touched_at": "${ts}"
+}
+EOF
+
+    cat > "$TEST_OMT_DIR/goal-state-${sid_b}.json" << EOF
+{
+  "active": true,
+  "phase": "planning",
+  "plan_path": "",
+  "resume_summary": "Beta planning summary - totally different text.",
+  "outcome": "Build feature X",
+  "iteration": 1,
+  "started_at": "${ts}",
+  "last_touched_at": "${ts}"
+}
+EOF
+
+    local out_a out_b
+    out_a=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid_a"'"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
+    out_b=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid_b"'"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
+
+    # Guidance text must be present (Fix B: this fails when GOAL_INSTRUCTION is empty)
+    local ctx_a
+    ctx_a=$(echo "$out_a" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
+    if ! echo "$ctx_a" | grep -q "Continue planning from the beginning"; then
+        echo "ASSERTION FAILED (Fix B): planning+no-plan must emit 'Continue planning from the beginning' guidance"
+        echo "  ctx_a: ${ctx_a:0:500}"
+        return 1
+    fi
+
+    # Output is session-invariant: byte-identical across two sids with different resume_summary
+    if [ "$out_a" != "$out_b" ]; then
+        echo "ASSERTION FAILED (Fix B): planning+no-plan guidance must be session-invariant (byte-identical across sids)"
+        echo "  out_a: ${out_a:0:500}"
+        echo "  out_b: ${out_b:0:500}"
+        return 1
+    fi
 }
 
 test_session_start_goal_plan_path_backslash_produces_valid_json() {
@@ -1703,18 +1760,20 @@ test_cache_safe_handoff_large_pointer() {
     fi
 }
 
-# AC6: prometheus restore output is byte-identical across two different session IDs
+# AC6: prometheus restore output is byte-identical across two different session IDs,
+# even when resume_summary differs — proving resume_summary is not embedded in output.
 test_cache_safe_prom_session_invariant() {
     local ts
     ts=$(date "+%Y-%m-%dT%H:%M:%S")
-    local state_body
-    state_body='{"active":true,"phase":"S3","plan_path":"/SENTINEL_PP_zzqqxx/plan.md","resume_summary":"SENTINEL_RS_variant_A","started_at":"'"$ts"'","last_touched_at":"'"$ts"'","steps":{"acceptance_criteria":{"done":false,"content":[],"recorded_at":""},"design_decisions":{"done":false,"ref":""},"plan":{"done":false}}}'
 
     local sid_a="aaaa-session-inv"
     local sid_b="zzqqxx-session-inv"
 
-    echo "$state_body" > "$TEST_OMT_DIR/prometheus-state-${sid_a}.json"
-    echo "$state_body" > "$TEST_OMT_DIR/prometheus-state-${sid_b}.json"
+    # Different resume_summary per sid: if resume_summary were still embedded, outputs would differ.
+    echo '{"active":true,"phase":"S3","plan_path":"/SENTINEL_PP_zzqqxx/plan.md","resume_summary":"SENTINEL_RS_alpha","started_at":"'"$ts"'","last_touched_at":"'"$ts"'","steps":{"acceptance_criteria":{"done":false,"content":[],"recorded_at":""},"design_decisions":{"done":false,"ref":""},"plan":{"done":false}}}' \
+        > "$TEST_OMT_DIR/prometheus-state-${sid_a}.json"
+    echo '{"active":true,"phase":"S3","plan_path":"/SENTINEL_PP_zzqqxx/plan.md","resume_summary":"SENTINEL_RS_beta","started_at":"'"$ts"'","last_touched_at":"'"$ts"'","steps":{"acceptance_criteria":{"done":false,"content":[],"recorded_at":""},"design_decisions":{"done":false,"ref":""},"plan":{"done":false}}}' \
+        > "$TEST_OMT_DIR/prometheus-state-${sid_b}.json"
 
     local out_a out_b
     out_a=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid_a"'"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
@@ -1728,18 +1787,20 @@ test_cache_safe_prom_session_invariant() {
     fi
 }
 
-# AC6: goal restore output is byte-identical across two different session IDs
+# AC6: goal restore output is byte-identical across two different session IDs,
+# even when resume_summary differs — proving resume_summary is not embedded in output.
 test_cache_safe_goal_session_invariant() {
     local ts
     ts=$(date "+%Y-%m-%dT%H:%M:%S")
-    local state_body
-    state_body='{"active":true,"phase":"pursuing","plan_path":"/SENTINEL_PP_zzqqxx/plan.md","resume_summary":"SENTINEL_RS_variant_B","outcome":"Test objective","iteration":3,"max_iterations":10,"started_at":"'"$ts"'","last_touched_at":"'"$ts"'"}'
 
     local sid_a="aaaa-goal-inv"
     local sid_b="zzqqxx-goal-inv"
 
-    echo "$state_body" > "$TEST_OMT_DIR/goal-state-${sid_a}.json"
-    echo "$state_body" > "$TEST_OMT_DIR/goal-state-${sid_b}.json"
+    # Different resume_summary per sid: if resume_summary were still embedded, outputs would differ.
+    echo '{"active":true,"phase":"pursuing","plan_path":"/SENTINEL_PP_zzqqxx/plan.md","resume_summary":"SENTINEL_RS_alpha","outcome":"Test objective","iteration":3,"max_iterations":10,"started_at":"'"$ts"'","last_touched_at":"'"$ts"'"}' \
+        > "$TEST_OMT_DIR/goal-state-${sid_a}.json"
+    echo '{"active":true,"phase":"pursuing","plan_path":"/SENTINEL_PP_zzqqxx/plan.md","resume_summary":"SENTINEL_RS_beta","outcome":"Test objective","iteration":3,"max_iterations":10,"started_at":"'"$ts"'","last_touched_at":"'"$ts"'"}' \
+        > "$TEST_OMT_DIR/goal-state-${sid_b}.json"
 
     local out_a out_b
     out_a=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid_a"'"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
@@ -1779,7 +1840,7 @@ main() {
     run_test test_session_start_uses_project_root_variable
 
     # Prometheus restore: resume_summary surfaced when plan file unavailable
-    run_test test_session_start_prometheus_surfaces_resume_summary_when_plan_unavailable
+    run_test test_session_start_prometheus_omits_resume_summary_and_emits_pointer_when_plan_unavailable
 
     # Prometheus restore: backslashes in resume_summary produce valid JSON and are preserved
     run_test test_session_start_prometheus_resume_summary_backslash_produces_valid_json
@@ -1790,6 +1851,7 @@ main() {
     run_test test_session_start_terminal_goal_state_not_restored
     run_test test_session_start_goal_pursuing_resume_rereads_plan
     run_test test_session_start_goal_pursuing_resume_no_plan_file
+    run_test test_session_start_goal_planning_no_plan_emits_guidance_and_is_invariant
 
     # Goal state restore: backslash in plan_path produces valid JSON
     run_test test_session_start_goal_plan_path_backslash_produces_valid_json

--- a/hooks/session-start_test.sh
+++ b/hooks/session-start_test.sh
@@ -527,11 +527,23 @@ EOF
     out_a=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid_a"'"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
     out_b=$(echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid_b"'"}' | "$SCRIPT_DIR/session-start.sh" 2>/dev/null) || true
 
-    # Guidance text must be present (Fix B: this fails when GOAL_INSTRUCTION is empty)
+    # Guidance text must be present: new defer-to-read-state wording
     local ctx_a
     ctx_a=$(echo "$out_a" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
-    if ! echo "$ctx_a" | grep -q "Continue planning from the beginning"; then
-        echo "ASSERTION FAILED (Fix B): planning+no-plan must emit 'Continue planning from the beginning' guidance"
+    if ! echo "$ctx_a" | grep -q "from the state you just read"; then
+        echo "ASSERTION FAILED: planning+no-plan must emit 'from the state you just read' guidance"
+        echo "  ctx_a: ${ctx_a:0:500}"
+        return 1
+    fi
+    if ! echo "$ctx_a" | grep -q "resume_summary"; then
+        echo "ASSERTION FAILED: planning+no-plan guidance must reference the 'resume_summary' field"
+        echo "  ctx_a: ${ctx_a:0:500}"
+        return 1
+    fi
+
+    # Regression guard: must NOT contain the old unconditional restart directive
+    if echo "$ctx_a" | grep -q "Continue planning from the beginning"; then
+        echo "ASSERTION FAILED (regression): planning+no-plan must NOT emit 'Continue planning from the beginning' directive"
         echo "  ctx_a: ${ctx_a:0:500}"
         return 1
     fi

--- a/skills/sisyphus/hooks/skill-catalog/index.test.ts
+++ b/skills/sisyphus/hooks/skill-catalog/index.test.ts
@@ -111,4 +111,36 @@ describe('main (통합)', () => {
     expect(joined).toContain('<skill-catalog>');
     expect(joined).toContain('</skill-catalog>');
   });
+
+  it('main stdout is byte-identical across two consecutive invocations (AC1c)', async () => {
+    // Controls: fake HOME with two known enabled plugins + no skill dirs,
+    // so both invocations see the same environment and filesystem state.
+    // This test documents the guarantee that Set/Map iteration order in
+    // readEnabledPlugins / buildCatalog never introduces session-to-session variance.
+    const fakeHome = join(tempDir, 'fakehome');
+    await mkdir(join(fakeHome, '.claude'), { recursive: true });
+    await writeFile(
+      join(fakeHome, '.claude', 'settings.json'),
+      JSON.stringify({
+        enabledPlugins: {
+          'superpowers@claude-plugins-official': true,
+          'frontend-design@claude-plugins-official': true,
+        },
+      }),
+    );
+    process.env.HOME = fakeHome;
+
+    // First invocation — consoleOutput is captured via the shared beforeEach console.log patch
+    consoleOutput = [];
+    await main();
+    const first = [...consoleOutput];
+
+    // Second invocation
+    consoleOutput = [];
+    await main();
+    const second = [...consoleOutput];
+
+    expect(first.length).toBeGreaterThan(0);
+    expect(first).toEqual(second);
+  });
 });

--- a/skills/sisyphus/hooks/skill-catalog/scanner.test.ts
+++ b/skills/sisyphus/hooks/skill-catalog/scanner.test.ts
@@ -95,6 +95,39 @@ describe('scanSkillDirectories', () => {
     const skills = await scanSkillDirectories(projectDir);
     expect(skills).toEqual(['real-skill']);
   });
+
+  it('returns skills in alphabetical order regardless of creation order', async () => {
+    const projectDir = join(tempDir, 'project');
+    const skillsDir = join(projectDir, '.claude', 'skills');
+
+    // Create in reverse alphabetical order to expose unsorted readdir
+    await mkdir(join(skillsDir, 'zebra-skill'), { recursive: true });
+    await mkdir(join(skillsDir, 'aardvark-skill'), { recursive: true });
+
+    const fakeHome = join(tempDir, 'fakehome');
+    await mkdir(fakeHome, { recursive: true });
+    process.env.HOME = fakeHome;
+
+    const skills = await scanSkillDirectories(projectDir);
+    expect(skills[0]).toBe('aardvark-skill');
+  });
+
+  it('returns identical arrays on repeated calls (stable output)', async () => {
+    const projectDir = join(tempDir, 'project');
+    const skillsDir = join(projectDir, '.claude', 'skills');
+    // Create in non-alphabetical order to expose unsorted readdir
+    await mkdir(join(skillsDir, 'zeta'), { recursive: true });
+    await mkdir(join(skillsDir, 'alpha'), { recursive: true });
+    await mkdir(join(skillsDir, 'mu'), { recursive: true });
+
+    const fakeHome = join(tempDir, 'fakehome');
+    await mkdir(fakeHome, { recursive: true });
+    process.env.HOME = fakeHome;
+
+    const first = await scanSkillDirectories(projectDir);
+    const second = await scanSkillDirectories(projectDir);
+    expect(first).toEqual(second);
+  });
 });
 
 describe('readEnabledPlugins', () => {

--- a/skills/sisyphus/hooks/skill-catalog/scanner.ts
+++ b/skills/sisyphus/hooks/skill-catalog/scanner.ts
@@ -39,7 +39,8 @@ export async function scanSkillDirectories(cwd: string): Promise<string[]> {
     }
   }
 
-  return result;
+  // Sort deterministically so output is session- and machine-invariant
+  return result.sort((l, r) => l.localeCompare(r));
 }
 
 // Read enabled plugin IDs from ~/.claude/settings.json


### PR DESCRIPTION
## 📌 Summary

SessionStart 등 **프리픽스 위치**에 주입되는 컨텍스트에서 세션마다 바뀌는 바이트(절대경로·세션 ID·iteration·정렬 안 된 `readdir`·정확한 개수)를 제거합니다. 프롬프트 캐시는 prefix 기반이라 앞쪽의 휘발 바이트 하나가 cross-session 재사용 상한을 만드는데, 이를 정적 state-file 포인터·정성 표현·결정적 정렬로 치환해 새 세션이 CLAUDE.md 너머까지 공유 prefix를 연장하도록 합니다.

---

## 🔧 Changes

### skill-catalog (출력 결정성)
- `scanner.ts`: dedup 결과를 `localeCompare`로 정렬 (저장소 기존 idiom `rules-injector/rules/scanner.ts` 채택)
- 매크로 엔트리포인트 stdout 2회 호출 바이트 동일성 e2e 테스트 추가

**영향 범위**: 매크로 출력 *순서*만 안정화하며 내용·컬럼은 불변. 합성 경로(`readEnabledPlugins` Set은 `.has()` 조회만, 고정순서 Map/SITUATIONS)는 이미 결정적임을 테스트로 문서화. 하위호환 영향 없음.

### session-start.sh (Class A/B 캐시 안전 전환)
- **prometheus/goal restore**: 세션-가변 필드(`plan_path`·`resume_summary`·`iteration`)를 드롭하고, 미확장 리터럴 `cat "$OMT_DIR/<state>-$OMT_SESSION_ID.json"` 포인터 + run-now 명령 + empty-var 가드로 치환
- **incomplete-count**: 정확한 개수 → 존재 여부만
- **large-handoff**: 확장된 절대경로 → 미확장 `cat` 포인터

**영향 범위**: restore 출력은 세션-불변. 드롭된 필드는 state JSON에 그대로 남아 포인터로 복구(무손실). handoff 파일 라이프사이클·`phase` 등 상황형 값은 불변.

### resume-forge-start.sh
- `State file: <파일명>` 라인 제거, `PASSED/TOTAL` → 정성 3버킷(`not started`/`in progress`/`complete`)

**영향 범위**: 복구는 스킬의 독립 재스캔으로 무손실. 이 훅은 `OMT_DIR`만 export(`OMT_SESSION_ID` 없음)하므로 `cat` 포인터 미사용.

### 가드 & 컨벤션
- `cache-safe-guard_test.sh`(신규): PREFIX 이미터 3종의 stdout이 휘발 패턴 집합(절대경로·세션 ID `zzqqxx`·`Iteration d/d`·resume-forge 파일명·`\d+ incomplete tasks`)에 매치 0임을 단언 + RED 시연
- `CLAUDE.md`: "Cache-Safe Context Injection" 컨벤션(5제약 + Accepted unavoidable 목록 + `CLAUDE_ENV_FILE` harness 가정 노트)

**영향 범위**: 문서·테스트 추가. 컨벤션은 `rules/`(always-loaded 토큰)가 아닌 CLAUDE.md에 배치.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.

### 1. restore 블록을 정적 state-file 포인터로 (인라인 유지/UserPromptSubmit 대신)

**배경 및 문제 상황:** prometheus/goal restore 블록은 `plan_path`·`resume_summary`·`iteration`을 prefix 앞쪽에 인라인했습니다. 이 값들은 세션마다 달라 cross-session prefix 재사용을 restore 블록 지점에서 끊습니다. 한편 goal 스킬은 active+non-pristine 상태에서 재호출을 거부하므로 "스킬을 다시 호출해 복원" 브리지는 막혀 있습니다.

**해결 방안:** 데이터를 드롭하고 미확장 리터럴 `cat "$OMT_DIR/<state>-$OMT_SESSION_ID.json"` + run-now 명령을 주입합니다. 리터럴은 변수명(값 아님)이라 세션-불변 → 캐시 가능하고, 에이전트의 Bash가 런타임에 `$OMT_DIR`/`$OMT_SESSION_ID`(`CLAUDE_ENV_FILE`로 export)를 확장해 JSON을 직독 → 무손실.

**구현 세부사항:** bash 소스에서 `\$`·`\"`로 이스케이프해 stdout에 미확장 리터럴이 emit되도록 했고, 라운드트립 테스트는 **훅이 쓴** `CLAUDE_ENV_FILE`을 source한 뒤 emit된 `cat`을 실행해 `.plan_path`/`.resume_summary`(`/.iteration`)가 비지 않음을 검증합니다(테스트 자체 export로 인한 env false-green 차단). large-handoff 포인터도 동일 기법으로 대칭화.

**선택과 트레이드오프:** 후보 — A(정적 포인터)/B(UserPromptSubmit으로 데이터를 tail로 이동, 전달 보장)/C(인라인 유지). env leg가 이 세션에서 라이브 검증되어 B의 견고성 이점은 발현되지 않는 위험에 대한 투기적 방어라 least-code상 기각, A 채택(최소 코드·`lazycodex` post-compact "MUST READ" 선례). 대가: 전달이 행동-게이트(에이전트가 run-now 명령을 따라야 함) — empty-var 가드로 silent-misrestore 완화.

### 2. `decision.ts`(Stop-hook reason)는 스코프 제외 — prefix vs tail 캐시 경제

**배경 및 문제 상황:** "어디까지 캐시 안전화할 것인가"에서 Stop-hook의 `reason` 숫자(iteration, 잔여 count)도 후보로 보였습니다.

**해결 방안:** 제외. SessionStart stdout은 prefix **앞**이라 정적화가 cross-session에 기여하지만, Stop-reason은 대화 **tail**이라 뒤에 무효화할 토큰이 없어 정적화해도 **캐시 이득 0**입니다.

**선택과 트레이드오프:** tail 위치 정적화는 노력·신호 손실만 발생하는 cache-theater라 기각하고 숫자 신호("12 remaining", "iteration 7/10")를 유지. 이득은 cross-session·TTL 한정이며 within-session(turn1 캐시 후 무료)에는 변화 없음을 명시.

### 3. harness 가정 + 잔존 인코딩 우려 (리뷰어 의견 요청)

**배경 및 문제 상황:** 포인터 설계는 `CLAUDE_ENV_FILE` export가 에이전트 Bash 환경에 도달한다는 가정에 의존합니다.

**구현 세부사항:** 라운드트립 AC는 훅의 write↔emit 정합성만 검증하며, "Claude Code가 그것을 에이전트 Bash에 source한다"는 leg는 **문서화된 가정**입니다(CLAUDE.md에 명시). 별도로, 독립 코드리뷰가 `session-start.sh`의 `$GOAL_PHASE` sed 인코딩이 큰따옴표만 이스케이프함을 지적했습니다 — pre-existing이고 `phase`는 항상 단일 ASCII 단어라 theoretical이라 이번 스코프에서 제외했습니다.

**선택과 트레이드오프:** env leg 실패가 실관측되면 옵션 B(UserPromptSubmit)가 즉시 대체 가능합니다(필요했을 latch와 동일 비용). 인코딩 우려를 이번 PR에서 함께 처리할지 의견 부탁드립니다.

---

## ✅ Checklist

### session-start.sh 캐시 안전
- [ ] prometheus/goal restore stdout에 `plan_path`/`resume_summary`/`iteration` 미노출, 미확장 `cat` 포인터 + run-now 명령 포함
  - `hooks/session-start.sh`
- [ ] restore stdout이 두 SESSION_ID·두 `resume_summary`에서 바이트 동일(prom+goal)
  - `hooks/session-start_test.sh`
- [ ] incomplete-count 블록이 개수 7 vs 3에서 바이트 동일(숫자 없음)
  - `hooks/session-start.sh`
- [ ] large-handoff 포인터 미확장 + 라운드트립으로 파일 복구, 대형 파일 보존
  - `hooks/session-start.sh`

### 결정성 & resume-forge
- [ ] scanner 알파벳 정렬 + 매크로 stdout 2회 호출 바이트 동일
  - `skills/sisyphus/hooks/skill-catalog/scanner.ts`, `skills/sisyphus/hooks/skill-catalog/index.test.ts`
- [ ] resume-forge restore에 파일명·`\d+/\d+` 없음, 두 state 파일 바이트 동일
  - `hooks/resume-forge-start.sh`

### 가드 · 컨벤션 · 제약
- [ ] 가드 테스트가 휘발 패턴 매치 0 단언 + RED 시연
  - `hooks/cache-safe-guard_test.sh`
- [ ] CLAUDE.md에 컨벤션 5제약 + Accepted unavoidable + harness 가정 노트
  - `CLAUDE.md`
- [ ] `decision.ts` 무변경 · 신규 CLI 없음 · `rules/` 파일 미생성
- [ ] `make test` · `make typecheck` · `make validate` 통과