### PR TITLE
refactor: deep-interview 요구사항/설계 인터뷰 페이즈 분리

### DIFF
--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -402,6 +402,17 @@ Once Phase 2 exits (via the residual-ambiguity seam, above) toward design work, 
 
 **Fact vs. strawman boundary:** a point the codebase or an external constraint already forces onto a single path is a **fact** — ground it with `explore`/`librarian` and state it as settled, do not manufacture a **strawman** alternative around it. Only present alternatives where a real choice exists; naming options nobody would pick is not a decision.
 
+**Persist each decision to state:** after the user answers a design question (or a forced point is fact-grounded), append the decision to interview state *before* moving to the next question — the same mechanism Step 2e and Step 2-fact use, so the resume path (`get`/`adopt`) and Phase 4 crystallization recover the chosen alternatives even across a session interruption. Without this, the decision lives only in the in-context transcript and is lost on cross-session resume. The existing `--append-round-stdin` accepts this shape with no schema change (exactly as the `fact-ground` round does), marked as a design round so it is distinguishable from requirements Q&A:
+
+```bash
+bun ${CLAUDE_SKILL_DIR}/scripts/deep-interview-state.ts update \
+  --append-round-stdin <<'OMT_DI_PAYLOAD_EOF'
+{"n":<round_number>,"kind":"design","decision":"<design question>","choice":"<chosen alternative>","alternatives":[<offered alternatives>],"rationale":"<why chosen>"}
+OMT_DI_PAYLOAD_EOF
+```
+
+The same JSON-encoding rule as Step 2e applies: the heredoc guards shell quoting only; all substituted string values must be JSON-encoded (`\"`, `\\`, newlines as `\n`).
+
 Continue this loop until **all design branches** are resolved — no open decision, alternative, or design-facing gap remains.
 
 **Design-completion exit:** when all design branches are resolved, do not bare-announce completion. Run the residual-ambiguity seam (Step 2-exit, above): reflect the residual ambiguity left in the design (any unresolved tension, edge case, or soft spot), then ask the user via `AskUserQuestion` whether to continue resolving design branches or proceed to Phase 4 (Crystallize).

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -17,7 +17,7 @@ Deep Interview implements Ouroboros-inspired Socratic questioning with mathemati
 - User wants to avoid "that's not what I meant" outcomes from autonomous execution
 - Task is complex enough that jumping to code would waste cycles on scope discovery
 - User wants mathematically-validated clarity before committing to execution
-- User knows roughly WHAT they want but a load-bearing design approach (HOW) is unresolved -- multiple viable, costly-to-change approaches must be decided before the spec is actionable
+- User wants every design decision interrogated with alternatives before building -- not just requirements clarified
 </Use_When>
 
 <Do_Not_Use_When>
@@ -127,22 +127,16 @@ The `init` subcommand performs a strict overlay of the rich state shape into the
 
 ## Phase 2: Interview Loop
 
-Repeat until `ambiguity ≤ threshold`; when the threshold is reached, run the how-readiness gate check before exiting Phase 2: if no unresolved load-bearing HOW-decision exists, proceed to Phase 4; if one exists, run the Design-fork detection gate below, record the chosen approach, then proceed to Phase 4. User-forced early exits (hard-cap, early-exit) bypass this gate and carry any unresolved fork into the spec risk-note; a literal user stop/cancel/abort instead halts and saves state, crystallizing no spec.
+Repeat until `ambiguity ≤ threshold`; when the threshold is reached, run the residual-ambiguity seam (Step 2-exit, below) to decide whether to keep clarifying requirements or move on to the Design Interview phase. User-forced early exits (hard-cap, early-exit) and a literal user stop/cancel/abort are handled by the seam itself, as described there.
 
-### Step 2-exit: Design-fork detection gate
+### Step 2-exit: Residual-Ambiguity Seam
 
-Run this ONLY after `ambiguity ≤ threshold` and before Phase 2 exits. This design-fork detection is orthogonal to the Step-2 stance selector: scan the accumulated interview state and transcript summary for load-bearing design forks — multiple viable approaches that are costly-to-change or cross-cutting. Trivial and single-approach situations clear the how-readiness gate without daedalus. On a load-bearing fork, dispatch `daedalus` with the evidence block defined below — `daedalus` is a consultation helper reserved for DIFFICULT or COMPLEX load-bearing forks (hard cross-cutting choices that warrant steelman antithesis and tradeoff tension analysis); routine multi-viable forks that arose during the interview are resolved in-loop via Step 2-alt (below) and do NOT reach this gate. Present the recommended approach via `AskUserQuestion` (tag "(Recommended)"), record the chosen approach for the spec's Approach section, then treat the how-readiness gate as clear for Phase 4. A user instruction to be quick or not over-think the design is NOT a user-forced escape hatch unless it is a literal stop/abort/early-exit signal; when the threshold was met on the normal path, resolve the load-bearing fork via the single daedalus + AskUserQuestion step (which already honors the hurry) rather than bypassing it.
+This is the single reusable stopping-and-checking pattern used at every phase exit in this skill — defined once here, referenced by both the requirements-threshold exit (Step 2d, below) and the design-completion exit (Design Interview phase, below). Do not bare-announce completion at either exit. Instead:
 
-```
-## Evidence
-- State JSON: output of `bun ${CLAUDE_SKILL_DIR}/scripts/deep-interview-state.ts get`
-- Interview packet prepared by the main agent: prompt-safe transcript summary, explicit user decisions, unresolved HOW-fork candidates, constraints, success criteria, ontology snapshots, and relevant evidence provenance labels.
+1. Reflect the residual ambiguity that remains — name any unresolved gap, weak dimension, or open design point, however small, instead of declaring the interview simply "done".
+2. Ask the user, via `AskUserQuestion`, whether to continue (keep clarifying requirements, or keep resolving design branches) or proceed to the next phase.
 
-## Focus
-- Enumerate 2–3 viable approaches for the unresolved HOW-fork; steelman each.
-- Surface tradeoff tensions and costly-to-change consequences.
-- Recommend one approach with rationale, using only the evidence packet and state JSON above.
-```
+User-forced early exits (hard-cap, early-exit) skip the interactive question and proceed directly, folding the residual ambiguity into the spec's risk-note instead. A literal user stop/cancel/abort halts and saves state for resume, crystallizing no spec.
 
 ### Step 2-head: Dialectic Rhythm Guard (pre-question stance selector)
 
@@ -231,24 +225,6 @@ If any prompt input is too large, summarize it first and then continue from the 
 | Success Criteria | "How do we know it works?" | "If I showed you the finished product, what would make you say 'yes, that's it'?" |
 | Context Clarity (brownfield) | "How does this fit?" | "I found JWT auth middleware in `src/auth/` (pattern: passport + JWT). Should this feature extend that path or intentionally diverge from it?" |
 | Scope-fuzzy / ontology stress | "What IS the core thing here?" | "You have named Tasks, Projects, and Workspaces across the last rounds. Which one is the core entity, and which are supporting views or containers?" |
-
-After generating the question (above), check whether the topic reveals a **multi-viable design choice** — if yes, run Step 2-alt below instead of Step 2b.
-
-### Step 2-alt: Multi-viable alternative presentation (fires in-loop)
-
-**Trigger:** question generation reveals a design choice with ≥2 viable approaches.
-
-**Multi-viable design choice (definition):** both conditions must hold: (1) ≥2 approaches each materially shape the spec — affecting architecture, data model, API contract, or user flow in a non-trivial way — AND (2) codebase facts and external research cannot decide between them; the choice requires human judgment.
-
-**Excluded — do not manufacture alternatives:** single-viable situations (one approach is forced by the codebase, a constraint, or an established fact) and pure factual questions. Example: if the codebase already mandates one auth path via a shared middleware, do NOT generate "JWT vs cookies vs API keys" — that is a strawman.
-
-**Presentation rule:** present 2-3 approaches via `AskUserQuestion`, tag one option `(Recommended)` with a brief rationale, and ask the user to choose. Do not silently default to any approach.
-
-**Main skill owns routine presentation — `daedalus` is for difficult/complex cases only.** For straightforward trade-offs with well-understood options, present the alternatives directly without dispatching `daedalus`. Reserve `daedalus` for choices that are genuinely hard or cross-cutting — where steelman antithesis and deep tradeoff tension analysis add value beyond a direct listing. `daedalus` is a consultation helper, NOT a gate and NOT the default enumerator for every multi-viable fork.
-
-**Seam note — no double-fire with the Phase-2-exit backstop:** The Step-2-exit Design-fork detection gate is a BACKSTOP that fires ONLY when an unresolved load-bearing fork remains at Phase-2 exit. Because Step 2-alt resolves multi-viable forks as they arise IN-LOOP, the backstop normally has nothing left to fire on when the threshold is reached. There is no double-fire: the backstop fires only on forks that slipped through (e.g., a fork that emerged very late in the interview or a user-forced early exit that bypassed in-loop resolution).
-
-After the user selects an approach, record the decision, then proceed to Step 2c (skip Step 2b — the `AskUserQuestion` in this step served as the question for this round).
 
 ### Step 2b: Ask the Question
 
@@ -354,7 +330,7 @@ Round {n} complete.
 
 **Next target:** {weakest_dimension} — {weakest_dimension_rationale}
 
-{score <= threshold ? "Clarity threshold met! Ready to proceed." : "Focusing next question on: {weakest_dimension}"}
+{score <= threshold ? "Threshold met — reflecting residual ambiguity via the Step 2-exit seam before proceeding." : "Focusing next question on: {weakest_dimension}"}
 ```
 
 ### Step 2e: Update State
@@ -416,29 +392,35 @@ bun ${CLAUDE_SKILL_DIR}/scripts/deep-interview-state.ts update \
 
 (Duplicate names are silently deduped; safe to call even if the mode was already recorded.)
 
+## Design Interview
+
+Once Phase 2 exits (via the residual-ambiguity seam, above) toward design work, interrogate the design **relentlessly** — probe **every aspect** of the design until reaching **shared understanding** with the user, going beyond requirements clarity.
+
+**Pacing:** ask design questions **one at a time**, exactly as in the requirements loop — never batch. For each question, offer a recommended answer so the user can accept or override it quickly. Before asking, check whether the codebase can already answer it — if so, run `explore` first and fold the finding into the question instead of asking the user to rediscover it.
+
+**Per-decision alternatives:** for **every design decision** — every point where the implementation genuinely could go more than one way — present **2-3 alternatives** with a recommendation, via `AskUserQuestion`. This isn't limited to costly-to-change choices: every real decision earns alternatives, not just the hardest ones.
+
+**Fact vs. strawman boundary:** a point the codebase or an external constraint already forces onto a single path is a **fact** — ground it with `explore`/`librarian` and state it as settled, do not manufacture a **strawman** alternative around it. Only present alternatives where a real choice exists; naming options nobody would pick is not a decision.
+
+Continue this loop until **all design branches** are resolved — no open decision, alternative, or design-facing gap remains.
+
+**Design-completion exit:** when all design branches are resolved, do not bare-announce completion. Run the residual-ambiguity seam (Step 2-exit, above): reflect the residual ambiguity left in the design (any unresolved tension, edge case, or soft spot), then ask the user via `AskUserQuestion` whether to continue resolving design branches or proceed to Phase 4 (Crystallize).
+
 ## Phase 4: Crystallize Spec
 
-When Phase 2 has exited with `ambiguity ≤ threshold` and the how-readiness gate clear, or when a user-forced escape hatch fires:
+When the Design Interview phase has exited with all design branches resolved, or when a user-forced escape hatch fires:
 
-The Design-fork detection gate has already run at Phase 2 exit for the normal path. In Phase 4, use the recorded chosen approach when drafting the Approach section; on a user-forced escape hatch with an unresolved fork, include the fork as a risk-note instead of dispatching daedalus here.
+1. **Generate the specification** with the prompt-safe transcript, using the design decisions recorded during the Design Interview phase for the Approach section; on a user-forced escape hatch, include any unresolved requirements gap or design branch as a risk-note instead. **Spec template: you MUST read `deep-interview-spec-template.md` now, before composing the spec.** Do not write the spec from memory.
 
-**Per-section approval loop**: Draft each spec section (Goal → Constraints → Success Criteria → Approach → ...) one at a time; present it and collect per-section approval before continuing. **Spec template: you MUST read `deep-interview-spec-template.md` now, before composing any section.** Do not write the spec from memory.
+**Diagram-authoring guidance**: the Ontology (Key Entities) `erDiagram` is REQUIRED. Self-audit every mermaid block before writing it (see `render-assembly.md`'s mermaid-validity note: no raw `;` in diagram text).
 
-**Whole-spec gate**: After all per-section approvals, assemble the draft and present the whole spec for final confirmation before writing.
+2. **Write to file**: `$OMT_DIR/deep-interview/{slug}.md`
 
-**Diagram-authoring guidance**: the Ontology (Key Entities) `erDiagram` is REQUIRED; the Architecture / Components / Data Flow / Error Handling diagrams are discretionary — add one only when it is clearer than prose. Self-audit every mermaid block before writing it (see `render-assembly.md`'s mermaid-validity note: no raw `;` in diagram text).
+**Inline self-review** (after writing), 4 checks: placeholder / consistency / scope / ambiguity — confirm no unfilled placeholders, no section contradictions, full interview coverage, no ambiguous text remains.
 
-1. **Write to file**: `$OMT_DIR/deep-interview/{slug}.md`
+3. **Render to HTML**: **You MUST read `references/render-assembly.md` first** — it is the single owner of the close-tag escape, the active-placeholder HTML-escape, and the prose-fragment guard; apply its full guard set before substituting. Fill `templates/spec-presentation.html` with the assembled spec markdown and the placeholder values, then write the render to `$OMT_DIR/deep-interview/{slug}.html` — reuse the SAME `{slug}` from the just-written `{slug}.md`; do NOT re-derive the slug. Tell the user to open it in a browser. If the final ontology has zero entities, the Ontology (Key Entities) `erDiagram` slot must render a `no entities yet` state rather than an empty/invalid erDiagram. **Lifecycle**: this render HTML is never auto-deleted, same as the `.md` spec.
 
-**2-layer review** (after writing):
-
-Inline self-review (4 checks): placeholder / consistency / scope / ambiguity — confirm no unfilled placeholders, no section contradictions, full interview coverage, no ambiguous text remains.
-
-Dispatch `spec-reviewer` — pass the spec path only. This loop is GATING on the reviewer's `Status`: while it returns `Status: Issues Found`, fix the named Issues and re-dispatch `spec-reviewer`, repeating until it returns `Status: Approved`. Do NOT emit the handoff token while any Issue remains — there is no advisory proceed-anyway / risk-note escape from an unresolved Issue. Only **Issues** gate; **Recommendations** are advisory and never block — carry any unaddressed ones into the spec's Risks section.
-
-2. **Render to HTML**: **You MUST read `references/render-assembly.md` first** — it is the single owner of the close-tag escape, the active-placeholder HTML-escape, and the prose-fragment guard; apply its full guard set before substituting. Fill `templates/spec-presentation.html` with the assembled spec markdown and the placeholder values, then write the render to `$OMT_DIR/deep-interview/{slug}.html` — reuse the SAME `{slug}` from the just-written `{slug}.md`; do NOT re-derive the slug. Tell the user to open it in a browser. If the final ontology has zero entities, the Ontology (Key Entities) `erDiagram` slot must render a `no entities yet` state rather than an empty/invalid erDiagram. **Lifecycle**: this render HTML is never auto-deleted, same as the `.md` spec.
-
-3. **Emit the handoff token** in the final assistant message before proceeding to Phase 5. The literal token `<deep-interview-done/>` must appear in the assistant turn that announces spec completion. This signals downstream hooks that the interview phase is complete and state cleanup may proceed.
+4. **Emit the handoff token** in the final assistant message before proceeding to Phase 5. The literal token `<deep-interview-done/>` must appear in the assistant turn that announces spec completion. This signals downstream hooks that the interview phase is complete and state cleanup may proceed.
 
 ### On-demand ontology render
 
@@ -501,22 +483,19 @@ Each execution option's Action: invoke `Skill(skill: "{chosen}")` with the spec 
 - **Early exit (round 3+)**: Allow with warning if ambiguity > threshold
 - **User says "stop", "cancel", "abort"**: Stop immediately, save state for resume
 - **Ambiguity stalls** (same score +-0.05 for 3 rounds): handled by the Step 2-head Dialectic Rhythm Guard stall rotation rule (selects Ontologist) — no separate activation here
-- **how-readiness gate**: Normal-path exit requires `ambiguity ≤ threshold` AND no unresolved load-bearing HOW-decision (costly-to-change, cross-cutting, or multiple genuinely divergent approaches). User-forced early exits (hard-cap, early-exit) bypass the gate but fold the unresolved fork into the spec's risk-note. A literal user stop/cancel/abort is NOT such an exit — it halts and saves state for resume per the rule above, crystallizing no spec.
-- **All dimensions at 0.9+**: Skip to spec generation ONLY after the Phase 2 how-readiness gate is clear; if a load-bearing HOW-fork is unresolved, resolve it via the Phase 2 Design-fork detection gate first.
+- **Threshold reached**: `ambiguity ≤ threshold` routes to the residual-ambiguity seam (Step 2-exit) rather than straight to Phase 4 — the seam decides whether to keep clarifying requirements or move to the Design Interview phase.
+- **All dimensions at 0.9+**: Route through the residual-ambiguity seam (Step 2-exit) the same as ordinary threshold-reached handling.
 - **Codebase exploration fails**: Proceed as greenfield, note the limitation
 </Escalation_And_Stop_Conditions>
 
 <Final_Checklist>
-- [ ] Interview completed (ambiguity ≤ threshold AND how-readiness gate clear, OR user chose early exit)
+- [ ] Interview completed (ambiguity ≤ threshold with all design branches resolved via the Design Interview phase, OR user chose early exit)
 - [ ] Oversized initial context/history was summarized before scoring, question generation, spec generation, or execution handoff
 - [ ] Ambiguity score displayed after every round
 - [ ] Every round explicitly names the weakest dimension and why it is the next target
 - [ ] Challenge stances selected by the Step 2-head Dialectic Rhythm Guard at the correct rotation conditions (Contrarian round 4+, Simplifier round 6+, Ontologist on stall or round 8+ with ambiguity > 0.3)
 - [ ] Spec file written to `$OMT_DIR/deep-interview/{slug}.md`
-- [ ] Per-section approval loop performed (each spec section approved before continuing)
-- [ ] Whole-spec gate: full spec confirmed before writing
 - [ ] Inline self-review (4 checks: placeholder / consistency / scope / ambiguity) performed
-- [ ] Spec-reviewer returned `Status: Approved` (fix→re-review loop ran until no Issues remain; Recommendations may be risk-noted)
 - [ ] Spec includes: goal, constraints, acceptance criteria, Approach & Design Decisions, clarity breakdown, transcript
 - [ ] Token `<deep-interview-done/>` emitted in the final assistant message before handoff
 - [ ] Execution bridge presented via AskUserQuestion

--- a/skills/deep-interview/SKILL.test.ts
+++ b/skills/deep-interview/SKILL.test.ts
@@ -213,6 +213,28 @@ describe('new-prose: residual-ambiguity seam on both exits', () => {
 });
 
 // ---------------------------------------------------------------------------
+// NEW-PROSE: Design Interview persists each decision to state (resume-safety)
+// (must FAIL before the persistence step is added to SKILL.md — RED)
+// ---------------------------------------------------------------------------
+
+describe('new-prose: Design Interview persists decisions to state', () => {
+  // Extract the Design Interview section: from its H2 heading to the next H2.
+  const start = skillMd.indexOf('## Design Interview');
+  const rest = skillMd.slice(start + '## Design Interview'.length);
+  const nextH2 = rest.indexOf('\n## ');
+  const designSection = nextH2 === -1 ? rest : rest.slice(0, nextH2);
+
+  test('persists each decision via the state CLI append', () => {
+    expect(designSection).toContain('deep-interview-state.ts update');
+    expect(designSection).toContain('--append-round-stdin');
+  });
+
+  test('persisted design round is marked kind:"design"', () => {
+    expect(designSection).toContain('"kind":"design"');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // REGRESSION GUARD (must PASS before AND after edits — invariant)
 // ---------------------------------------------------------------------------
 

--- a/skills/deep-interview/SKILL.test.ts
+++ b/skills/deep-interview/SKILL.test.ts
@@ -7,10 +7,14 @@ import { join } from 'path';
 // Mirrors the presence/absence assertion style of
 // skills/ultraresearch/SKILL.test.ts.
 //
-// RED step (pre-edit state):
-//   - new-prose assertions FAIL  (phrases not yet in SKILL.md)
-//   - template assertions FAIL   (section not yet in template)
-//   - regression-guard assertions PASS (invariants that must never break)
+// RED step (pre-edit state — requirements-clarity vs design-clarity split):
+//   - strip assertions (design-machinery phrases flipped to absent) FAIL
+//     because the phrases are still present in SKILL.md
+//   - new design-interview-prose assertions FAIL (phrases not yet in SKILL.md)
+//   - template design-coverage-absent assertions FAIL (sections not yet
+//     removed from the template)
+//   - preserved render-pipeline + regression-guard assertions PASS
+//     (invariants that must never break)
 // ---------------------------------------------------------------------------
 
 const skillMd = readFileSync(join(import.meta.dir, 'SKILL.md'), 'utf8');
@@ -20,75 +24,85 @@ const template = readFileSync(
 );
 
 // ---------------------------------------------------------------------------
-// NEW-PROSE (must FAIL before T4 edits — RED)
+// STRIP: design-machinery phrases removed by the Design Interview reshape
+// (must FAIL before T3 edits SKILL.md — RED)
 // ---------------------------------------------------------------------------
 
-describe('new-prose: daedalus dispatch', () => {
-  test('daedalus dispatch mention is present', () => {
-    expect(skillMd).toContain('daedalus');
+describe('strip: daedalus dispatch removed', () => {
+  test('daedalus dispatch mention is absent', () => {
+    expect(skillMd).not.toContain('daedalus');
   });
 });
 
-describe('new-prose: design-fork detection', () => {
-  test('design-fork detection mention is present', () => {
-    expect(skillMd).toContain('load-bearing design forks');
+describe('strip: design-fork detection gate removed', () => {
+  test('load-bearing design forks mention is absent', () => {
+    expect(skillMd).not.toContain('load-bearing design forks');
   });
 });
 
-describe('new-prose: Use_When design approach trigger', () => {
-  test('Use_When block advertises load-bearing design approach resolution', () => {
-    expect(skillMd).toContain('load-bearing design approach');
+describe('strip: Use_When design approach trigger removed', () => {
+  test('load-bearing design approach mention is absent', () => {
+    expect(skillMd).not.toContain('load-bearing design approach');
   });
 });
 
-describe('new-prose: pressure loophole closed at Step 2-exit gate', () => {
-  test('"be quick" instruction is NOT a user-forced escape hatch', () => {
-    expect(skillMd).toContain('NOT a user-forced escape hatch');
+describe('strip: pressure loophole phrase removed', () => {
+  test('"NOT a user-forced escape hatch" phrase is absent', () => {
+    expect(skillMd).not.toContain('NOT a user-forced escape hatch');
   });
 });
 
-describe('new-prose: HOW-readiness gate', () => {
-  test('HOW-readiness gate termination condition is present', () => {
-    expect(skillMd).toContain('how-readiness');
+describe('strip: HOW-readiness gate removed', () => {
+  test('how-readiness gate mention is absent', () => {
+    expect(skillMd).not.toContain('how-readiness');
   });
 });
 
-describe('new-prose: section-by-section approval loop', () => {
-  test('per-section approval loop is present', () => {
-    expect(skillMd).toContain('per-section');
-    expect(skillMd).toContain('approval');
+describe('strip: per-section approval loop removed', () => {
+  test('per-section mention is absent', () => {
+    expect(skillMd).not.toContain('per-section');
   });
 });
 
-describe('new-prose: final whole-spec gate', () => {
-  test('final whole-spec review gate is present', () => {
-    expect(skillMd).toContain('whole spec');
+describe('strip: final whole-spec gate removed', () => {
+  test('whole spec mention is absent', () => {
+    expect(skillMd).not.toContain('whole spec');
   });
 });
 
-describe('new-prose: inline self-review', () => {
+describe('strip: spec-reviewer dispatch removed', () => {
+  test('spec-reviewer dispatch mention is absent', () => {
+    expect(skillMd).not.toContain('spec-reviewer');
+  });
+});
+
+describe('strip: bare threshold announcement removed', () => {
+  test('"Clarity threshold met! Ready to proceed." bare announcement is absent (superseded by the seam)', () => {
+    expect(skillMd).not.toContain('Clarity threshold met! Ready to proceed.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PRESERVED (must PASS before AND after edits — invariant)
+// ---------------------------------------------------------------------------
+
+describe('preserved: inline self-review', () => {
   test('inline self-review is present', () => {
     expect(skillMd).toContain('self-review');
   });
 });
 
-describe('new-prose: spec-reviewer dispatch', () => {
-  test('spec-reviewer dispatch is present', () => {
-    expect(skillMd).toContain('spec-reviewer');
-  });
-});
-
-describe('new-prose: brainstorm-delegation phrase removal', () => {
+describe('preserved: brainstorm-delegation phrase removal', () => {
   test('"explore options or brainstorm" phrase is absent', () => {
     expect(skillMd).not.toContain('explore options or brainstorm');
   });
 });
 
 // ---------------------------------------------------------------------------
-// NEW-PROSE: mermaid visualization render-orchestration (must FAIL — RED)
+// PRESERVED: mermaid visualization render-orchestration (must PASS — invariant)
 // ---------------------------------------------------------------------------
 
-describe('new-prose: spec-presentation render target', () => {
+describe('preserved: spec-presentation render target', () => {
   test('spec-presentation.html render target is present', () => {
     expect(skillMd).toContain('spec-presentation.html');
   });
@@ -102,7 +116,7 @@ describe('new-prose: spec-presentation render target', () => {
   });
 });
 
-describe('new-prose: ontology-preview on-demand render', () => {
+describe('preserved: ontology-preview on-demand render', () => {
   test('ontology-preview.html render target is present', () => {
     expect(skillMd).toContain('ontology-preview.html');
   });
@@ -120,9 +134,81 @@ describe('new-prose: ontology-preview on-demand render', () => {
   });
 });
 
-describe('new-prose: render-assembly reference', () => {
+describe('preserved: render-assembly reference', () => {
   test('render-assembly.md reference is present', () => {
     expect(skillMd).toContain('render-assembly.md');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NEW-PROSE: Design Interview phase, seam, grill-me, every-decision framing
+// (must FAIL before T3 edits SKILL.md — RED)
+// ---------------------------------------------------------------------------
+
+describe('new-prose: Design Interview phase heading', () => {
+  test('"## Design Interview" phase heading is present', () => {
+    expect(skillMd).toContain('## Design Interview');
+  });
+});
+
+describe('new-prose: grill-me relentlessness', () => {
+  test('"relentlessly" is present', () => {
+    expect(skillMd).toContain('relentlessly');
+  });
+
+  test('"every aspect" is present', () => {
+    expect(skillMd).toContain('every aspect');
+  });
+});
+
+describe('new-prose: shared understanding target', () => {
+  test('"shared understanding" is present', () => {
+    expect(skillMd).toContain('shared understanding');
+  });
+});
+
+describe('new-prose: one-at-a-time decision pacing', () => {
+  test('"one at a time" is present', () => {
+    expect(skillMd).toContain('one at a time');
+  });
+});
+
+describe('new-prose: 2-3 alternatives per decision', () => {
+  test('"2-3 alternatives" is present', () => {
+    expect(skillMd).toContain('2-3 alternatives');
+  });
+});
+
+describe('new-prose: every-decision framing', () => {
+  test('"every design decision" is present (case-insensitive)', () => {
+    expect(skillMd.toLowerCase()).toContain('every design decision');
+  });
+});
+
+describe('new-prose: strawman-forcing grill', () => {
+  test('"strawman" is present', () => {
+    expect(skillMd).toContain('strawman');
+  });
+});
+
+describe('new-prose: all design branches covered', () => {
+  test('"all design branches" is present', () => {
+    expect(skillMd).toContain('all design branches');
+  });
+});
+
+describe('new-prose: residual-ambiguity seam on both exits', () => {
+  test('"residual ambiguity" appears at least twice (both exit paths)', () => {
+    const matches = skillMd.match(/residual ambiguity/g) || [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('requirements-threshold exit call-site references the seam', () => {
+    expect(skillMd).toContain('reflecting residual ambiguity via the Step 2-exit seam');
+  });
+
+  test('design-completion exit call-site references the seam', () => {
+    expect(skillMd).toContain('Design-completion exit');
   });
 });
 
@@ -141,7 +227,7 @@ describe('regression-guard', () => {
 });
 
 // ---------------------------------------------------------------------------
-// TEMPLATE (must FAIL before T3 edit — RED)
+// TEMPLATE (must PASS before AND after edits — invariant)
 // ---------------------------------------------------------------------------
 
 describe('template: approach and design decisions section', () => {
@@ -151,21 +237,47 @@ describe('template: approach and design decisions section', () => {
 });
 
 // ---------------------------------------------------------------------------
-// TEMPLATE: mermaid ontology erDiagram slot (must FAIL — RED)
+// TEMPLATE: mermaid ontology erDiagram slot (must PASS — invariant)
 // ---------------------------------------------------------------------------
 
 describe('template: mermaid ontology erDiagram slot', () => {
   test('erDiagram is present in template', () => {
     expect(template).toContain('erDiagram');
   });
+});
 
-  test('"clearer than prose" rationale is present in template', () => {
-    expect(template).toContain('clearer than prose');
+// ---------------------------------------------------------------------------
+// TEMPLATE: design-coverage sections removed (must FAIL before T4 edit — RED)
+// ---------------------------------------------------------------------------
+
+describe('template: design-coverage sections removed', () => {
+  test('"## Architecture" is absent from template', () => {
+    expect(template).not.toContain('## Architecture');
+  });
+
+  test('"## Components" is absent from template', () => {
+    expect(template).not.toContain('## Components');
+  });
+
+  test('"## Data Flow" is absent from template', () => {
+    expect(template).not.toContain('## Data Flow');
+  });
+
+  test('"## Error Handling" is absent from template', () => {
+    expect(template).not.toContain('## Error Handling');
+  });
+
+  test('"## Testing" is absent from template', () => {
+    expect(template).not.toContain('## Testing');
+  });
+
+  test('"spec-reviewer" is absent from template', () => {
+    expect(template).not.toContain('spec-reviewer');
   });
 });
 
 // ---------------------------------------------------------------------------
-// FILE-EXISTENCE: mermaid visualization assets (must FAIL — RED)
+// FILE-EXISTENCE: mermaid visualization assets (must PASS — invariant)
 // ---------------------------------------------------------------------------
 
 describe('file-existence: mermaid visualization assets', () => {

--- a/skills/deep-interview/deep-interview-spec-template.md
+++ b/skills/deep-interview/deep-interview-spec-template.md
@@ -52,38 +52,15 @@
 - **Rationale:** {why the selected approach was chosen over alternatives}
 - **Tradeoffs:** {what is gained and what is given up with this approach}
 
-Downstream (prometheus) consumes this as a FIXED input — does not re-decide the approach. When a user-forced exit left a load-bearing HOW-fork unresolved, do NOT invent a Selected approach — record the fork under **Risks & Unresolved Forks** below.
+Downstream (prometheus) consumes this as a FIXED input — does not re-decide the approach. When a user-forced exit left a design branch unresolved, do NOT invent a Selected approach — record the fork under **Risks & Unresolved Forks** below.
 
 ## Risks & Unresolved Forks
-- **Unresolved approach forks:** {load-bearing HOW-decisions left open at a user-forced exit — name the fork and its divergent options; empty if all forks were resolved}
-- **Risks / open questions:** {known risks, advisory spec-reviewer notes carried forward, or assumptions not fully validated}
+- **Unresolved approach forks:** {design decisions left open at a user-forced exit — name the branch and its divergent options; empty if all branches were resolved}
+- **Risks / open questions:** {known risks or assumptions not fully validated}
 
 ## Technical Context
 {brownfield: relevant codebase findings from explore agent}
 {greenfield: technology choices and constraints}
-
-## Architecture
-{overall structure: how the major components are arranged and how they relate to each other}
-
-> Add a diagram here when it is clearer than prose: state the reason, embed a ```mermaid fence, then interpret it.
-
-## Components
-{each component: its single responsibility and direct dependencies}
-
-> Add a diagram here when it is clearer than prose: state the reason, embed a ```mermaid fence, then interpret it.
-
-## Data Flow
-{sources → transformations → sinks: trace data from ingestion to output}
-
-> Add a diagram here when it is clearer than prose: state the reason, embed a ```mermaid fence, then interpret it.
-
-## Error Handling
-{failure modes and their responses: what can go wrong and how the system handles it}
-
-> Add a diagram here when it is clearer than prose: state the reason, embed a ```mermaid fence, then interpret it.
-
-## Testing
-{what is verified: behaviors, boundaries, and invariants covered by the test suite}
 
 ## Ontology (Key Entities)
 {Fill from the FINAL round's ontology extraction, not just crystallization-time generation}


### PR DESCRIPTION
## 📌 Summary
deep-interview 스킬이 하나로 뭉쳐 있던 두 관심사 — 요구사항 명료화(WHAT)와 설계 명료화(HOW) — 를 별도 페이즈로 분리했습니다. 6/30 배치가 Phase 2/4에 주입한 설계 기계장치를 제거하고, 요구사항 완료와 spec 크리스털라이즈 사이에 전용 Design Interview 페이즈를 신설했습니다.

---

## 🔧 Changes

### deep-interview 스킬 (`SKILL.md`)

- Phase 2에서 Step 2-alt(다중 viable 대안 제시)·Step 2-exit(design-fork 감지 게이트) 제거
- Phase 4를 6/23 transcriber 형태로 복원 — per-section approval loop·spec-reviewer gating·design-coverage 섹션 제거, inline self-review는 보존
- Phase 3과 Phase 4 사이에 신규 `## Design Interview` 페이즈 추가
- 양쪽 phase exit(requirements-threshold·design-completion)에 단일 residual-ambiguity seam 재사용

배경: 4-axis 모호도 점수는 요구사항 명료도만 측정하고 설계(HOW) 명료도엔 이진 게이트만 있어, 인터뷰가 요구사항은 threshold까지 몰아붙이면서 설계는 거의 탐색하지 않는 비대칭이 있었습니다. 6/30이 요구사항 크리스털라이저에 설계 저작을 볼트온한 게 "혼합" 느낌의 원인이었고, 이를 전용 Design Interview 페이즈로 분리했습니다.

**영향 범위**
- `skills/deep-interview/` 단일 스킬만 변경. 외부 스킬·훅 영향 없음.
- 4-axis 스코어링·threshold·config·6/23 grounding(stance selector·Fact-ground·provenance)·7/01 mermaid render 파이프라인 전부 보존(회귀 없음).
- 미배포: `make sync` 전까지 배포본은 구버전.

### 테스트 계약 (`SKILL.test.ts`)

- prose-contract 테스트 재저작: 제거된 기계장치를 absent로 단언 flip, 신규 Design Interview/seam/grill-me를 present로 단언
- seam "both exits" 테스트를 bare count proxy → 양쪽 call-site 앵커로 강화
- `template.not.toContain('spec-reviewer')` 추가(커버리지 갭 봉합)

**영향 범위**
- 테스트 전용. 최종 80 pass / 0 fail.

### output spec 템플릿 (`deep-interview-spec-template.md`)

- design-coverage 섹션 5개(Architecture/Components/Data Flow/Error Handling/Testing) 제거
- `## Approach & Design Decisions`(resolved decisions 스냅샷 자리)·erDiagram·requirements 섹션 보존
- 잔존 spec-reviewer 참조·stale HOW-fork 용어 정리

**영향 범위**
- Phase 4가 채우는 출력 spec의 섹션 구성 변경. 렌더 파이프라인 슬롯(erDiagram) 무관.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. "6/23으로 revert"의 문자적 적용 거부 — AC 계약을 우선한 render 파이프라인 보존

**배경 및 문제 상황:**
요구사항 spec의 설계결정 D2는 "Phase 4를 6/23 커밋으로 revert"를 지시했습니다. 그러나 spec의 git-archaeology는 5/23·6/23·6/30만 다루고, 바로 전날(7/01) 랜딩된 mermaid 시각화 render 파이프라인(erDiagram·HTML render·on-demand ontology preview, git log 7커밋)을 인지하지 못한 채 작성됐습니다. D2를 문자 그대로 적용하면 이 최신 기능이 회귀합니다.

**해결 방안:**
falsifiable 계약(AC 8개, 특히 AC2의 "3항목만 제거")을 primary로, git-show 6/23은 transcriber "shape"의 참조로만 사용했습니다. render 파이프라인·6/23 grounding·inline self-review는 AC의 strip 대상이 아니므로 보존했습니다.

**선택과 트레이드오프:**
"baseline으로 되돌린다"가 baseline 이후 랜딩된 무관 기능을 지우지 않도록 AC를 경계로 삼았습니다. 대안(문자적 revert)은 diff가 더 크고 최신 기능을 파괴합니다. 리뷰어는 spec D2 의도와 이 해석(계약 우선)이 일치하는지 확인해 주세요.

---

### 2. 템플릿 design-coverage 제거 범위 — "Approach & Design Decisions"는 보존

**배경 및 문제 상황:**
AC2는 "요구사항 경로에 design-coverage 섹션 없음"을 요구합니다. spec은 design-coverage로 Approach/Architecture/Components/Data Flow/Error Handling/Testing을 나열하지만, 동시에 Target Architecture는 "requirements + resolved design decisions를 snapshot"하라고 명시합니다.

**해결 방안:**
heavy 설계-문서 섹션 5개는 제거하고, `## Approach & Design Decisions`는 신규 Design Interview가 해소한 resolved decisions의 스냅샷 자리로 보존했습니다.

**선택과 트레이드오프:**
`Approach`도 spec의 design-coverage 목록에 있으나 제거하면 해소된 설계결정을 담을 곳이 없어집니다. 이 PR은 heavy 5섹션 제거 / decisions 스냅샷 보존이라는 경계를 택했습니다.

---

### 3. residual-ambiguity seam — 양쪽 exit 단일 재사용 패턴

**배경 및 문제 상황:**
기존엔 threshold 도달 시 bare 발표("Clarity threshold met!")만 있어 남은 모호함을 반영하지 않고 진행했습니다. 이제 exit이 둘(요구사항·설계)로 늘어 "언제 relentless를 멈추는가"의 정의가 두 곳에 필요했습니다.

**해결 방안:**
Step 2-exit에 seam 패턴을 한 번 정의(residual 반영 → continue/finish 질문)하고 양쪽 exit이 참조하도록 했습니다. 정의가 한 곳이라 "충분히 relentless한가" 기준이 단일 소스입니다.

**선택과 트레이드오프:**
대안(각 exit 독립 발표문)은 두 exit 행동 발산 위험이 있습니다. 단일 seam은 일관성 보장하나 두 exit이 정확히 같은 UX를 갖게 강제합니다. 현재는 일관성을 우선했습니다.

---

### 4. writing-skills TDD RED = 테스트 하네스 flip + 독립 code-review가 잡은 누락

**배경 및 문제 상황:**
기존 `SKILL.test.ts`가 제거 대상 기계장치를 present로 단언하고 있어, 스킬을 고치면 테스트가 깨지는 구조였습니다.

**해결 방안:**
RED에서 그 단언을 absent로 flip하고 신규 페이즈/seam present 단언을 추가해 현재 파일에 FAIL(RED)을 만들었습니다. 이후 GREEN 편집으로 통과시켰습니다. 독립 code-review 레인이 template의 spec-reviewer orphan(SKILL.md엔 제거·template로 미전파)을 CONFIRMED로 적발했고, 근본원인(테스트가 SKILL.md에만 단언한 커버리지 갭)까지 봉합했습니다.

**선택과 트레이드오프:**
prose 스킬을 grep-단언으로 테스트하면 구조는 강하게 핀하나 행동은 못 잡습니다. 이를 행동 probe(설계 풍부 태스크·strawman 경계 5-rep)로 보완했습니다. probe는 편집된 repo 파일을 직접 Read 주입해 배포본 stale 함정을 피했습니다.

---

## ✅ Checklist

### 요구사항 경로 de-inflate
- [ ] Phase 2에 Step 2-alt / Step 2-exit design-fork 기계장치가 없다
  - `skills/deep-interview/SKILL.md`
- [ ] Phase 4가 transcriber(per-section approval·spec-reviewer gating·design-coverage 섹션 없음)
  - `skills/deep-interview/SKILL.md`
  - `skills/deep-interview/deep-interview-spec-template.md`
- [ ] 4-axis 스코어링 formula·threshold가 변경되지 않았다
  - `skills/deep-interview/SKILL.md`

### Design Interview 페이즈
- [ ] Design Interview 페이즈가 requirements 완료 후 crystallize 전에 존재한다
  - `skills/deep-interview/SKILL.md`
- [ ] 모든 genuine 설계결정에 2-3 alternatives+추천, forced point는 Fact-ground(strawman 아님)
  - `skills/deep-interview/SKILL.md`
- [ ] grill-me relentless 키워드가 페이즈 프레이밍에 존재한다
  - `skills/deep-interview/SKILL.md`

### seam
- [ ] requirements-threshold·design-completion 양쪽에서 residual 반영+continue/finish, bare 발표 없음
  - `skills/deep-interview/SKILL.md`

### 회귀 방지
- [ ] render 파이프라인(spec-presentation.html·on-demand ontology·erDiagram) 보존
  - `skills/deep-interview/SKILL.md`
  - `skills/deep-interview/deep-interview-spec-template.md`
- [ ] `bun test skills/deep-interview/` 전체 통과
  - `skills/deep-interview/SKILL.test.ts`
