### PR TITLE
feat(goal): 서브스킬 정합성 가드와 완료 게이트 보강

### DIFF
--- a/hooks/persistent-mode/decision.test.ts
+++ b/hooks/persistent-mode/decision.test.ts
@@ -133,6 +133,8 @@ describe("makeDecision", () => {
 			const deepInterviewState = {
 				active: true,
 				sessionId: "test-session",
+				started_at: new Date().toISOString(),
+				last_touched_at: new Date().toISOString(),
 				state: { phase: "in_progress" },
 			};
 			await writeFile(
@@ -152,6 +154,8 @@ describe("makeDecision", () => {
 			const deepInterviewState = {
 				active: true,
 				sessionId: "test-session",
+				started_at: new Date().toISOString(),
+				last_touched_at: new Date().toISOString(),
 				state: { phase: "in_progress" },
 			};
 			await writeFile(
@@ -192,6 +196,8 @@ describe("makeDecision", () => {
 			const deepInterviewState = {
 				active: true,
 				sessionId: "test-session",
+				started_at: new Date().toISOString(),
+				last_touched_at: new Date().toISOString(),
 				state: { phase: "in_progress" },
 			};
 			const markerPath = join(omtDir, "deep-interview-active-state-test-session.json");
@@ -236,15 +242,17 @@ describe("makeDecision", () => {
 		});
 
 		it("non-pristine active DI state (has state key) still blocks session stop", async () => {
-			// A DI state with a rich `state` object is non-pristine — the interview is genuinely
-			// in progress and must continue blocking until the done-token or active:false.
+			// A DI state with a rich `state` object is non-pristine AND live (recent heartbeat) —
+			// the interview is genuinely in progress and must continue blocking until the
+			// done-token or active:false.
+			const fresh = new Date().toISOString();
 			const markerPath = join(omtDir, "deep-interview-active-state-test-session.json");
 			await writeFile(
 				markerPath,
 				JSON.stringify({
 					active: true,
-					started_at: "2025-01-01T00:00:00+00:00",
-					last_touched_at: "2025-01-01T00:00:00+00:00",
+					started_at: fresh,
+					last_touched_at: fresh,
 					state: { phase: "in_progress", answers: {} },
 				}),
 			);
@@ -256,11 +264,40 @@ describe("makeDecision", () => {
 			expect(result.decision).toBe("block");
 			expect(result.reason).toContain("<deep-interview-continuation>");
 		});
+
+		it("stale (TTL-expired) non-pristine active DI does NOT block — GC reaps it", async () => {
+			// active:true + non-pristine but idle past ACTIVE_IDLE_TTL (6h): the interview
+			// process is effectively dead. session-start GC (is_state_live) and goal's
+			// check-subskill (isSubskillHalfOpen) both treat it as reapable; the Stop hook
+			// must agree and NOT wedge the session on a corpse the GC will sweep.
+			const stale = "2020-01-01T00:00:00+00:00";
+			const markerPath = join(omtDir, "deep-interview-active-state-test-session.json");
+			await writeFile(
+				markerPath,
+				JSON.stringify({
+					active: true,
+					started_at: stale,
+					last_touched_at: stale,
+					state: { phase: "in_progress", answers: {} },
+				}),
+			);
+
+			const context = createContext({ lastAssistantMessage: "some message without done token" });
+
+			const result = makeDecision(context);
+
+			expect(result).toEqual({ continue: true });
+		});
 	});
 
 	describe("Priority 1.5: Prometheus State Protection", () => {
 		it("makeDecision blocks with prometheus-continuation when state active and no token", async () => {
-			const prometheusState = { active: true, sessionId: "test-session" };
+			const prometheusState = {
+			active: true,
+			sessionId: "test-session",
+			started_at: new Date().toISOString(),
+			last_touched_at: new Date().toISOString(),
+		};
 			await writeFile(
 				join(omtDir, "prometheus-state-test-session.json"),
 				JSON.stringify(prometheusState),
@@ -275,7 +312,12 @@ describe("makeDecision", () => {
 		});
 
 		it("makeDecision cleans up prometheus state when token present in lastAssistantMessage", async () => {
-			const prometheusState = { active: true, sessionId: "test-session" };
+			const prometheusState = {
+			active: true,
+			sessionId: "test-session",
+			started_at: new Date().toISOString(),
+			last_touched_at: new Date().toISOString(),
+		};
 			await writeFile(
 				join(omtDir, "prometheus-state-test-session.json"),
 				JSON.stringify(prometheusState),
@@ -291,7 +333,12 @@ describe("makeDecision", () => {
 		});
 
 		it("makeDecision allows stop after MAX_BLOCK_COUNT token-less blocks (bounded escape)", async () => {
-			const prometheusState = { active: true, sessionId: "test-session" };
+			const prometheusState = {
+			active: true,
+			sessionId: "test-session",
+			started_at: new Date().toISOString(),
+			last_touched_at: new Date().toISOString(),
+		};
 			await writeFile(
 				join(omtDir, "prometheus-state-test-session.json"),
 				JSON.stringify(prometheusState),
@@ -317,7 +364,12 @@ describe("makeDecision", () => {
 			// so that if prometheus wrongly shares it, it would escape immediately.
 			await writeFile(join(stateDir, "block-count-test-session"), "5");
 
-			const prometheusState = { active: true, sessionId: "test-session" };
+			const prometheusState = {
+			active: true,
+			sessionId: "test-session",
+			started_at: new Date().toISOString(),
+			last_touched_at: new Date().toISOString(),
+		};
 			await writeFile(
 				join(omtDir, "prometheus-state-test-session.json"),
 				JSON.stringify(prometheusState),
@@ -336,7 +388,12 @@ describe("makeDecision", () => {
 			// Pre-load prometheus-specific counter to MAX_BLOCK_COUNT
 			await writeFile(join(stateDir, "block-count-prometheus-test-session"), "5");
 
-			const prometheusState = { active: true, sessionId: "test-session" };
+			const prometheusState = {
+			active: true,
+			sessionId: "test-session",
+			started_at: new Date().toISOString(),
+			last_touched_at: new Date().toISOString(),
+		};
 			await writeFile(
 				join(omtDir, "prometheus-state-test-session.json"),
 				JSON.stringify(prometheusState),
@@ -355,7 +412,12 @@ describe("makeDecision", () => {
 			// Pre-load prometheus-specific counter to simulate in-progress session
 			await writeFile(join(stateDir, "block-count-prometheus-test-session"), "3");
 
-			const prometheusState = { active: true, sessionId: "test-session" };
+			const prometheusState = {
+			active: true,
+			sessionId: "test-session",
+			started_at: new Date().toISOString(),
+			last_touched_at: new Date().toISOString(),
+		};
 			await writeFile(
 				join(omtDir, "prometheus-state-test-session.json"),
 				JSON.stringify(prometheusState),
@@ -370,6 +432,28 @@ describe("makeDecision", () => {
 			expect(existsSync(join(omtDir, "prometheus-state-test-session.json"))).toBe(false);
 			// Prometheus-specific counter file also deleted
 			expect(existsSync(join(stateDir, "block-count-prometheus-test-session"))).toBe(false);
+		});
+
+		it("stale (TTL-expired) active prometheus does NOT block — GC reaps it", async () => {
+			// active:true but idle past ACTIVE_IDLE_TTL (6h): the planning process is
+			// effectively dead. Consistent with session-start GC and goal's check-subskill,
+			// the Stop hook must NOT wedge the session on a corpse the GC will sweep.
+			const stale = "2020-01-01T00:00:00+00:00";
+			await writeFile(
+				join(omtDir, "prometheus-state-test-session.json"),
+				JSON.stringify({
+					active: true,
+					sessionId: "test-session",
+					started_at: stale,
+					last_touched_at: stale,
+				}),
+			);
+
+			const context = createContext({ lastAssistantMessage: "some message without done token" });
+
+			const result = makeDecision(context);
+
+			expect(result).toEqual({ continue: true });
 		});
 	});
 
@@ -773,6 +857,8 @@ describe("makeDecision", () => {
 				JSON.stringify({
 					active: true,
 					sessionId: "test-session",
+					started_at: new Date().toISOString(),
+					last_touched_at: new Date().toISOString(),
 					state: { phase: "in_progress" },
 				}),
 			);
@@ -797,6 +883,8 @@ describe("makeDecision", () => {
 				JSON.stringify({
 					active: true,
 					sessionId: "test-session",
+					started_at: new Date().toISOString(),
+					last_touched_at: new Date().toISOString(),
 					state: { phase: "in_progress" },
 				}),
 			);

--- a/hooks/persistent-mode/decision.ts
+++ b/hooks/persistent-mode/decision.ts
@@ -15,7 +15,7 @@ import { detectDeepInterviewDone, detectPrometheusDone } from "./transcript-dete
 import { generateAttemptId, ensureDir } from "./utils.ts";
 import { join } from "path";
 import { getOmtDir } from "@lib/omt-dir";
-import { isPristine } from "@lib/state-core";
+import { isPristine, isStateLive } from "@lib/state-core";
 
 export interface DecisionContext {
 	projectRoot: string;
@@ -272,6 +272,7 @@ export function makeDecision(context: DecisionContext): HookOutput {
 	// readDeepInterviewState returns as null, causing delete to never fire and leaving
 	// orphaned files on disk). active:false → delete without requiring the done-token.
 	// active:true path is unchanged: done-token → delete, no token → block + continuation.
+	const nowEpoch = Math.floor(Date.now() / 1000);
 	const deepInterviewStateRaw = readDeepInterviewStateRaw(sessionId);
 	if (deepInterviewStateRaw) {
 		if (!deepInterviewStateRaw.active) {
@@ -279,12 +280,18 @@ export function makeDecision(context: DecisionContext): HookOutput {
 			cleanupDeepInterviewState(sessionId);
 		} else if (detectDeepInterviewDone(lastAssistantMessage)) {
 			cleanupDeepInterviewState(sessionId);
-		} else if (!isPristine("deep-interview", toRecord(deepInterviewStateRaw))) {
-			// Pristine exception: a seed-only file (no rich `state` object) was written by the
-			// PreToolUse hook before the skill prose ran. If the skill died before `init`
-			// (permission denial, ESC, crash), the seed lingers. A pristine state is INERT to
-			// all consumers — it must not block session stop. The orphan ages toward TTL and is
-			// GC'd naturally.
+		} else if (
+			!isPristine("deep-interview", toRecord(deepInterviewStateRaw)) &&
+			isStateLive(deepInterviewStateRaw, nowEpoch)
+		) {
+			// Block only a LIVE non-pristine interview. Two fall-through exceptions:
+			//   - Pristine seed (no rich `state`): a seed-only file written by the PreToolUse
+			//     hook before the skill prose ran; INERT to all consumers.
+			//   - TTL-stale (idle past ACTIVE_IDLE_TTL): the interview process is effectively
+			//     dead. Blocking here would wedge the session on a corpse that session-start GC
+			//     (is_state_live) and goal's check-subskill (isSubskillHalfOpen) already treat
+			//     as reapable — the three consumers must agree.
+			// Either orphan ages toward TTL and is GC'd naturally; neither blocks session stop.
 			return formatBlockOutput(buildDeepInterviewContinuationMessage());
 		}
 	}
@@ -296,7 +303,11 @@ export function makeDecision(context: DecisionContext): HookOutput {
 		if (detectPrometheusDone(lastAssistantMessage)) {
 			cleanupPrometheusState(sessionId);
 			cleanupBlockCountFiles(stateDir, prometheusAttemptId);
-		} else {
+		} else if (isStateLive(prometheusState, nowEpoch)) {
+			// TTL-stale (idle past ACTIVE_IDLE_TTL) → fall through, no block: the planning
+			// process is dead and session-start GC will reap it, consistent with goal's
+			// check-subskill. done-token cleanup above stays unconditional (an emitted token
+			// finalizes regardless of liveness).
 			const blockCount = getBlockCount(stateDir, prometheusAttemptId);
 			if (blockCount >= MAX_BLOCK_COUNT) {
 				cleanupBlockCountFiles(stateDir, prometheusAttemptId);

--- a/hooks/persistent-mode/types.ts
+++ b/hooks/persistent-mode/types.ts
@@ -21,24 +21,31 @@ export interface ParsedInput {
  * Minimal contract the persistent-mode hook reads from the deep-interview
  * state file. The on-disk file may carry additional fields at runtime
  * (e.g. current phase, interview rounds, ambiguity scores, ontology
- * snapshots) written by the interview skill itself; only `active` is
- * consulted here. Writers must merge rather than overwrite — replacing
- * the file with this minimal shape discards in-flight interview data.
+ * snapshots) written by the interview skill itself; the hook consults
+ * `active` plus the heartbeat timestamps (for TTL liveness — see isStateLive).
+ * Writers must merge rather than overwrite — replacing the file with this
+ * minimal shape discards in-flight interview data.
  */
 export interface DeepInterviewState {
 	active: boolean;
+	/** Heartbeat timestamps (managed StateType) — read by the isStateLive TTL check. */
+	last_touched_at?: string;
+	started_at?: string;
 }
 
 /**
  * Minimal contract the persistent-mode hook reads from the prometheus
  * state file. The on-disk file may carry additional fields at runtime
- * (e.g. phase, plan_path, resume_summary, started_at) written by the
- * prometheus skill itself; only `active` is consulted here. Writers must
- * merge rather than overwrite — replacing the file with this minimal shape
- * discards in-flight prometheus data.
+ * (e.g. phase, plan_path, resume_summary) written by the prometheus skill
+ * itself; the hook consults `active` plus the heartbeat timestamps (for
+ * TTL liveness — see isStateLive). Writers must merge rather than overwrite —
+ * replacing the file with this minimal shape discards in-flight prometheus data.
  */
 export interface PrometheusState {
 	active: boolean;
+	/** Heartbeat timestamps (managed StateType) — read by the isStateLive TTL check. */
+	last_touched_at?: string;
+	started_at?: string;
 }
 
 /**

--- a/skills/goal/SKILL.md
+++ b/skills/goal/SKILL.md
@@ -60,71 +60,9 @@ If no candidates exist, say so and proceed fresh. The branch never renames on it
 
 ---
 
-## Six Slots
+## Planning: Six Slots & Story Definition
 
-The Entry Gate's falsifiable objective is captured as six slots. **Four are captured from the request (or the crystallized spec); two are minted by this orchestrator.** All six are written through `set --phase planning` at seed time.
-
-Four content slots (from capture):
-
-1. **outcome** (`--outcome`) — what is true when the objective is reached (the desired end state).
-2. **verification-surface** (`--verification-surface`) — the concrete evidence that proves success (test, benchmark, artifact, observable behavior). This is the load-bearing slot: it is the only one that makes the objective machine-decidable.
-3. **constraints** (`--constraints`) — what must NOT regress while pursuing (correctness suites stay green, contracts preserved).
-4. **boundaries** (`--boundaries`) — the allowed files, tools, and resources the pursuit may touch.
-
-Two minted slots (not in the request — this orchestrator supplies them):
-
-5. **iteration-policy** → `max_iterations` (`--max-iterations <n>`) — the finite cap on pursuit blocks. Default **10** when not overridden at invocation; invocation-overridable. This is the SOLE soft-stop bound: when pursuit hits `max_iterations` the loop soft-stops (state preserved), it does NOT hard-kill.
-6. **blocked-stop** (`--blocked-stop <text>`) — the objective-specific predicate that means "no valid path forward". A decidable, point-in-time condition (no cross-iteration memory); when met, pursuit stops and reports the blocker, non-complete.
-
-Seed example (run at the first `planning` transition):
-
-```
-bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts set --phase planning \
-  --outcome "<desired end state>" \
-  --verification-surface "<concrete evidence that proves success>" \
-  --constraints "<what must not regress>" \
-  --boundaries "<allowed files/tools/resources>" \
-  --max-iterations 10 \
-  --blocked-stop "<objective-specific no-path-forward predicate>"
-```
-
-<!-- story-layer:start -->
-
-## Story Definition (Planning Phase)
-
-After capturing the six slots and before dispatching to prometheus or sisyphus, define the WHAT-slices of the objective with the user, story by story. Each story is an independently verifiable chunk of the objective — not a task (HOW) but a stated outcome (WHAT).
-
-**When to slice vs. use single-derivation.** If the objective is a single WHAT — one deliverable, one verification surface, no meaningful sub-goals — run:
-
-```
-bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts set-stories --single
-```
-
-This derives one story directly from the current `outcome` and marks it `confirmed` immediately (no separate `confirm-story` call needed). Use `--single` for objectives where slicing into multiple stories would introduce ceremony without value.
-
-For objectives with multiple distinct WHAT-slices, define them one at a time with the user. For each story, establish:
-
-1. A **WHAT statement** — the desired outcome for this slice, stated concretely.
-2. At least one **acceptance criterion** — a falsifiable check that, when met, confirms the slice is done.
-3. A **verification surface** — the concrete evidence that proves the AC is met (a test, an artifact, a command output, an observable behavior).
-
-Once you have agreed on the full story set with the user, ingest it:
-
-```
-bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts set-stories --json '<array-of-stories>'
-```
-
-`set-stories --json` refuses an empty array, any story missing acceptance criteria or a verification surface, duplicate ids, an empty `outcome`, or a `phase` other than `planning`. Every ingested story starts `unconfirmed`.
-
-**Per-story confirmation.** After the user approves each story in the planning dialogue, confirm it:
-
-```
-bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts confirm-story <id>
-```
-
-`confirm-story` is the sole path from `unconfirmed` to `confirmed`. No other subcommand (`set`, `set-verdict`, `set-stories --json` re-ingestion) can produce `confirmed`. The pursuing phase is refused while any story remains `unconfirmed` — `set --phase pursuing` names the offending ids on stderr. Once all stories are `confirmed` (or `retired`), the pursuing transition is allowed.
-
-<!-- story-layer:end -->
+**You MUST read `references/planning.md` first** before seeding the six slots (`set --phase planning`), defining or confirming stories (`set-stories`/`confirm-story`), or applying any mid-flight story mutation (`add-story`/`revise-story`/`retire-story`) — it is the single owner of the slot definitions and the full story lifecycle.
 
 ---
 
@@ -135,6 +73,39 @@ Goal does not reimplement decomposition or execution. It invokes the existing sk
 - **Vague** (the verification surface cannot be derived without questioning the user) → `Skill(skill: "deep-interview")` passing the marker `caller=goal`. The interview crystallizes a spec at `$OMT_DIR/deep-interview/{slug}.md`; because the `caller=goal` marker is present, deep-interview's re-entrancy guard returns that crystallized spec to goal and emits NO `goal` handoff (preventing a goal→deep-interview→goal loop). Goal receives the returned spec and routes downstream itself; the spec's acceptance criteria feed the verification-surface slot.
 - **Complex** (the objective needs decomposition into a TODO plan with waves and acceptance criteria — multi-component, 3+ files, or any non-trivial build) → `Skill(skill: "prometheus")`. Prometheus runs its full planning pipeline (its human gates UN-wrapped) and ends by dispatching to sisyphus with a plan path at `$OMT_DIR/plans/{name}.md`.
 - **Execution** (a plan or crystallized spec already exists and the objective is ready to be built) → dispatch to sisyphus for execution: `Skill(skill: "sisyphus")` with the plan path.
+
+### Clarity gate
+
+When the Vague branch above returns a crystallized spec, goal trusts deep-interview's crystallized clarity (ambiguity ≤ the resolved threshold, default 0.15) as the requirements-clarity signal and does not re-interrogate the user before routing downstream — the spec's own clearance is already satisfied, not re-litigated by goal.
+
+### Fast-path gate
+
+Not every Complex-shaped objective needs prometheus's full planning pipeline. When a Complex objective clears all three fast-path signals — (1) the objective is Complex on file-count alone, with each individual change mechanical and localized, (2) no competing design fork exists — a single obvious approach, not a choice among architectures, and (3) no T1-tier risk is present (no security or data-integrity surface) — goal skips prometheus, captures the objective's acceptance criteria directly into the Story Definition layer, and dispatches straight to sisyphus. This fast-path judgment is goal's own inline prose gate, not a CLI subcommand — goal reads the three signals itself and decides. It presupposes the Clarity gate above: the fast-path evaluation only runs once deep-interview's crystallized clarity has already cleared, so the three signals are judged against a spec whose ambiguity is already resolved, not a foggy one.
+
+A live design fork disqualifies the fast-path outright: competing design alternatives are exactly what prometheus's planning pipeline exists to adjudicate, so an objective with a design fork always routes through prometheus regardless of file count or risk tier.
+
+When the three-signal verdict is on the fence — not clearly cleared, not clearly failed — the asymmetric default resolves it toward prometheus, never toward the fast path: a user wrongly silenced by a skipped planning gate is worse than one extra round of design review, so an ambiguous fast-path judgment falls back to the full prometheus pipeline.
+
+### Finalize-before-advance guard
+
+Before invoking a subskill at ANY dispatch site below, cross-read the OTHER stateful subskill's own state file to confirm it is not left half-open from an earlier call in this session:
+
+```
+bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts check-subskill --skill deep-interview
+bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts check-subskill --skill prometheus
+```
+
+A non-zero exit means that subskill's own state file is `active:true`, TTL-live, and non-pristine — it ran and never finalized (no done-token emitted). Before advancing with the dispatch you were about to make, emit that subskill's own done-token (`<deep-interview-done/>` or `<prometheus-done/>`) to finalize it first, THEN proceed. `check-subskill` exits 0 (pass) when the peer state is absent, terminal (`active:false`), pristine (freshly seeded, no real work), or TTL-stale — none of those block advancing.
+
+This guard runs at every dispatch site in the pipeline:
+
+- **Initial planning** — before the first `deep-interview` or `prometheus` call (the Vague/Complex branch above), check the OTHER of the two.
+- **Initial sisyphus execution** — before the first `sisyphus` dispatch (the Execution branch, and the fast-path direct-to-sisyphus that skips prometheus), check both `deep-interview` and `prometheus`.
+- **Re-plan loop-back** — before re-invoking `prometheus` (Strategic plan inadequacy, below), check `deep-interview`.
+- **REQUEST_CHANGES sisyphus re-dispatch** — before re-invoking `sisyphus` on named incomplete work items, check both `deep-interview` and `prometheus`.
+- **CONFIRMED-finding sisyphus re-dispatch** — before re-invoking `sisyphus` on code-review findings, check both `deep-interview` and `prometheus`.
+
+**Un-wedge recovery.** If a subskill exits without emitting its done-token (crash, interruption, forgotten emit), its state file sticks at `active:true` — half-open — and blocks the next dispatch site indefinitely. Recovery: emit that subskill's done-token to finalize the stuck state (or let the TTL-based GC reap it once its idle window elapses). Because this is a cross-read of the PEER skill's own state file, goal never gets wedged on its own state — only the peer's leaked half-open state, which self-heals via TTL even if no one ever emits the done-token.
 
 ### Phase transitions
 
@@ -152,109 +123,11 @@ The autonomous loop blocks ONLY when `phase=pursuing`. Set the phase around the 
 
 Initial path: `set --phase planning` (seed slots) → invoke prometheus / deep-interview → on sisyphus dispatch `set --phase pursuing`. Re-plan loop-back: `set --phase planning` (clears the verdict) → invoke prometheus again → `set --phase pursuing` after the fresh sisyphus dispatch.
 
-<!-- story-layer:start -->
-
-### Mid-flight Story Mutations
-
-Stories can be discovered, corrected, or retired during pursuit. Use the per-story mutation subcommands when the situation changes mid-flight:
-
-- **`add-story --json '<story>'`** — appends one new story with status `unconfirmed`. Allowed in both `planning` and `pursuing`. A newly added story must be confirmed via `confirm-story <id>` before completion is allowed (an `unconfirmed` story blocks `request-complete`).
-- **`revise-story <id> --json '<patch>'`** — patches an existing story's text, acceptance criteria, or verification surface. Revision ALWAYS resets the story's status to `unconfirmed` — a story whose definition changed requires fresh user approval. Refused on retired stories and unknown ids.
-- **`retire-story <id>`** — marks a story `retired`. An `unconfirmed` story is retirable in any phase. A `confirmed` story is retirable ONLY while `phase=planning` — retiring a confirmed story mid-pursuit is refused (run `set --phase planning` first to re-enter planning, then retire). This fence prevents retiring a confirmed WHAT mid-pursuit as a way to remove it from the completion gate.
-
-Re-plan (`set --phase planning`) preserves `stories[]` including per-story statuses, while resetting `objective_verdict` and `completion_evidence_paths` exactly as today. Stories survive re-planning; only verdict state is cleared.
-
-<!-- story-layer:end -->
-
 ---
 
 ## Completion Gate
 
-After a sisyphus pass, completion is NOT self-declared by stopping. Run the objective-level completion check yourself (the orchestrator), inline: take the **verification surface as PROSE requirements** — a completeness Spec — and confirm that every prose-stated requirement is reflected in the deliverable, rendering an APPROVE / REQUEST_CHANGES / COMMENT verdict.
-
-Run the **automated checks (build / test / lint)** inline and map the verification surface to concrete evidence per the rubric below. The expensive **hands-on adversarial matrix is NOT run in the autonomous loop** — that final, costly QA is the human's, performed once after the loop reports complete (the objective self-check covers automated correctness + completeness; the human covers hands-on confidence). The rubric forces an evidence-based verdict and asserts each element independently:
-
-- **prompt-to-artifact mapping** — map every explicit requirement, numbered item, named file, command, test, gate, and deliverable in the verification surface to concrete evidence; an unmapped requirement is incomplete.
-- **proxy-signal refusal** — refuse proxy signals as completion by themselves: passing tests, a green build, a complete manifest, or substantial effort count only insofar as they cover every requirement in the verification surface.
-- **verify-the-verifier** — confirm that any test suite, manifest, or green status actually COVERS the objective's requirements before relying on it (the FALSE-GREEN guard: not "are tests green?" but "do the green tests cover every objective requirement?").
-- **uncertainty = not-achieved** — treat any uncertain, weakly-verified, or uncovered requirement as not achieved; doubt drives REQUEST_CHANGES, never APPROVE.
-
-Because the orchestrator now runs this check on its own pursuit, the rubric is the discipline against self-deception — the objective lane is self-attested, and the genuinely independent structural teeth are the **code-review lane** (a fresh reviewer, below) and the human's final hands-on QA. Apply the rubric strictly: a self-attested APPROVE that skips proxy-refusal or verify-the-verifier is exactly the false-complete the gate exists to prevent.
-
-<!-- story-layer:start -->
-
-**Per-story re-derivation (same inline check).** The same self-check also re-derives a verdict for every non-retired story and authors the structured verdict artifact at `$OMT_DIR/goal-verdict-{sid}.json`. The orchestrator writes this file directly. (`request-complete` validates the artifact's schema and per-story verdicts, not its author — so the structural gate is unchanged.) The artifact schema is:
-
-```json
-{
-  "objective_verdict": "APPROVE | REQUEST_CHANGES | COMMENT",
-  "stories": [
-    { "id": "<story-id>", "verdict": "APPROVE | REQUEST_CHANGES", "evidence_refs": ["<path>"] }
-  ],
-  "verifier": "<orchestrator objective self-check>",
-  "at": "<ISO timestamp>"
-}
-```
-
-For each non-retired story, map the story's acceptance criteria and verification surface to concrete evidence and render an `APPROVE` or `REQUEST_CHANGES` per-story verdict. A single non-APPROVE per-story entry blocks completion regardless of the `objective_verdict` field — `objective_verdict === 'APPROVE'` alone is never sufficient.
-
-`request-complete` reads the artifact from the conventional path internally (no path argument). It refuses if: the artifact is absent or schema-invalid; any non-retired story entry is non-APPROVE; any non-retired story is `unconfirmed`; an entry is missing for any non-retired story; zero non-retired stories exist; or the existing dual gate is unmet (`objective_verdict !== 'APPROVE'` in state, or empty `completion_evidence_paths`). As a second structural refusal lane, `request-complete` also reads the code-review artifact (`goal-codereview-{sid}.json`) from its conventional path internally (no path argument) and refuses if that artifact is absent, schema-invalid, or contains any `CONFIRMED` finding (see code-review lane below); this refusal is structural — it runs inside `request-complete` itself independent of the orchestrator loop, so completion is blocked even if the loop misbehaves. When all checks pass, `request-complete` writes `phase=complete` and `active=false`.
-
-<!-- story-layer:end -->
-
-**Code-review lane (runs alongside the objective self-check).** After each sisyphus pass, an independent code-review lane runs alongside the objective lane. Dispatch a fresh **code-reviewer** agent independently of the builder (sisyphus); self-review by the builder is forbidden. This lane is the autonomous loop's one genuinely independent gate — a fresh instance, not the orchestrator — so it carries the structural anti-anchoring teeth the objective self-check no longer provides. Before dispatching the code-reviewer, the orchestrator runs `bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts serialize-requirements` and feeds its stdout block into the reviewer's `{REQUIREMENTS}` input so the reviewer can detect requirement-gap findings (stories the diff does not satisfy). The code-reviewer writes `$OMT_DIR/goal-codereview-{sid}.json` directly (it has file tools); the orchestrator passes only the session-derived path and never transcribes finding content. The artifact schema the code-reviewer must emit:
-
-```json
-{
-  "findings": [
-    { "class": "correctness|cleanup|requirement-gap", "verdict": "CONFIRMED|PLAUSIBLE", "ref": "<file:line>" }
-  ],
-  "reviewer": "<reviewer id>",
-  "at": "<ISO timestamp>"
-}
-```
-
-**Pass signal:** any finding where `verdict === "CONFIRMED"` blocks completion — whether `class` is `correctness`, `cleanup`, or `requirement-gap`. `PLAUSIBLE` findings are non-blocking; they are reported but do not prevent completion. `class` is an informational label the gate does not key on (the gate keys solely on `verdict === "CONFIRMED"`).
-
-A blocking code-review finding (any CONFIRMED) routes back to sisyphus re-dispatch targeted at those specific findings — the same concrete-progress shape as an objective-lane REQUEST_CHANGES verdict.
-
-**Completion fires ONLY on an objective-lane APPROVE AND an objective-scope Evidence Audit pass.** A **COMMENT verdict is NOT sufficient** for completion — not because COMMENT is a distinct severity tier, but because the never-false-complete invariant in `request-complete` structurally requires `objective_verdict=APPROVE`. COMMENT is a soft pass: no blocking issue but non-blocking notes remain — on COMMENT, address those notes and re-verify until APPROVE. **On an APPROVE,** the Evidence Audit applies the verify-the-verifier shape to your own check: confirm the verdict HOLDS UP by reading the evidence you collected (does it demonstrate the verification surface was met?). If the evidence is missing or does not demonstrate the verification surface, it is an Evidence Gap → continue pursuit, do not complete.
-
-On pass (APPROVE + Evidence Audit holds), run the completion sequence in this exact order — **record the Evidence Audit artifact paths FIRST, then flip the verdict, then request completion:**
-
-```
-bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts set --phase pursuing --completion-evidence <audit-artifact-paths>
-bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts set-verdict --verdict APPROVE
-bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts request-complete
-```
-
-`<audit-artifact-paths>` is a comma-separated list of the artifacts the Evidence Audit read (the evidence that demonstrates the verification surface was met). `set --phase pursuing --completion-evidence` keeps the phase `pursuing` and only records the evidence — it can never write `complete`.
-
-**Why evidence is recorded BEFORE the verdict flips:** so that whenever `objective_verdict=APPROVE` is observed, the completion evidence is already present. `request-complete` is the ONLY path to `phase=complete` — the hook layer never writes `complete` under any condition (cap reached → `budget_limited` block, not complete). Recording evidence first ensures the full `request-complete` gate (verdict + evidence + per-story artifact checks) is satisfiable the moment the verdict flips. When the cap is reached before the gate is met, the hook writes `budget_limited` and blocks for that turn; calling `request-complete` in the same turn is still possible and succeeds if the gate is met — ADR-7 complete-wins means `request-complete` prevails over a prior `budget_limited` state. If `request-complete` is refused, report the blocker honestly and stop.
-
-APPROVE alone does NOT leave the goal pursuing/active — the `request-complete` handoff is what transitions to terminal `complete` (and it is structurally gated on completion-evidence, so a write that never reached the gate cannot false-complete).
-
-**Once `request-complete` reaches terminal `complete`, hand off to the human for the final hands-on QA.** The autonomous loop proved the verification surface through automated checks and the code-review lane; the hands-on adversarial matrix was deliberately left out of the loop (see the Completion Gate opening). So when you report completion, also prompt the user to run their own final hands-on pass before shipping — the heavy `Skill(skill: "qa")` battery is available if they want it.
-
-**Two lanes gate completion: the objective self-check and code-review.** The completion path runs both the objective-level self-check (correctness, completeness, and evidence audit) and the independent code-review lane (static quality and conventions) — both must be clean for `request-complete` to pass. No design or architecture lane gates completion: daedalus and design-review are plan-time advisory only, not completion gates. Code-review is a completion-time quality lane and is distinct from design-review — the two must not be conflated.
-
-### Concrete progress action per non-APPROVE verdict
-
-Every non-APPROVE verdict drives a concrete progress action — never action-less spin. Each action is **scoped re-review**: it re-dispatches only the rejected unit (the named incomplete TODOs, or the specific CONFIRMED findings), never a full re-walk of already-passed work. A full re-plan via prometheus is the exception, reserved for a strategic plan inadequacy where the decomposition itself is wrong:
-
-- **REQUEST_CHANGES naming incomplete work items** (tactical — the work is unfinished, the plan is sound) → re-dispatch `Skill(skill: "sisyphus")` on the named incomplete TODOs. This stays inside sisyphus's junior loop; phase remains `pursuing`.
-- **Strategic plan inadequacy** (the plan itself cannot reach the objective — the decomposition is wrong, not merely unfinished) → re-plan via `Skill(skill: "prometheus")`: run `set --phase planning` first (which clears the verdict), let prometheus's human design gates run un-wrapped, then `set --phase pursuing` after the fresh sisyphus dispatch.
-- **COMMENT (soft pass — non-blocking notes)** → re-dispatch `Skill(skill: "sisyphus")` to address the self-check notes, then re-verify toward APPROVE; do NOT `request-complete` on a COMMENT (the code gate requires `objective_verdict=APPROVE`).
-- **Code-review lane: any CONFIRMED finding** → re-dispatch `Skill(skill: "sisyphus")` on the specific findings in `goal-codereview-{sid}.json`. Phase remains `pursuing`; run a fresh code-review dispatch after sisyphus resolves the findings.
-
-### Blocked-stop
-
-Pursuit stops as blocked (non-complete) ONLY on a decidable, point-in-time predicate — there is no cross-iteration stall detector; `max_iterations` absorbs genuine stalls. Exactly two conditions trip blocked:
-
-- **B1** — the objective self-check names NO actionable incomplete work item while the objective is still unmet (no valid progress path: nothing to re-dispatch and the verification surface is not satisfied).
-- **B2** — the captured **blocked-stop** slot's objective-specific condition is met.
-
-On either condition: run `set-blocked --reason "<blocker>"`, report the blocker to the user, and stop. A blocked pursuit is non-complete — `set-blocked` can never write `complete`.
+**You MUST read `references/completion-gate.md` first** before rendering the objective-lane verdict, evaluating the code-review lane, or running the completion sequence (`set-verdict`/`request-complete`) — it is the single owner of the evidence rubric, the per-story and code-review artifact schemas, the pass signal, the concrete-progress routing per verdict, and the blocked-stop conditions.
 
 ---
 

--- a/skills/goal/SKILL.test.ts
+++ b/skills/goal/SKILL.test.ts
@@ -1,0 +1,202 @@
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// ---------------------------------------------------------------------------
+// Prose-contract test for skills/goal/SKILL.md — l4a-clarity-gate.
+//
+// goal must trust deep-interview's crystallized ambiguity score as the
+// requirements-clarity signal and skip re-interrogating the user before
+// routing downstream. This asserts the load-bearing sentence body-wide
+// (toContain over the whole file, not a heading-slice) so a later heading
+// reshape (lever 5) does not break this test.
+// ---------------------------------------------------------------------------
+
+const skillMd = readFileSync(join(import.meta.dir, "SKILL.md"), "utf8");
+const planningMd = readFileSync(
+	join(import.meta.dir, "references/planning.md"),
+	"utf8",
+);
+const completionGateMd = readFileSync(
+	join(import.meta.dir, "references/completion-gate.md"),
+	"utf8",
+);
+// Union of body + both references — the behavior-preservation surface after
+// the L1-compress split. A required phrase must survive SOMEWHERE in this
+// union; which file it lives in is a routing detail, not a contract.
+const combined = skillMd + planningMd + completionGateMd;
+
+describe("clarity gate: goal trusts deep-interview's crystallized ambiguity", () => {
+	test("SKILL.md states goal trusts DI's crystallized clarity and does not re-interrogate", () => {
+		expect(skillMd).toContain(
+			"goal trusts deep-interview's crystallized clarity (ambiguity ≤ the resolved threshold, default 0.15) as the requirements-clarity signal and does not re-interrogate the user before routing downstream",
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Prose-contract test for skills/goal/SKILL.md — l4-fastpath-gate.
+//
+// goal must fold the Complex→prometheus branch: when a Complex objective
+// clears three fast-path signals (file-count-only Complex, no design fork,
+// no T1 risk) goal skips prometheus and dispatches straight to sisyphus via
+// the Story layer. A live design fork must be named explicitly as a
+// fast-path exclusion signal so design-fork work never leaks onto the fast
+// path. On-the-fence judgments default toward prometheus (asymmetric
+// default), never toward the fast path.
+//
+// Asserted body-wide (toContain over the whole file, not a heading-slice)
+// so a later heading reshape (lever 5) does not break this test. Per the
+// plan, the Conditional Orchestration section (where this prose lives)
+// stays in SKILL.md's body after lever 5 — it is not relocated to
+// references/ — so a plain whole-file toContain remains valid post-L1.
+// ---------------------------------------------------------------------------
+
+describe("fast-path gate: goal conditionally folds prometheus for Complex objectives", () => {
+	test("SKILL.md states the three fast-path signals, naming a design fork as an exclusion signal", () => {
+		expect(skillMd).toContain(
+			"When a Complex objective clears all three fast-path signals — (1) the objective is Complex on file-count alone, with each individual change mechanical and localized, (2) no competing design fork exists — a single obvious approach, not a choice among architectures, and (3) no T1-tier risk is present (no security or data-integrity surface) — goal skips prometheus, captures the objective's acceptance criteria directly into the Story Definition layer, and dispatches straight to sisyphus.",
+		);
+	});
+
+	test("SKILL.md states the asymmetric default: on-the-fence falls back to prometheus", () => {
+		expect(skillMd).toContain(
+			"a user wrongly silenced by a skipped planning gate is worse than one extra round of design review, so an ambiguous fast-path judgment falls back to the full prometheus pipeline",
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// l5-compress: SKILL.md is compressed to a router; Six Slots, Story
+// Definition, Mid-flight Story Mutations, and Completion Gate move to
+// references/planning.md and references/completion-gate.md verbatim. Content
+// must be behaviorally invariant — every required phrase survives SOMEWHERE
+// in the body+references union — while the moved detail is actually gone
+// from the body (proving the move happened, not just that a copy exists).
+// ---------------------------------------------------------------------------
+
+describe("read-discipline: SKILL.md points at the extracted references", () => {
+	test("SKILL.md instructs reading references/planning.md before planning/story subcommands", () => {
+		expect(skillMd).toContain(
+			"You MUST read `references/planning.md` first",
+		);
+	});
+
+	test("SKILL.md instructs reading references/completion-gate.md before the completion sequence", () => {
+		expect(skillMd).toContain(
+			"You MUST read `references/completion-gate.md` first",
+		);
+	});
+});
+
+describe("strip: Six Slots and Story Definition detail moved out of SKILL.md body", () => {
+	test("slot-definition detail is absent from SKILL.md body", () => {
+		expect(skillMd).not.toContain(
+			"**outcome** (`--outcome`) — what is true when the objective is reached",
+		);
+	});
+
+	test("slot-definition detail is present in references/planning.md", () => {
+		expect(planningMd).toContain(
+			"**outcome** (`--outcome`) — what is true when the objective is reached",
+		);
+	});
+
+	test("set-stories --single detail is absent from SKILL.md body", () => {
+		expect(skillMd).not.toContain(
+			"bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts set-stories --single",
+		);
+	});
+
+	test("set-stories --single detail is present in references/planning.md", () => {
+		expect(planningMd).toContain(
+			"bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts set-stories --single",
+		);
+	});
+
+	test("Mid-flight Story Mutations subcommand detail is absent from SKILL.md body", () => {
+		expect(skillMd).not.toContain(
+			"**`add-story --json '<story>'`** — appends one new story with status `unconfirmed`",
+		);
+	});
+
+	test("Mid-flight Story Mutations subcommand detail is present in references/planning.md", () => {
+		expect(planningMd).toContain(
+			"**`add-story --json '<story>'`** — appends one new story with status `unconfirmed`",
+		);
+	});
+});
+
+describe("strip: Completion Gate detail moved out of SKILL.md body", () => {
+	test("evidence rubric detail is absent from SKILL.md body", () => {
+		expect(skillMd).not.toContain(
+			"**prompt-to-artifact mapping** — map every explicit requirement, numbered item, named file, command, test, gate, and deliverable in the verification surface to concrete evidence",
+		);
+	});
+
+	test("evidence rubric detail is present in references/completion-gate.md", () => {
+		expect(completionGateMd).toContain(
+			"**prompt-to-artifact mapping** — map every explicit requirement, numbered item, named file, command, test, gate, and deliverable in the verification surface to concrete evidence",
+		);
+	});
+
+	test("code-review artifact schema detail is absent from SKILL.md body", () => {
+		expect(skillMd).not.toContain('"status": "COMPLETE|INCONCLUSIVE"');
+	});
+
+	test("code-review artifact schema detail is present in references/completion-gate.md", () => {
+		expect(completionGateMd).toContain(
+			'"status": "COMPLETE|INCONCLUSIVE"',
+		);
+	});
+
+	test("Blocked-stop B1/B2 detail is absent from SKILL.md body", () => {
+		expect(skillMd).not.toContain(
+			"**B1** — the objective self-check names NO actionable incomplete work item",
+		);
+	});
+
+	test("Blocked-stop B1/B2 detail is present in references/completion-gate.md", () => {
+		expect(completionGateMd).toContain(
+			"**B1** — the objective self-check names NO actionable incomplete work item",
+		);
+	});
+});
+
+describe("preserved (regression): required phrases survive somewhere in body+references", () => {
+	test("all six slot names are named somewhere in the union", () => {
+		expect(combined).toContain("**outcome** (`--outcome`)");
+		expect(combined).toContain(
+			"**verification-surface** (`--verification-surface`)",
+		);
+		expect(combined).toContain("**constraints** (`--constraints`)");
+		expect(combined).toContain("**boundaries** (`--boundaries`)");
+		expect(combined).toContain(
+			"**iteration-policy** → `max_iterations` (`--max-iterations <n>`)",
+		);
+		expect(combined).toContain(
+			"**blocked-stop** (`--blocked-stop <text>`)",
+		);
+	});
+
+	test("the never-false-complete invariant survives in the union", () => {
+		expect(combined).toContain(
+			"the never-false-complete invariant in `request-complete` structurally requires `objective_verdict=APPROVE`",
+		);
+	});
+
+	test("INCONCLUSIVE status routing survives in the union", () => {
+		expect(combined).toContain(
+			'`status === "INCONCLUSIVE"` blocks regardless of findings',
+		);
+		expect(combined).toContain(
+			"An `INCONCLUSIVE` status routes to a **reviewer-only re-run** instead — re-dispatch a fresh **code-reviewer** over the same diff, NOT sisyphus",
+		);
+	});
+
+	test("the fast-path three signals survive in the union (body-resident per plan)", () => {
+		expect(combined).toContain(
+			"When a Complex objective clears all three fast-path signals",
+		);
+	});
+});

--- a/skills/goal/references/completion-gate.md
+++ b/skills/goal/references/completion-gate.md
@@ -1,0 +1,91 @@
+## Completion Gate
+
+After a sisyphus pass, completion is NOT self-declared by stopping. Run the objective-level completion check yourself (the orchestrator), inline: take the **verification surface as PROSE requirements** — a completeness Spec — and confirm that every prose-stated requirement is reflected in the deliverable, rendering an APPROVE / REQUEST_CHANGES / COMMENT verdict.
+
+Run the **automated checks (build / test / lint)** inline and map the verification surface to concrete evidence per the rubric below. The expensive **hands-on adversarial matrix is NOT run in the autonomous loop** — that final, costly QA is the human's, performed once after the loop reports complete (the objective self-check covers automated correctness + completeness; the human covers hands-on confidence). The rubric forces an evidence-based verdict and asserts each element independently:
+
+- **prompt-to-artifact mapping** — map every explicit requirement, numbered item, named file, command, test, gate, and deliverable in the verification surface to concrete evidence; an unmapped requirement is incomplete.
+- **proxy-signal refusal** — refuse proxy signals as completion by themselves: passing tests, a green build, a complete manifest, or substantial effort count only insofar as they cover every requirement in the verification surface.
+- **verify-the-verifier** — confirm that any test suite, manifest, or green status actually COVERS the objective's requirements before relying on it (the FALSE-GREEN guard: not "are tests green?" but "do the green tests cover every objective requirement?").
+- **uncertainty = not-achieved** — treat any uncertain, weakly-verified, or uncovered requirement as not achieved; doubt drives REQUEST_CHANGES, never APPROVE.
+
+Because the orchestrator now runs this check on its own pursuit, the rubric is the discipline against self-deception — the objective lane is self-attested, and the genuinely independent structural teeth are the **code-review lane** (a fresh reviewer, below) and the human's final hands-on QA. Apply the rubric strictly: a self-attested APPROVE that skips proxy-refusal or verify-the-verifier is exactly the false-complete the gate exists to prevent.
+
+<!-- story-layer:start -->
+
+**Per-story re-derivation (same inline check).** The same self-check also re-derives a verdict for every non-retired story and authors the structured verdict artifact at `$OMT_DIR/goal-verdict-{sid}.json`. The orchestrator writes this file directly. (`request-complete` validates the artifact's schema and per-story verdicts, not its author — so the structural gate is unchanged.) The artifact schema is:
+
+```json
+{
+  "objective_verdict": "APPROVE | REQUEST_CHANGES | COMMENT",
+  "stories": [
+    { "id": "<story-id>", "verdict": "APPROVE | REQUEST_CHANGES", "evidence_refs": ["<path>"] }
+  ],
+  "verifier": "<orchestrator objective self-check>",
+  "at": "<ISO timestamp>"
+}
+```
+
+For each non-retired story, map the story's acceptance criteria and verification surface to concrete evidence and render an `APPROVE` or `REQUEST_CHANGES` per-story verdict. A single non-APPROVE per-story entry blocks completion regardless of the `objective_verdict` field — `objective_verdict === 'APPROVE'` alone is never sufficient.
+
+`request-complete` reads the artifact from the conventional path internally (no path argument). It refuses if: the artifact is absent or schema-invalid; any non-retired story entry is non-APPROVE; any non-retired story is `unconfirmed`; an entry is missing for any non-retired story; zero non-retired stories exist; or the existing dual gate is unmet (`objective_verdict !== 'APPROVE'` in state, or empty `completion_evidence_paths`). As a second structural refusal lane, `request-complete` also reads the code-review artifact (`goal-codereview-{sid}.json`) from its conventional path internally (no path argument) and refuses if that artifact is absent or schema-invalid (a missing `status` field is schema-invalid — there is no default-to-COMPLETE coercion), has `status: "INCONCLUSIVE"`, or contains any `CONFIRMED` finding (see code-review lane below); this refusal is structural — it runs inside `request-complete` itself independent of the orchestrator loop, so completion is blocked even if the loop misbehaves. When all checks pass, `request-complete` writes `phase=complete` and `active=false`.
+
+<!-- story-layer:end -->
+
+**Code-review lane (runs alongside the objective self-check).** After each sisyphus pass, an independent code-review lane runs alongside the objective lane. Dispatch a fresh **code-reviewer** agent independently of the builder (sisyphus); self-review by the builder is forbidden. This lane is the autonomous loop's one genuinely independent gate — a fresh instance, not the orchestrator — so it carries the structural anti-anchoring teeth the objective self-check no longer provides. Before dispatching the code-reviewer, the orchestrator runs `bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts serialize-requirements` and feeds its stdout block into the reviewer's `{REQUIREMENTS}` input so the reviewer can detect requirement-gap findings (stories the diff does not satisfy). The code-reviewer writes `$OMT_DIR/goal-codereview-{sid}.json` directly (it has file tools); the orchestrator passes only the session-derived path and never transcribes finding content. The artifact schema the code-reviewer must emit:
+
+```json
+{
+  "status": "COMPLETE|INCONCLUSIVE",
+  "findings": [
+    { "class": "correctness|cleanup|requirement-gap", "verdict": "CONFIRMED|PLAUSIBLE", "ref": "<file:line>" }
+  ],
+  "reviewer": "<reviewer id>",
+  "at": "<ISO timestamp>"
+}
+```
+
+`status` is **required** — a top-level 3-state signal that separates a review that finished from one that did not. `status: "COMPLETE"` means the reviewer actually rendered a verdict over the diff (findings, possibly empty, are trustworthy). `status: "INCONCLUSIVE"` means the review itself did not finish — reviewer timeout, an ack-only response, a `BLOCKED` reviewer, or genuine reviewer uncertainty — and `findings` cannot be trusted as exhaustive even if empty. There is no default-to-COMPLETE coercion: an artifact missing `status` is schema-invalid and refused exactly like an absent artifact (fail-safe — never let a legacy or malformed artifact round up to a clean pass).
+
+**Pass signal:** completion requires `status === "COMPLETE"` AND no finding with `verdict === "CONFIRMED"` (whether `class` is `correctness`, `cleanup`, or `requirement-gap`). `status === "INCONCLUSIVE"` blocks regardless of findings. `PLAUSIBLE` findings are non-blocking; they are reported but do not prevent completion. `class` is an informational label the gate does not key on (the gate keys solely on `verdict === "CONFIRMED"`).
+
+The two block reasons route differently: a blocking code-review finding (any CONFIRMED, under `status: "COMPLETE"`) routes back to sisyphus re-dispatch targeted at those specific findings — the same concrete-progress shape as an objective-lane REQUEST_CHANGES verdict. An `INCONCLUSIVE` status routes to a **reviewer-only re-run** instead — re-dispatch a fresh **code-reviewer** over the same diff, NOT sisyphus (there is no confirmed work item to fix; the review itself just needs to finish).
+
+**Completion fires ONLY on an objective-lane APPROVE AND an objective-scope Evidence Audit pass.** A **COMMENT verdict is NOT sufficient** for completion — not because COMMENT is a distinct severity tier, but because the never-false-complete invariant in `request-complete` structurally requires `objective_verdict=APPROVE`. COMMENT is a soft pass: no blocking issue but non-blocking notes remain — on COMMENT, address those notes and re-verify until APPROVE. **On an APPROVE,** the Evidence Audit applies the verify-the-verifier shape to your own check: confirm the verdict HOLDS UP by reading the evidence you collected (does it demonstrate the verification surface was met?). If the evidence is missing or does not demonstrate the verification surface, it is an Evidence Gap → continue pursuit, do not complete.
+
+On pass (APPROVE + Evidence Audit holds), run the completion sequence in this exact order — **record the Evidence Audit artifact paths FIRST, then flip the verdict, then request completion:**
+
+```
+bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts set --phase pursuing --completion-evidence <audit-artifact-paths>
+bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts set-verdict --verdict APPROVE
+bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts request-complete
+```
+
+`<audit-artifact-paths>` is a comma-separated list of the artifacts the Evidence Audit read (the evidence that demonstrates the verification surface was met). `set --phase pursuing --completion-evidence` keeps the phase `pursuing` and only records the evidence — it can never write `complete`.
+
+**Why evidence is recorded BEFORE the verdict flips:** so that whenever `objective_verdict=APPROVE` is observed, the completion evidence is already present. `request-complete` is the ONLY path to `phase=complete` — the hook layer never writes `complete` under any condition (cap reached → `budget_limited` block, not complete). Recording evidence first ensures the full `request-complete` gate (verdict + evidence + per-story artifact checks) is satisfiable the moment the verdict flips. When the cap is reached before the gate is met, the hook writes `budget_limited` and blocks for that turn; calling `request-complete` in the same turn is still possible and succeeds if the gate is met — ADR-7 complete-wins means `request-complete` prevails over a prior `budget_limited` state. If `request-complete` is refused, report the blocker honestly and stop.
+
+APPROVE alone does NOT leave the goal pursuing/active — the `request-complete` handoff is what transitions to terminal `complete` (and it is structurally gated on completion-evidence, so a write that never reached the gate cannot false-complete).
+
+**Once `request-complete` reaches terminal `complete`, hand off to the human for the final hands-on QA.** The autonomous loop proved the verification surface through automated checks and the code-review lane; the hands-on adversarial matrix was deliberately left out of the loop (see the Completion Gate opening). So when you report completion, also prompt the user to run their own final hands-on pass before shipping — the heavy `Skill(skill: "qa")` battery is available if they want it.
+
+**Two lanes gate completion: the objective self-check and code-review.** The completion path runs both the objective-level self-check (correctness, completeness, and evidence audit) and the independent code-review lane (static quality and conventions) — both must be clean for `request-complete` to pass. No design or architecture lane gates completion: daedalus and design-review are plan-time advisory only, not completion gates. Code-review is a completion-time quality lane and is distinct from design-review — the two must not be conflated.
+
+### Concrete progress action per non-APPROVE verdict
+
+Every non-APPROVE verdict drives a concrete progress action — never action-less spin. Each action is **scoped re-review**: it re-dispatches only the rejected unit (the named incomplete TODOs, or the specific CONFIRMED findings), never a full re-walk of already-passed work. A full re-plan via prometheus is the exception, reserved for a strategic plan inadequacy where the decomposition itself is wrong:
+
+- **REQUEST_CHANGES naming incomplete work items** (tactical — the work is unfinished, the plan is sound) → re-dispatch `Skill(skill: "sisyphus")` on the named incomplete TODOs. This stays inside sisyphus's junior loop; phase remains `pursuing`.
+- **Strategic plan inadequacy** (the plan itself cannot reach the objective — the decomposition is wrong, not merely unfinished) → re-plan via `Skill(skill: "prometheus")`: run `set --phase planning` first (which clears the verdict), let prometheus's human design gates run un-wrapped, then `set --phase pursuing` after the fresh sisyphus dispatch.
+- **COMMENT (soft pass — non-blocking notes)** → re-dispatch `Skill(skill: "sisyphus")` to address the self-check notes, then re-verify toward APPROVE; do NOT `request-complete` on a COMMENT (the code gate requires `objective_verdict=APPROVE`).
+- **Code-review lane: any CONFIRMED finding** (under `status: "COMPLETE"`) → re-dispatch `Skill(skill: "sisyphus")` on the specific findings in `goal-codereview-{sid}.json`. Phase remains `pursuing`; run a fresh code-review dispatch after sisyphus resolves the findings.
+- **Code-review lane: `status: "INCONCLUSIVE"`** (reviewer timeout, ack-only response, `BLOCKED` reviewer, or genuine reviewer uncertainty) → re-dispatch a **fresh code-reviewer only** over the same diff — NOT sisyphus, since no finding was confirmed. Phase remains `pursuing`.
+
+### Blocked-stop
+
+Pursuit stops as blocked (non-complete) ONLY on a decidable, point-in-time predicate — there is no cross-iteration stall detector; `max_iterations` absorbs genuine stalls. Exactly two conditions trip blocked:
+
+- **B1** — the objective self-check names NO actionable incomplete work item while the objective is still unmet (no valid progress path: nothing to re-dispatch and the verification surface is not satisfied).
+- **B2** — the captured **blocked-stop** slot's objective-specific condition is met.
+
+On either condition: run `set-blocked --reason "<blocker>"`, report the blocker to the user, and stop. A blocked pursuit is non-complete — `set-blocked` can never write `complete`.

--- a/skills/goal/references/planning.md
+++ b/skills/goal/references/planning.md
@@ -1,0 +1,81 @@
+## Six Slots
+
+The Entry Gate's falsifiable objective is captured as six slots. **Four are captured from the request (or the crystallized spec); two are minted by this orchestrator.** All six are written through `set --phase planning` at seed time.
+
+Four content slots (from capture):
+
+1. **outcome** (`--outcome`) — what is true when the objective is reached (the desired end state).
+2. **verification-surface** (`--verification-surface`) — the concrete evidence that proves success (test, benchmark, artifact, observable behavior). This is the load-bearing slot: it is the only one that makes the objective machine-decidable.
+3. **constraints** (`--constraints`) — what must NOT regress while pursuing (correctness suites stay green, contracts preserved).
+4. **boundaries** (`--boundaries`) — the allowed files, tools, and resources the pursuit may touch.
+
+Two minted slots (not in the request — this orchestrator supplies them):
+
+5. **iteration-policy** → `max_iterations` (`--max-iterations <n>`) — the finite cap on pursuit blocks. Default **10** when not overridden at invocation; invocation-overridable. This is the SOLE soft-stop bound: when pursuit hits `max_iterations` the loop soft-stops (state preserved), it does NOT hard-kill.
+6. **blocked-stop** (`--blocked-stop <text>`) — the objective-specific predicate that means "no valid path forward". A decidable, point-in-time condition (no cross-iteration memory); when met, pursuit stops and reports the blocker, non-complete.
+
+Seed example (run at the first `planning` transition):
+
+```
+bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts set --phase planning \
+  --outcome "<desired end state>" \
+  --verification-surface "<concrete evidence that proves success>" \
+  --constraints "<what must not regress>" \
+  --boundaries "<allowed files/tools/resources>" \
+  --max-iterations 10 \
+  --blocked-stop "<objective-specific no-path-forward predicate>"
+```
+
+<!-- story-layer:start -->
+
+## Story Definition (Planning Phase)
+
+After capturing the six slots and before dispatching to prometheus or sisyphus, define the WHAT-slices of the objective with the user, story by story. Each story is an independently verifiable chunk of the objective — not a task (HOW) but a stated outcome (WHAT).
+
+**When to slice vs. use single-derivation.** If the objective is a single WHAT — one deliverable, one verification surface, no meaningful sub-goals — run:
+
+```
+bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts set-stories --single
+```
+
+This derives one story directly from the current `outcome` and marks it `confirmed` immediately (no separate `confirm-story` call needed). Use `--single` for objectives where slicing into multiple stories would introduce ceremony without value.
+
+For objectives with multiple distinct WHAT-slices, define them one at a time with the user. For each story, establish:
+
+1. A **WHAT statement** — the desired outcome for this slice, stated concretely.
+2. At least one **acceptance criterion** — a falsifiable check that, when met, confirms the slice is done.
+3. A **verification surface** — the concrete evidence that proves the AC is met (a test, an artifact, a command output, an observable behavior).
+
+Once you have agreed on the full story set with the user, ingest it:
+
+```
+bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts set-stories --json '<array-of-stories>'
+```
+
+`set-stories --json` refuses an empty array, any story missing acceptance criteria or a verification surface, duplicate ids, an empty `outcome`, or a `phase` other than `planning`. Every ingested story starts `unconfirmed`.
+
+**Per-story confirmation.** After the user approves each story in the planning dialogue, confirm it:
+
+```
+bun ${CLAUDE_SKILL_DIR}/scripts/goal-state.ts confirm-story <id>
+```
+
+`confirm-story` is the sole path from `unconfirmed` to `confirmed`. No other subcommand (`set`, `set-verdict`, `set-stories --json` re-ingestion) can produce `confirmed`. The pursuing phase is refused while any story remains `unconfirmed` — `set --phase pursuing` names the offending ids on stderr. Once all stories are `confirmed` (or `retired`), the pursuing transition is allowed.
+
+<!-- story-layer:end -->
+
+---
+
+<!-- story-layer:start -->
+
+### Mid-flight Story Mutations
+
+Stories can be discovered, corrected, or retired during pursuit. Use the per-story mutation subcommands when the situation changes mid-flight:
+
+- **`add-story --json '<story>'`** — appends one new story with status `unconfirmed`. Allowed in both `planning` and `pursuing`. A newly added story must be confirmed via `confirm-story <id>` before completion is allowed (an `unconfirmed` story blocks `request-complete`).
+- **`revise-story <id> --json '<patch>'`** — patches an existing story's text, acceptance criteria, or verification surface. Revision ALWAYS resets the story's status to `unconfirmed` — a story whose definition changed requires fresh user approval. Refused on retired stories and unknown ids.
+- **`retire-story <id>`** — marks a story `retired`. An `unconfirmed` story is retirable in any phase. A `confirmed` story is retirable ONLY while `phase=planning` — retiring a confirmed story mid-pursuit is refused (run `set --phase planning` first to re-enter planning, then retire). This fence prevents retiring a confirmed WHAT mid-pursuit as a way to remove it from the completion gate.
+
+Re-plan (`set --phase planning`) preserves `stories[]` including per-story statuses, while resetting `objective_verdict` and `completion_evidence_paths` exactly as today. Stories survive re-planning; only verdict state is cleared.
+
+<!-- story-layer:end -->

--- a/skills/goal/scripts/goal-state-codereview-contract.test.ts
+++ b/skills/goal/scripts/goal-state-codereview-contract.test.ts
@@ -81,6 +81,7 @@ describe("V8: code-review 아티팩트 열거형 계약 보존 (redesign 경로)
 	// -------------------------------------------------------------------------
 	test("유효한 스키마: `readCodeReviewArtifact`가 redesign 경로 아티팩트에 대해 null이 아닌 값 반환 (R1 fail-closed)", () => {
 		writeArtifact(SID, {
+			status: "COMPLETE",
 			findings: REDESIGN_FINDINGS,
 			reviewer: "code-reviewer",
 			at: "2026-06-26T10:00:00",
@@ -95,6 +96,7 @@ describe("V8: code-review 아티팩트 열거형 계약 보존 (redesign 경로)
 	// -------------------------------------------------------------------------
 	test("모든 finding verdict가 {CONFIRMED, PLAUSIBLE}에 속함 — redesign 경로에서 열거형 계약 보존", () => {
 		writeArtifact(SID, {
+			status: "COMPLETE",
 			findings: REDESIGN_FINDINGS,
 			reviewer: "code-reviewer",
 			at: "2026-06-26T10:00:00",
@@ -112,6 +114,7 @@ describe("V8: code-review 아티팩트 열거형 계약 보존 (redesign 경로)
 	// -------------------------------------------------------------------------
 	test("모든 finding class가 {correctness, cleanup}에 속함 — redesign 경로에서 열거형 계약 보존", () => {
 		writeArtifact(SID, {
+			status: "COMPLETE",
 			findings: REDESIGN_FINDINGS,
 			reviewer: "code-reviewer",
 			at: "2026-06-26T10:00:00",
@@ -140,6 +143,7 @@ describe("V8: code-review 아티팩트 열거형 계약 보존 (redesign 경로)
 	// -------------------------------------------------------------------------
 	test("CRITICAL: 직렬화된 finding 문자열에 confidence 없음 (`readCodeReviewArtifact`는 추가 키 무시 — raw 스캔이 유일한 보호, T5/ADR-D3/R1)", () => {
 		writeArtifact(SID, {
+			status: "COMPLETE",
 			findings: REDESIGN_FINDINGS,
 			reviewer: "code-reviewer",
 			at: "2026-06-26T10:00:00",

--- a/skills/goal/scripts/goal-state.test.ts
+++ b/skills/goal/scripts/goal-state.test.ts
@@ -29,9 +29,12 @@ import {
 	addStory,
 	retireStory,
 	serializeRequirements,
+	isSubskillHalfOpen,
+	readCodeReviewArtifact,
 	type GoalPhase,
 	type Story,
 } from "./goal-state.ts";
+import { STATE_PREFIX, ACTIVE_IDLE_TTL_SECONDS } from "@lib/state-core";
 
 let tmpDir: string;
 const originalOmtDir = process.env.OMT_DIR;
@@ -216,6 +219,7 @@ describe("goal state", () => {
 			"utf8",
 		);
 		writeCodeReviewArtifact(S2, {
+			status: "COMPLETE",
 			findings: [],
 			reviewer: "code-reviewer",
 			at: "2026-06-12T00:00:00",
@@ -266,6 +270,7 @@ describe("goal state", () => {
 
 		// APPROVE-backed request-complete must win over the prior budget_limited
 		writeCodeReviewArtifact(S, {
+			status: "COMPLETE",
 			findings: [],
 			reviewer: "code-reviewer",
 			at: "2026-06-12T00:00:00",
@@ -331,6 +336,7 @@ describe("goal state", () => {
 			"utf8",
 		);
 		writeCodeReviewArtifact(Sc, {
+			status: "COMPLETE",
 			findings: [],
 			reviewer: "code-reviewer",
 			at: "2026-06-12T00:00:00",
@@ -424,6 +430,7 @@ describe("goal state", () => {
 			"utf8",
 		);
 		writeCodeReviewArtifact(S, {
+			status: "COMPLETE",
 			findings: [],
 			reviewer: "code-reviewer",
 			at: "2026-06-12T00:00:00",
@@ -499,6 +506,7 @@ describe("goal state", () => {
 			"utf8",
 		);
 		writeCodeReviewArtifact(S, {
+			status: "COMPLETE",
 			findings: [],
 			reviewer: "code-reviewer",
 			at: "2026-06-12T00:00:00",
@@ -1631,6 +1639,7 @@ function buildSatisfiedFixture(sid: string): object {
 	// Code-review lane: a clean (no-findings) artifact so the second completion lane passes
 	// by default. Callers asserting a BLOCK overwrite this with a CONFIRMED/invalid one.
 	writeCodeReviewArtifact(sid, {
+		status: "COMPLETE",
 		findings: [],
 		reviewer: "code-reviewer",
 		at: "2026-06-12T00:00:00",
@@ -1828,6 +1837,7 @@ describe("story layer: request-complete verdict gate (T4)", () => {
 			at: "2026-06-12T00:00:00",
 		});
 		writeCodeReviewArtifact(S2, {
+			status: "COMPLETE",
 			findings: [],
 			reviewer: "code-reviewer",
 			at: "2026-06-12T00:00:00",
@@ -1952,6 +1962,7 @@ describe("story layer: code-review completion lane (TODO 1)", () => {
 		const artifact = buildSatisfiedFixture(S);
 		writeVerdictArtifact(S, artifact); // objective lane fully green
 		writeCodeReviewArtifact(S, {
+			status: "COMPLETE",
 			findings: [{ class: "cleanup", verdict: "CONFIRMED", ref: "foo.ts:1" }],
 			reviewer: "code-reviewer",
 			at: "2026-06-12T00:00:00",
@@ -1964,6 +1975,7 @@ describe("story layer: code-review completion lane (TODO 1)", () => {
 		const artifact = buildSatisfiedFixture(S);
 		writeVerdictArtifact(S, artifact);
 		writeCodeReviewArtifact(S, {
+			status: "COMPLETE",
 			findings: [{ class: "correctness", verdict: "CONFIRMED", ref: "foo.ts:2" }],
 			reviewer: "code-reviewer",
 			at: "2026-06-12T00:00:00",
@@ -1977,6 +1989,7 @@ describe("story layer: code-review completion lane (TODO 1)", () => {
 		const artifact = buildSatisfiedFixture(S);
 		writeVerdictArtifact(S, artifact);
 		writeCodeReviewArtifact(S, {
+			status: "COMPLETE",
 			findings: [],
 			reviewer: "code-reviewer",
 			at: "2026-06-12T00:00:00",
@@ -1989,6 +2002,7 @@ describe("story layer: code-review completion lane (TODO 1)", () => {
 		const artifact = buildSatisfiedFixture(S);
 		writeVerdictArtifact(S, artifact);
 		writeCodeReviewArtifact(S, {
+			status: "COMPLETE",
 			findings: [{ class: "cleanup", verdict: "PLAUSIBLE", ref: "foo.ts:3" }],
 			reviewer: "code-reviewer",
 			at: "2026-06-12T00:00:00",
@@ -2019,6 +2033,7 @@ describe("story layer: code-review completion lane (TODO 1)", () => {
 		const artifact = buildSatisfiedFixture(S);
 		writeVerdictArtifact(S, artifact);
 		writeCodeReviewArtifact(S, {
+			status: "COMPLETE",
 			findings: [{ class: "correctness", verdict: "BOGUS", ref: "foo.ts:4" }],
 			reviewer: "code-reviewer",
 			at: "2026-06-12T00:00:00",
@@ -2030,7 +2045,12 @@ describe("story layer: code-review completion lane (TODO 1)", () => {
 	test("code-review invalid artifact refuses (empty reviewer)", () => {
 		const artifact = buildSatisfiedFixture(S);
 		writeVerdictArtifact(S, artifact);
-		writeCodeReviewArtifact(S, { findings: [], reviewer: "", at: "2026-06-12T00:00:00" });
+		writeCodeReviewArtifact(S, {
+			status: "COMPLETE",
+			findings: [],
+			reviewer: "",
+			at: "2026-06-12T00:00:00",
+		});
 		expect(requestComplete(S)).toBe(false);
 		expect(rawState().phase).toBe("pursuing");
 	});
@@ -2041,6 +2061,7 @@ describe("story layer: code-review completion lane (TODO 1)", () => {
 		const artifact = buildSatisfiedFixture(S);
 		writeVerdictArtifact(S, artifact);
 		writeCodeReviewArtifact(S, {
+			status: "COMPLETE",
 			findings: [],
 			reviewer: "code-reviewer",
 			at: "2026-06-12T00:00:00",
@@ -2072,6 +2093,66 @@ describe("story layer: code-review completion lane (TODO 1)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// TODO 2: inconclusive-state (D1 = Option B, status required)
+// ---------------------------------------------------------------------------
+
+describe("story layer: code-review INCONCLUSIVE status (TODO 2)", () => {
+	// RED: an artifact whose review itself did not finish (status=INCONCLUSIVE)
+	// must block completion even when findings are empty and every other gate
+	// (objective verdict, evidence, confirmed stories) is green. Distinct from
+	// the CONFIRMED-finding block: here the review never rendered a verdict at all.
+	test("code-review status INCONCLUSIVE blocks completion even with empty findings", () => {
+		const artifact = buildSatisfiedFixture(S);
+		writeVerdictArtifact(S, artifact);
+		writeCodeReviewArtifact(S, {
+			status: "INCONCLUSIVE",
+			findings: [],
+			reviewer: "code-reviewer",
+			at: "2026-06-12T00:00:00",
+		});
+		expect(requestComplete(S)).toBe(false);
+		expect(rawState().phase).toBe("pursuing");
+	});
+
+	// required-status fail-safe: a legacy/malformed artifact with no `status` key
+	// at all must be schema-invalid (never default-coerced to COMPLETE) — the
+	// reader must refuse it outright, degrading toward block (never-false-complete).
+	test("code-review artifact missing status is schema-invalid (readCodeReviewArtifact null)", () => {
+		writeCodeReviewArtifact(S, { findings: [], reviewer: "code-reviewer", at: "2026-06-12T00:00:00" });
+		expect(readCodeReviewArtifact(S)).toBeNull();
+	});
+
+	// control (GREEN): status COMPLETE + empty findings + every other gate green -> true.
+	test("code-review status COMPLETE with empty findings permits completion (control)", () => {
+		const artifact = buildSatisfiedFixture(S);
+		writeVerdictArtifact(S, artifact);
+		writeCodeReviewArtifact(S, {
+			status: "COMPLETE",
+			findings: [],
+			reviewer: "code-reviewer",
+			at: "2026-06-12T00:00:00",
+		});
+		expect(requestComplete(S)).toBe(true);
+		expect(rawState().phase).toBe("complete");
+	});
+
+	// control (GREEN, existing behavior preserved): status COMPLETE + a CONFIRMED
+	// finding still blocks completion — INCONCLUSIVE handling must not loosen this.
+	test("code-review status COMPLETE with a CONFIRMED finding still blocks completion (control)", () => {
+		const artifact = buildSatisfiedFixture(S);
+		writeVerdictArtifact(S, artifact);
+		writeCodeReviewArtifact(S, {
+			status: "COMPLETE",
+			findings: [{ class: "correctness", verdict: "CONFIRMED", ref: "foo.ts:9" }],
+			reviewer: "code-reviewer",
+			at: "2026-06-12T00:00:00",
+		});
+		expect(requestComplete(S)).toBe(false);
+		expect(rawState().phase).toBe("pursuing");
+	});
+});
+
+// ---------------------------------------------------------------------------
 // TODO 6: requirement-gap class (Hop E) + serialize-requirements (Hop B)
 // ---------------------------------------------------------------------------
 
@@ -2084,6 +2165,7 @@ describe("requirement-gap class: validator accepts and gate keys on verdict", ()
 		const artifact = buildSatisfiedFixture(S);
 		writeVerdictArtifact(S, artifact);
 		writeCodeReviewArtifact(S, {
+			status: "COMPLETE",
 			findings: [{ class: "requirement-gap", verdict: "PLAUSIBLE", ref: "foo.ts:1" }],
 			reviewer: "code-reviewer",
 			at: "2026-06-12T00:00:00",
@@ -2099,6 +2181,7 @@ describe("requirement-gap class: validator accepts and gate keys on verdict", ()
 		const artifact = buildSatisfiedFixture(S);
 		writeVerdictArtifact(S, artifact);
 		writeCodeReviewArtifact(S, {
+			status: "COMPLETE",
 			findings: [{ class: "requirement-gap", verdict: "CONFIRMED", ref: "foo.ts:2" }],
 			reviewer: "code-reviewer",
 			at: "2026-06-12T00:00:00",
@@ -2214,5 +2297,112 @@ describe("re-plan 시 verdict 아티팩트 무효화", () => {
 		setGoalState(S, { phase: "planning", outcome: "초기 목표" });
 		// 에러 없이 진행됐는지 확인
 		expect(rawState().phase).toBe("planning");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Lever 1: finalize-before-advance cross-read guard
+// ---------------------------------------------------------------------------
+
+describe("isSubskillHalfOpen: cross-read half-open detector", () => {
+	/** Path derived from STATE_PREFIX — same constant the detector uses, so fixture and detector cannot drift. */
+	function diStatePath(sid: string): string {
+		return join(tmpDir, `${STATE_PREFIX["deep-interview"]}${sid}.json`);
+	}
+
+	function writeDiState(sid: string, fields: Record<string, unknown>): void {
+		writeFileSync(diStatePath(sid), JSON.stringify(fields), "utf8");
+	}
+
+	function isoSecondsAgo(secondsAgo: number): string {
+		const d = new Date(Date.now() - secondsAgo * 1000);
+		const pad = (n: number) => String(n).padStart(2, "0");
+		const tzOffset = -d.getTimezoneOffset();
+		const tzSign = tzOffset >= 0 ? "+" : "-";
+		const tzH = pad(Math.floor(Math.abs(tzOffset) / 60));
+		const tzM = pad(Math.abs(tzOffset) % 60);
+		return (
+			`${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+			`T${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}` +
+			`${tzSign}${tzH}:${tzM}`
+		);
+	}
+
+	test("half-open: active:true, live, non-pristine (rich state object) -> true", () => {
+		const now = nowIso();
+		writeDiState(S, {
+			active: true,
+			started_at: now,
+			last_touched_at: now,
+			state: { initial_idea: "some idea" },
+		});
+		expect(isSubskillHalfOpen(S, "deep-interview")).toBe(true);
+	});
+
+	test("terminal: active:false -> false regardless of freshness/content", () => {
+		const now = nowIso();
+		writeDiState(S, {
+			active: false,
+			started_at: now,
+			last_touched_at: now,
+			state: { initial_idea: "some idea" },
+		});
+		expect(isSubskillHalfOpen(S, "deep-interview")).toBe(false);
+	});
+
+	test("pristine: active:true but no rich `state` object (freshly seeded) -> false", () => {
+		const now = nowIso();
+		writeDiState(S, { active: true, started_at: now, last_touched_at: now });
+		expect(isSubskillHalfOpen(S, "deep-interview")).toBe(false);
+	});
+
+	test("TTL-stale: active:true, non-pristine, but idle beyond ACTIVE_IDLE_TTL_SECONDS -> false", () => {
+		const old = isoSecondsAgo(ACTIVE_IDLE_TTL_SECONDS + 60);
+		writeDiState(S, {
+			active: true,
+			started_at: old,
+			last_touched_at: old,
+			state: { initial_idea: "some idea" },
+		});
+		expect(isSubskillHalfOpen(S, "deep-interview")).toBe(false);
+	});
+
+	test("absent: no state file for the session -> false", () => {
+		expect(isSubskillHalfOpen("no-such-session", "deep-interview")).toBe(false);
+	});
+});
+
+describe("check-subskill CLI subcommand", () => {
+	function diStatePath(sid: string): string {
+		return join(tmpDir, `${STATE_PREFIX["deep-interview"]}${sid}.json`);
+	}
+
+	function writeDiState(sid: string, fields: Record<string, unknown>): void {
+		writeFileSync(diStatePath(sid), JSON.stringify(fields), "utf8");
+	}
+
+	test("half-open DI state -> non-zero exit", () => {
+		const now = nowIso();
+		writeDiState(S, {
+			active: true,
+			started_at: now,
+			last_touched_at: now,
+			state: { initial_idea: "some idea" },
+		});
+		expect(() => runCli("check-subskill --skill deep-interview")).toThrow();
+	});
+
+	test("pristine DI state -> exit 0", () => {
+		const now = nowIso();
+		writeDiState(S, { active: true, started_at: now, last_touched_at: now });
+		expect(() => runCli("check-subskill --skill deep-interview")).not.toThrow();
+	});
+
+	test("absent DI state -> exit 0", () => {
+		expect(() => runCli("check-subskill --skill deep-interview")).not.toThrow();
+	});
+
+	test("invalid --skill value -> non-zero exit", () => {
+		expect(() => runCli("check-subskill --skill sisyphus")).toThrow();
 	});
 });

--- a/skills/goal/scripts/goal-state.ts
+++ b/skills/goal/scripts/goal-state.ts
@@ -39,6 +39,7 @@
 
 import { readFileSync, unlinkSync } from "fs";
 import { execSync } from "child_process";
+import { join } from "path";
 import { getOmtDir } from "@lib/omt-dir";
 import {
 	mergeWithHeartbeat,
@@ -48,6 +49,8 @@ import {
 	writeFileNoCreate,
 	isPristine,
 	ensureSeed,
+	isStateLive,
+	STATE_PREFIX,
 } from "@lib/state-core";
 
 export type GoalPhase = "planning" | "pursuing" | "budget_limited" | "blocked" | "complete";
@@ -725,6 +728,7 @@ interface CodeReviewFinding {
 }
 
 interface CodeReviewArtifact {
+	status: "COMPLETE" | "INCONCLUSIVE";
 	findings: CodeReviewFinding[];
 	reviewer: string;
 	at: string;
@@ -807,6 +811,8 @@ function resolveCodeReviewArtifactPath(sessionId: string): string {
 function isCodeReviewArtifact(value: unknown): value is CodeReviewArtifact {
 	if (!isRecord(value)) return false;
 	// Required top-level fields
+	const VALID_STATUS = ["COMPLETE", "INCONCLUSIVE"];
+	if (!isOneOf(value["status"], VALID_STATUS)) return false;
 	if (!Array.isArray(value["findings"])) return false;
 	const reviewer = value["reviewer"];
 	if (typeof reviewer !== "string" || reviewer.length === 0) return false;
@@ -825,7 +831,7 @@ function isCodeReviewArtifact(value: unknown): value is CodeReviewArtifact {
 /**
  * Reads and validates the code-review artifact. Returns the parsed artifact on
  * success, or null when the file is absent or the schema is invalid (never throws).
- * Schema: { findings: [{class, verdict, ref?}], reviewer, at } — NO `lane` field
+ * Schema: { status, findings: [{class, verdict, ref?}], reviewer, at } — NO `lane` field
  * (the path already identifies the lane).
  * `reviewer` must be a NON-EMPTY string — one notch stricter than the verdict
  * artifact's verifier string-check, because self-review bias is maximal at the
@@ -943,6 +949,12 @@ export function requestComplete(sessionId: string): boolean {
 	if (codeReview === null) {
 		return false;
 	}
+	// INCONCLUSIVE (D1): the review itself did not finish (timeout/ack-only/BLOCKED/
+	// genuinely uncertain) — distinct from a finished review that found CONFIRMED work.
+	// Blocks completion without implying a sisyphus re-dispatch is warranted.
+	if (codeReview.status === "INCONCLUSIVE") {
+		return false;
+	}
 	if (codeReview.findings.some((f) => f.verdict === "CONFIRMED")) {
 		return false;
 	}
@@ -967,6 +979,35 @@ export function serializeRequirements(sessionId: string): string {
 			`[${s.id}] ${s.story} — AC: ${s.acceptance_criteria.join("; ")} — verify: ${s.verification_surface}`,
 	);
 	return lines.join("\n") + "\n";
+}
+
+// ---------------------------------------------------------------------------
+// Cross-skill half-open detector (lever 1: finalize-before-advance guard)
+// ---------------------------------------------------------------------------
+
+export type CrossReadSkill = "deep-interview" | "prometheus";
+
+/**
+ * True iff `skill`'s OWN state file for `sessionId` is half-open: it ran, is
+ * still ACTIVE and TTL-live, and holds real (non-pristine) work — meaning it
+ * exited without emitting its done-token. Cross-reads the peer skill's state
+ * file directly via STATE_PREFIX; never reads or writes goal's own state.
+ *
+ * Absent file, parse failure, terminal (`active:false`), pristine seed, or
+ * TTL-stale all read as false (not half-open) — reused verbatim from
+ * @lib/state-core's isStateLive/isPristine, never reimplemented here.
+ */
+export function isSubskillHalfOpen(sessionId: string, skill: CrossReadSkill): boolean {
+	const path = join(getOmtDir(), `${STATE_PREFIX[skill]}${sessionId}.json`);
+	let parsed;
+	try {
+		parsed = JSON.parse(readFileSync(path, "utf8"));
+	} catch {
+		return false;
+	}
+	if (!isRecord(parsed)) return false;
+	const nowEpoch = Math.floor(Date.now() / 1000);
+	return parsed.active === true && isStateLive(parsed, nowEpoch) && !isPristine(skill, parsed);
 }
 
 // ---------------------------------------------------------------------------
@@ -1179,9 +1220,26 @@ function main(): void {
 			retireStory(sessionId, rawId);
 		} else if (subcommand === "serialize-requirements") {
 			process.stdout.write(serializeRequirements(sessionId));
+		} else if (subcommand === "check-subskill") {
+			const skillArg = str(args["skill"]);
+			const ALLOWED_SKILLS: CrossReadSkill[] = ["deep-interview", "prometheus"];
+			if (!isOneOf(skillArg, ALLOWED_SKILLS)) {
+				process.stderr.write(
+					`check-subskill: --skill must be one of ${ALLOWED_SKILLS.join("|")} (got "${String(skillArg)}")\n`,
+				);
+				process.exit(1);
+			}
+			if (isSubskillHalfOpen(sessionId, skillArg)) {
+				process.stderr.write(
+					`check-subskill: ${skillArg} state for session "${sessionId}" is half-open ` +
+						`(active, live, non-pristine — likely exited without its done-token). ` +
+						`Finalize it before advancing.\n`,
+				);
+				process.exit(1);
+			}
 		} else {
 			process.stderr.write(
-				"Usage: goal-state.ts <set|set-verdict|set-budget-limited|set-blocked|request-complete|get|status|list-others|adopt|set-stories|confirm-story|revise-story|add-story|retire-story|serialize-requirements> [options]\n",
+				"Usage: goal-state.ts <set|set-verdict|set-budget-limited|set-blocked|request-complete|get|status|list-others|adopt|set-stories|confirm-story|revise-story|add-story|retire-story|serialize-requirements|check-subskill> [options]\n",
 			);
 			process.exit(1);
 		}


### PR DESCRIPTION
## 📌 Summary

goal 스킬이 하위스킬(deep-interview/prometheus)을 오케스트레이션하는 경계를 보강합니다. dispatch 전 하위스킬의 half-open 상태를 감지하는 정합성 가드, code-review 미완(INCONCLUSIVE)을 작업 미완과 분리하는 완료 게이트, 요구사항 명료도 기반 fast-path 분기를 추가하고, 비대해진 SKILL.md의 정의 블록을 `references/`로 분리했습니다.

---

## 🔧 Changes

### goal-state.ts — 상태머신 (실행코드)

- 하위스킬 half-open 감지기 `isSubskillHalfOpen(sessionId, skill)` 및 CLI 서브커맨드 `check-subskill --skill <deep-interview|prometheus>` 추가. 상대 하위스킬의 자기 상태파일을 `STATE_PREFIX` 맵으로 cross-read해, `active && TTL-live && !pristine` 3조건을 모두 만족하면 half-open으로 판정하고 non-zero exit로 차단.
- `CodeReviewArtifact`에 `status: "COMPLETE" | "INCONCLUSIVE"` 필드를 **required**로 추가. `requestComplete`에 INCONCLUSIVE 차단 분기 추가 — 리뷰 자체가 끝나지 않은 상태(timeout/ack-only/BLOCKED)를 CONFIRMED finding(작업 미완)과 별개 사유로 완료 차단.

`STATE_PREFIX`·`isStateLive`·`isPristine`을 `@lib/state-core`에서 그대로 재사용해 판정 로직 재구현을 피했습니다. 감지기는 파일 부재·파싱 실패·terminal·pristine·TTL-stale을 모두 "half-open 아님(=진행 허용)"으로 degrade합니다.

**영향 범위**
- code-review 아티팩트 스키마 변경: `status` 필드가 이제 필수. 누락된 아티팩트는 스키마 무효 → `readCodeReviewArtifact` null → 완료 차단(fail-safe 방향). 아티팩트는 세션 단위 임시 상태파일이라 영속 데이터 마이그레이션 부담은 없으며, 테스트 fixture는 이 PR에서 함께 갱신.
- half-open cross-read 대상은 stateful 하위스킬 2개(deep-interview/prometheus)만. sisyphus는 `StateType`에 없어(goal-readable 상태파일 부재) 대상에서 제외.

### SKILL.md — 오케스트레이션 규율 (프로즈)

- **clarity 게이트**: deep-interview가 crystallize한 spec(ambiguity ≤ 임계값)으로 진입 시, 그 명료도를 요구사항 명료 신호로 신뢰해 재질의 없이 진행. prometheus의 게이트 문언을 이식(참조 아님 — prometheus 무편집).
- **fast-path 게이트**: 파일수만 Complex + 설계포크 없음 + T1 리스크 없음인 객체는 prometheus를 생략하고 Story 레이어로 AC를 직접 캡처. on-the-fence면 prometheus로 기우는 비대칭 기본값 명시.
- **finalize-before-advance 규율**: 각 하위스킬 dispatch 사이트에 `check-subskill` 가드와 done-token 복구 노트 추가.
- **SKILL.md 슬림화**: Six Slots·Story Definition·Completion Gate 정의 블록을 신규 `references/planning.md`·`references/completion-gate.md`로 이관하고, 본문에는 라우팅 로직과 MUST-read 포인터만 잔류(약 300줄 → 136줄).

**영향 범위**
- prometheus/deep-interview/sisyphus SKILL.md는 0라인 편집(불변식). clarity·fast-path는 문언 이식이라 원본 스킬 의존 없음.
- `references/`는 skill 디렉토리 통째 복사로 배포되어 sync.yaml 신규 entry 불필요.

### 테스트

- `SKILL.test.ts` 신규: 프로즈 계약(clarity/fast-path 리터럴 존재, 이관 블록 strip/preserved, prometheus 무편집 회귀 가드)을 `readFileSync` 기반으로 검증.
- `goal-state.test.ts`·`goal-state-codereview-contract.test.ts`: status 필수화에 따른 fixture 마이그레이션 + half-open/INCONCLUSIVE 신규 케이스.

**영향 범위**
- 프로즈 검증은 배포본이 아닌 repo 파일 대상(`readFileSync`) — 미sync 편집도 정확히 검증.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. code-review status를 optional-default가 아닌 required로

**배경 및 문제 상황:**
완료 게이트는 code-review 아티팩트의 findings에 CONFIRMED가 없으면 완료를 허용합니다. 여기에 "리뷰가 끝나긴 했는가"라는 별개 축(INCONCLUSIVE)을 도입하면서, 기존 `{findings:[], reviewer, at}` 형태의 status-없는 아티팩트를 어떻게 취급할지 결정이 필요했습니다.

**해결 방안:**
`status`를 required로 두고, 누락 시 스키마 무효 → null → 완료 차단으로 처리했습니다. optional-default-COMPLETE(누락 시 COMPLETE로 간주) 안은 기각했습니다.

**구현 세부사항:**
`isCodeReviewArtifact`에서 `status`를 `["COMPLETE","INCONCLUSIVE"]` enum으로 검증하고, `requestComplete`는 null 차단 → INCONCLUSIVE 차단 → CONFIRMED 차단 순으로 독립 분기합니다.

```typescript
const codeReview = readCodeReviewArtifact(sessionId);
if (codeReview === null) return false;                 // 스키마 무효(status 누락 포함)
if (codeReview.status === "INCONCLUSIVE") return false; // 리뷰 미완
if (codeReview.findings.some((f) => f.verdict === "CONFIRMED")) return false; // 작업 미완
```

**선택과 트레이드오프:**
optional-default-COMPLETE는 legacy `{findings:[]}` 아티팩트를 COMPLETE로 반올림해, "빈 findings + status 없음"이 곧 완료로 통과하는 구멍을 재개방합니다. required는 기존 fixture 갱신 비용을 지불하는 대신 never-false-complete 불변식을 스키마 레벨에서 강제합니다. 아티팩트가 세션 임시 파일이라 영속 마이그레이션 부담이 없다는 점이 이 선택을 뒷받침했습니다.

### 2. half-open 감지를 goal-local 포인터가 아닌 서브스킬 상태 cross-read로

**배경 및 문제 상황:**
하위스킬이 done-token 없이 비정상 종료하면 자기 상태파일이 `active:true`로 남습니다(half-open). goal이 다음 하위스킬로 전진하기 전 이 누수를 감지해야 하는데, goal이 별도 포인터를 자기 상태에 기록하는 방식과, 하위스킬 상태를 직접 읽는 방식 중 선택이 필요했습니다.

**해결 방안:**
하위스킬의 **자기 상태파일 `active` 플래그를 cross-read**하는 방식을 택했습니다. goal-local 포인터안은 폐기했습니다.

**구현 세부사항:**
`STATE_PREFIX[skill]`로 경로를 유도(deep-interview는 `deep-interview-active-state-`, prometheus는 `prometheus-state-`로 접두어가 다름)하고, `active && isStateLive && !isPristine` 3조건을 재사용 헬퍼로 판정합니다. TTL-stale(죽은 것)은 GC 대상이지 half-open이 아니므로 `isStateLive`로 제외합니다.

**선택과 트레이드오프:**
goal-local 포인터는 goal이 기록한 시점 이후의 하위스킬 상태 변화를 반영하지 못해, 하위스킬이 조용히 종료한 half-open을 놓칩니다. cross-read는 "기존 플래그를 확인만 하는 가드"라는 제약(완전 FSM 금지)에 부합하며, goal-local 상태에 고착점을 만들지 않아 복구가 하위스킬 자기 파일의 done-token emit으로 국소화됩니다. 트레이드오프로 goal이 하위스킬의 상태파일 명명 규칙(`STATE_PREFIX`)에 의존하게 되지만, 이미 공유 상수라 drift 위험은 없습니다.

### 3. SKILL.md 정의 블록의 references/ 비연속 이관

**배경 및 문제 상황:**
SKILL.md가 라우팅 로직과 상세 정의(슬롯/스토리/완료게이트)를 한 파일에 담아 비대해졌습니다. lever 1~4가 fast-path·clarity·완료게이트 문언을 편집하므로, 이관은 콘텐츠가 확정된 뒤 마지막에 1회 수행해야 했습니다.

**해결 방안:**
정의 블록만 `references/planning.md`·`references/completion-gate.md`로 옮기고, 라우팅 로직(Conditional Orchestration·Phase transitions)은 본문에 잔류시켰습니다. 본문에는 "You MUST read references/X.md first" 명령형 포인터를 남겼습니다.

**선택과 트레이드오프:**
이관은 행동 불변이어야 하므로, goal-state.ts를 건드리지 않는 lever 5는 `goal-state.test.ts`·`codereview-contract.test.ts` 전량 GREEN 유지가 곧 상태머신 행동 불변의 증거가 됩니다. 프로즈 측면은 `SKILL.test.ts`의 strip/preserved 계약(이관 블록은 본문에서 제거·reference에 존재, 필수 phrase는 body-or-reference에 존재)으로 회귀를 방지합니다.

---

## ✅ Checklist

### 서브스킬 정합성 가드
- [ ] deep-interview/prometheus 상태가 active+live+non-pristine이면 `check-subskill`이 non-zero exit로 차단한다
  - `skills/goal/scripts/goal-state.ts`
- [ ] terminal·pristine·TTL-stale·파일부재·파싱실패는 모두 exit 0(진행 허용)으로 degrade한다
  - `skills/goal/scripts/goal-state.ts`
- [ ] allowlist 밖 skill 인자(sisyphus 등)와 경로 traversal 인자는 경로 조립 전 usage 에러로 거부된다
  - `skills/goal/scripts/goal-state.ts`

### 완료 게이트
- [ ] code-review status 누락 아티팩트는 스키마 무효로 완료를 차단한다(fail-safe)
  - `skills/goal/scripts/goal-state.ts`
- [ ] status=INCONCLUSIVE는 findings가 비어도 완료를 차단한다
  - `skills/goal/scripts/goal-state.ts`
- [ ] status=COMPLETE + CONFIRMED finding은 여전히 완료를 차단한다
  - `skills/goal/scripts/goal-state.ts`
- [ ] status=COMPLETE + 빈 findings + 나머지 게이트 충족 시 완료된다
  - `skills/goal/scripts/goal-state.ts`

### 프로즈·회귀
- [ ] prometheus/deep-interview/sisyphus SKILL.md는 0라인 편집이다
  - `skills/goal/SKILL.test.ts`
- [ ] 이관된 정의 블록은 SKILL.md 본문에서 제거되고 references/에 존재한다
  - `skills/goal/SKILL.test.ts`
- [ ] `make test`가 0 실패로 통과한다(fixture 마이그레이션 후)
  - `skills/goal/scripts/goal-state.test.ts`