### PR TITLE
feat: rules-injector 컴팩션 static 회수·상태 GC·mode 제거

### DIFF
--- a/hooks/rules-injector/codex-hook.ts
+++ b/hooks/rules-injector/codex-hook.ts
@@ -169,6 +169,38 @@ export async function runPostToolUseHook(
 		return "";
 	}
 
+	const cachePath = sessionCachePath(input.session_id, options.pluginDataRoot);
+
+	// D-1/D-2 (Option C): one-shot static reclaim in the autonomous post-compaction
+	// window. Gated behind the lock-free hasPostCompactPending pre-check (a single
+	// unlocked read) so the steady-state hot path (the overwhelming majority of tool
+	// calls — no compaction pending) never pays for claimPostCompactPending's
+	// write-lock cycle. Runs before the no-target early-return so a no-target
+	// PostToolUse still reclaims (T1-AC7); after the disabled gate so the
+	// kill-switch is honored (T1-AC8). Reuses runStaticInjection's existing
+	// recovery path (buildPostCompactReadDirective / runPostCompactRecovery in
+	// static-injection.ts) rather than forking a parallel injector. Recovery
+	// completes the static channel in this one turn (no recovering-hold, lease
+	// freed); a budget-overflow tail stays un-marked in staticDedup and self-heals
+	// via the next UserPromptSubmit's existing normal static path.
+	let staticReclaimText = "";
+	if (hasPostCompactPending(cachePath)) {
+		const staticClaim = claimPostCompactPending(cachePath, "static");
+		if (staticClaim === "claimed") {
+			const staticOutput = runStaticInjection(
+				input.cwd,
+				input.transcript_path,
+				"PostToolUse",
+				cachePath,
+				options,
+				"static",
+				{ latestCompactedReplacementOnly: true },
+				input.model,
+			);
+			staticReclaimText = extractAdditionalContext(staticOutput);
+		}
+	}
+
 	const targetPaths = extractCodexToolPaths(unwrapShellCommandInput(input), input.cwd);
 	debugTimer.lap("extract", {
 		targets: targetPaths.length,
@@ -177,20 +209,22 @@ export async function runPostToolUseHook(
 	});
 	const firstTargetPath = targetPaths[0];
 	if (firstTargetPath === undefined) {
-		debugTimer.done({ outputBytes: 0, reason: "no-target" });
-		return "";
+		const output = formatAdditionalContextOutput("PostToolUse", staticReclaimText);
+		debugTimer.done({ outputBytes: Buffer.byteLength(output), reason: "no-target" });
+		return output;
 	}
 
-	const cachePath = sessionCachePath(input.session_id, options.pluginDataRoot);
 	const postCompactClaim = claimPostCompactPending(cachePath, "dynamic");
 	if (postCompactClaim === "not-pending" && transcriptHasContextPressureMarker(input.transcript_path)) {
-		debugTimer.done({ outputBytes: 0, reason: "context-pressure-transcript" });
-		return "";
+		const output = formatAdditionalContextOutput("PostToolUse", staticReclaimText);
+		debugTimer.done({ outputBytes: Buffer.byteLength(output), reason: "context-pressure-transcript" });
+		return output;
 	}
 	const completedPostCompactKind = claimedPostCompactKind(postCompactClaim, "dynamic");
 	if (shouldSkipPostCompactClaim(postCompactClaim, isPostCompactRecoveryInProgress(cachePath, "dynamic"))) {
-		debugTimer.done({ outputBytes: 0, reason: "post-compact-recovery-in-progress" });
-		return "";
+		const output = formatAdditionalContextOutput("PostToolUse", staticReclaimText);
+		debugTimer.done({ outputBytes: Buffer.byteLength(output), reason: "post-compact-recovery-in-progress" });
+		return output;
 	}
 	const dynamicConfig = withDynamicBudget(config);
 	const engine = createRulesEngine(
@@ -218,8 +252,9 @@ export async function runPostToolUseHook(
 	if (rules.length === 0) {
 		persistEngineState(engine, cachePath, completedPostCompactKind);
 		debugTimer.lap("persist", { reason: "no-rules" });
-		debugTimer.done({ outputBytes: 0, reason: "no-rules" });
-		return "";
+		const output = formatAdditionalContextOutput("PostToolUse", staticReclaimText);
+		debugTimer.done({ outputBytes: Buffer.byteLength(output), reason: "no-rules" });
+		return output;
 	}
 
 	// Attribute the injection header to the target that actually matched the rules being
@@ -248,8 +283,9 @@ export async function runPostToolUseHook(
 	if (emittedRules.length === 0) {
 		persistEngineState(engine, cachePath, completedPostCompactKind);
 		debugTimer.lap("persist", { reason: "all-dropped" });
-		debugTimer.done({ outputBytes: 0, reason: "all-dropped" });
-		return "";
+		const output = formatAdditionalContextOutput("PostToolUse", staticReclaimText);
+		debugTimer.done({ outputBytes: Buffer.byteLength(output), reason: "all-dropped" });
+		return output;
 	}
 	// P2 (dynamic analogue): mark only rules whose marker survives the 32K byte clamp.
 	// formatAdditionalContextOutput normalizes block then clamps to MAX_ADDITIONAL_CONTEXT_BYTES.
@@ -262,9 +298,35 @@ export async function runPostToolUseHook(
 	}
 	persistEngineState(engine, cachePath, completedPostCompactKind);
 	debugTimer.lap("persist", { reason: "emit" });
-	const output = formatAdditionalContextOutput("PostToolUse", block);
+	// D-2 merge seam: the static directive goes first (budget-sensitive, not
+	// cosmetic) and both raw strings are combined once at the tail into a single
+	// hookSpecificOutput envelope.
+	const output = formatAdditionalContextOutput("PostToolUse", combineContext(staticReclaimText, block));
 	debugTimer.done({ outputBytes: Buffer.byteLength(output), reason: "emit" });
 	return output;
+}
+
+/**
+ * D-2 merge seam: runStaticInjection always returns a fully wrapped hook JSON
+ * envelope (or ""), which is its correct contract for its other two callers
+ * (SessionStart, UserPromptSubmit — untouched). The PostToolUse static reclaim
+ * needs the raw additionalContext text so it can be combined with the dynamic
+ * block into a single envelope before the tail formatAdditionalContextOutput
+ * call. Unwrapping here keeps that merge local to the one caller that needs it.
+ */
+function extractAdditionalContext(wrappedOutput: string): string {
+	if (wrappedOutput.length === 0) return "";
+	try {
+		const parsed = JSON.parse(wrappedOutput) as { hookSpecificOutput?: { additionalContext?: string } };
+		return parsed.hookSpecificOutput?.additionalContext ?? "";
+	} catch {
+		return "";
+	}
+}
+
+/** Joins non-empty raw context blocks with a blank line, dropping empties. */
+function combineContext(...parts: readonly string[]): string {
+	return parts.filter((part) => part.trim().length > 0).join("\n\n");
 }
 
 /** Tool names whose payload carries a raw shell command that may be wrapper-wrapped. */

--- a/hooks/rules-injector/codex-hook.ts
+++ b/hooks/rules-injector/codex-hook.ts
@@ -4,7 +4,7 @@ import { dirname } from "node:path";
 import type { CodexRulesHookOptions } from "./codex-hook-options.js";
 import { configFromEnvironment } from "./config.js";
 import { hasContextPressureMarker, transcriptHasContextPressureMarker } from "./context-pressure.js";
-import { createHookDebugTimer, rotateErrorLog } from "./debug-log.js";
+import { createHookDebugTimer, rotateErrorLog, writeErrorBreadcrumb } from "./debug-log.js";
 import { withDynamicBudget } from "./event-budget.js";
 import { formatAdditionalContextOutput, limitAdditionalContextText } from "./hook-output.js";
 import { displayPath, uniqueStrings } from "./path-utils.js";
@@ -13,6 +13,7 @@ import {
 	clearSessionState,
 	hasPostCompactPending,
 	hydrateEngineState,
+	isPostCompactPending,
 	isPostCompactRecoveryInProgress,
 	markSessionCompacted,
 	persistEngineState,
@@ -24,7 +25,7 @@ import { claimedPostCompactKind, shouldSkipPostCompactClaim } from "./post-compa
 import type { DynamicLoadedRule } from "./rules/engine-dynamic-loader.js";
 import { formatDynamicBlock, ruleMarkerLine } from "./rules/index.js";
 import { createRulesEngine } from "./rules-engine-factory.js";
-import { runStaticInjection } from "./static-injection.js";
+import { combineStaticContext, runStaticInjection } from "./static-injection.js";
 import { extractCodexToolPaths } from "./tool-paths.js";
 import { filterRulesAlreadyInTranscript } from "./transcript-rule-filter.js";
 
@@ -194,19 +195,28 @@ export async function runPostToolUseHook(
 	const cachePath = sessionCachePath(input.session_id, options.pluginDataRoot);
 
 	// D-1/D-2 (Option C): one-shot static reclaim in the autonomous post-compaction
-	// window. Gated behind the lock-free hasPostCompactPending pre-check (a single
-	// unlocked read) so the steady-state hot path (the overwhelming majority of tool
-	// calls — no compaction pending) never pays for claimPostCompactPending's
-	// write-lock cycle. Runs before the no-target early-return so a no-target
-	// PostToolUse still reclaims (T1-AC7); after the disabled gate so the
-	// kill-switch is honored (T1-AC8). Reuses runStaticInjection's existing
-	// recovery path (buildPostCompactReadDirective / runPostCompactRecovery in
-	// static-injection.ts) rather than forking a parallel injector. Recovery
-	// completes the static channel in this one turn (no recovering-hold, lease
-	// freed); a budget-overflow tail stays un-marked in staticDedup and self-heals
-	// via the next UserPromptSubmit's existing normal static path.
+	// window. Gated behind a lock-free pre-check (two unlocked reads: is STATIC
+	// specifically pending, or already mid-recovery) so the steady-state hot path (the
+	// overwhelming majority of tool calls — no compaction pending) never pays for
+	// claimPostCompactPending's write-lock cycle. The check is narrowed to the static
+	// kind specifically: hasPostCompactPending(cachePath) would also be true when only
+	// DYNAMIC is pending, and claimPostCompactPending(cachePath, "static") would still
+	// pay for the write-lock cycle on a doomed "not-pending" claim in that case. Runs
+	// before the no-target early-return so a no-target PostToolUse still reclaims
+	// (T1-AC7); after the disabled gate so the kill-switch is honored (T1-AC8). Reuses
+	// runStaticInjection's existing recovery path (buildPostCompactReadDirective /
+	// runPostCompactRecovery in static-injection.ts) rather than forking a parallel
+	// injector. Recovery completes the static channel in this one turn (no
+	// recovering-hold, lease freed); a budget-overflow tail stays un-marked in
+	// staticDedup and self-heals via the next UserPromptSubmit's existing normal static
+	// path.
 	let staticReclaimText = "";
-	if (hasPostCompactPending(cachePath)) {
+	const returnStaticOnly = (reason: string): string => {
+		const output = formatAdditionalContextOutput("PostToolUse", staticReclaimText);
+		debugTimer.done({ outputBytes: Buffer.byteLength(output), reason });
+		return output;
+	};
+	if (isPostCompactPending(cachePath, "static") || isPostCompactRecoveryInProgress(cachePath, "static")) {
 		const staticClaim = claimPostCompactPending(cachePath, "static");
 		if (staticClaim === "claimed") {
 			const staticOutput = runStaticInjection(
@@ -231,22 +241,16 @@ export async function runPostToolUseHook(
 	});
 	const firstTargetPath = targetPaths[0];
 	if (firstTargetPath === undefined) {
-		const output = formatAdditionalContextOutput("PostToolUse", staticReclaimText);
-		debugTimer.done({ outputBytes: Buffer.byteLength(output), reason: "no-target" });
-		return output;
+		return returnStaticOnly("no-target");
 	}
 
 	const postCompactClaim = claimPostCompactPending(cachePath, "dynamic");
 	if (postCompactClaim === "not-pending" && transcriptHasContextPressureMarker(input.transcript_path)) {
-		const output = formatAdditionalContextOutput("PostToolUse", staticReclaimText);
-		debugTimer.done({ outputBytes: Buffer.byteLength(output), reason: "context-pressure-transcript" });
-		return output;
+		return returnStaticOnly("context-pressure-transcript");
 	}
 	const completedPostCompactKind = claimedPostCompactKind(postCompactClaim, "dynamic");
 	if (shouldSkipPostCompactClaim(postCompactClaim, isPostCompactRecoveryInProgress(cachePath, "dynamic"))) {
-		const output = formatAdditionalContextOutput("PostToolUse", staticReclaimText);
-		debugTimer.done({ outputBytes: Buffer.byteLength(output), reason: "post-compact-recovery-in-progress" });
-		return output;
+		return returnStaticOnly("post-compact-recovery-in-progress");
 	}
 	const dynamicConfig = withDynamicBudget(config);
 	const engine = createRulesEngine(
@@ -274,9 +278,7 @@ export async function runPostToolUseHook(
 	if (rules.length === 0) {
 		persistEngineState(engine, cachePath, completedPostCompactKind);
 		debugTimer.lap("persist", { reason: "no-rules" });
-		const output = formatAdditionalContextOutput("PostToolUse", staticReclaimText);
-		debugTimer.done({ outputBytes: Buffer.byteLength(output), reason: "no-rules" });
-		return output;
+		return returnStaticOnly("no-rules");
 	}
 
 	// Attribute the injection header to the target that actually matched the rules being
@@ -305,25 +307,26 @@ export async function runPostToolUseHook(
 	if (emittedRules.length === 0) {
 		persistEngineState(engine, cachePath, completedPostCompactKind);
 		debugTimer.lap("persist", { reason: "all-dropped" });
-		const output = formatAdditionalContextOutput("PostToolUse", staticReclaimText);
-		debugTimer.done({ outputBytes: Buffer.byteLength(output), reason: "all-dropped" });
-		return output;
+		return returnStaticOnly("all-dropped");
 	}
-	// P2 (dynamic analogue): mark only rules whose marker survives the 32K byte clamp.
-	// formatAdditionalContextOutput normalizes block then clamps to MAX_ADDITIONAL_CONTEXT_BYTES.
-	// A rule whose marker falls past the clamp must stay pending so the next turn re-injects it.
-	const limitedBlock = limitAdditionalContextText(block.replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim());
+	// P2 (dynamic analogue): mark only rules whose marker survives the 32K byte clamp
+	// applied to the ACTUAL emitted text. D-2 merge seam: the real output is
+	// staticReclaimText + block combined and clamped TOGETHER (formatAdditionalContextOutput
+	// below), not `block` clamped alone — clamping block alone under-counts the static
+	// prefix's bytes and can mark a rule "injected" whose marker the combined clamp
+	// actually cuts, silently dropping it forever. Compute the combined string once, mark
+	// against ITS clamp, then emit that same combined string (re-clamping an
+	// already-under-limit string is idempotent).
+	const combined = combineStaticContext(staticReclaimText, block);
+	const limitedCombined = limitAdditionalContextText(combined.replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim());
 	for (const rule of emittedRules) {
-		if (limitedBlock.includes(ruleMarkerLine(rule.path))) {
+		if (limitedCombined.includes(ruleMarkerLine(rule.path))) {
 			engine.markDynamicInjected(rule);
 		}
 	}
 	persistEngineState(engine, cachePath, completedPostCompactKind);
 	debugTimer.lap("persist", { reason: "emit" });
-	// D-2 merge seam: the static directive goes first (budget-sensitive, not
-	// cosmetic) and both raw strings are combined once at the tail into a single
-	// hookSpecificOutput envelope.
-	const output = formatAdditionalContextOutput("PostToolUse", combineContext(staticReclaimText, block));
+	const output = formatAdditionalContextOutput("PostToolUse", combined);
 	debugTimer.done({ outputBytes: Buffer.byteLength(output), reason: "emit" });
 	return output;
 }
@@ -341,14 +344,14 @@ function extractAdditionalContext(wrappedOutput: string): string {
 	try {
 		const parsed = JSON.parse(wrappedOutput) as { hookSpecificOutput?: { additionalContext?: string } };
 		return parsed.hookSpecificOutput?.additionalContext ?? "";
-	} catch {
+	} catch (error) {
+		// A non-empty, non-JSON result here means runStaticInjection's envelope contract
+		// (fully wrapped hook JSON or "") broke — swallowing that silently would mask a
+		// real regression as a merely-empty static reclaim. Leave the breadcrumb; the
+		// advisory exit-0 contract still holds (this hook must never throw).
+		writeErrorBreadcrumb("extractAdditionalContext:parse", error);
 		return "";
 	}
-}
-
-/** Joins non-empty raw context blocks with a blank line, dropping empties. */
-function combineContext(...parts: readonly string[]): string {
-	return parts.filter((part) => part.trim().length > 0).join("\n\n");
 }
 
 /** Tool names whose payload carries a raw shell command that may be wrapper-wrapped. */

--- a/hooks/rules-injector/codex-hook.ts
+++ b/hooks/rules-injector/codex-hook.ts
@@ -76,7 +76,7 @@ export async function runSessionStartHook(
 	options: CodexRulesHookOptions = {},
 ): Promise<string> {
 	const config = configFromEnvironment(options.env, input.cwd);
-	if (config.disabled || config.mode === "off" || config.mode === "dynamic") {
+	if (config.disabled) {
 		return "";
 	}
 	const cachePath = sessionCachePath(input.session_id, options.pluginDataRoot);
@@ -130,7 +130,7 @@ export async function runUserPromptSubmitHook(
 	options: CodexRulesHookOptions = {},
 ): Promise<string> {
 	const config = configFromEnvironment(options.env, input.cwd);
-	if (config.disabled || config.mode === "off" || config.mode === "dynamic") {
+	if (config.disabled) {
 		return "";
 	}
 	if (hasContextPressureMarker(input.prompt)) {
@@ -163,8 +163,8 @@ export async function runPostToolUseHook(
 ): Promise<string> {
 	const debugTimer = createHookDebugTimer("PostToolUse");
 	const config = configFromEnvironment(options.env, input.cwd);
-	debugTimer.lap("config", { disabled: config.disabled, mode: config.mode });
-	if (config.disabled || config.mode === "off" || config.mode === "static") {
+	debugTimer.lap("config", { disabled: config.disabled });
+	if (config.disabled) {
 		debugTimer.done({ outputBytes: 0, reason: "disabled" });
 		return "";
 	}

--- a/hooks/rules-injector/codex-hook.ts
+++ b/hooks/rules-injector/codex-hook.ts
@@ -1,7 +1,10 @@
+import { existsSync, utimesSync } from "node:fs";
+import { dirname } from "node:path";
+
 import type { CodexRulesHookOptions } from "./codex-hook-options.js";
 import { configFromEnvironment } from "./config.js";
 import { hasContextPressureMarker, transcriptHasContextPressureMarker } from "./context-pressure.js";
-import { createHookDebugTimer } from "./debug-log.js";
+import { createHookDebugTimer, rotateErrorLog } from "./debug-log.js";
 import { withDynamicBudget } from "./event-budget.js";
 import { formatAdditionalContextOutput, limitAdditionalContextText } from "./hook-output.js";
 import { displayPath, uniqueStrings } from "./path-utils.js";
@@ -14,6 +17,7 @@ import {
 	markSessionCompacted,
 	persistEngineState,
 	sessionCachePath,
+	sweepStaleSessionStates,
 } from "./persistent-cache.js";
 import { withPostCompactBudget } from "./post-compact-budget.js";
 import { claimedPostCompactKind, shouldSkipPostCompactClaim } from "./post-compact-claim.js";
@@ -80,6 +84,24 @@ export async function runSessionStartHook(
 		return "";
 	}
 	const cachePath = sessionCachePath(input.session_id, options.pluginDataRoot);
+
+	// D-6: best-effort GC pre-step, run before any clear/recovery logic so it can
+	// never perturb recovery. Order matters: touch our own mtime FIRST — a
+	// concurrent-resume session must never look stale to the sibling sweep that
+	// follows in the same call. Days->ms conversion happens here at the call site;
+	// sweepStaleSessionStates/rotateErrorLog already swallow their own errors, so
+	// only the touch step needs its own try/catch.
+	try {
+		if (existsSync(cachePath)) {
+			const now = new Date();
+			utimesSync(cachePath, now, now);
+		}
+	} catch {
+		// best-effort; must never throw into the hook
+	}
+	sweepStaleSessionStates(dirname(cachePath), config.sessionStateTtlDays * 86_400_000, cachePath);
+	rotateErrorLog(config.errorLogMaxBytes);
+
 	if (input.source === "clear") {
 		clearSessionState(cachePath);
 	} else if (input.source !== "resume" && input.source !== "compact" && !hasPostCompactPending(cachePath)) {

--- a/hooks/rules-injector/config.test.ts
+++ b/hooks/rules-injector/config.test.ts
@@ -84,3 +84,29 @@ test("session-state TTL and error-log cap defaults + override", () => {
 	const invalidFallback = configFromEnvironment({ CODEX_RULES_SESSION_STATE_TTL_DAYS: "abc" });
 	expect(invalidFallback.sessionStateTtlDays).toBe(7);
 });
+
+test("session-state TTL: PI_RULES_ alias also overrides", () => {
+	const ttlOverride = configFromEnvironment({ PI_RULES_SESSION_STATE_TTL_DAYS: "4" });
+	expect(ttlOverride.sessionStateTtlDays).toBe(4);
+});
+
+test("error-log cap: CODEX_RULES_ alias also overrides", () => {
+	const errorLogOverride = configFromEnvironment({ CODEX_RULES_ERROR_LOG_MAX_BYTES: "2000" });
+	expect(errorLogOverride.errorLogMaxBytes).toBe(2000);
+});
+
+test("session-state TTL: CODEX_RULES_ takes precedence over PI_RULES_ when both set", () => {
+	const config = configFromEnvironment({
+		CODEX_RULES_SESSION_STATE_TTL_DAYS: "5",
+		PI_RULES_SESSION_STATE_TTL_DAYS: "9",
+	});
+	expect(config.sessionStateTtlDays).toBe(5);
+});
+
+test("error-log cap: CODEX_RULES_ takes precedence over PI_RULES_ when both set", () => {
+	const config = configFromEnvironment({
+		CODEX_RULES_ERROR_LOG_MAX_BYTES: "3000",
+		PI_RULES_ERROR_LOG_MAX_BYTES: "6000",
+	});
+	expect(config.errorLogMaxBytes).toBe(3000);
+});

--- a/hooks/rules-injector/config.test.ts
+++ b/hooks/rules-injector/config.test.ts
@@ -67,3 +67,20 @@ test("C6: DISABLE_BUNDLED=0 (unset) keeps enabledSources as auto", () => {
 	const config = configFromEnvironment({});
 	expect(config.enabledSources).toBe("auto");
 });
+
+// ── D-7: sessionStateTtlDays / errorLogMaxBytes defaults + env override ─────
+
+test("session-state TTL and error-log cap defaults + override", () => {
+	const defaults = configFromEnvironment({});
+	expect(defaults.sessionStateTtlDays).toBe(7);
+	expect(defaults.errorLogMaxBytes).toBe(5_242_880);
+
+	const ttlOverride = configFromEnvironment({ CODEX_RULES_SESSION_STATE_TTL_DAYS: "3" });
+	expect(ttlOverride.sessionStateTtlDays).toBe(3);
+
+	const errorLogOverride = configFromEnvironment({ PI_RULES_ERROR_LOG_MAX_BYTES: "1000" });
+	expect(errorLogOverride.errorLogMaxBytes).toBe(1000);
+
+	const invalidFallback = configFromEnvironment({ CODEX_RULES_SESSION_STATE_TTL_DAYS: "abc" });
+	expect(invalidFallback.sessionStateTtlDays).toBe(7);
+});

--- a/hooks/rules-injector/config.ts
+++ b/hooks/rules-injector/config.ts
@@ -47,6 +47,12 @@ export function configFromEnvironment(env: NodeJS.ProcessEnv = process.env, cwd?
 		firstEnv(env, "CODEX_RULES_ENABLED_SOURCES", "PI_RULES_ENABLED_SOURCES"),
 		disableBundledRules,
 	);
+	config.sessionStateTtlDays =
+		parsePositiveInteger(firstEnv(env, "CODEX_RULES_SESSION_STATE_TTL_DAYS", "PI_RULES_SESSION_STATE_TTL_DAYS")) ??
+		config.sessionStateTtlDays;
+	config.errorLogMaxBytes =
+		parsePositiveInteger(firstEnv(env, "CODEX_RULES_ERROR_LOG_MAX_BYTES", "PI_RULES_ERROR_LOG_MAX_BYTES")) ??
+		config.errorLogMaxBytes;
 	return config;
 }
 

--- a/hooks/rules-injector/debug-log.ts
+++ b/hooks/rules-injector/debug-log.ts
@@ -1,4 +1,4 @@
-import { appendFileSync, mkdirSync } from "node:fs";
+import { appendFileSync, mkdirSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { performance } from "node:perf_hooks";
@@ -80,5 +80,22 @@ export function writeErrorBreadcrumb(context: string, error: unknown): void {
 		appendFileSync(sink, `[${new Date().toISOString()}] ${context}: ${detail}\n`);
 	} catch {
 		// best-effort; the error sink must never throw or block the turn
+	}
+}
+
+/**
+ * Best-effort rotation for the error.log breadcrumb sink (D-5). If the log has
+ * grown past `maxBytes`, truncate it to empty — no generation kept, no
+ * rename/backup. Never throws; a missing file or stat/write fault is a silent
+ * no-op, mirroring `writeErrorBreadcrumb`'s never-throw discipline.
+ */
+export function rotateErrorLog(maxBytes: number): void {
+	try {
+		const sink = join(homedir(), ".omt", "rules-injector", "error.log");
+		if (statSync(sink).size > maxBytes) {
+			writeFileSync(sink, "");
+		}
+	} catch {
+		// best-effort; rotation must never throw or block the turn
 	}
 }

--- a/hooks/rules-injector/error-log-rotate.test.ts
+++ b/hooks/rules-injector/error-log-rotate.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+// HERMETIC HOME: rotateErrorLog derives its sink from node:os homedir(), which
+// under Bun is resolved once at process start and does NOT follow a mutation
+// of process.env.HOME within the same process (unlike Node). So each test
+// spawns a fresh `bun` subprocess with HOME pinned to a temp dir at spawn
+// time — the only way to make homedir() observe the override — keeping the
+// real ~/.omt/rules-injector/error.log untouched.
+const DEBUG_LOG_URL = pathToFileURL(join(dirname(fileURLToPath(import.meta.url)), "debug-log.ts")).href;
+
+function sinkFor(home: string): string {
+	return join(home, ".omt", "rules-injector", "error.log");
+}
+
+function runRotate(home: string, maxBytes: number): void {
+	const result = spawnSync(
+		"bun",
+		["-e", `const { rotateErrorLog } = await import(${JSON.stringify(DEBUG_LOG_URL)}); rotateErrorLog(${maxBytes});`],
+		{ env: { ...process.env, HOME: home }, encoding: "utf-8" },
+	);
+	if (result.status !== 0) {
+		throw new Error(`rotateErrorLog subprocess failed: ${result.stderr}`);
+	}
+}
+
+test("truncates oversized error.log", () => {
+	const home = mkdtempSync(join(tmpdir(), "ri-error-log-"));
+	const sink = sinkFor(home);
+	mkdirSync(dirname(sink), { recursive: true });
+	writeFileSync(sink, "x".repeat(100));
+	expect(statSync(sink).size).toBe(100);
+
+	runRotate(home, 10);
+
+	expect(statSync(sink).size).toBe(0);
+});
+
+test("rotate leaves under-cap log untouched", () => {
+	const home = mkdtempSync(join(tmpdir(), "ri-error-log-"));
+	const sink = sinkFor(home);
+	mkdirSync(dirname(sink), { recursive: true });
+	writeFileSync(sink, "x".repeat(5));
+	expect(statSync(sink).size).toBe(5);
+
+	runRotate(home, 10);
+
+	expect(statSync(sink).size).toBe(5);
+});
+
+test("rotate error is swallowed", () => {
+	// Force a genuine fault: make the sink path itself a directory. statSync
+	// succeeds (non-zero size), the size check passes, but writeFileSync on a
+	// directory throws EISDIR — rotateErrorLog must swallow it and never throw
+	// (the subprocess must still exit 0).
+	const home = mkdtempSync(join(tmpdir(), "ri-error-log-"));
+	const sink = sinkFor(home);
+	mkdirSync(sink, { recursive: true });
+
+	expect(() => runRotate(home, 0)).not.toThrow();
+});

--- a/hooks/rules-injector/persistent-cache.ts
+++ b/hooks/rules-injector/persistent-cache.ts
@@ -223,7 +223,7 @@ export function sweepStaleSessionStates(dir: string, ttlMs: number, ownCachePath
 				continue;
 			}
 			try {
-				if (!isStale(siblingPath, ttlMs) || hasLiveLockHolder(siblingPath)) {
+				if (!isStale(siblingPath, ttlMs) || !isSessionStateFile(siblingPath) || hasLiveLockHolder(siblingPath)) {
 					continue;
 				}
 				clearSessionState(siblingPath);
@@ -267,6 +267,20 @@ function isStale(path: string, ttlMs: number): boolean {
 function hasLiveLockHolder(cachePath: string): boolean {
 	const pid = readLockHolderPid(`${cachePath}.lock`);
 	return pid !== undefined && isPidAlive(pid);
+}
+
+// Positively identify one of our own <sid>.json records before deleting. When
+// pluginDataRoot points at a directory shared with unrelated JSON (a config or
+// package.json), a stale `.json` sibling that is NOT a session-state record must
+// never be reaped. Mirrors readSessionState's discriminator (version + shape);
+// a corrupt/foreign file fails it and is left untouched rather than deleted.
+function isSessionStateFile(path: string): boolean {
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf8"));
+		return isRecord(parsed) && parsed["version"] === STATE_VERSION && isSerializedSessionState(parsed);
+	} catch {
+		return false;
+	}
 }
 
 function readSessionState(cachePath: string): SerializedSessionState {

--- a/hooks/rules-injector/persistent-cache.ts
+++ b/hooks/rules-injector/persistent-cache.ts
@@ -19,6 +19,7 @@ import {
 } from "./recovery-lease.js";
 import type { Engine } from "./rules/index.js";
 import {
+	readLockHolderPid,
 	SESSION_STATE_LOCK_CONTENDED,
 	type SessionStateLockResult,
 	withSessionStateLock,
@@ -261,16 +262,11 @@ function isStale(path: string, ttlMs: number): boolean {
 	return statSync(path).mtimeMs + ttlMs < Date.now();
 }
 
-// Mirrors session-state-lock.ts's readLockHolderPid + isPidAlive check: a sibling
-// whose `.lock/pid` names a still-running process is being actively recovered and
-// must not be reaped out from under it.
+// A sibling whose `.lock/pid` names a still-running process is being actively
+// recovered and must not be reaped out from under it.
 function hasLiveLockHolder(cachePath: string): boolean {
-	try {
-		const pid = Number.parseInt(readFileSync(join(`${cachePath}.lock`, "pid"), "utf8").trim(), 10);
-		return Number.isInteger(pid) && pid > 0 && isPidAlive(pid);
-	} catch {
-		return false;
-	}
+	const pid = readLockHolderPid(`${cachePath}.lock`);
+	return pid !== undefined && isPidAlive(pid);
 }
 
 function readSessionState(cachePath: string): SerializedSessionState {

--- a/hooks/rules-injector/persistent-cache.ts
+++ b/hooks/rules-injector/persistent-cache.ts
@@ -1,7 +1,8 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { type Dirent, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
+import { writeErrorBreadcrumb } from "./debug-log.js";
 import {
 	type PostCompactPendingKind,
 	type PostCompactPendingState,
@@ -11,6 +12,7 @@ import {
 } from "./post-compact-state.js";
 import {
 	type RecoveryLease,
+	isPidAlive,
 	isRecoveryLease,
 	isRecoveryLeaseActive,
 	newRecoveryLease,
@@ -178,6 +180,97 @@ export function completePostCompactRecovery(cachePath: string, kind: PostCompact
 export function sessionCachePath(sessionId: string, pluginDataRoot?: string): string {
 	const root = pluginDataRoot ?? join(homedir(), ".omt", "rules-injector");
 	return join(root, `${safePathSegment(sessionId)}.json`);
+}
+
+// Reused as the leaked-directory backstop below: no legitimate lock hold lasts a
+// full day (the lock only wraps in-memory RMW), so this also doubles as the sweep
+// throttle window — at most once per `dir` per day, bounding the readdir+stat cost
+// on the pathological thousands-of-files dir this sweep targets.
+const STALE_SESSION_SWEEP_THROTTLE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Best-effort GC: deletes sibling `<sid>.json` session-state files (plus their
+ * `.lock` dir, via `clearSessionState`) whose mtime is older than `ttlMs`, except
+ * `ownCachePath` (self-preservation — a stale-mtime resume must never delete its
+ * own pending recovery state) and any sibling whose `.lock/pid` names a live
+ * process (never break mutual exclusion out from under an active holder).
+ * Throttled by a `last-swept` marker file so it runs at most once per 24h per
+ * `dir`. Every fs op is wrapped; on error it records a breadcrumb and continues.
+ * Never throws.
+ */
+export function sweepStaleSessionStates(dir: string, ttlMs: number, ownCachePath: string): void {
+	try {
+		if (isSweepThrottled(dir)) {
+			return;
+		}
+		touchSweepMarker(dir);
+
+		let entries: Dirent[];
+		try {
+			entries = readdirSync(dir, { withFileTypes: true });
+		} catch (error) {
+			writeErrorBreadcrumb("sweepStaleSessionStates:readdir", error);
+			return;
+		}
+
+		for (const entry of entries) {
+			if (!entry.isFile() || !entry.name.endsWith(".json")) {
+				continue;
+			}
+			const siblingPath = join(dir, entry.name);
+			if (siblingPath === ownCachePath) {
+				continue;
+			}
+			try {
+				if (!isStale(siblingPath, ttlMs) || hasLiveLockHolder(siblingPath)) {
+					continue;
+				}
+				clearSessionState(siblingPath);
+			} catch (error) {
+				writeErrorBreadcrumb("sweepStaleSessionStates:entry", error);
+			}
+		}
+	} catch (error) {
+		writeErrorBreadcrumb("sweepStaleSessionStates", error);
+	}
+}
+
+function sweepMarkerPath(dir: string): string {
+	return join(dir, "last-swept");
+}
+
+function isSweepThrottled(dir: string): boolean {
+	try {
+		return Date.now() - statSync(sweepMarkerPath(dir)).mtimeMs < STALE_SESSION_SWEEP_THROTTLE_MS;
+	} catch {
+		// No marker yet (or unreadable): not throttled.
+		return false;
+	}
+}
+
+function touchSweepMarker(dir: string): void {
+	try {
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(sweepMarkerPath(dir), "");
+	} catch (error) {
+		writeErrorBreadcrumb("sweepStaleSessionStates:marker", error);
+	}
+}
+
+function isStale(path: string, ttlMs: number): boolean {
+	return statSync(path).mtimeMs + ttlMs < Date.now();
+}
+
+// Mirrors session-state-lock.ts's readLockHolderPid + isPidAlive check: a sibling
+// whose `.lock/pid` names a still-running process is being actively recovered and
+// must not be reaped out from under it.
+function hasLiveLockHolder(cachePath: string): boolean {
+	try {
+		const pid = Number.parseInt(readFileSync(join(`${cachePath}.lock`, "pid"), "utf8").trim(), 10);
+		return Number.isInteger(pid) && pid > 0 && isPidAlive(pid);
+	} catch {
+		return false;
+	}
 }
 
 function readSessionState(cachePath: string): SerializedSessionState {

--- a/hooks/rules-injector/post-tool-use-static-reclaim.test.ts
+++ b/hooks/rules-injector/post-tool-use-static-reclaim.test.ts
@@ -9,7 +9,6 @@
  * normal static path (no new drain mechanism).
  */
 import { test, expect, beforeEach, afterEach } from "bun:test";
-import { dirname } from "node:path";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -22,7 +21,9 @@ import type {
 	CodexUserPromptSubmitInput,
 } from "./codex-hook.js";
 import { runPostCompactHook, runPostToolUseHook, runSessionStartHook, runUserPromptSubmitHook } from "./codex-hook.js";
-import { sessionCachePath } from "./persistent-cache.js";
+import { displayPath } from "./path-utils.js";
+import { claimPostCompactPending, sessionCachePath } from "./persistent-cache.js";
+import { ruleMarkerLine } from "./rules/index.js";
 
 let scratchDir = "";
 let pluginDataRoot = "";
@@ -157,10 +158,10 @@ test("first PostToolUse emits static recovery", async () => {
 // T1-AC2 — overflow tail re-emitted by next UserPromptSubmit
 // ---------------------------------------------------------------------------
 
-test("overflow tail re-emitted on next UserPromptSubmit", async () => {
+test("overflow tail re-emitted on next UserPromptSubmit, not drained by intervening PostToolUse", async () => {
 	const sessionId = "ac2-session";
 	const rule1Path = writeRule("ac2-a-rule1.md", "alwaysApply: true", "AC2_RULE1_BODY: recovered directly.");
-	writeRule("ac2-b-rule2.md", "alwaysApply: true", "AC2_RULE2_BODY: overflow tail.");
+	const rule2Path = writeRule("ac2-b-rule2.md", "alwaysApply: true", "AC2_RULE2_BODY: overflow tail.");
 	writeTarget();
 
 	await runSessionStartHook(sessionStartInput(sessionId), dataOptions());
@@ -176,12 +177,29 @@ test("overflow tail re-emitted on next UserPromptSubmit", async () => {
 	);
 	const reclaimCtx = parseContext(reclaim);
 	expect(reclaimCtx).toContain(rule1Path);
-	expect(reclaimCtx).not.toContain("AC2_RULE2_BODY");
+	// rule2's PATH LINE (the directive's actual unit of emission) is absent — a
+	// body-absence check alone would be vacuous, since directive-only recovery never
+	// emits rule bodies regardless of whether the path itself was dropped by budget.
+	expect(reclaimCtx).not.toContain(rule2Path);
+
+	// An intervening PostToolUse must NOT drain the overflow tail: Option C completes
+	// the static channel in the ONE reclaim turn (no PostToolUse-side drain
+	// mechanism) — rule2 must still be absent here too. No-target input isolates this
+	// from the (unrelated) dynamic-injection path, since an alwaysApply rule also
+	// matches the dynamic loader for any target (see T1-AC3a's note).
+	const intervening = await runPostToolUseHook(
+		postToolUseInput(sessionId, { tool_input: { command: "echo hello" } }),
+		dataOptions(),
+	);
+	const interveningCtx = parseContext(intervening);
+	expect(interveningCtx).not.toContain(rule2Path);
+	expect(interveningCtx).not.toContain(ruleMarkerLine(rule2Path));
 
 	// Next UserPromptSubmit (open budget): the overflow tail (rule2) self-heals via
-	// the existing normal static path — no drain mechanism on PostToolUse itself.
+	// the existing normal static path — its marker (and body) now appear.
 	const ups = await runUserPromptSubmitHook(userPromptInput(sessionId, "continue"), dataOptions());
 	const upsCtx = parseContext(ups);
+	expect(upsCtx).toContain(ruleMarkerLine(rule2Path));
 	expect(upsCtx).toContain("AC2_RULE2_BODY");
 	// rule1 was already recovered+marked — must not be re-emitted.
 	expect(upsCtx).not.toContain("AC2_RULE1_BODY");
@@ -252,21 +270,18 @@ test("no double static recovery under race", async () => {
 	const sessionId = "ac4-session";
 	writeRule("ac4-rule.md", "alwaysApply: true", "AC4_BOULDER: must not double-recover.");
 
-	// Simulate a PostToolUse recovery already IN FLIGHT (the state a real PostToolUse
-	// would have written right after claimPostCompactPending("static") succeeded):
-	// static moved pending -> recovering, with a fresh lease owned by this process.
+	await runSessionStartHook(sessionStartInput(sessionId), dataOptions());
+	await runPostCompactHook(postCompactInput(sessionId), dataOptions());
+
+	// Drive the REAL claim path — the exact claimPostCompactPending(cachePath, "static")
+	// call runPostToolUseHook makes internally (codex-hook.ts) — to move static recovery
+	// pending -> recovering with a fresh lease, simulating a PostToolUse recovery already
+	// IN FLIGHT from a concurrent process. Using the production state-transition function
+	// (rather than a hand-authored JSON fixture) exercises the actual claim/lease code
+	// this test is meant to guard, instead of a schema the test merely assumes.
 	const cachePath = sessionCachePath(sessionId, pluginDataRoot);
-	mkdirSync(dirname(cachePath), { recursive: true });
-	writeFileSync(
-		cachePath,
-		`${JSON.stringify({
-			version: 1,
-			staticDedup: [],
-			dynamicDedup: {},
-			postCompactRecovering: { static: true },
-			recoveryLease: { static: { ownerPid: process.pid, startedAt: Date.now(), leaseTTL: 60_000 } },
-		})}\n`,
-	);
+	const claim = claimPostCompactPending(cachePath, "static");
+	expect(claim).toBe("claimed");
 
 	// A UserPromptSubmit racing against that in-flight recovery must be suppressed
 	// by the existing (untouched) lease/contended guard — no double recovery, and no
@@ -283,15 +298,28 @@ test("no double static recovery under race", async () => {
 test("no static when not post-compact", async () => {
 	const sessionId = "ac6-session";
 	writeRule("ac6-rule.md", "alwaysApply: true", "AC6_BOULDER: never appears without compaction.");
-	writeTarget();
 
 	// Normal SessionStart, no compaction ever happened for this session.
 	await runSessionStartHook(sessionStartInput(sessionId), dataOptions());
 
-	const result = await runPostToolUseHook(postToolUseInput(sessionId), dataOptions());
-	const ctx = parseContext(result);
+	const cachePath = sessionCachePath(sessionId, pluginDataRoot);
+	const stateBefore = readFileSync(cachePath, "utf8");
 
+	// No-target call: isolates the lock-free pre-check from the (unrelated) dynamic
+	// path's own persistEngineState write, so any session-state change observed below
+	// can only have come from the static claim's write-lock cycle.
+	const result = await runPostToolUseHook(
+		postToolUseInput(sessionId, { tool_input: { command: "echo hello" } }),
+		dataOptions(),
+	);
+	const ctx = parseContext(result);
 	expect(ctx).not.toContain("POST-COMPACTION RULE RECOVERY");
+
+	// Prove the short-circuit actually fired (not just that no static text happened to
+	// appear): with nothing pending, claimPostCompactPending("static") must never run
+	// its write-lock cycle, so the session-state file is byte-identical afterward.
+	const stateAfter = readFileSync(cachePath, "utf8");
+	expect(stateAfter).toBe(stateBefore);
 });
 
 // ---------------------------------------------------------------------------
@@ -340,4 +368,103 @@ test("no reclaim when disabled", async () => {
 	const reenabled = await runPostToolUseHook(postToolUseInput(sessionId), dataOptions());
 	const ctx = parseContext(reenabled);
 	expect(ctx).toContain("POST-COMPACTION RULE RECOVERY");
+});
+
+// ---------------------------------------------------------------------------
+// Byte-clamp regression — a rule dropped by the COMBINED (static + dynamic)
+// 32K clamp must not be marked dynamicInjected. The dynamic-dedup marking must
+// be computed against the SAME string that is actually emitted
+// (staticReclaimText + dynamic block, clamped together), not against the
+// dynamic block clamped alone — clamping the block alone under-counts the
+// static prefix's bytes and can mark a rule "injected" that the real output
+// never delivered, silently dropping it forever.
+// ---------------------------------------------------------------------------
+
+test("dynamic rule dropped by the combined static+dynamic clamp is not marked injected", async () => {
+	// Scope rule discovery to just this project's .claude/rules so the byte math below
+	// is not perturbed by whatever global (~/.claude/rules) rules happen to exist on the
+	// machine running this test.
+	const scopedEnv = {
+		CODEX_RULES_ENABLED_SOURCES: ".claude/rules",
+		CODEX_RULES_MAX_RULE_CHARS: "100000",
+		CODEX_RULES_MAX_RESULT_CHARS: "100000",
+		CODEX_RULES_DYNAMIC_MAX_RULE_CHARS: "100000",
+		CODEX_RULES_DYNAMIC_MAX_RESULT_CHARS: "100000",
+		// The first PostToolUse after compaction also claims the (separate) "dynamic"
+		// post-compact channel, which applies withPostCompactBudget on top of the dynamic
+		// budget above — override its defaults too so the char-budget layer never
+		// truncates ahead of the 32K byte clamp under test.
+		CODEX_RULES_POST_COMPACT_MAX_RULE_CHARS: "100000",
+		CODEX_RULES_POST_COMPACT_MAX_RESULT_CHARS: "100000",
+	};
+	writeRule("clamp-static.md", "alwaysApply: true", "CLAMP_STATIC_BODY_MARKER");
+	const tailPath = writeRule("z-tail.md", 'globs: ["**/*.ts"]', "TAIL_BODY_MARKER");
+	const fillerPath = join(projectDir, ".claude", "rules", "a-filler.md");
+	writeTarget();
+
+	// Measure the exact static-reclaim directive byte length for THIS run's absolute
+	// rule path (varies per test run via mkdtempSync) using a disposable probe session.
+	// Option C completes the static channel in ONE turn, so the probe must never be
+	// reused for the real assertions below.
+	const probeSessionId = "clamp-probe-session";
+	await runSessionStartHook(sessionStartInput(probeSessionId), dataOptions(scopedEnv));
+	await runPostCompactHook(postCompactInput(probeSessionId), dataOptions(scopedEnv));
+	const probeResult = await runPostToolUseHook(
+		postToolUseInput(probeSessionId, { tool_input: { command: "echo hello" } }),
+		dataOptions(scopedEnv),
+	);
+	const staticReclaimBytes = Buffer.byteLength(parseContext(probeResult), "utf8");
+	const MAX_BYTES = 32_000;
+	// Overshoot must stay well under staticReclaimBytes so the DYNAMIC BLOCK ALONE still
+	// fits under the cap (block-alone clamp is a no-op, tail marker trivially survives it)
+	// while the COMBINED text (static prefix + block) is pushed past the cap by exactly
+	// this many bytes once the static directive is prepended.
+	const OVERSHOOT_MARGIN = 300;
+	expect(staticReclaimBytes).toBeGreaterThan(OVERSHOOT_MARGIN);
+
+	// Reproduce formatDynamicBlock's exact layout (rules/formatter.ts) to size the filler
+	// rule so the tail rule's marker lands just under the cap in the block ALONE.
+	const targetRelativePath = displayPath(projectDir, join(projectDir, "src", "x.ts"));
+	const header = `Additional project instructions matched for ${targetRelativePath}:`;
+	const fillerMarker = ruleMarkerLine(fillerPath);
+	const tailMarker = ruleMarkerLine(tailPath);
+	const tailBody = "TAIL_BODY_MARKER";
+	const RULE_BLOCK_CLOSE = "\n</rules>";
+	const fixedOverhead =
+		header.length +
+		2 + // header -> rules separator
+		fillerMarker.length +
+		1 + // marker -> body newline
+		RULE_BLOCK_CLOSE.length +
+		2 + // filler -> tail separator
+		tailMarker.length +
+		1 + // marker -> body newline
+		tailBody.length +
+		RULE_BLOCK_CLOSE.length;
+	const blockLenTarget = MAX_BYTES - staticReclaimBytes - 2 + OVERSHOOT_MARGIN;
+	const fillerLen = blockLenTarget - fixedOverhead;
+	expect(fillerLen).toBeGreaterThan(0);
+	writeFileSync(fillerPath, `---\nglobs: ["**/*.ts"]\n---\n${"F".repeat(fillerLen)}\n`);
+
+	const realSessionId = "clamp-real-session";
+	await runSessionStartHook(sessionStartInput(realSessionId), dataOptions(scopedEnv));
+	await runPostCompactHook(postCompactInput(realSessionId), dataOptions(scopedEnv));
+
+	const first = await runPostToolUseHook(postToolUseInput(realSessionId), dataOptions(scopedEnv));
+	const firstCtx = parseContext(first);
+
+	// Sanity: the combined output actually got clamped, and the filler (which sits
+	// well before the cut point) survived while the tail was cut.
+	expect(Buffer.byteLength(firstCtx, "utf8")).toBeLessThanOrEqual(MAX_BYTES);
+	expect(firstCtx).toContain(fillerMarker);
+	expect(firstCtx).not.toContain(tailMarker);
+
+	// THE REGRESSION CHECK: the tail rule was dropped from what was actually emitted, so
+	// it must stay pending — a second PostToolUse in the SAME session (static channel
+	// already complete, so no static text competes for budget this time) must be able to
+	// re-offer it. Under the byte-clamp bug, the tail rule was wrongly marked injected on
+	// the first call and would never reappear here.
+	const second = await runPostToolUseHook(postToolUseInput(realSessionId), dataOptions(scopedEnv));
+	const secondCtx = parseContext(second);
+	expect(secondCtx).toContain(tailMarker);
 });

--- a/hooks/rules-injector/post-tool-use-static-reclaim.test.ts
+++ b/hooks/rules-injector/post-tool-use-static-reclaim.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Task1 — PostToolUse static reclaim (Option C, one-shot). See D-1/D-2/D-3 in
+ * plans/rules-injector-improvements.md.
+ *
+ * The first post-compaction PostToolUse restores always-apply (static) rules via a
+ * directive-only (pointer) recovery, completing the static channel in ONE turn
+ * (Option C — no recovering-hold, lease freed). A budget-overflow tail stays
+ * un-marked in staticDedup and self-heals via the next UserPromptSubmit's existing
+ * normal static path (no new drain mechanism).
+ */
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { dirname } from "node:path";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type {
+	CodexPostCompactInput,
+	CodexPostToolUseInput,
+	CodexRulesHookOptions,
+	CodexSessionStartInput,
+	CodexUserPromptSubmitInput,
+} from "./codex-hook.js";
+import { runPostCompactHook, runPostToolUseHook, runSessionStartHook, runUserPromptSubmitHook } from "./codex-hook.js";
+import { sessionCachePath } from "./persistent-cache.js";
+
+let scratchDir = "";
+let pluginDataRoot = "";
+let projectDir = "";
+
+beforeEach(() => {
+	scratchDir = mkdtempSync(join(tmpdir(), "pt-reclaim-"));
+	pluginDataRoot = join(scratchDir, "data");
+	projectDir = join(scratchDir, "project");
+	mkdirSync(join(projectDir, ".claude", "rules"), { recursive: true });
+	mkdirSync(join(projectDir, "src"), { recursive: true });
+	writeFileSync(join(projectDir, "package.json"), '{"name":"pt-reclaim"}\n');
+});
+
+afterEach(() => {
+	if (scratchDir.length > 0) rmSync(scratchDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function writeRule(fileName: string, frontmatter: string, body: string): string {
+	const rulePath = join(projectDir, ".claude", "rules", fileName);
+	writeFileSync(rulePath, `---\n${frontmatter}\n---\n${body}\n`);
+	return rulePath;
+}
+
+function writeTarget(): void {
+	writeFileSync(join(projectDir, "src", "x.ts"), "export const x = 1;\n");
+}
+
+function sessionStartInput(sessionId: string, overrides: Partial<CodexSessionStartInput> = {}): CodexSessionStartInput {
+	return {
+		session_id: sessionId,
+		transcript_path: null,
+		cwd: projectDir,
+		hook_event_name: "SessionStart",
+		model: "gpt-5.5",
+		permission_mode: "default",
+		source: "startup",
+		...overrides,
+	};
+}
+
+function postCompactInput(sessionId: string, overrides: Partial<CodexPostCompactInput> = {}): CodexPostCompactInput {
+	return {
+		session_id: sessionId,
+		turn_id: "compact-1",
+		transcript_path: null,
+		cwd: projectDir,
+		hook_event_name: "PostCompact",
+		model: "gpt-5.5",
+		trigger: "manual",
+		...overrides,
+	};
+}
+
+function postToolUseInput(sessionId: string, overrides: Partial<CodexPostToolUseInput> = {}): CodexPostToolUseInput {
+	return {
+		session_id: sessionId,
+		turn_id: "t1",
+		transcript_path: null,
+		cwd: projectDir,
+		hook_event_name: "PostToolUse",
+		model: "gpt-5.5",
+		permission_mode: "default",
+		tool_name: "Bash",
+		tool_input: { command: "cat src/x.ts" },
+		tool_response: {},
+		tool_use_id: "u1",
+		...overrides,
+	};
+}
+
+function userPromptInput(
+	sessionId: string,
+	prompt: string,
+	overrides: Partial<CodexUserPromptSubmitInput> = {},
+): CodexUserPromptSubmitInput {
+	return {
+		session_id: sessionId,
+		turn_id: "up-1",
+		transcript_path: null,
+		cwd: projectDir,
+		hook_event_name: "UserPromptSubmit",
+		model: "gpt-5.5",
+		permission_mode: "default",
+		prompt,
+		...overrides,
+	};
+}
+
+function parseContext(output: string): string {
+	if (output.trim().length === 0) return "";
+	const parsed = JSON.parse(output) as { hookSpecificOutput?: { additionalContext?: string } };
+	return parsed.hookSpecificOutput?.additionalContext ?? "";
+}
+
+function dataOptions(env?: Record<string, string>): CodexRulesHookOptions {
+	return env === undefined ? { pluginDataRoot } : { pluginDataRoot, env };
+}
+
+// ---------------------------------------------------------------------------
+// T1-AC1 — first post-compact PostToolUse emits static directive
+// ---------------------------------------------------------------------------
+
+test("first PostToolUse emits static recovery", async () => {
+	const sessionId = "ac1-session";
+	const rulePath = writeRule("ac1-rule.md", "alwaysApply: true", "AC1_BOULDER: recovered via PostToolUse.");
+	writeTarget();
+
+	const first = await runSessionStartHook(sessionStartInput(sessionId), dataOptions());
+	expect(first).toContain("AC1_BOULDER");
+
+	await runPostCompactHook(postCompactInput(sessionId), dataOptions());
+
+	const result = await runPostToolUseHook(postToolUseInput(sessionId), dataOptions());
+	const ctx = parseContext(result);
+	expect(ctx).toContain("POST-COMPACTION RULE RECOVERY");
+	expect(ctx).toContain(rulePath);
+
+	// Option C: the static channel completes THIS turn — recovering cleared, no
+	// held lease across turns.
+	const cachePath = sessionCachePath(sessionId, pluginDataRoot);
+	const state = JSON.parse(readFileSync(cachePath, "utf8")) as Record<string, unknown>;
+	const recovering = state["postCompactRecovering"] as Record<string, unknown> | undefined;
+	expect(recovering?.["static"]).toBeUndefined();
+});
+
+// ---------------------------------------------------------------------------
+// T1-AC2 — overflow tail re-emitted by next UserPromptSubmit
+// ---------------------------------------------------------------------------
+
+test("overflow tail re-emitted on next UserPromptSubmit", async () => {
+	const sessionId = "ac2-session";
+	const rule1Path = writeRule("ac2-a-rule1.md", "alwaysApply: true", "AC2_RULE1_BODY: recovered directly.");
+	writeRule("ac2-b-rule2.md", "alwaysApply: true", "AC2_RULE2_BODY: overflow tail.");
+	writeTarget();
+
+	await runSessionStartHook(sessionStartInput(sessionId), dataOptions());
+	await runPostCompactHook(postCompactInput(sessionId), dataOptions());
+
+	// Extremely tight post-compact budget: the buildPostCompactReadDirective
+	// implementation always admits the FIRST path regardless of budget (the
+	// lines.length===0 bypass) but rejects every subsequent one — deterministic
+	// regardless of temp-dir path length.
+	const reclaim = await runPostToolUseHook(
+		postToolUseInput(sessionId),
+		dataOptions({ CODEX_RULES_POST_COMPACT_MAX_RESULT_CHARS: "1" }),
+	);
+	const reclaimCtx = parseContext(reclaim);
+	expect(reclaimCtx).toContain(rule1Path);
+	expect(reclaimCtx).not.toContain("AC2_RULE2_BODY");
+
+	// Next UserPromptSubmit (open budget): the overflow tail (rule2) self-heals via
+	// the existing normal static path — no drain mechanism on PostToolUse itself.
+	const ups = await runUserPromptSubmitHook(userPromptInput(sessionId, "continue"), dataOptions());
+	const upsCtx = parseContext(ups);
+	expect(upsCtx).toContain("AC2_RULE2_BODY");
+	// rule1 was already recovered+marked — must not be re-emitted.
+	expect(upsCtx).not.toContain("AC2_RULE1_BODY");
+});
+
+// ---------------------------------------------------------------------------
+// T1-AC3a — reclaim output has no dynamic body
+// ---------------------------------------------------------------------------
+
+test("static reclaim excludes dynamic body", async () => {
+	const sessionId = "ac3a-session";
+	const rulePath = writeRule("ac3a-rule.md", "alwaysApply: true", "AC3A_STATIC_BODY: pointer only.");
+
+	await runSessionStartHook(sessionStartInput(sessionId), dataOptions());
+	await runPostCompactHook(postCompactInput(sessionId), dataOptions());
+
+	// No target path: dynamic injection never runs (see T1-AC7), isolating the
+	// static reclaim's own contribution. NOTE: an alwaysApply rule also matches the
+	// DYNAMIC loader (matcher.ts) for any target, so a target-present call would let
+	// the dynamic path re-emit this rule's full body independently of the reclaim —
+	// the no-target call is what actually isolates "reclaim output has no dynamic
+	// body" as a property of the reclaim itself.
+	const result = await runPostToolUseHook(
+		postToolUseInput(sessionId, { tool_input: { command: "echo hello" } }),
+		dataOptions(),
+	);
+	const ctx = parseContext(result);
+
+	expect(ctx).toContain("POST-COMPACTION RULE RECOVERY");
+	expect(ctx).toContain(rulePath);
+	// Directive-only: no dynamic block header, and no full rule BODY (only the path
+	// pointer — the body itself is never emitted by the directive-only recovery for
+	// a non-never-truncated rule).
+	expect(ctx).not.toContain("Additional project instructions matched for");
+	expect(ctx).not.toContain("AC3A_STATIC_BODY");
+});
+
+// ---------------------------------------------------------------------------
+// T1-AC3b — path-matched file still gets dynamic injection same call
+// ---------------------------------------------------------------------------
+
+test("dynamic injection still fires alongside static directive", async () => {
+	const sessionId = "ac3b-session";
+	const staticRulePath = writeRule("ac3b-static.md", "alwaysApply: true", "AC3B_STATIC_BODY: recovered pointer.");
+	writeRule("ac3b-dynamic.md", 'globs: ["**/*.ts"]', "AC3B_DYNAMIC_MARKER: matched target file.");
+	writeTarget();
+
+	await runSessionStartHook(sessionStartInput(sessionId), dataOptions());
+	await runPostCompactHook(postCompactInput(sessionId), dataOptions());
+
+	const result = await runPostToolUseHook(postToolUseInput(sessionId), dataOptions());
+	const ctx = parseContext(result);
+
+	// Static reclaim directive present ...
+	expect(ctx).toContain("POST-COMPACTION RULE RECOVERY");
+	expect(ctx).toContain(staticRulePath);
+	// ... AND the dynamic glob rule matched by the same tool call still injects, in
+	// the SAME hook return (single merged envelope, static directive first).
+	expect(ctx).toContain("AC3B_DYNAMIC_MARKER");
+	expect(ctx.indexOf("POST-COMPACTION RULE RECOVERY")).toBeLessThan(ctx.indexOf("AC3B_DYNAMIC_MARKER"));
+});
+
+// ---------------------------------------------------------------------------
+// T1-AC4 — no double static recovery under a UPS race
+// ---------------------------------------------------------------------------
+
+test("no double static recovery under race", async () => {
+	const sessionId = "ac4-session";
+	writeRule("ac4-rule.md", "alwaysApply: true", "AC4_BOULDER: must not double-recover.");
+
+	// Simulate a PostToolUse recovery already IN FLIGHT (the state a real PostToolUse
+	// would have written right after claimPostCompactPending("static") succeeded):
+	// static moved pending -> recovering, with a fresh lease owned by this process.
+	const cachePath = sessionCachePath(sessionId, pluginDataRoot);
+	mkdirSync(dirname(cachePath), { recursive: true });
+	writeFileSync(
+		cachePath,
+		`${JSON.stringify({
+			version: 1,
+			staticDedup: [],
+			dynamicDedup: {},
+			postCompactRecovering: { static: true },
+			recoveryLease: { static: { ownerPid: process.pid, startedAt: Date.now(), leaseTTL: 60_000 } },
+		})}\n`,
+	);
+
+	// A UserPromptSubmit racing against that in-flight recovery must be suppressed
+	// by the existing (untouched) lease/contended guard — no double recovery, and no
+	// silent regression to the untouched UPS caller (the exact hazard that refuted
+	// Option A in D-1).
+	const result = await runUserPromptSubmitHook(userPromptInput(sessionId, "continue"), dataOptions());
+	expect(parseContext(result)).toBe("");
+});
+
+// ---------------------------------------------------------------------------
+// T1-AC6 — steady-state no-op (lock-free gated)
+// ---------------------------------------------------------------------------
+
+test("no static when not post-compact", async () => {
+	const sessionId = "ac6-session";
+	writeRule("ac6-rule.md", "alwaysApply: true", "AC6_BOULDER: never appears without compaction.");
+	writeTarget();
+
+	// Normal SessionStart, no compaction ever happened for this session.
+	await runSessionStartHook(sessionStartInput(sessionId), dataOptions());
+
+	const result = await runPostToolUseHook(postToolUseInput(sessionId), dataOptions());
+	const ctx = parseContext(result);
+
+	expect(ctx).not.toContain("POST-COMPACTION RULE RECOVERY");
+});
+
+// ---------------------------------------------------------------------------
+// T1-AC7 — no-target PostToolUse still emits the one-shot reclaim
+// ---------------------------------------------------------------------------
+
+test("reclaim fires when PostToolUse has no path", async () => {
+	const sessionId = "ac7-session";
+	const rulePath = writeRule("ac7-rule.md", "alwaysApply: true", "AC7_BOULDER: no-target still reclaims.");
+
+	await runSessionStartHook(sessionStartInput(sessionId), dataOptions());
+	await runPostCompactHook(postCompactInput(sessionId), dataOptions());
+
+	// "echo hello" resolves to zero target paths: neither token is an existing file,
+	// and addCommandPaths requires mustExist for Bash-tool tokens.
+	const result = await runPostToolUseHook(
+		postToolUseInput(sessionId, { tool_input: { command: "echo hello" } }),
+		dataOptions(),
+	);
+	const ctx = parseContext(result);
+
+	expect(ctx).toContain("POST-COMPACTION RULE RECOVERY");
+	expect(ctx).toContain(rulePath);
+});
+
+// ---------------------------------------------------------------------------
+// T1-AC8 — reclaim honors the disabled kill-switch
+// ---------------------------------------------------------------------------
+
+test("no reclaim when disabled", async () => {
+	const sessionId = "ac8-session";
+	writeRule("ac8-rule.md", "alwaysApply: true", "AC8_BOULDER: must not leak under kill-switch.");
+	writeTarget();
+
+	await runSessionStartHook(sessionStartInput(sessionId), dataOptions());
+	await runPostCompactHook(postCompactInput(sessionId), dataOptions());
+
+	const disabledResult = await runPostToolUseHook(
+		postToolUseInput(sessionId),
+		dataOptions({ CODEX_RULES_DISABLED: "1" }),
+	);
+	expect(disabledResult).toBe("");
+
+	// The disabled run must not have consumed the pending state: re-enabling later
+	// still sees it pending (mirrors the existing C2 SessionStart guarantee).
+	const reenabled = await runPostToolUseHook(postToolUseInput(sessionId), dataOptions());
+	const ctx = parseContext(reenabled);
+	expect(ctx).toContain("POST-COMPACTION RULE RECOVERY");
+});

--- a/hooks/rules-injector/rules/constants.ts
+++ b/hooks/rules-injector/rules/constants.ts
@@ -104,6 +104,16 @@ export const DEFAULT_PROMPT_MAX_RULE_CHARS = 6000;
 export const DEFAULT_PROMPT_MAX_RESULT_CHARS = 16000;
 
 /**
+ * Session-state cache TTL, in days (default).
+ */
+export const DEFAULT_SESSION_STATE_TTL_DAYS = 7;
+
+/**
+ * Error log file size cap, in bytes (default).
+ */
+export const DEFAULT_ERROR_LOG_MAX_BYTES = 5_242_880;
+
+/**
  * Truncation marker template. `{path}` is replaced with the relative path.
  */
 export const TRUNCATION_NOTICE = "\n\n[Truncated. Full: {path}]";

--- a/hooks/rules-injector/rules/engine.ts
+++ b/hooks/rules-injector/rules/engine.ts
@@ -9,12 +9,14 @@ import {
 import {
 	DEFAULT_DYNAMIC_MAX_RESULT_CHARS,
 	DEFAULT_DYNAMIC_MAX_RULE_CHARS,
+	DEFAULT_ERROR_LOG_MAX_BYTES,
 	DEFAULT_MAX_RESULT_CHARS,
 	DEFAULT_MAX_RULE_CHARS,
 	DEFAULT_POST_COMPACT_MAX_RESULT_CHARS,
 	DEFAULT_POST_COMPACT_MAX_RULE_CHARS,
 	DEFAULT_PROMPT_MAX_RESULT_CHARS,
 	DEFAULT_PROMPT_MAX_RULE_CHARS,
+	DEFAULT_SESSION_STATE_TTL_DAYS,
 } from "./constants.js";
 import { loadDynamicCandidates } from "./engine-dynamic-loader.js";
 import { loadStaticCandidates } from "./engine-static-loader.js";
@@ -28,7 +30,6 @@ export type { Engine, EngineDeps } from "./engine-types.js";
 export function defaultConfig(): PiRulesConfig {
 	return {
 		disabled: false,
-		mode: "both",
 		maxRuleChars: DEFAULT_MAX_RULE_CHARS,
 		maxResultChars: DEFAULT_MAX_RESULT_CHARS,
 		postCompactMaxRuleChars: DEFAULT_POST_COMPACT_MAX_RULE_CHARS,
@@ -38,6 +39,8 @@ export function defaultConfig(): PiRulesConfig {
 		promptMaxRuleChars: DEFAULT_PROMPT_MAX_RULE_CHARS,
 		promptMaxResultChars: DEFAULT_PROMPT_MAX_RESULT_CHARS,
 		enabledSources: "auto",
+		sessionStateTtlDays: DEFAULT_SESSION_STATE_TTL_DAYS,
+		errorLogMaxBytes: DEFAULT_ERROR_LOG_MAX_BYTES,
 	};
 }
 
@@ -47,7 +50,7 @@ export function createEngine(config: PiRulesConfig, deps: EngineDeps): Engine {
 
 	function loadStaticRules(cwd: string): { rules: LoadedRule[]; diagnostics: RuleDiagnostic[] } {
 		state.cwd = cwd;
-		if (config.disabled || config.mode === "off" || config.mode === "dynamic") {
+		if (config.disabled) {
 			return emptyLoadResult(state);
 		}
 
@@ -72,7 +75,7 @@ export function createEngine(config: PiRulesConfig, deps: EngineDeps): Engine {
 		targetPaths: ReadonlyArray<string>,
 	): { rules: LoadedRule[]; diagnostics: RuleDiagnostic[] } {
 		state.cwd = cwd;
-		if (config.disabled || config.mode === "off" || config.mode === "static" || targetPaths.length === 0) {
+		if (config.disabled || targetPaths.length === 0) {
 			return emptyLoadResult(state);
 		}
 

--- a/hooks/rules-injector/rules/sources.test.ts
+++ b/hooks/rules-injector/rules/sources.test.ts
@@ -12,7 +12,6 @@ import type { PiRulesConfig } from "./types.js";
 function autoConfig(): PiRulesConfig {
 	return {
 		disabled: false,
-		mode: "both",
 		maxRuleChars: 12000,
 		maxResultChars: 40000,
 		postCompactMaxRuleChars: 3500,
@@ -22,6 +21,8 @@ function autoConfig(): PiRulesConfig {
 		promptMaxRuleChars: 6000,
 		promptMaxResultChars: 16000,
 		enabledSources: "auto",
+		sessionStateTtlDays: 7,
+		errorLogMaxBytes: 5_242_880,
 	};
 }
 

--- a/hooks/rules-injector/rules/types.ts
+++ b/hooks/rules-injector/rules/types.ts
@@ -107,7 +107,6 @@ export interface TruncationResult {
  */
 export interface PiRulesConfig {
 	disabled: boolean;
-	mode: "static" | "dynamic" | "both" | "off";
 	maxRuleChars: number;
 	maxResultChars: number;
 	postCompactMaxRuleChars: number;
@@ -117,6 +116,8 @@ export interface PiRulesConfig {
 	promptMaxRuleChars: number;
 	promptMaxResultChars: number;
 	enabledSources: RuleSource[] | "auto";
+	sessionStateTtlDays: number;
+	errorLogMaxBytes: number;
 }
 
 /**

--- a/hooks/rules-injector/session-state-lock.ts
+++ b/hooks/rules-injector/session-state-lock.ts
@@ -62,7 +62,7 @@ function isLockStealable(lockPath: string): boolean {
 	return lockMtimeMs(lockPath) + LOCK_STALE_TTL_MS < Date.now();
 }
 
-function readLockHolderPid(lockPath: string): number | undefined {
+export function readLockHolderPid(lockPath: string): number | undefined {
 	try {
 		const pid = Number.parseInt(readFileSync(join(lockPath, "pid"), "utf8").trim(), 10);
 		return Number.isInteger(pid) && pid > 0 ? pid : undefined;

--- a/hooks/rules-injector/state-gc-sweep.test.ts
+++ b/hooks/rules-injector/state-gc-sweep.test.ts
@@ -213,3 +213,117 @@ test("SessionStart hook runs sweep and rotate", () => {
 		rmSync(projectDir, { recursive: true, force: true });
 	}
 });
+
+// ── Fix-round T1-AC5: GC pre-step must not perturb compact recovery ──────────
+//
+// Combines a post-compact SessionStart (source: "compact", the real recovery
+// path) with GC-triggering conditions (an aged sibling <sid>.json + an
+// oversized error.log) in the same hermetic HOME. Proves the D-6 GC pre-step
+// (own-mtime touch -> sweep -> rotate) coexists with recovery without
+// altering it: both the GC side effects AND the unchanged recovery
+// additionalContext must be observed from the same hook run.
+
+test("SessionStart compact-source recovery is unchanged by GC pre-step", () => {
+	const pluginDataDir = join(tempHome, ".omt");
+	mkdirSync(pluginDataDir, { recursive: true });
+
+	const projectDir = mkdtempSync(join(tmpdir(), "rules-injector-gc-recovery-proj-"));
+	try {
+		const rulesDir = join(projectDir, ".claude", "rules");
+		mkdirSync(rulesDir, { recursive: true });
+		const rulePath = join(rulesDir, "recovery.md");
+		writeFileSync(join(projectDir, "package.json"), '{"name":"ri-gc-recovery-fixture"}\n');
+		writeFileSync(rulePath, "---\nalwaysApply: true\n---\nGC_RECOVERY_MARKER\n");
+
+		const sessionId = "gc-recovery-session";
+		const baseEnv = {
+			...process.env,
+			HOME: tempHome,
+			PI_RULES_DISABLE_BUNDLED: "1",
+			PLUGIN_DATA: pluginDataDir,
+		};
+
+		// 1. Normal startup SessionStart injects the rule and records staticDedup.
+		//    No GC-triggering conditions exist yet, so this run is a plain baseline
+		//    that seeds the state the compact-source recovery below depends on.
+		const first = spawnSync("bun", ["run", CLI_PATH, "hook", "session-start"], {
+			input: JSON.stringify({
+				hook_event_name: "SessionStart",
+				session_id: sessionId,
+				transcript_path: null,
+				cwd: projectDir,
+				model: "gpt-5",
+				permission_mode: "default",
+				source: "startup",
+			}),
+			env: baseEnv,
+			encoding: "utf8",
+		});
+		expect(first.status).toBe(0);
+		expect(first.stderr).toBe("");
+		const firstParsed = JSON.parse(first.stdout.trim()) as {
+			hookSpecificOutput?: { additionalContext?: string };
+		};
+		expect(firstParsed.hookSpecificOutput?.additionalContext ?? "").toContain("GC_RECOVERY_MARKER");
+
+		// 2. Seed GC-triggering conditions: an aged sibling session-state file (must
+		//    be swept given the 1-day TTL override below) and an oversized error.log
+		//    (rotateErrorLog derives its sink from homedir() directly, ignoring
+		//    PLUGIN_DATA, so it always lives at HOME/.omt/rules-injector/error.log).
+		// The GC pre-step in step 1 already touched pluginDataDir's own 24h sweep
+		// throttle marker (it runs unconditionally on every SessionStart, even with
+		// nothing to sweep), so age that marker back out of the throttle window —
+		// otherwise step 3's sweep would be silently skipped and this test would
+		// prove nothing about the sweep actually running on the compact-source call.
+		age(join(pluginDataDir, "last-swept"), 2 * 24 * 60 * 60 * 1000);
+
+		const staleSiblingPath = join(pluginDataDir, "stale-sibling.json");
+		writeFileSync(staleSiblingPath, "{}");
+		age(staleSiblingPath, 2 * 24 * 60 * 60 * 1000);
+
+		const errorLogPath = join(tempHome, ".omt", "rules-injector", "error.log");
+		mkdirSync(dirname(errorLogPath), { recursive: true });
+		writeFileSync(errorLogPath, "x".repeat(50));
+
+		// 3. SessionStart source="compact": no PostCompact ran for this session, so
+		//    this takes the arrival-order inversion fallback (staticDedup is still
+		//    populated from step 1) and recovers the rule — the real post-compact
+		//    recovery path this AC guards. The GC pre-step runs first on this same
+		//    call, so this is the exact combination the requirement gap named.
+		const recovery = spawnSync("bun", ["run", CLI_PATH, "hook", "session-start"], {
+			input: JSON.stringify({
+				hook_event_name: "SessionStart",
+				session_id: sessionId,
+				transcript_path: null,
+				cwd: projectDir,
+				model: "gpt-5",
+				permission_mode: "default",
+				source: "compact",
+			}),
+			env: {
+				...baseEnv,
+				PI_RULES_SESSION_STATE_TTL_DAYS: "1",
+				PI_RULES_ERROR_LOG_MAX_BYTES: "10",
+			},
+			encoding: "utf8",
+		});
+
+		expect(recovery.status).toBe(0);
+		expect(recovery.stderr).toBe("");
+		const recoveredParsed = JSON.parse(recovery.stdout.trim()) as {
+			hookSpecificOutput?: { additionalContext?: string };
+		};
+		const recoveredContext = recoveredParsed.hookSpecificOutput?.additionalContext ?? "";
+
+		// GC pre-step effects landed: aged sibling swept, oversized error.log
+		// truncated.
+		expect(existsSync(staleSiblingPath)).toBe(false);
+		expect(statSync(errorLogPath).size).toBe(0);
+
+		// Recovery output present and unchanged by the GC pre-step running first.
+		expect(recoveredContext).toContain("POST-COMPACTION RULE RECOVERY");
+		expect(recoveredContext).toContain(rulePath);
+	} finally {
+		rmSync(projectDir, { recursive: true, force: true });
+	}
+});

--- a/hooks/rules-injector/state-gc-sweep.test.ts
+++ b/hooks/rules-injector/state-gc-sweep.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -145,4 +145,71 @@ test("sweep error is swallowed", () => {
 	const errorLogPath = join(tempHome, ".omt", "rules-injector", "error.log");
 	expect(existsSync(errorLogPath)).toBe(true);
 	expect(readFileSync(errorLogPath, "utf8")).toContain("sweepStaleSessionStates");
+});
+
+// ── TODO5 / D-6: SessionStart wiring end-to-end ──────────────────────────────
+//
+// Exercises the real CLI (not the in-process sweep function) so it proves the
+// GC pre-step is actually reachable from runSessionStartHook: an aged sibling
+// <sid>.json under the resolved cachePath dir is swept, an oversized error.log
+// is truncated, and the normal additionalContext injection is unaffected.
+
+const CLI_PATH = resolve(dirname(fileURLToPath(import.meta.url)), "cli.ts");
+
+test("SessionStart hook runs sweep and rotate", () => {
+	const pluginDataDir = join(tempHome, ".omt");
+	mkdirSync(pluginDataDir, { recursive: true });
+
+	// Aged sibling session-state file: must be swept given the 1-day TTL override below.
+	const staleSiblingPath = join(pluginDataDir, "stale-sibling.json");
+	writeFileSync(staleSiblingPath, "{}");
+	age(staleSiblingPath, 2 * 24 * 60 * 60 * 1000);
+
+	// Oversized error.log: rotateErrorLog derives its sink from homedir() directly
+	// (ignores PLUGIN_DATA), so it always lives at HOME/.omt/rules-injector/error.log.
+	const errorLogPath = join(tempHome, ".omt", "rules-injector", "error.log");
+	mkdirSync(dirname(errorLogPath), { recursive: true });
+	writeFileSync(errorLogPath, "x".repeat(50));
+
+	const projectDir = mkdtempSync(join(tmpdir(), "rules-injector-gc-proj-"));
+	try {
+		mkdirSync(join(projectDir, ".claude", "rules"), { recursive: true });
+		writeFileSync(join(projectDir, "package.json"), '{"name":"ri-gc-fixture"}\n');
+		writeFileSync(
+			join(projectDir, ".claude", "rules", "always.md"),
+			"---\nalwaysApply: true\n---\nGC_SESSION_START_MARKER\n",
+		);
+
+		const result = spawnSync("bun", ["run", CLI_PATH, "hook", "session-start"], {
+			input: JSON.stringify({
+				hook_event_name: "SessionStart",
+				session_id: "gc-e2e-session",
+				transcript_path: null,
+				cwd: projectDir,
+				model: "gpt-5",
+				permission_mode: "default",
+				source: "startup",
+			}),
+			env: {
+				...process.env,
+				HOME: tempHome,
+				PI_RULES_DISABLE_BUNDLED: "1",
+				PLUGIN_DATA: pluginDataDir,
+				PI_RULES_SESSION_STATE_TTL_DAYS: "1",
+				PI_RULES_ERROR_LOG_MAX_BYTES: "10",
+			},
+			encoding: "utf8",
+		});
+
+		expect(result.status).toBe(0);
+		expect(result.stderr).toBe("");
+		const stdout = result.stdout.trim();
+		const parsed = JSON.parse(stdout) as { hookSpecificOutput?: { additionalContext?: string } };
+		expect(parsed.hookSpecificOutput?.additionalContext ?? "").toContain("GC_SESSION_START_MARKER");
+
+		expect(existsSync(staleSiblingPath)).toBe(false);
+		expect(statSync(errorLogPath).size).toBe(0);
+	} finally {
+		rmSync(projectDir, { recursive: true, force: true });
+	}
 });

--- a/hooks/rules-injector/state-gc-sweep.test.ts
+++ b/hooks/rules-injector/state-gc-sweep.test.ts
@@ -46,12 +46,17 @@ function age(path: string, ageMs: number): void {
 	utimesSync(path, seconds, seconds);
 }
 
+// A minimal but valid <sid>.json payload: the sweep only reaps files that parse
+// as one of our session-state records (version + dedup shape), so "should be
+// swept" fixtures must carry this shape, not a bare `{}`.
+const SESSION_STATE_JSON = JSON.stringify({ version: 1, staticDedup: [], dynamicDedup: {} });
+
 test("sweeps stale sibling json and lock", () => {
 	const ownCachePath = join(scratchDir, "own.json");
 	writeFileSync(ownCachePath, "{}");
 
 	const siblingPath = join(scratchDir, "sibling.json");
-	writeFileSync(siblingPath, "{}");
+	writeFileSync(siblingPath, SESSION_STATE_JSON);
 	age(siblingPath, 10_000);
 	const lockPath = `${siblingPath}.lock`;
 	mkdirSync(lockPath);
@@ -63,12 +68,36 @@ test("sweeps stale sibling json and lock", () => {
 	expect(existsSync(ownCachePath)).toBe(true);
 });
 
+test("preserves stale foreign json that is not a session-state record", () => {
+	const ownCachePath = join(scratchDir, "own.json");
+	writeFileSync(ownCachePath, SESSION_STATE_JSON);
+
+	// A stale, unrelated JSON sibling (e.g. a package.json when pluginDataRoot
+	// points at a directory shared with other tools): lacks our version + dedup
+	// shape, so the sweep must leave it untouched even though its mtime is well
+	// past the TTL. Deleting it would be data loss outside our ownership.
+	const foreignPath = join(scratchDir, "package.json");
+	writeFileSync(foreignPath, JSON.stringify({ name: "unrelated", dependencies: {} }));
+	age(foreignPath, 10_000);
+
+	// A stale, corrupt/truncated .json: also not positively one of our records,
+	// so preserved rather than deleted (leak over destroy on ambiguity).
+	const corruptPath = join(scratchDir, "corrupt.json");
+	writeFileSync(corruptPath, "{ not valid json");
+	age(corruptPath, 10_000);
+
+	sweepStaleSessionStates(scratchDir, TTL_MS, ownCachePath);
+
+	expect(existsSync(foreignPath)).toBe(true);
+	expect(existsSync(corruptPath)).toBe(true);
+});
+
 test("preserves fresh sibling", () => {
 	const ownCachePath = join(scratchDir, "own.json");
 	writeFileSync(ownCachePath, "{}");
 
 	const freshSiblingPath = join(scratchDir, "fresh-sibling.json");
-	writeFileSync(freshSiblingPath, "{}");
+	writeFileSync(freshSiblingPath, SESSION_STATE_JSON);
 
 	sweepStaleSessionStates(scratchDir, TTL_MS, ownCachePath);
 
@@ -94,7 +123,7 @@ test("ignores non-session files and respects 24h throttle", () => {
 	age(errorLogPath, 10_000);
 
 	const firstSiblingPath = join(scratchDir, "sibling-a.json");
-	writeFileSync(firstSiblingPath, "{}");
+	writeFileSync(firstSiblingPath, SESSION_STATE_JSON);
 	age(firstSiblingPath, 10_000);
 
 	sweepStaleSessionStates(scratchDir, TTL_MS, ownCachePath);
@@ -105,7 +134,7 @@ test("ignores non-session files and respects 24h throttle", () => {
 	expect(existsSync(firstSiblingPath)).toBe(false);
 
 	const secondSiblingPath = join(scratchDir, "sibling-b.json");
-	writeFileSync(secondSiblingPath, "{}");
+	writeFileSync(secondSiblingPath, SESSION_STATE_JSON);
 	age(secondSiblingPath, 10_000);
 
 	sweepStaleSessionStates(scratchDir, TTL_MS, ownCachePath);
@@ -162,7 +191,7 @@ test("SessionStart hook runs sweep and rotate", () => {
 
 	// Aged sibling session-state file: must be swept given the 1-day TTL override below.
 	const staleSiblingPath = join(pluginDataDir, "stale-sibling.json");
-	writeFileSync(staleSiblingPath, "{}");
+	writeFileSync(staleSiblingPath, SESSION_STATE_JSON);
 	age(staleSiblingPath, 2 * 24 * 60 * 60 * 1000);
 
 	// Oversized error.log: rotateErrorLog derives its sink from homedir() directly
@@ -278,7 +307,7 @@ test("SessionStart compact-source recovery is unchanged by GC pre-step", () => {
 		age(join(pluginDataDir, "last-swept"), 2 * 24 * 60 * 60 * 1000);
 
 		const staleSiblingPath = join(pluginDataDir, "stale-sibling.json");
-		writeFileSync(staleSiblingPath, "{}");
+		writeFileSync(staleSiblingPath, SESSION_STATE_JSON);
 		age(staleSiblingPath, 2 * 24 * 60 * 60 * 1000);
 
 		const errorLogPath = join(tempHome, ".omt", "rules-injector", "error.log");

--- a/hooks/rules-injector/state-gc-sweep.test.ts
+++ b/hooks/rules-injector/state-gc-sweep.test.ts
@@ -1,0 +1,148 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { sweepStaleSessionStates } from "./persistent-cache.js";
+
+// Absolute path to this module, for the subprocess probe below (bun's os.homedir()
+// resolves once at process start and ignores a runtime-mutated process.env.HOME, so
+// asserting on the writeErrorBreadcrumb sink requires setting HOME before spawn —
+// same reason cli.ts's breadcrumb path is only ever tested via spawnSync elsewhere
+// in this suite, e.g. fidelity-and-lanes.test.ts's "C1" test).
+const PERSISTENT_CACHE_PATH = resolve(dirname(fileURLToPath(import.meta.url)), "persistent-cache.ts");
+
+// HERMETIC HOME: sweepStaleSessionStates records forced-fault errors via
+// writeErrorBreadcrumb, which appends to $HOME/.omt/rules-injector/error.log. A
+// fresh HOME per test keeps that sink (and any real ~/.omt) untouched.
+let tempHome = "";
+let realHome: string | undefined;
+let scratchDir = "";
+
+beforeEach(() => {
+	realHome = process.env["HOME"];
+	tempHome = mkdtempSync(join(tmpdir(), "rules-injector-gc-home-"));
+	process.env["HOME"] = tempHome;
+	scratchDir = mkdtempSync(join(tmpdir(), "rules-injector-gc-"));
+});
+
+afterEach(() => {
+	if (realHome === undefined) {
+		delete process.env["HOME"];
+	} else {
+		process.env["HOME"] = realHome;
+	}
+	rmSync(tempHome, { recursive: true, force: true });
+	rmSync(scratchDir, { recursive: true, force: true });
+});
+
+const TTL_MS = 1_000;
+
+// Ages a file's mtime to `ageMs` in the past, well beyond any TTL used in these tests.
+function age(path: string, ageMs: number): void {
+	const seconds = (Date.now() - ageMs) / 1000;
+	utimesSync(path, seconds, seconds);
+}
+
+test("sweeps stale sibling json and lock", () => {
+	const ownCachePath = join(scratchDir, "own.json");
+	writeFileSync(ownCachePath, "{}");
+
+	const siblingPath = join(scratchDir, "sibling.json");
+	writeFileSync(siblingPath, "{}");
+	age(siblingPath, 10_000);
+	const lockPath = `${siblingPath}.lock`;
+	mkdirSync(lockPath);
+
+	sweepStaleSessionStates(scratchDir, TTL_MS, ownCachePath);
+
+	expect(existsSync(siblingPath)).toBe(false);
+	expect(existsSync(lockPath)).toBe(false);
+	expect(existsSync(ownCachePath)).toBe(true);
+});
+
+test("preserves fresh sibling", () => {
+	const ownCachePath = join(scratchDir, "own.json");
+	writeFileSync(ownCachePath, "{}");
+
+	const freshSiblingPath = join(scratchDir, "fresh-sibling.json");
+	writeFileSync(freshSiblingPath, "{}");
+
+	sweepStaleSessionStates(scratchDir, TTL_MS, ownCachePath);
+
+	expect(existsSync(freshSiblingPath)).toBe(true);
+});
+
+test("preserves current session on stale-mtime resume", () => {
+	const ownCachePath = join(scratchDir, "own.json");
+	writeFileSync(ownCachePath, "{}");
+	age(ownCachePath, 10_000);
+
+	sweepStaleSessionStates(scratchDir, TTL_MS, ownCachePath);
+
+	expect(existsSync(ownCachePath)).toBe(true);
+});
+
+test("ignores non-session files and respects 24h throttle", () => {
+	const ownCachePath = join(scratchDir, "own.json");
+	writeFileSync(ownCachePath, "{}");
+
+	const errorLogPath = join(scratchDir, "error.log");
+	writeFileSync(errorLogPath, "boom\n");
+	age(errorLogPath, 10_000);
+
+	const firstSiblingPath = join(scratchDir, "sibling-a.json");
+	writeFileSync(firstSiblingPath, "{}");
+	age(firstSiblingPath, 10_000);
+
+	sweepStaleSessionStates(scratchDir, TTL_MS, ownCachePath);
+
+	// non-.json file never swept, even though it is stale
+	expect(existsSync(errorLogPath)).toBe(true);
+	// stale sibling swept on the (unthrottled) first run
+	expect(existsSync(firstSiblingPath)).toBe(false);
+
+	const secondSiblingPath = join(scratchDir, "sibling-b.json");
+	writeFileSync(secondSiblingPath, "{}");
+	age(secondSiblingPath, 10_000);
+
+	sweepStaleSessionStates(scratchDir, TTL_MS, ownCachePath);
+
+	// second run happens within the 24h throttle window: no-op, so the new
+	// stale sibling survives even though it would otherwise qualify.
+	expect(existsSync(secondSiblingPath)).toBe(true);
+});
+
+test("sweep error is swallowed", () => {
+	// Pass a `dir` that is actually a regular file, not a directory, so every fs op
+	// inside the sweep (marker stat/write, readdir) fails with ENOTDIR/EEXIST.
+	const notADirPath = join(scratchDir, "not-a-dir");
+	writeFileSync(notADirPath, "not a directory");
+
+	// In-process, direct calls can't verify the breadcrumb sink (HOME override is
+	// ineffective post-start), so this runs in a subprocess with HOME set at spawn
+	// time — both to confirm the fault never throws (a non-zero exit / stderr would
+	// mean it did) and that the error was recorded, not silently dropped.
+	const probeScriptPath = join(scratchDir, "sweep-fault-probe.mjs");
+	writeFileSync(
+		probeScriptPath,
+		[
+			`import { sweepStaleSessionStates } from ${JSON.stringify(PERSISTENT_CACHE_PATH)};`,
+			`sweepStaleSessionStates(${JSON.stringify(notADirPath)}, ${TTL_MS}, ${JSON.stringify(join(notADirPath, "own.json"))});`,
+		].join("\n"),
+	);
+
+	const result = spawnSync("bun", ["run", probeScriptPath], {
+		env: { ...process.env, HOME: tempHome },
+		encoding: "utf8",
+	});
+
+	expect(result.status).toBe(0);
+	expect(result.stderr).toBe("");
+
+	const errorLogPath = join(tempHome, ".omt", "rules-injector", "error.log");
+	expect(existsSync(errorLogPath)).toBe(true);
+	expect(readFileSync(errorLogPath, "utf8")).toContain("sweepStaleSessionStates");
+});

--- a/hooks/rules-injector/static-injection.ts
+++ b/hooks/rules-injector/static-injection.ts
@@ -27,7 +27,7 @@ export function runStaticInjection(
 	model?: string,
 ): string {
 	const config = configFromEnvironment(options.env);
-	if (config.disabled || config.mode === "off" || config.mode === "dynamic") {
+	if (config.disabled) {
 		if (completedPostCompactChannel !== undefined) {
 			completePostCompactRecovery(cachePath, completedPostCompactChannel);
 		}

--- a/hooks/rules-injector/static-injection.ts
+++ b/hooks/rules-injector/static-injection.ts
@@ -232,6 +232,6 @@ function ruleDisplayPath(rule: LoadedRule): string {
 	return rule.relativePath.length > 0 ? rule.relativePath : rule.path;
 }
 
-function combineStaticContext(...blocks: readonly string[]): string {
+export function combineStaticContext(...blocks: readonly string[]): string {
 	return blocks.filter((block) => block.trim().length > 0).join("\n\n");
 }

--- a/hooks/rules-injector/static-injection.ts
+++ b/hooks/rules-injector/static-injection.ts
@@ -19,7 +19,7 @@ import { readTranscriptSearchText } from "./transcript-search.js";
 export function runStaticInjection(
 	cwd: string,
 	transcriptPath: string | null,
-	eventName: "SessionStart" | "UserPromptSubmit",
+	eventName: "SessionStart" | "UserPromptSubmit" | "PostToolUse",
 	cachePath: string,
 	options: CodexRulesHookOptions,
 	completedPostCompactChannel?: "static",
@@ -88,7 +88,7 @@ export function runStaticInjection(
 interface PostCompactRecoveryInput {
 	cwd: string;
 	transcriptPath: string | null;
-	eventName: "SessionStart" | "UserPromptSubmit";
+	eventName: "SessionStart" | "UserPromptSubmit" | "PostToolUse";
 	cachePath: string;
 	options: CodexRulesHookOptions;
 	channel: "static";


### PR DESCRIPTION
## 📌 Summary

rules-injector(Codex 훅)의 세 가지 빈틈을 닫습니다. (1) 컴팩션 직후 첫 이벤트가 PostToolUse일 때 static 규칙 회수가 누락되던 창을 메우고, (2) 무한 증가하던 세션 상태 파일과 error.log를 SessionStart에서 best-effort로 정리하며, (3) 항상 "both"로 고정돼 죽은 코드였던 `config.mode`를 제거합니다.

---

## 🔧 Changes

### config 스키마 기반 (`config.ts`, `rules/types.ts`, `rules/constants.ts`)

- `PiRulesConfig`에서 `mode` 필드 제거, `sessionStateTtlDays`(기본 7일)·`errorLogMaxBytes`(기본 5MB) 추가
- 두 신규 설정에 dual-env 배선: `CODEX_RULES_*` 우선, `PI_RULES_*` 폴백

세 과제가 공통으로 딛는 설정 토대라 먼저 정리했습니다. `mode` 제거는 D-6(env 파싱 제거)에서 남겨둔 필드·분기를 마저 걷어내는 마무리입니다.

**영향 범위**
`mode`는 이미 항상 `"both"`로 동작하던 죽은 코드라 동작 변화 없음. 소스 제어는 기존 `enabledSources`, 킬스위치는 `disabled`가 그대로 담당. 신규 설정은 기본값이 있어 하위 호환.

### PostToolUse static 회수 (`codex-hook.ts`, `static-injection.ts`)

- `runPostToolUseHook`이 `"dynamic"`뿐 아니라 `"static"` 채널도 claim하도록 확장
- 기존 포인터 회수 디렉티브(`buildPostCompactReadDirective`/`runPostCompactRecovery`)를 재사용, `eventName` union에 `"PostToolUse"` 추가
- Option C(1회 회수): 컴팩션 후 첫 PostToolUse가 한 번 회수하고 같은 턴에 채널을 닫음

**영향 범위**
UserPromptSubmit/SessionStart의 기존 회수 경로(static+dynamic)는 불변. PostCompact 이벤트 자체에는 주입하지 않음(Codex가 해당 이벤트의 additionalContext를 거부하는 제약과 무관하게 유지). 새 injector를 만들지 않고 기존 하이브리드 경로를 재사용.

### 세션 상태 GC + error.log 로테이션 (`persistent-cache.ts`, `debug-log.ts`, `session-state-lock.ts`, SessionStart 연동)

- `sweepStaleSessionStates`: SessionStart에서 stale `<sid>.json`(mtime-TTL)을 스윕
- `rotateErrorLog`: error.log가 cap을 넘으면 truncate
- `runSessionStartHook`에 GC 프리스텝 연동(자기 mtime 갱신 → 스윕 → 로테이션)
- 락 홀더 pid 읽기 중복 제거(`readLockHolderPid` export 후 재사용)

**영향 범위**
활성 세션은 매 훅에서 자기 mtime를 갱신하므로 스윕 대상에서 안전(PID 추적 불필요). 스윕은 자기 파일·live-lock 보유 sibling·error.log·비세션 파일을 절대 삭제하지 않고 예외를 던지지 않음. SessionEnd 훅이 없는 Codex 환경에서 유일한 정리 지점.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. Option C(1회 회수) vs 드레인 방식 — 설계 반전

**배경 및 문제 상황:**
컴팩션 직후 첫 이벤트가 PostToolUse(사용자 프롬프트 이전의 도구 호출)이면, 기존 코드는 `"dynamic"` 채널만 claim해서 static 규칙 회수 디렉티브가 그 창에서 방출되지 않았습니다. 설계 초안은 "recovering 상태를 유지해 이후 PostToolUse들이 overflow 꼬리를 다 드레인할 때까지 반복"하는 방식이었습니다.

**해결 방안:**
드레인 방식을 버리고 Option C로 반전했습니다. 첫 PostToolUse가 static을 1회 회수하고 같은 턴에 채널을 닫아 lease를 즉시 해제합니다. budget-overflow로 잘린 꼬리는 다음 UserPromptSubmit의 기존 normal static 경로가 자가복구합니다(꼬리는 보통 tiny-pointer라 대개 비어 있음).

**선택과 트레이드오프:**
드레인 방식은 recovering 상태를 유지하는 동안 30초 recovery-lease를 붙잡습니다. 그러면 다음 PostToolUse가 `contended`가 돼 드레인이 오히려 불가능해지고, 더 나쁘게는 30초 안에 실제 UserPromptSubmit이 들어와도 contended로 static 주입이 억제되는 무성 회귀가 생깁니다. Option C는 lease 경합 자체를 없앱니다. 대가로 overflow 꼬리 회수를 다음 UPS로 미루지만, 꼬리가 사실상 비어 있어 실무상 손실이 없다고 판단했습니다.

### 2. byte-clamp 병합 seam 버그 (독립 코드리뷰가 적발)

**배경 및 문제 상황:**
static 회수 텍스트와 dynamic 블록을 함께 방출할 때, 최종 출력은 `combineStaticContext(staticReclaimText, block)`으로 합친 뒤 32K로 클램프됩니다. 그런데 dynamic dedup "주입됨" 마킹은 `block` 단독을 32K로 클램프한 기준으로 계산하고 있었습니다.

**해결 방안:**
마킹 기준을 실제 방출·클램프되는 합산 문자열(`combineStaticContext(...)`의 결과)로 교정했습니다.

**선택과 트레이드오프:**
버그 조건은 static 회수 텍스트가 존재하고 dynamic 규칙이 32K 경계 근처일 때입니다. 이 경우 규칙이 최종 페이로드에서 잘려 나갔는데도 "주입됨"으로 마킹돼 영영 재주입되지 않습니다(static이 비어 있을 때만 무해). 이 결함은 저자 self-check APPROVE를 통과했고 독립 code-review 레인이 CONFIRMED로 잡았습니다. 회귀 테스트는 수정을 되돌리면 RED로 떨어지는 것까지 재검증했습니다.

### 3. mtime-TTL 스윕 vs PID 기반 리핑

**배경 및 문제 상황:**
Codex 환경에는 SessionEnd 훅이 없어 세션 종료 시점을 잡을 방법이 없습니다. 그래서 "어떤 상태 파일이 죽은 세션 것인가"를 판정할 신호가 필요했습니다.

**해결 방안:**
활성 세션이 매 훅에서 자기 상태 파일 mtime를 갱신한다는 점을 이용해, SessionStart에서 TTL(기본 7일)을 넘긴 sibling만 스윕합니다. PID 추적은 하지 않습니다.

**선택과 트레이드오프:**
PID 기반 active-reaping은 PID 재사용 시 살아 있는 세션 파일을 오삭제할 위험이 있어 배제했습니다. mtime-TTL은 그 위험이 없고 상태가 필요 없습니다. 스윕은 자기 파일·live-lock 보유 sibling·error.log·비세션 파일을 제외하고 예외를 던지지 않는 best-effort입니다. `rotateErrorLog`에 statSync→writeFileSync 사이 TOCTOU 잔여 리스크가 PLAUSIBLE로 남지만, 진단 로그 전용이라 플랜 pre-mortem에서 의식적으로 수용했습니다(원하면 truncate-from-head로 후속).

---

## ✅ Checklist

### PostToolUse static 회수
- [ ] 컴팩션 후 첫 PostToolUse가 `POST-COMPACTION RULE RECOVERY` 디렉티브를 방출한다
  - `hooks/rules-injector/codex-hook.ts`
- [ ] 두 번째 PostToolUse는 회수를 반복하지 않는다(1회성)
  - `hooks/rules-injector/codex-hook.ts`
- [ ] 컴팩션 이전 정상 상태의 PostToolUse는 회수 디렉티브를 방출하지 않는다
  - `hooks/rules-injector/post-tool-use-static-reclaim.test.ts`
- [ ] dynamic dedup 마킹이 합산·클램프된 최종 출력 기준으로 계산된다(byte-clamp 회귀)
  - `hooks/rules-injector/post-tool-use-static-reclaim.test.ts`

### 세션 상태 GC / 로테이션
- [ ] TTL 초과 sibling 상태 파일은 스윕되고, 자기 파일·live-lock sibling은 보존된다
  - `hooks/rules-injector/persistent-cache.ts`
  - `hooks/rules-injector/state-gc-sweep.test.ts`
- [ ] error.log가 cap 초과 시 truncate된다
  - `hooks/rules-injector/debug-log.ts`
  - `hooks/rules-injector/error-log-rotate.test.ts`
- [ ] GC 프리스텝이 기존 post-compact 회수와 공존한다(source=compact SessionStart)
  - `hooks/rules-injector/state-gc-sweep.test.ts`
- [ ] `sessionStateTtlDays`·`errorLogMaxBytes`가 4개 env alias·precedence로 오버라이드된다
  - `hooks/rules-injector/config.test.ts`

### config.mode 제거
- [ ] `config.mode` 참조가 코드베이스에 남아 있지 않다
  - `hooks/rules-injector/config.ts`
  - `hooks/rules-injector/rules/types.ts`

### 회귀 없음
- [ ] `make validate` / `make test` / `make typecheck` 모두 통과
- [ ] `bun test hooks/rules-injector/` 226 pass / 0 fail

---

검증 상태(참고): `make validate`·`make test`·`make typecheck` 모두 exit 0, 훅 테스트 226 pass, 독립 code-review 0 CONFIRMED(1 PLAUSIBLE = rotateErrorLog TOCTOU, 수용), QA APPROVE.
