### PR TITLE
feat(deep-interview): 온톨로지 mermaid 시각화 추가

### DIFF
--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -436,7 +436,7 @@ Inline self-review (4 checks): placeholder / consistency / scope / ambiguity —
 
 Dispatch `spec-reviewer` — pass the spec path only. This loop is GATING on the reviewer's `Status`: while it returns `Status: Issues Found`, fix the named Issues and re-dispatch `spec-reviewer`, repeating until it returns `Status: Approved`. Do NOT emit the handoff token while any Issue remains — there is no advisory proceed-anyway / risk-note escape from an unresolved Issue. Only **Issues** gate; **Recommendations** are advisory and never block — carry any unaddressed ones into the spec's Risks section.
 
-2. **Render to HTML**: **You MUST read `references/render-assembly.md` first** — it is the single owner of the close-tag escape and the active-placeholder HTML-escape; apply both before substituting. Fill `templates/spec-presentation.html` with the assembled spec markdown and the placeholder values, then write the render to `$OMT_DIR/deep-interview/{slug}.html` — reuse the SAME `{slug}` from the just-written `{slug}.md`; do NOT re-derive the slug. Tell the user to open it in a browser. If the final ontology has zero entities, the Ontology (Key Entities) `erDiagram` slot must render a `no entities yet` state rather than an empty/invalid erDiagram. **Lifecycle**: this render HTML is never auto-deleted, same as the `.md` spec.
+2. **Render to HTML**: **You MUST read `references/render-assembly.md` first** — it is the single owner of the close-tag escape, the active-placeholder HTML-escape, and the prose-fragment guard; apply its full guard set before substituting. Fill `templates/spec-presentation.html` with the assembled spec markdown and the placeholder values, then write the render to `$OMT_DIR/deep-interview/{slug}.html` — reuse the SAME `{slug}` from the just-written `{slug}.md`; do NOT re-derive the slug. Tell the user to open it in a browser. If the final ontology has zero entities, the Ontology (Key Entities) `erDiagram` slot must render a `no entities yet` state rather than an empty/invalid erDiagram. **Lifecycle**: this render HTML is never auto-deleted, same as the `.md` spec.
 
 3. **Emit the handoff token** in the final assistant message before proceeding to Phase 5. The literal token `<deep-interview-done/>` must appear in the assistant turn that announces spec completion. This signals downstream hooks that the interview phase is complete and state cleanup may proceed.
 
@@ -446,7 +446,7 @@ At any point during the interview — not gated to Phase 4 — recognize a natur
 
 1. Read current state via `bun ${CLAUDE_SKILL_DIR}/scripts/deep-interview-state.ts get` and take the latest `ontology_snapshots` entry.
 2. Compose an ontology-only markdown `erDiagram` from that snapshot's entities and relationships. If the latest snapshot's entities are absent or empty, emit a `no entities yet` state instead of an empty/invalid erDiagram.
-3. **You MUST read `references/render-assembly.md` first** and apply the same close-tag escape and active-placeholder HTML-escape it defines.
+3. **You MUST read `references/render-assembly.md` first** and apply its full guard set — the same close-tag escape, active-placeholder HTML-escape, and prose-fragment guard it defines.
 4. Write the render to `$OMT_DIR/deep-interview/ontology-preview.html`.
 
 This on-demand ontology render is a lightweight, ontology-only preview, distinct from the Phase 4 final render (which embeds the full spec).
@@ -539,6 +539,6 @@ Read these files at the moment indicated — not speculatively upfront.
 | `deep-interview-spec-template.md` | The Phase 4 output spec markdown template | When composing the output spec (Phase 4 crystallize) |
 | `deep-interview-examples.md` | Question-quality calibration examples (Good/Bad) | When calibrating or debugging question quality |
 | `deep-interview-advanced.md` | Resume, configuration (ambiguityThreshold), cross-session continuation, prometheus integration, and the weights / challenge-modes / score-interpretation tables | When resuming, configuring, continuing across sessions, integrating with prometheus, or needing the interpretation tables |
-| `render-assembly.md` | The substitution-time injection guard (close-tag escape), active-placeholder HTML-escape, and mermaid self-audit for HTML renders | Before both render call sites: the Phase 4 final render and the on-demand ontology render |
+| `render-assembly.md` | The substitution-time injection guards (close-tag escape, active-placeholder HTML-escape, prose-fragment guard), and mermaid self-audit for HTML renders | Before both render call sites: the Phase 4 final render and the on-demand ontology render |
 
 Task: {{ARGUMENTS}}

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -447,7 +447,7 @@ At any point during the interview — not gated to Phase 4 — recognize a natur
 1. Read current state via `bun ${CLAUDE_SKILL_DIR}/scripts/deep-interview-state.ts get` and take the latest `ontology_snapshots` entry.
 2. Compose an ontology-only markdown `erDiagram` from that snapshot's entities and relationships. If the latest snapshot's entities are absent or empty, emit a `no entities yet` state instead of an empty/invalid erDiagram.
 3. **You MUST read `references/render-assembly.md` first** and apply its full guard set — the same close-tag escape, active-placeholder HTML-escape, and prose-fragment guard it defines.
-4. Write the render to `$OMT_DIR/deep-interview/ontology-preview.html`.
+4. Fill the SAME `templates/spec-presentation.html` template used by the Phase 4 render: the ontology-only markdown becomes `{{SPEC_MARKDOWN_JSON}}`. For the mid-interview meta placeholders, source values from current state rather than final-spec values — `{{AMBIGUITY_SCORE}}` and `{{ROUND_COUNT}}` from the latest state, `{{SPEC_TITLE}}` and `{{HTML_TITLE}}` = "Ontology Preview", `{{SPEC_FILE_PATH}}` = the preview path. Write the render to `$OMT_DIR/deep-interview/ontology-preview.html`.
 
 This on-demand ontology render is a lightweight, ontology-only preview, distinct from the Phase 4 final render (which embeds the full spec).
 

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -426,6 +426,8 @@ The Design-fork detection gate has already run at Phase 2 exit for the normal pa
 
 **Whole-spec gate**: After all per-section approvals, assemble the draft and present the whole spec for final confirmation before writing.
 
+**Diagram-authoring guidance**: the Ontology (Key Entities) `erDiagram` is REQUIRED; the Architecture / Components / Data Flow / Error Handling diagrams are discretionary — add one only when it is clearer than prose. Self-audit every mermaid block before writing it (see `render-assembly.md`'s mermaid-validity note: no raw `;` in diagram text).
+
 1. **Write to file**: `$OMT_DIR/deep-interview/{slug}.md`
 
 **2-layer review** (after writing):
@@ -434,7 +436,20 @@ Inline self-review (4 checks): placeholder / consistency / scope / ambiguity —
 
 Dispatch `spec-reviewer` — pass the spec path only. This loop is GATING on the reviewer's `Status`: while it returns `Status: Issues Found`, fix the named Issues and re-dispatch `spec-reviewer`, repeating until it returns `Status: Approved`. Do NOT emit the handoff token while any Issue remains — there is no advisory proceed-anyway / risk-note escape from an unresolved Issue. Only **Issues** gate; **Recommendations** are advisory and never block — carry any unaddressed ones into the spec's Risks section.
 
-2. **Emit the handoff token** in the final assistant message before proceeding to Phase 5. The literal token `<deep-interview-done/>` must appear in the assistant turn that announces spec completion. This signals downstream hooks that the interview phase is complete and state cleanup may proceed.
+2. **Render to HTML**: **You MUST read `references/render-assembly.md` first** — it is the single owner of the close-tag escape and the active-placeholder HTML-escape; apply both before substituting. Fill `templates/spec-presentation.html` with the assembled spec markdown and the placeholder values, then write the render to `$OMT_DIR/deep-interview/{slug}.html` — reuse the SAME `{slug}` from the just-written `{slug}.md`; do NOT re-derive the slug. Tell the user to open it in a browser. If the final ontology has zero entities, the Ontology (Key Entities) `erDiagram` slot must render a `no entities yet` state rather than an empty/invalid erDiagram. **Lifecycle**: this render HTML is never auto-deleted, same as the `.md` spec.
+
+3. **Emit the handoff token** in the final assistant message before proceeding to Phase 5. The literal token `<deep-interview-done/>` must appear in the assistant turn that announces spec completion. This signals downstream hooks that the interview phase is complete and state cleanup may proceed.
+
+### On-demand ontology render
+
+At any point during the interview — not gated to Phase 4 — recognize a natural-language request (Korean or English) to see, preview, or visualize the model, the ontology, the entities, or a diagram, and treat it as a request for an on-demand ontology render:
+
+1. Read current state via `bun ${CLAUDE_SKILL_DIR}/scripts/deep-interview-state.ts get` and take the latest `ontology_snapshots` entry.
+2. Compose an ontology-only markdown `erDiagram` from that snapshot's entities and relationships. If the latest snapshot's entities are absent or empty, emit a `no entities yet` state instead of an empty/invalid erDiagram.
+3. **You MUST read `references/render-assembly.md` first** and apply the same close-tag escape and active-placeholder HTML-escape it defines.
+4. Write the render to `$OMT_DIR/deep-interview/ontology-preview.html`.
+
+This on-demand ontology render is a lightweight, ontology-only preview, distinct from the Phase 4 final render (which embeds the full spec).
 
 ## Phase 5: Execution Bridge
 
@@ -524,5 +539,6 @@ Read these files at the moment indicated — not speculatively upfront.
 | `deep-interview-spec-template.md` | The Phase 4 output spec markdown template | When composing the output spec (Phase 4 crystallize) |
 | `deep-interview-examples.md` | Question-quality calibration examples (Good/Bad) | When calibrating or debugging question quality |
 | `deep-interview-advanced.md` | Resume, configuration (ambiguityThreshold), cross-session continuation, prometheus integration, and the weights / challenge-modes / score-interpretation tables | When resuming, configuring, continuing across sessions, integrating with prometheus, or needing the interpretation tables |
+| `render-assembly.md` | The substitution-time injection guard (close-tag escape), active-placeholder HTML-escape, and mermaid self-audit for HTML renders | Before both render call sites: the Phase 4 final render and the on-demand ontology render |
 
 Task: {{ARGUMENTS}}

--- a/skills/deep-interview/SKILL.test.ts
+++ b/skills/deep-interview/SKILL.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 
 // ---------------------------------------------------------------------------
@@ -85,6 +85,48 @@ describe('new-prose: brainstorm-delegation phrase removal', () => {
 });
 
 // ---------------------------------------------------------------------------
+// NEW-PROSE: mermaid visualization render-orchestration (must FAIL — RED)
+// ---------------------------------------------------------------------------
+
+describe('new-prose: spec-presentation render target', () => {
+  test('spec-presentation.html render target is present', () => {
+    expect(skillMd).toContain('spec-presentation.html');
+  });
+
+  test('{slug}.html output naming is present', () => {
+    expect(skillMd).toContain('{slug}.html');
+  });
+
+  test('"open it in a browser" instruction is present', () => {
+    expect(skillMd).toContain('open it in a browser');
+  });
+});
+
+describe('new-prose: ontology-preview on-demand render', () => {
+  test('ontology-preview.html render target is present', () => {
+    expect(skillMd).toContain('ontology-preview.html');
+  });
+
+  test('on-demand ontology render mention is present', () => {
+    expect(skillMd).toContain('on-demand ontology render');
+  });
+
+  test('"see, preview, or visualize the model" trigger phrase is present', () => {
+    expect(skillMd).toContain('see, preview, or visualize the model');
+  });
+
+  test('"no entities yet" guard is present', () => {
+    expect(skillMd).toContain('no entities yet');
+  });
+});
+
+describe('new-prose: render-assembly reference', () => {
+  test('render-assembly.md reference is present', () => {
+    expect(skillMd).toContain('render-assembly.md');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // REGRESSION GUARD (must PASS before AND after edits — invariant)
 // ---------------------------------------------------------------------------
 
@@ -105,5 +147,33 @@ describe('regression-guard', () => {
 describe('template: approach and design decisions section', () => {
   test('"## Approach & Design Decisions" is present in template', () => {
     expect(template).toContain('## Approach & Design Decisions');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TEMPLATE: mermaid ontology erDiagram slot (must FAIL — RED)
+// ---------------------------------------------------------------------------
+
+describe('template: mermaid ontology erDiagram slot', () => {
+  test('erDiagram is present in template', () => {
+    expect(template).toContain('erDiagram');
+  });
+
+  test('"clearer than prose" rationale is present in template', () => {
+    expect(template).toContain('clearer than prose');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FILE-EXISTENCE: mermaid visualization assets (must FAIL — RED)
+// ---------------------------------------------------------------------------
+
+describe('file-existence: mermaid visualization assets', () => {
+  test('templates/spec-presentation.html exists', () => {
+    expect(existsSync(join(import.meta.dir, 'templates/spec-presentation.html'))).toBe(true);
+  });
+
+  test('references/render-assembly.md exists', () => {
+    expect(existsSync(join(import.meta.dir, 'references/render-assembly.md'))).toBe(true);
   });
 });

--- a/skills/deep-interview/deep-interview-spec-template.md
+++ b/skills/deep-interview/deep-interview-spec-template.md
@@ -1,6 +1,6 @@
 # Deep Interview Spec Template
 
-```markdown
+````markdown
 # Deep Interview Spec: {title}
 
 ## Metadata
@@ -80,6 +80,22 @@ Downstream (prometheus) consumes this as a FIXED input — does not re-decide th
 ## Ontology (Key Entities)
 {Fill from the FINAL round's ontology extraction, not just crystallization-time generation}
 
+**Entity-relationship diagram (REQUIRED):** Render the final entities and their relationships as a mermaid `erDiagram`. Map cardinality from the relationship phrase — "has many" → `||--o{`, "has one" → `||--||`, "has zero or one" → `||--o|`; draw each relationship ONCE (skip the inverse "belongs to" restatement). Put each entity's key fields inside its block. Replace the example below with the interview's actual entities.
+
+```mermaid
+erDiagram
+    USER ||--o{ ORDER : "has many"
+    ORDER ||--|| PAYMENTMETHOD : "paid via"
+    USER {
+        string id
+        string email
+    }
+    ORDER {
+        datetime createdAt
+        money total
+    }
+```
+
 | Entity | Type | Fields | Relationships |
 |--------|------|--------|---------------|
 | {entity.name} | {entity.type} | {entity.fields} | {entity.relationships} |
@@ -105,4 +121,4 @@ Downstream (prometheus) consumes this as a FIXED input — does not re-decide th
 
 ...
 </details>
-```
+````

--- a/skills/deep-interview/deep-interview-spec-template.md
+++ b/skills/deep-interview/deep-interview-spec-template.md
@@ -91,6 +91,7 @@ Downstream (prometheus) consumes this as a FIXED input — does not re-decide th
 ```mermaid
 erDiagram
     %% Fill from the FINAL round's ontology: one entity per ontology entity, one edge per relationship.
+    %% Zero entities: replace this entire block with the literal text "no entities yet" — do NOT emit this example or a bare erDiagram.
     ENTITY_A ||--o{ ENTITY_B : "relationship label"
 ```
 

--- a/skills/deep-interview/deep-interview-spec-template.md
+++ b/skills/deep-interview/deep-interview-spec-template.md
@@ -91,6 +91,7 @@ Downstream (prometheus) consumes this as a FIXED input — does not re-decide th
 ```mermaid
 erDiagram
     %% Fill from the FINAL round's ontology: one entity per ontology entity, one edge per relationship.
+    %% Entity names with spaces or punctuation MUST be double-quoted, e.g. "Discount Code" — an unquoted spaced name renders an error SVG in mermaid.
     %% Zero entities: replace this entire block with the literal text "no entities yet" — do NOT emit this example or a bare erDiagram.
     ENTITY_A ||--o{ ENTITY_B : "relationship label"
 ```

--- a/skills/deep-interview/deep-interview-spec-template.md
+++ b/skills/deep-interview/deep-interview-spec-template.md
@@ -1,6 +1,6 @@
 # Deep Interview Spec Template
 
-```markdown
+````markdown
 # Deep Interview Spec: {title}
 
 ## Metadata
@@ -65,20 +65,34 @@ Downstream (prometheus) consumes this as a FIXED input — does not re-decide th
 ## Architecture
 {overall structure: how the major components are arranged and how they relate to each other}
 
+> Add a diagram here when it is clearer than prose: state the reason, embed a ```mermaid fence, then interpret it.
+
 ## Components
 {each component: its single responsibility and direct dependencies}
+
+> Add a diagram here when it is clearer than prose: state the reason, embed a ```mermaid fence, then interpret it.
 
 ## Data Flow
 {sources → transformations → sinks: trace data from ingestion to output}
 
+> Add a diagram here when it is clearer than prose: state the reason, embed a ```mermaid fence, then interpret it.
+
 ## Error Handling
 {failure modes and their responses: what can go wrong and how the system handles it}
+
+> Add a diagram here when it is clearer than prose: state the reason, embed a ```mermaid fence, then interpret it.
 
 ## Testing
 {what is verified: behaviors, boundaries, and invariants covered by the test suite}
 
 ## Ontology (Key Entities)
 {Fill from the FINAL round's ontology extraction, not just crystallization-time generation}
+
+```mermaid
+erDiagram
+    %% Fill from the FINAL round's ontology: one entity per ontology entity, one edge per relationship.
+    ENTITY_A ||--o{ ENTITY_B : "relationship label"
+```
 
 | Entity | Type | Fields | Relationships |
 |--------|------|--------|---------------|
@@ -105,4 +119,4 @@ Downstream (prometheus) consumes this as a FIXED input — does not re-decide th
 
 ...
 </details>
-```
+````

--- a/skills/deep-interview/deep-interview-spec-template.md
+++ b/skills/deep-interview/deep-interview-spec-template.md
@@ -1,6 +1,6 @@
 # Deep Interview Spec Template
 
-````markdown
+```markdown
 # Deep Interview Spec: {title}
 
 ## Metadata
@@ -80,22 +80,6 @@ Downstream (prometheus) consumes this as a FIXED input — does not re-decide th
 ## Ontology (Key Entities)
 {Fill from the FINAL round's ontology extraction, not just crystallization-time generation}
 
-**Entity-relationship diagram (REQUIRED):** Render the final entities and their relationships as a mermaid `erDiagram`. Map cardinality from the relationship phrase — "has many" → `||--o{`, "has one" → `||--||`, "has zero or one" → `||--o|`; draw each relationship ONCE (skip the inverse "belongs to" restatement). Put each entity's key fields inside its block. Replace the example below with the interview's actual entities.
-
-```mermaid
-erDiagram
-    USER ||--o{ ORDER : "has many"
-    ORDER ||--|| PAYMENTMETHOD : "paid via"
-    USER {
-        string id
-        string email
-    }
-    ORDER {
-        datetime createdAt
-        money total
-    }
-```
-
 | Entity | Type | Fields | Relationships |
 |--------|------|--------|---------------|
 | {entity.name} | {entity.type} | {entity.fields} | {entity.relationships} |
@@ -121,4 +105,4 @@ erDiagram
 
 ...
 </details>
-````
+```

--- a/skills/deep-interview/references/render-assembly.md
+++ b/skills/deep-interview/references/render-assembly.md
@@ -55,7 +55,8 @@ Escape each active value, then write the substituted HTML:
 
 ```bash
 mkdir -p $OMT_DIR/deep-interview
-# write to: $OMT_DIR/deep-interview/{slug}.html
+# write to the render path chosen by the caller (SKILL.md owns the path):
+#   Phase 4 final render → {slug}.html   |   on-demand ontology render → ontology-preview.html
 ```
 
 `{{SPEC_MARKDOWN_JSON}}` is exempt from the HTML-escape — it sits in the inert `<script type="application/json">` container and already carries the close-tag escape above.

--- a/skills/deep-interview/references/render-assembly.md
+++ b/skills/deep-interview/references/render-assembly.md
@@ -1,0 +1,56 @@
+## Table of Contents
+
+- [Injection Guard (close-tag escape)](#injection-guard-close-tag-escape)
+- [Active-Placeholder HTML-Escape](#active-placeholder-html-escape)
+- [Mermaid Validity](#mermaid-validity)
+- [Placeholder Table](#placeholder-table)
+- [Write Command](#write-command)
+
+---
+
+## Injection Guard (close-tag escape)
+
+**Injection guard — close-tag escape**: The render sink is `container.innerHTML = marked.parse(md)` with no DOM sanitizer. The rendered body is USER-AUTHORED spec prose — interview transcript and ontology entity names — that routinely contains `</script>`-like and fenced fragments. Apply this escape to the assembled spec markdown before substituting it into the inert JSON container:
+
+```js
+JSON.stringify(md).replace(/<\/(script)([\s/>])/gi, '<\\/$1$2')
+```
+
+## Active-Placeholder HTML-Escape
+
+**Active-placeholder HTML-escape**: every active placeholder (all EXCEPT `{{SPEC_MARKDOWN_JSON}}`) lands in a live HTML position (`<title>`, `<h1>`, `<span>`) and MUST be HTML-escaped:
+
+```js
+const esc = (s) => String(s).replace(/[&<>"']/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c]));
+```
+
+## Mermaid Validity
+
+**Mermaid validity**: mermaid treats `;` as a statement separator — a raw `;` inside sequence-message text (e.g. `mkdir -p; rm`) silently splits the line and the whole diagram renders as an error SVG. mermaid source MUST be syntactically valid: keep sequence-message text free of raw `;` (rephrase to `then`, a comma, or omit).
+
+## Placeholder Table
+
+Substitute into the template placeholders (shared verbatim with the render template `templates/spec-presentation.html`):
+
+| Placeholder | Value |
+|-------------|-------|
+| `{{LANG_CODE}}` | BCP-47 language tag of the session language (e.g. `ko`, `en`) |
+| `{{HTML_TITLE}}` | Human-readable spec title, e.g. `{slug} — Deep Interview Spec` |
+| `{{SPEC_TITLE}}` | Short kicker, e.g. `Deep Interview Spec` |
+| `{{TOC_TITLE}}` | TOC nav label in session language, e.g. `목차` / `Contents` |
+| `{{AMBIGUITY_SCORE}}` | Meta pill, e.g. `Ambiguity 7%` |
+| `{{ROUND_COUNT}}` | Meta pill, e.g. `12 rounds` |
+| `{{SPEC_FILE_PATH}}` | Absolute path to the written HTML file |
+| `{{SPEC_MARKDOWN_JSON}}` | close-tag-escaped JSON string of the assembled spec markdown (inert container) |
+| `{{FOOTER_NOTE}}` | Session-language note |
+
+## Write Command
+
+Escape each active value, then write the substituted HTML:
+
+```bash
+mkdir -p $OMT_DIR/deep-interview
+# write to: $OMT_DIR/deep-interview/{slug}.html
+```
+
+`{{SPEC_MARKDOWN_JSON}}` is exempt from the HTML-escape — it sits in the inert `<script type="application/json">` container and already carries the close-tag escape above.

--- a/skills/deep-interview/references/render-assembly.md
+++ b/skills/deep-interview/references/render-assembly.md
@@ -31,7 +31,7 @@ const esc = (s) => String(s).replace(/[&<>"']/g, c => ({ '&':'&amp;','<':'&lt;',
 
 ## Mermaid Validity
 
-**Mermaid validity**: mermaid treats `;` as a statement separator — a raw `;` inside sequence-message text (e.g. `mkdir -p; rm`) silently splits the line and the whole diagram renders as an error SVG. mermaid source MUST be syntactically valid: keep sequence-message text free of raw `;` (rephrase to `then`, a comma, or omit).
+**Mermaid validity**: mermaid treats `;` as a statement separator — a raw `;` inside sequence-message text (e.g. `mkdir -p; rm`) silently splits the line and the whole diagram renders as an error SVG. mermaid source MUST be syntactically valid: keep sequence-message text free of raw `;` (rephrase to `then`, a comma, or omit). In `erDiagram` blocks, any entity name containing a space or punctuation MUST be double-quoted (e.g. `"Discount Code" ||--o{ "Free Product" : grants`) — an unquoted spaced name (common for ontology entity names) renders an error SVG; verified against mermaid@11.4.1 (the `NAME["label"]` alias form is invalid in ER diagrams — quote the name directly).
 
 ## Placeholder Table
 

--- a/skills/deep-interview/references/render-assembly.md
+++ b/skills/deep-interview/references/render-assembly.md
@@ -2,6 +2,7 @@
 
 - [Injection Guard (close-tag escape)](#injection-guard-close-tag-escape)
 - [Active-Placeholder HTML-Escape](#active-placeholder-html-escape)
+- [Injection Guard (prose)](#injection-guard-prose)
 - [Mermaid Validity](#mermaid-validity)
 - [Placeholder Table](#placeholder-table)
 - [Write Command](#write-command)
@@ -23,6 +24,10 @@ JSON.stringify(md).replace(/<\/(script)([\s/>])/gi, '<\\/$1$2')
 ```js
 const esc = (s) => String(s).replace(/[&<>"']/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c]));
 ```
+
+## Injection Guard (prose)
+
+**Injection guard — prose fields too**: The render sink is `container.innerHTML = marked.parse(md)` with NO DOM sanitizer (marked removed its `sanitize` option in v8). The rendered spec BODY — the interview transcript and ontology entity names — is USER-AUTHORED and may contain fragments like `</script>` or `<img src=x onerror=BOOM>`; unlike the close-tag escape above (which only protects the inert JSON container), a fragment echoed bare in the rendered spec prose reaches innerHTML as LIVE markup. Every code-derived fragment echoed in rendered spec prose MUST be wrapped in an inline-code span (backticks) so marked escapes it as code — or HTML-escaped if an inline-code span does not fit. If the fragment itself contains a backtick, delimit the span with a longer backtick run (CommonMark matches an inline-code span on an equal-length backtick run). NEVER echo a code fragment bare in spec prose.
 
 ## Mermaid Validity
 

--- a/skills/deep-interview/templates/spec-presentation.html
+++ b/skills/deep-interview/templates/spec-presentation.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="{{LANG_CODE}}">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{HTML_TITLE}}</title>
+<script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js" integrity="sha384-/TQbtLCAerC3jgaim+N78RZSDYV7ryeoBCVqTuzRrFec2akfBkHS7ACQ3PQhvMVi" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js" integrity="sha384-rbtjAdnIQE/aQJGEgXrVUlMibdfTSa4PQju4HDhN3sR2PmaKFzhEafuePsl9H/9I" crossorigin="anonymous"></script>
+<style>
+:root {
+  --bg: #fafafa;
+  --panel: #ffffff;
+  --text: #1a1a1a;
+  --muted: #6b7280;
+  --border: #e5e7eb;
+  --accent: #2563eb;
+  --accent-bg: #eff6ff;
+  --code-bg: #f3f4f6;
+  --ok: #059669;
+  --warn: #d97706;
+  --info: #7c3aed;
+  --danger: #dc2626;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f1115;
+    --panel: #161921;
+    --text: #e5e7eb;
+    --muted: #9ca3af;
+    --border: #2a2f3a;
+    --accent: #60a5fa;
+    --accent-bg: #1e293b;
+    --code-bg: #1a1f2b;
+    --ok: #34d399;
+    --warn: #fbbf24;
+    --info: #a78bfa;
+    --danger: #f87171;
+  }
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans KR", "Apple SD Gothic Neo", sans-serif;
+  font-size: 15px;
+  line-height: 1.65;
+}
+.layout { display: grid; grid-template-columns: 260px minmax(0, 1fr); min-height: 100vh; }
+nav.toc {
+  position: sticky; top: 0;
+  height: 100vh; overflow-y: auto;
+  border-right: 1px solid var(--border);
+  background: var(--panel);
+  padding: 20px 16px;
+  font-size: 13px;
+}
+nav.toc .title { font-weight: 700; color: var(--muted); text-transform: uppercase; font-size: 11px; letter-spacing: 1px; margin-bottom: 12px; }
+nav.toc ul { list-style: none; padding: 0; margin: 0; }
+nav.toc li { margin: 4px 0; }
+nav.toc a { color: var(--muted); text-decoration: none; display: block; padding: 3px 6px; border-radius: 4px; }
+nav.toc a:hover { background: var(--accent-bg); color: var(--accent); }
+nav.toc .lvl-2 { padding-left: 0; }
+nav.toc .lvl-3 { padding-left: 14px; font-size: 12px; }
+nav.toc .lvl-4 { padding-left: 28px; font-size: 11.5px; color: var(--muted); }
+main { padding: 32px 48px 80px; max-width: 960px; }
+header.hero { border-bottom: 1px solid var(--border); margin-bottom: 24px; padding-bottom: 20px; }
+header.hero .kicker { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 1px; }
+header.hero h1 { font-size: 28px; margin: 4px 0 4px; }
+header.hero .meta { color: var(--muted); font-size: 13px; display: flex; gap: 16px; flex-wrap: wrap; margin-top: 8px; }
+header.hero .meta .pill { background: var(--accent-bg); color: var(--accent); padding: 2px 10px; border-radius: 12px; font-weight: 600; }
+article#spec-content { padding-top: 8px; }
+article h1 { display: none; }
+article h2 { font-size: 22px; margin-top: 40px; padding-bottom: 6px; border-bottom: 1px solid var(--border); }
+article h3 { font-size: 17px; margin-top: 28px; }
+article h4 { font-size: 14.5px; margin-top: 20px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; }
+article code { background: var(--code-bg); padding: 1px 5px; border-radius: 3px; font-size: 0.9em; font-family: ui-monospace, SF Mono, Menlo, monospace; }
+article pre { background: var(--code-bg); border: 1px solid var(--border); border-radius: 4px; padding: 12px 14px; overflow-x: auto; font-size: 12.5px; line-height: 1.5; }
+article pre code { background: transparent; padding: 0; }
+article table { border-collapse: collapse; width: 100%; margin: 16px 0; font-size: 13.5px; }
+article th, article td { border: 1px solid var(--border); padding: 7px 10px; text-align: left; vertical-align: top; }
+article th { background: var(--code-bg); font-weight: 600; }
+article blockquote { border-left: 3px solid var(--accent); background: var(--accent-bg); margin: 14px 0; padding: 10px 14px; color: var(--text); }
+article hr { border: none; border-top: 1px solid var(--border); margin: 28px 0; }
+article ul, article ol { padding-left: 22px; }
+article li { margin: 3px 0; }
+article li input[type="checkbox"] { margin-right: 6px; }
+article a { color: var(--accent); }
+article .mermaid { display: block; margin: 22px 0; text-align: center; }
+article .mermaid svg { max-width: 100%; height: auto; }
+.footer-note { margin-top: 60px; padding-top: 20px; border-top: 1px solid var(--border); color: var(--muted); font-size: 12px; }
+@media (max-width: 900px) {
+  .layout { grid-template-columns: 1fr; }
+  nav.toc { position: relative; height: auto; max-height: 300px; }
+  main { padding: 20px; }
+}
+</style>
+</head>
+<body>
+<div class="layout">
+<nav class="toc"><div class="title">{{TOC_TITLE}}</div><ul id="toc"></ul></nav>
+<main>
+<header class="hero">
+  <div class="kicker">{{SPEC_TITLE}}</div>
+  <h1>{{HTML_TITLE}}</h1>
+  <div class="meta">
+    <span class="pill">{{AMBIGUITY_SCORE}}</span>
+    <span class="pill">{{ROUND_COUNT}}</span>
+    <span>{{SPEC_FILE_PATH}}</span>
+  </div>
+</header>
+
+<article id="spec-content"></article>
+
+<div class="footer-note">{{FOOTER_NOTE}}</div>
+
+</main>
+</div>
+
+<script type="application/json" id="spec-md">{{SPEC_MARKDOWN_JSON}}</script>
+<script>
+(function() {
+  const md = JSON.parse(document.getElementById('spec-md').textContent);
+  marked.setOptions({ gfm: true, breaks: false });
+  const container = document.getElementById('spec-content');
+  container.innerHTML = marked.parse(md);
+  // Diagram enrichment: marked renders a ```mermaid fence as <pre><code class="language-mermaid">.
+  // Convert each into a <div class="mermaid"> that the Mermaid runtime renders into SVG.
+  container.querySelectorAll('pre > code.language-mermaid').forEach(code => {
+    const div = document.createElement('div');
+    div.className = 'mermaid';
+    div.textContent = code.textContent;
+    code.parentElement.replaceWith(div);
+  });
+  if (window.mermaid) {
+    const dark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    mermaid.initialize({ startOnLoad: false, theme: dark ? 'dark' : 'default', securityLevel: 'strict' });
+    mermaid.run({ querySelector: '.mermaid' });
+  }
+  const toc = document.getElementById('toc');
+  const headings = container.querySelectorAll('h2, h3, h4');
+  const slugify = (t) => t.toLowerCase().trim().replace(/[^\p{L}\p{N}\s-]/gu, '').replace(/\s+/g, '-') || 'sec';
+  const used = new Set();
+  headings.forEach(h => {
+    let id = h.id || slugify(h.textContent);
+    let base = id, i = 2;
+    while (used.has(id)) { id = base + '-' + i; i++; }
+    used.add(id);
+    h.id = id;
+    const lvl = parseInt(h.tagName.substring(1));
+    const li = document.createElement('li');
+    li.className = 'lvl-' + lvl;
+    const a = document.createElement('a');
+    a.href = '#' + id;
+    a.textContent = h.textContent;
+    li.appendChild(a);
+    toc.appendChild(li);
+  });
+})();
+</script>
+</body>
+</html>

--- a/skills/deep-interview/tests/application-scenarios.md
+++ b/skills/deep-interview/tests/application-scenarios.md
@@ -436,3 +436,74 @@ Current deep-interview Phase 1 performs only brownfield/greenfield detection and
 **RED confirmation target:** V1 FAILS — no decomposition proposal is visible in the first 2 assistant turns.
 
 Evidence path: `$OMT_DIR/evidence/deep-interview-prometheus-boundary-reshape/red-d1/`
+
+---
+
+## Scenario E1: Ontology Mermaid ER Diagram Embedding & Browser Render
+
+**Target Agent:** deep-interview
+**Primary Behavior:** At Phase 4 crystallization, deep-interview embeds a REQUIRED ontology `erDiagram` (mermaid) in `spec.md` — in addition to the existing Ontology (Key Entities) table — and writes a `{slug}.html` browser-render artifact under `$OMT_DIR/deep-interview/`. Mid-interview, an on-demand ontology-preview request issued while the ontology is still empty must show the literal state "no entities yet" rather than an empty or invalid `erDiagram`.
+**Reference behavior:** deep-interview spec-crystallization contract — the Ontology (Key Entities) section requires a rendered entity-relationship diagram (mermaid `erDiagram`) alongside the table, plus a browser-viewable render of the crystallized spec and an on-demand ontology preview during the interview.
+
+**How to run:**
+1. Dispatch a fresh deep-interview subagent with Fixture Prompt A (below) verbatim as the user's idea. Let it run to Phase 4 spec crystallization. Do NOT guide it toward producing a diagram or a render.
+2. Locate the crystallized `spec.md` and score it against Verification Point a. Locate `$OMT_DIR/deep-interview/` and score it against Verification Point b.
+3. Separately, dispatch a SECOND fresh deep-interview subagent (clean session) with Fixture Prompt B (below): the same idea, immediately followed by an on-demand preview request BEFORE answering any interview question. Score the resulting preview output against Verification Point c.
+4. Do NOT guide either session toward mermaid, HTML, or the phrase "no entities yet" — record whatever the baseline agent actually produces.
+
+**Test discipline:** Do NOT tell deep-interview to draw a diagram, render anything, or use the words "mermaid" or "no entities yet". If it answers the preview request with plain prose describing an empty ontology instead of the literal contract phrase, record that as FAIL on point c — that is the RED observation.
+
+---
+
+### Fixture Prompt A (crystallization run — for points a and b)
+
+Hand to the fresh deep-interview agent verbatim:
+
+> We want to add a loyalty points redemption feature to our e-commerce platform. Customers earn loyalty points on purchases, and can redeem points for rewards — either a discount code or a free product from a fixed rewards catalog. Each redemption should be logged so we can audit point balances later. Points expire after 12 months if unused.
+
+### Fixture Prompt B (empty-ontology probe — for point c)
+
+Hand to a SEPARATE fresh deep-interview agent verbatim, as the first two turns of the session, in order:
+
+> Turn 1 (idea): We want to add a loyalty points redemption feature to our e-commerce platform. Customers earn loyalty points on purchases, and can redeem points for rewards — either a discount code or a free product from a fixed rewards catalog. Each redemption should be logged so we can audit point balances later. Points expire after 12 months if unused.
+>
+> Turn 2 (sent immediately, before answering any interview question the agent asks): Before we go any further — can you show me a preview of the ontology model so far?
+
+---
+
+### Entity Manifest (for scoring point a)
+
+The fixture domain names these entities; at least 3 must appear (case-insensitive) inside the mermaid block for point a to PASS:
+
+| Entity | Role |
+|--------|------|
+| Customer | initiates redemptions, holds a LoyaltyAccount |
+| LoyaltyAccount | holds a point balance for a Customer |
+| Reward | catalog item redeemable for points (discount code or free product) |
+| Redemption | audit record linking a Customer/LoyaltyAccount to a Reward |
+
+---
+
+### Verification Points
+
+| # | Check | Expected GREEN Behavior | How to Measure |
+|---|-------|------------------------|----------------|
+| a | Crystallized `spec.md` contains an ontology `erDiagram` | The spec.md produced by Fixture Prompt A contains a ` ```mermaid ` fenced block whose body contains `erDiagram`, and that block names at least 3 of the entities in the Entity Manifest above | `grep -A40 '```mermaid' <spec.md>` extracted, then `grep -c 'erDiagram'` on that extract must be ≥ 1; grep the same extract for entity names, count of distinct manifest entities found must be ≥ 3 |
+| b | `{slug}.html` render artifact exists | A non-empty `.html` file exists under `$OMT_DIR/deep-interview/` produced by the Fixture Prompt A run | `ls "$OMT_DIR/deep-interview/"*.html` returns at least one path; `test -s <path>` on that file succeeds (non-empty) |
+| c | Empty-ontology on-demand preview shows literal "no entities yet" | The response to Turn 2 of Fixture Prompt B (issued before any entity has been extracted) contains the literal string `no entities yet`, and does NOT contain an `erDiagram` fence with zero entity blocks inside it | `grep -c "no entities yet"` on the Turn-2 response must be ≥ 1; if the response contains a ` ```mermaid ` fence, it must also contain at least one entity block — a bare `erDiagram` with no entity definitions is a FAIL |
+
+### RED-Result Note
+
+**TRUE RED (current skill emits neither the diagram nor the render):**
+The current deep-interview skill and spec template produce only the existing "Ontology (Key Entities)" markdown table (see the table format used throughout Scenario A2's fixtures) — there is no mermaid `erDiagram` embedding step anywhere in the crystallization flow, no HTML render step of any kind, and no on-demand ontology-preview affordance. Baseline predictions:
+- Point a FAILS: `spec.md` contains the Ontology table only; no ` ```mermaid ` fence exists anywhere in the file.
+- Point b FAILS: no `.html` file is ever written by deep-interview; `$OMT_DIR/deep-interview/` may not even exist as a directory.
+- Point c FAILS: deep-interview has no concept of a "preview" request. Turn 2 of Fixture Prompt B most likely receives either a refusal, a plain-prose restatement of the idea, or a bare description of "no entities extracted yet" in the agent's own words — never the literal contract string `no entities yet`, and never any erDiagram concept at all.
+
+**False-GREEN this note must guard against — do not let a pre-existing check masquerade as coverage of this new behavior:**
+1. The pre-existing Ontology (Key Entities) *table* already appears in crystallized specs today. Its presence is NOT evidence for point a — point a requires the additional mermaid `erDiagram` fenced block, not the table that already exists independently of this scenario.
+2. `skills/deep-interview/SKILL.test.ts` already contains static string-presence assertions (`new-prose: spec-presentation render target`, `new-prose: ontology-preview on-demand render`, `template: mermaid ontology erDiagram slot`, `file-existence: mermaid visualization assets`) that grep SKILL.md and the template source files for phrases like `erDiagram`, `{slug}.html`, `ontology-preview.html`, and `no entities yet`. Those are a SEPARATE, purely static prose-contract layer scored by `bun test` against the skill's own instruction text — they do not run a subagent and cannot prove that a live interview session actually produces the artifacts. A future edit that merely inserts these phrases into SKILL.md would turn `SKILL.test.ts` green without making any of points a, b, or c here true; conversely this scenario can still fail even after `SKILL.test.ts` passes, if the agent does not follow through at runtime. GREEN on `SKILL.test.ts` must never be cited as GREEN on this scenario.
+
+**RED confirmation target:** a, b, and c all FAIL on an unmodified deep-interview skill.
+
+Evidence path: `$OMT_DIR/evidence/deep-interview-prometheus-boundary-reshape/red-e1/`


### PR DESCRIPTION
## 📌 Summary

`deep-interview` 스킬에 온톨로지를 mermaid ER 다이어그램으로 시각화하는 기능을 추가합니다. 크리스탈라이즈된 spec에 diff 가능한 영속 `erDiagram`을 심고(Tier 1), CLI 런타임에서 mermaid가 인라인 렌더되지 않는 현실을 감안해 서버리스 브라우저 HTML 렌더를 실제 시각 산출물로 제공합니다(Tier 2).

---

## 🔧 Changes

### 스펙 템플릿 — Tier 1 영속 소스 (`deep-interview-spec-template.md`)

- `## Ontology (Key Entities)` 섹션에 REQUIRED `erDiagram` 슬롯 추가 (엔티티 테이블 위)
- 표시 래퍼를 3-백틱 → 4-백틱으로 상향, 내부 mermaid는 3-백틱 유지
- Architecture / Components / Data Flow / Error Handling 4개 섹션에 재량적 다이어그램 가이드("clearer than prose") 추가

크리스탈라이즈된 spec 자체가 온톨로지 ER의 SSOT이자 diff 대상이 되도록, 슬롯을 오케스트레이션 프롬프트가 아닌 템플릿(shape 정의처)에 둡니다.

**영향 범위**: deep-interview Phase-4 산출물 구조만. 기존 엔티티/수렴 테이블·전사 섹션 불변. 하위 호환 유지.

### 렌더 표면 — Tier 2 (`templates/spec-presentation.html`, `references/render-assembly.md` 신규)

- 서버리스 브라우저 렌더 템플릿: marked@12.0.2 + mermaid@11.4.1 CDN+SRI, inert JSON 컨테이너, `marked.parse → language-mermaid 재작성 → mermaid.run({securityLevel:'strict'})` 배선
- `render-assembly.md`: 치환 시점 인젝션 가드(close-tag escape + active-placeholder HTML-escape + prose-fragment 가드) + mermaid self-audit + placeholder 테이블의 단일 owner

review-report의 렌더 메커니즘을 미러링(별도 shared lib 미추출). 두 신규 파일은 동일한 9-토큰 placeholder 계약을 공유합니다.

**영향 범위**: 신규 파일 2개. 서버/네트워크 프리미티브 없음(순수 정적 파일). CDN 도달 실패 시 다이어그램만 blank(텍스트는 렌더).

### 오케스트레이션 (`SKILL.md`)

- Phase-4 최종 렌더: spec.md 작성 후 `render-assembly.md` mandatory-read → 가드 적용 → `{slug}.html` 작성(슬러그 재사용)
- on-demand 온톨로지 렌더: 자연어 트리거("see, preview, or visualize the model", KO/EN) → `deep-interview-state.ts get`으로 스냅샷 조회 → `ontology-preview.html`
- 빈 온톨로지 시 두 경로 모두 "no entities yet" 상태 방출(무효 erDiagram 금지)

**영향 범위**: SKILL.md 프로즈 17줄 추가. cleanup 경로·`decision.ts`·`state.ts`·`prometheus` 불변.

### 테스트 (`SKILL.test.ts`, `tests/application-scenarios.md`)

- 구조 앵커 12개(erDiagram 슬롯·렌더 프로즈·파일 존재) + 행동 시나리오 E1, TDD RED→GREEN
- 기존 스위트 무회귀(62 pass / 0 fail)

**영향 범위**: 테스트만. 기존 REGRESSION-GUARD 밴드 불변.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.

### 1. 왜 2-tier인가 — 영속 소스와 렌더 표면의 분리

**배경 및 문제 상황:** 완성된 spec의 다이어그램을 주로 CLI 런타임(Claude Code / Codex / OpenCode)에서 보는데, 이들은 mermaid를 인라인 렌더하지 않습니다(claude-code#14375). `.md` 안의 fence만으로는 사용자가 실제 그림을 볼 수 없습니다.

**해결 방안:** 두 티어를 합성 — spec.md에 diffable `erDiagram` fence(Tier 1)를 심고, 브라우저에서 여는 HTML 렌더(Tier 2)를 실제 시각 산출물로 둡니다.

**구현 세부사항:** 렌더 파이프라인은 `securityLevel:'strict'`로 다이어그램 측 HTML 실행을 차단하고, fence를 DOM에서 `<div class="mermaid">`로 재작성한 뒤 `mermaid.run`합니다. (`;`는 mermaid statement separator라 시퀀스 메시지 텍스트에 raw `;`를 쓰지 않았습니다 — 이 PR이 도입한 self-audit 규칙의 실사용)

```mermaid
sequenceDiagram
    participant S as SKILL.md Phase-4
    participant R as render-assembly.md
    participant T as spec-presentation.html
    S->>R: mandatory-read 가드 절차
    S->>S: close-tag escape then HTML-escape 적용
    S->>T: placeholder 치환 후 slug.html 작성
    T->>T: marked.parse then mermaid.run(strict)
```

**선택과 트레이드오프:** 영속 fence는 raw CLI 뷰에서 안 보이는 대신 diff·durability를 얻고(+), 렌더는 런타임 무관 브라우저 시각을 보장하나 자동 새로고침은 없습니다(−). prometheus의 ephemeral-only 모델(fence 미영속) 대신 durability를 택했습니다.

### 2. Mirror-don't-share — shared render-lib 미추출

**배경 및 문제 상황:** `lib/`에 공유 렌더 유틸이 없고, prometheus·review-report는 각자 정적 템플릿 + placeholder 치환을 소유합니다.

**해결 방안:** review-report 템플릿을 deep-interview 디렉토리로 미러링하고 placeholder를 재정의, shared lib은 유보.

**선택과 트레이드오프:** 소비자 3개·검증된 공유 계약 부재 상태에서 shared lib은 조기 추상화입니다. 미러가 리포의 기존 선례(두 독립 복사본)입니다. 대가는 세 템플릿 독립 드리프트(변경 빈도 낮아 수용). 네 번째 소비자 등장 시 재검토.

### 3. Fence-nesting 정정 — 바깥 4-백틱 / 내부 3-백틱 (D-4)

**배경 및 문제 상황:** 표시 래퍼(4-백틱 markdown fence) 안에 mermaid 예시를 래퍼를 조기 종료시키지 않고 넣어야 합니다. 원 스펙은 "내부 mermaid를 4-백틱으로"라 명시했으나 이는 CommonMark 역방향입니다.

**해결 방안:** marked@12.0.2로 실증 — 내부 4-백틱 close 라인이 3-백틱 래퍼를 조기 종료시켜 후속 내용이 `<p>`로 유출(BREAK). 바깥 래퍼를 4-백틱으로 올리고 내부 mermaid를 3-백틱으로 두면 단일 `language-markdown` 블록으로 파싱(WORKS).

**선택과 트레이드오프:** CommonMark은 close fence가 opener 이상 길이를 요구하므로 바깥이 최장이어야 합니다. 실제 핀 렌더러로 실증해 스펙의 Risk #1 문구를 정정(문서화)했습니다.

### 4. 인젝션 가드와 하드닝 — code-review 레인이 잡은 4번째 가드

**배경 및 문제 상황:** 렌더 sink는 `container.innerHTML = marked.parse(md)`이고 marked는 v8부터 sanitize를 제거했습니다. 렌더 본문은 사용자 저작 spec 프로즈(인터뷰 전사·온톨로지 이름)라 `</script>`·`<img onerror>` 유입 가능.

**해결 방안:** `render-assembly.md`가 가드의 단일 owner. 최초 계획은 3-가드(close-tag escape + active-placeholder HTML-escape + mermaid self-audit)였으나, 독립 code-review 레인이 review-report의 **4번째 가드(Injection Guard prose — 본문 코드 조각을 inline-code/HTML-escape)** 누락을 marked 실행으로 적발 → 추가해 미러를 완성했습니다.

**구현 세부사항:** close-tag escape `JSON.stringify(md).replace(/<\/(script)([\s/>])/gi, '<\\/$1$2')`가 inert JSON 컨테이너의 조기 종료를 막고, prose 가드가 본문 raw HTML의 live 실행을 막습니다. agent-browser로 `file://` 렌더를 열어 유효 SVG 1개·error-SVG 0개, `</script>`+raw`;` 본문에도 컨테이너 무손상을 실증했습니다.

**선택과 트레이드오프:** 위협 실 심각도는 낮음(file:// self-render, 저자=열람자, cross-origin 없음)이나 D-12가 "review-report의 렌더 안전 미러"를 owner에 위임했으므로 4번째 가드 추가는 스코프 확장이 아닌 미러 완성입니다. code-level sanitizer/의존성은 도입하지 않음(프로즈 가드 일관).

### 5. code-review PLAUSIBLE 3건 — 검증 후 반영 완료 (커밋 `2e731206`)

code-review 레인이 비차단(0 CONFIRMED)으로 남긴 어드바이저리 3건을, 각각 실제 바이트로 검증한 뒤 반영했습니다:

- **`spec-template.md` erDiagram empty-state 분기** — 슬롯 주석에 "zero entities → 'no entities yet'로 대체" 지침을 co-locate. SKILL.md 프로즈에만 있던 규칙을 슬롯 자체에 붙여, 에이전트가 템플릿을 읽는 지점에서 바로 보이도록. (fence integrity 재검증 — 단일 language-markdown 블록 유지)
- **`SKILL.md` on-demand 렌더 명세 보강** — Phase-4와 동일한 `spec-presentation.html`을 채우도록 템플릿을 명시하고, mid-interview meta placeholder(AMBIGUITY_SCORE/ROUND_COUNT는 현재 상태값, SPEC_TITLE/HTML_TITLE="Ontology Preview") 소싱 규칙을 추가.
- **`render-assembly.md` write-command 경로-중립화** — D-12상 render-assembly.md는 경로를 소유하지 않으므로, 주석을 양 호출지점(`{slug}.html` / `ontology-preview.html`)을 모두 보여주는 경로-중립 형태로 정정.

---

## ✅ Checklist

### mermaid 시각화
- [ ] `bun test skills/deep-interview/`가 62 pass / 0 fail (RED 앵커 12개 GREEN 전환, 기존 스위트 무회귀)
  - `skills/deep-interview/SKILL.test.ts`
  - `skills/deep-interview/tests/application-scenarios.md`
- [ ] spec-template이 marked@12.0.2에서 정확히 1개의 `language-markdown` 블록으로 파싱되고 `erDiagram`을 포함
  - `skills/deep-interview/deep-interview-spec-template.md`
- [ ] 브라우저 렌더가 유효(non-error) SVG를 생성하고, `</script>`+raw`;` 본문에도 inert JSON 컨테이너가 무손상
  - `skills/deep-interview/templates/spec-presentation.html`
  - `skills/deep-interview/references/render-assembly.md`
- [ ] CDN 스크립트 태그의 버전 핀·SRI가 mirror 소스(review-report)와 byte-identical
  - `skills/deep-interview/templates/spec-presentation.html`
- [ ] diff footprint가 `skills/deep-interview/` 하위 6파일로 한정(prometheus·decision.ts·state.ts cleanup 불변)
