### PR TITLE
feat(deep-interview): 설계 인터뷰 의존성 순회·압박 가드 추가

### DIFF
--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -396,11 +396,14 @@ bun ${CLAUDE_SKILL_DIR}/scripts/deep-interview-state.ts update \
 
 Once Phase 2 exits (via the residual-ambiguity seam, above) toward design work, interrogate the design **relentlessly** — probe **every aspect** of the design until reaching **shared understanding** with the user, going beyond requirements clarity.
 
-**Pacing:** ask design questions **one at a time**, exactly as in the requirements loop — never batch. For each question, offer a recommended answer so the user can accept or override it quickly. Before asking, check whether the codebase can already answer it — if so, run `explore` first and fold the finding into the question instead of asking the user to rediscover it.
+**Interrogate every open design decision, one at a time, in dependency order.** Walk the design tree from its root — settle a decision that gates others before the branches that depend on it (an upstream answer can reshape or delete a downstream one's alternatives); never batch. Put each genuinely-open decision to the user (via `AskUserQuestion`) with **2-3 alternatives** and your reasoned recommendation among them — every real decision, including low-stakes, cheap-to-reverse ones, not just the hardest. Before asking, check whether the codebase already settles it; if so, run `explore` and fold the finding in rather than making the user rediscover it.
 
-**Per-decision alternatives:** for **every design decision** — every point where the implementation genuinely could go more than one way — present **2-3 alternatives** with a recommendation, via `AskUserQuestion`. This isn't limited to costly-to-change choices: every real decision earns alternatives, not just the hardest ones.
+**Red flags — you're about to swallow a decision:**
+- *"User's in a hurry — batch the rest into one question"*
+- *"This one's low-risk / reversible — apply a default, let them veto"*
+- *"The sketch already covers it — close enough to settled"*
 
-**Fact vs. strawman boundary:** a point the codebase or an external constraint already forces onto a single path is a **fact** — ground it with `explore`/`librarian` and state it as settled, do not manufacture a **strawman** alternative around it. Only present alternatives where a real choice exists; naming options nobody would pick is not a decision.
+All mean STOP. Under pressure you still put **every** open decision to the user with its real alternatives and a reasoned recommendation — pressure never thins the alternatives or skips the decision. The only thing settled without a question is a path the codebase or an external constraint **forces** onto a single path — a **fact** (ground it with `explore`/`librarian`; don't manufacture a **strawman** alternative around a forced path), not one you deem low-risk. An explicit early-exit (Step 2f) still exits.
 
 **Persist each decision to state:** after the user answers a design question (or a forced point is fact-grounded), append the decision to interview state *before* moving to the next question — the same mechanism Step 2e and Step 2-fact use, so the resume path (`get`/`adopt`) and Phase 4 crystallization recover the chosen alternatives even across a session interruption. Without this, the decision lives only in the in-context transcript and is lost on cross-session resume. The existing `--append-round-stdin` accepts this shape with no schema change (exactly as the `fact-ground` round does), marked as a design round so it is distinguishable from requirements Q&A:
 


### PR DESCRIPTION
## 📌 Summary

grill-me의 relentless 설계 인터뷰(의존성 순회 + 압박에도 모든 결정 캐묻기)를 deep-interview의 Design Interview 페이즈로 이관하고, 겹치던 라벨 5개를 3블록으로 압축했습니다.

## 🔧 Changes

### deep-interview — Design Interview 페이즈
- 설계 결정을 **의존성 순서(뿌리→가지)**로 하나씩 인터뷰하는 규칙 추가 — 상위 결정이 하위 결정의 대안을 재구성/삭제하므로 먼저 착지
- **Red flags** 리스트 추가 — 시간 압박 하에서 열린 결정을 silent default로 접는 세 가지 rationalization을 STOP 트리거로 명시 차단
- 질문 없이 확정 가능한 것을 코드/제약이 강제하는 **fact**로 한정, "저위험이라 판단함"은 예외 아님으로 경계 고정
- 겹치던 라벨 5개(Pacing / Per-decision / Dependency / Red flags / Fact)를 **directive 1 + red-flags + resolution 3블록**으로 압축

기존 페이즈에 "relentlessly / one at a time" 지침은 이미 있었으나, 서브에이전트 압박 시나리오에서 저위험·되돌리기 쉬운 결정(재시도 정책·워처 vs 폴링)을 조용히 기본값으로 접는 실패가 재현됐습니다. 무조건 지침만으로는 압박에서 무너져, loophole을 명시 차단하는 red-flags 형태가 필요했습니다.

**영향 범위**
- deep-interview 스킬의 Design Interview 페이즈 프롬프트 동작만 변경. 요구사항 루프·상태 스크립트·렌더 파이프라인 무영향
- 순변화 +6/−3 (1 file). 기존 구조 테스트 `SKILL.test.ts` 45/45 유지
- 하위 호환: 기존 계약(one at a time / 2-3 alternatives / strawman 금지)을 보존한 채 추가·압축

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.

### 1. 압박 하 relentless를 "삭제"가 아닌 "red-flags 이동"으로

**배경 및 문제 상황:** grill-me의 무조건 relentless 지침은 이미 페이즈에 존재했으나, 압박 시나리오에서 baseline이 5/5로 무너졌습니다 — 저위험 결정을 silent default로 접음. 지침의 *텍스트* 존재가 *행동*을 보장하지 못했습니다.

**해결 방안:** 압박 처리 규칙을 핵심 directive에서 분리해 별도 **red-flags 리스트**로 두고, 실패 rationalization을 verbatim 노출했습니다.

**구현 세부사항:** `"User's in a hurry — batch the rest"`, `"low-risk/reversible — apply a default"`, `"sketch already covers it"` 세 가지를 STOP 트리거로. resolution에서 *"압박은 대안을 얇게 하거나 결정을 건너뛰지 못함"*.

**선택과 트레이드오프:** "무조건 지침만 남기고 압박 절 삭제" 안은 5/5 회귀라 기각(삭제 vs 이동의 분기). red-flags 형태는 인라인 recipe 대비 가독성 우위 + 동일 binding(둘 다 압박 시나리오 5/5). writing-skills의 "압박 하 discipline 실패 = red-flags" 캐논과 일치합니다.

### 2. depth-over-speed — 추천답의 목적 재정의

**배경 및 문제 상황:** 기존 문구가 추천답을 *"빠르게 수락/override"*의 **속도 장치**로 프레이밍해 relentless·deep 인터뷰 목적과 충돌했습니다(사용자를 끄덕임으로 밀어붙임).

**해결 방안:** 추천답을 *"깊이 고민한 판단 + 진짜 대안 제시"*로 재정의하고 `"a nod closes it fast"` 등 speed 문구를 제거했습니다.

**선택과 트레이드오프:** speed valve 제거가 압박 방어를 약화시킬 위험 → 재검증 5/5 유지(회귀 없음). grill-me 원문 ③도 speed 언급이 없어 원문과 정합합니다.

### 3. fact 예외의 좁은 경계

**배경 및 문제 상황:** "저위험/되돌리기 쉬움"을 fact로 오분류해 질문 없이 확정하는 것이 baseline 실패의 핵심 rationalization이었습니다.

**해결 방안:** 질문 없이 확정 가능한 것 = 코드/외부 제약이 단일 경로로 **강제**하는 fact뿐. "저위험 판단"은 명시적으로 예외 아님으로 못박았습니다.

**선택과 트레이드오프:** 엄격한 경계가 저위험 결정도 매번 묻게 해 질문 수 증가 → 추천답 선제시로 마찰 완화(대안 유지, 속도는 추천으로 흡수).

> **공통 검증:** 서브에이전트 압박 시나리오(열린 설계 결정 4개 + 조급한 사용자)로 RED(baseline 5/5 silent-default) → GREEN(5/5 모든 결정을 대안과 함께 질문) 대조. 압축본도 최종 5/5 확인.

## ✅ Checklist

### deep-interview Design Interview
- [ ] 압박 시나리오에서 저위험 열린 결정(재시도·변경감지)도 대안과 함께 개별 질문된다 (silent default 없음)
  - `skills/deep-interview/SKILL.md`
- [ ] 설계 결정이 의존성 순서(상위 gate 결정 우선)로 인터뷰된다
  - `skills/deep-interview/SKILL.md`
- [ ] fact(코드/제약 강제)만 질문 없이 확정되고 "저위험 판단"은 확정 근거가 아니다
  - `skills/deep-interview/SKILL.md`
- [ ] 기존 구조 계약(one at a time / 2-3 alternatives / strawman) 리터럴이 보존된다
  - `skills/deep-interview/SKILL.test.ts`

## 📎 References
- [grill-me SKILL.md (mattpocock/skills)](https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md)
