### PR TITLE
feat: 컴팩션 핸드오프 전체-읽기 강제 PreToolUse 게이트

### DIFF
--- a/hooks/cache-safe-guard_test.sh
+++ b/hooks/cache-safe-guard_test.sh
@@ -234,6 +234,26 @@ EOF
         return 1
     fi
 
+    # AC21: the large-handoff pointer must carry the CRITICAL marker + the 3
+    # named rationalizations (Red-flags hardening, ADR D-11b) as static bytes,
+    # and this whole combined blob is already checked for raw-sid absence below.
+    if ! printf '%s' "$ss_out" | grep -qF 'CRITICAL'; then
+        echo "ASSERTION FAILED (AC21): session-start.sh large-handoff pointer must contain CRITICAL"
+        return 1
+    fi
+    if ! printf '%s' "$ss_out" | grep -qiF 'native compaction summary'; then
+        echo "ASSERTION FAILED (AC21): large-handoff pointer must name 'native compaction summary'"
+        return 1
+    fi
+    if ! printf '%s' "$ss_out" | grep -qiF 'only the new part'; then
+        echo "ASSERTION FAILED (AC21): large-handoff pointer must name 'only the new part'"
+        return 1
+    fi
+    if ! printf '%s' "$ss_out" | grep -qiF 'save tokens'; then
+        echo "ASSERTION FAILED (AC21): large-handoff pointer must name 'save tokens'"
+        return 1
+    fi
+
     # --- resume-forge-start.sh fixture: active resume-forge state ---
     # The restore block emits qualitative phrase ("in progress"), not filename or digit/digit.
     cat > "$TEST_OMT_DIR/state/resume-forge-guard-test.json" << 'EOF'

--- a/hooks/pre-tool-enforcer.sh
+++ b/hooks/pre-tool-enforcer.sh
@@ -28,6 +28,131 @@ EOF
     exit 0
 fi
 
+# Handoff-gate arm (ADR D-1/D-2/D-5..D-9): while armed, forces a single clean
+# `cat` of the compaction handoff before any other tool call. Uses
+# permissionDecision:"deny" (denies only THIS call, the turn continues) --
+# NOT the TaskOutput arm's continue:false (halts the whole turn). Do not
+# copy continue:false here; a denied tool call must not also halt the turn.
+_hg_sid="${OMT_SESSION_ID:-}"
+if [[ -n "$_hg_sid" ]] && ! echo "$_hg_sid" | grep -qE '^[A-Za-z0-9_-]{1,200}$'; then
+    _hg_sid=""
+fi
+if [[ -z "$_hg_sid" ]]; then
+    _hg_stdin_sid=$(extract_json_field "session_id" "")
+    if [[ -n "$_hg_stdin_sid" ]] && echo "$_hg_stdin_sid" | grep -qE '^[A-Za-z0-9_-]{1,200}$'; then
+        _hg_sid="$_hg_stdin_sid"
+    fi
+fi
+
+_hg_omt_dir="${OMT_DIR:-}"
+if [[ -z "$_hg_omt_dir" ]]; then
+    _hg_stdin_cwd=$(extract_json_field "cwd" "")
+    if [[ -n "$_hg_stdin_cwd" ]]; then
+        # BASH_SOURCE-relative sourcing for resolve_omt_dir (mirrors :40-41,:58 below)
+        _hg_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        _hg_omt_dir=$(source "$_hg_script_dir/lib/omt-dir.sh" && unset OMT_DIR && resolve_omt_dir "$_hg_stdin_cwd")
+    fi
+fi
+
+# Arming predicate: ALL must hold, else fail-open (fall through silently).
+# Writability + jq availability are part of arming, not deferred, so a
+# non-cat call under an unwritable dir / jq-less box fails OPEN, not denied
+# (no-livelock).
+_hg_armed=0
+if [[ -n "$_hg_sid" && -n "$_hg_omt_dir" ]]; then
+    _hg_H="$_hg_omt_dir/handoff-${_hg_sid}.md"
+    _hg_M="$_hg_omt_dir/handoff-consumed-${_hg_sid}"
+    if [[ -f "$_hg_H" && ! -f "$_hg_M" && -w "$_hg_omt_dir" ]] && command -v jq > /dev/null 2>&1; then
+        _hg_armed=1
+    fi
+fi
+
+if [[ "$_hg_armed" -eq 1 ]]; then
+    # Quote-aware tokenizer (no eval/bash -c/$(...) on decoded bytes): splits
+    # $1 into _hg_tokens[], stripping quote delimiters. _hg_sqdollar[k]=1
+    # marks a token whose content came from inside single quotes AND held a
+    # literal '$' -- the shell would not expand that, so substituting it here
+    # would be a false-allow silent-skip; treated as a deny signal below.
+    _hg_tokenize() {
+        local s="$1" i=0 len c cur="" in_token=0 quote="" cur_sqdollar=0
+        len=${#s}
+        _hg_tokens=()
+        _hg_sqdollar=()
+        while [[ "$i" -lt "$len" ]]; do
+            c="${s:$i:1}"
+            if [[ -n "$quote" ]]; then
+                if [[ "$c" == "$quote" ]]; then
+                    quote=""
+                else
+                    [[ "$quote" == "'" && "$c" == '$' ]] && cur_sqdollar=1
+                    cur+="$c"
+                fi
+            else
+                case "$c" in
+                    ' '|$'\t')
+                        if [[ "$in_token" -eq 1 ]]; then
+                            _hg_tokens+=("$cur")
+                            _hg_sqdollar+=("$cur_sqdollar")
+                            cur=""
+                            in_token=0
+                            cur_sqdollar=0
+                        fi
+                        ;;
+                    '"'|"'")
+                        quote="$c"
+                        in_token=1
+                        ;;
+                    *)
+                        cur+="$c"
+                        in_token=1
+                        ;;
+                esac
+            fi
+            i=$((i + 1))
+        done
+        if [[ -n "$quote" ]]; then
+            return 1
+        fi
+        if [[ "$in_token" -eq 1 ]]; then
+            _hg_tokens+=("$cur")
+            _hg_sqdollar+=("$cur_sqdollar")
+        fi
+        return 0
+    }
+
+    _hg_allow=0
+    if [[ "$toolName" == "Bash" ]]; then
+        _hg_cmd=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) || _hg_cmd=""
+        # Deny BEFORE any expansion -- the subshell/redirect/chain below is
+        # never executed, only string-matched.
+        if ! echo "$_hg_cmd" | grep -qE '[|;<>&`]|\$\(|tail|head|sed'; then
+            if _hg_tokenize "$_hg_cmd"; then
+                if [[ "${#_hg_tokens[@]}" -eq 2 && "${_hg_tokens[0]}" == "cat" \
+                    && "${_hg_sqdollar[1]:-0}" != "1" ]]; then
+                    _hg_arg="${_hg_tokens[1]}"
+                    _hg_candidate="${_hg_arg//\$OMT_DIR/$_hg_omt_dir}"
+                    _hg_candidate="${_hg_candidate//\$OMT_SESSION_ID/$_hg_sid}"
+                    _hg_expected="$_hg_omt_dir/handoff-${_hg_sid}.md"
+                    if [[ "$_hg_candidate" == "$_hg_expected" ]]; then
+                        _hg_allow=1
+                    fi
+                fi
+            fi
+        fi
+    fi
+
+    if [[ "$_hg_allow" -eq 1 ]]; then
+        # Marker write is EXCLUSIVE to this branch -- never a shared prologue.
+        : > "$_hg_M" 2>/dev/null || true
+        # Fall through to the existing allow path below.
+    else
+        # permissionDecision:"deny" (deny-this-one-call) -- NOT continue:false
+        # (halt-turn); see the header comment above.
+        printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Read the full compaction handoff FIRST — run: cat \"$OMT_DIR/handoff-$OMT_SESSION_ID.md\" (no truncation, no other tool until then)"}}'
+        exit 0
+    fi
+fi
+
 # Single-creation-point seeds for skill state files (ADR-7).
 # Resolution precedence: (1) env OMT_SESSION_ID / OMT_DIR when present and valid;
 # (2) stdin payload session_id (same safety regex) + cwd via resolve_omt_dir;

--- a/hooks/pre-tool-enforcer.sh
+++ b/hooks/pre-tool-enforcer.sh
@@ -73,11 +73,19 @@ if [[ "$_hg_armed" -eq 1 ]]; then
     # marks a token whose content came from inside single quotes AND held a
     # literal '$' -- the shell would not expand that, so substituting it here
     # would be a false-allow silent-skip; treated as a deny signal below.
+    # _hg_unqdollar[k]=1 is the symmetric case: a token holding a '$' that was
+    # OUTSIDE any quotes. Unquoted expansion is subject to word-splitting and
+    # globbing, so an unquoted $OMT_DIR carrying a space (or glob char) would
+    # make our pure textual substitution diverge from what bash actually runs
+    # (cat receives split args, never reads the handoff) -- also a deny signal.
+    # Only a double-quoted '$' is safe (expands without split/glob), which is
+    # exactly the canonical form the deny message instructs.
     _hg_tokenize() {
-        local s="$1" i=0 len c cur="" in_token=0 quote="" cur_sqdollar=0
+        local s="$1" i=0 len c cur="" in_token=0 quote="" cur_sqdollar=0 cur_unqdollar=0
         len=${#s}
         _hg_tokens=()
         _hg_sqdollar=()
+        _hg_unqdollar=()
         while [[ "$i" -lt "$len" ]]; do
             c="${s:$i:1}"
             if [[ -n "$quote" ]]; then
@@ -93,9 +101,11 @@ if [[ "$_hg_armed" -eq 1 ]]; then
                         if [[ "$in_token" -eq 1 ]]; then
                             _hg_tokens+=("$cur")
                             _hg_sqdollar+=("$cur_sqdollar")
+                            _hg_unqdollar+=("$cur_unqdollar")
                             cur=""
                             in_token=0
                             cur_sqdollar=0
+                            cur_unqdollar=0
                         fi
                         ;;
                     '"'|"'")
@@ -103,6 +113,7 @@ if [[ "$_hg_armed" -eq 1 ]]; then
                         in_token=1
                         ;;
                     *)
+                        [[ "$c" == '$' ]] && cur_unqdollar=1
                         cur+="$c"
                         in_token=1
                         ;;
@@ -116,6 +127,7 @@ if [[ "$_hg_armed" -eq 1 ]]; then
         if [[ "$in_token" -eq 1 ]]; then
             _hg_tokens+=("$cur")
             _hg_sqdollar+=("$cur_sqdollar")
+            _hg_unqdollar+=("$cur_unqdollar")
         fi
         return 0
     }
@@ -128,7 +140,8 @@ if [[ "$_hg_armed" -eq 1 ]]; then
         if ! echo "$_hg_cmd" | grep -qE '[|;<>&`]|\$\(|tail|head|sed'; then
             if _hg_tokenize "$_hg_cmd"; then
                 if [[ "${#_hg_tokens[@]}" -eq 2 && "${_hg_tokens[0]}" == "cat" \
-                    && "${_hg_sqdollar[1]:-0}" != "1" ]]; then
+                    && "${_hg_sqdollar[1]:-0}" != "1" \
+                    && "${_hg_unqdollar[1]:-0}" != "1" ]]; then
                     _hg_arg="${_hg_tokens[1]}"
                     _hg_candidate="${_hg_arg//\$OMT_DIR/$_hg_omt_dir}"
                     _hg_candidate="${_hg_candidate//\$OMT_SESSION_ID/$_hg_sid}"

--- a/hooks/pre-tool-enforcer_test.sh
+++ b/hooks/pre-tool-enforcer_test.sh
@@ -753,6 +753,440 @@ test_fail_loud_write_failure_warns_not_silent() {
 }
 
 # =============================================================================
+# Handoff-gate arm (TODO 1 of handoff-full-read-teeth plan)
+# Shared harness: arm_handoff() creates $HG_H (handoff file) and clears $HG_M
+# (consumed marker) under the already-exported $OMT_DIR/$OMT_SESSION_ID from
+# setup_test_env. hg_is_deny/hg_is_allow classify hook stdout.
+# =============================================================================
+
+arm_handoff() {
+    HG_H="$OMT_DIR/handoff-$OMT_SESSION_ID.md"
+    : > "$HG_H"
+    HG_M="$OMT_DIR/handoff-consumed-$OMT_SESSION_ID"
+    rm -f "$HG_M"
+}
+
+hg_is_deny() {
+    echo "$1" | jq -e '.hookSpecificOutput.hookEventName=="PreToolUse" and .hookSpecificOutput.permissionDecision=="deny"' > /dev/null 2>&1
+}
+
+hg_is_allow() {
+    ! hg_is_deny "$1"
+}
+
+hg_bash_json() {
+    # $1 = raw command string, already fully resolved by the caller (no shell
+    # expansion happens inside this helper -- jq --arg treats it as a literal)
+    jq -n --arg cmd "$1" '{tool_name: "Bash", tool_input: {command: $cmd}}'
+}
+
+hg_reason() {
+    echo "$1" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty'
+}
+
+test_hg_ac1_pipe_tail_denied() {
+    arm_handoff
+    local cmd="cat \"$HG_H\" | tail -40"
+    local out
+    out=$(printf '%s' "$(hg_bash_json "$cmd")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" || { echo "ASSERTION FAILED AC1: expected deny for piped tail. Got: $out"; return 1; }
+}
+
+test_hg_ac2_read_offset_denied_reason_mentions_cat() {
+    arm_handoff
+    local out
+    out=$(jq -n --arg fp "$HG_H" '{tool_name: "Read", tool_input: {file_path: $fp, offset: 1, limit: 40}}' \
+        | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" || { echo "ASSERTION FAILED AC2: expected deny for Read. Got: $out"; return 1; }
+    hg_reason "$out" | grep -qi "cat" \
+        || { echo "ASSERTION FAILED AC2: reason should mention cat. Got: $(hg_reason "$out")"; return 1; }
+}
+
+test_hg_ac3_read_no_offset_denied() {
+    arm_handoff
+    local out
+    out=$(jq -n --arg fp "$HG_H" '{tool_name: "Read", tool_input: {file_path: $fp}}' \
+        | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" || { echo "ASSERTION FAILED AC3: expected deny for Read w/o offset. Got: $out"; return 1; }
+}
+
+test_hg_ac4a_write_denied_reason_mentions_handoff_or_cat() {
+    arm_handoff
+    local out
+    out=$(jq -n --arg fp "$HG_H" '{tool_name: "Write", tool_input: {file_path: $fp, content: "x"}}' \
+        | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" || { echo "ASSERTION FAILED AC4a: expected deny for Write. Got: $out"; return 1; }
+    hg_reason "$out" | grep -qiE "handoff|cat" \
+        || { echo "ASSERTION FAILED AC4a: reason should mention handoff/cat. Got: $(hg_reason "$out")"; return 1; }
+}
+
+test_hg_ac4b_bash_ls_denied() {
+    arm_handoff
+    local out
+    out=$(printf '%s' "$(hg_bash_json "ls")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" || { echo "ASSERTION FAILED AC4b: expected deny for bash ls. Got: $out"; return 1; }
+}
+
+test_hg_ac5_recognition_edge_cases_denied() {
+    arm_handoff
+    local out
+
+    out=$(printf '%s' "$(hg_bash_json "cat \"$HG_H\" > /tmp/x")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" || { echo "ASSERTION FAILED AC5a: redirect should deny. Got: $out"; return 1; }
+
+    out=$(printf '%s' "$(hg_bash_json "cat \"$HG_H\"; ls")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" || { echo "ASSERTION FAILED AC5b: chained ; should deny. Got: $out"; return 1; }
+
+    out=$(printf '%s' "$(hg_bash_json "cat \"$HG_H\" && echo hi")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" || { echo "ASSERTION FAILED AC5c: chained && should deny. Got: $out"; return 1; }
+
+    out=$(printf '%s' "$(hg_bash_json "echo cat")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" || { echo "ASSERTION FAILED AC5d: echo cat should deny. Got: $out"; return 1; }
+
+    out=$(printf '%s' "$(hg_bash_json "cat -n \"$HG_H\"")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" || { echo "ASSERTION FAILED AC5e: cat -n (two args) should deny. Got: $out"; return 1; }
+}
+
+test_hg_ac6_wrong_path_denied_reason_redirects_to_handoff() {
+    arm_handoff
+    local out
+    out=$(printf '%s' "$(hg_bash_json 'cat "/etc/hostname"')" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" || { echo "ASSERTION FAILED AC6: wrong path should deny. Got: $out"; return 1; }
+    hg_reason "$out" | grep -qi "handoff" \
+        || { echo "ASSERTION FAILED AC6: reason should redirect to handoff. Got: $(hg_reason "$out")"; return 1; }
+}
+
+test_hg_ac7_other_state_file_denied_generic_reason() {
+    arm_handoff
+    local cmd='cat "$OMT_DIR/prometheus-state-$OMT_SESSION_ID.json"'
+    local out
+    out=$(printf '%s' "$(hg_bash_json "$cmd")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" || { echo "ASSERTION FAILED AC7: other state-file path should deny. Got: $out"; return 1; }
+    hg_reason "$out" | grep -qi "handoff" \
+        || { echo "ASSERTION FAILED AC7: reason should be generic handoff-first. Got: $(hg_reason "$out")"; return 1; }
+}
+
+test_hg_ac8a_command_substitution_denied() {
+    arm_handoff
+    local cmd='cat "$(echo /etc/hostname)"'
+    local out
+    out=$(printf '%s' "$(hg_bash_json "$cmd")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" || { echo "ASSERTION FAILED AC8a: command substitution should deny. Got: $out"; return 1; }
+}
+
+test_hg_ac8b_command_substitution_never_executed() {
+    arm_handoff
+    local pwned="$OMT_DIR/PWNED"
+    rm -f "$pwned"
+    local cmd='cat "$(touch "$OMT_DIR/PWNED"; echo "$OMT_DIR")/handoff-$OMT_SESSION_ID.md"'
+    local out
+    out=$(printf '%s' "$(hg_bash_json "$cmd")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" || { echo "ASSERTION FAILED AC8b: should deny. Got: $out"; return 1; }
+    [[ ! -e "$pwned" ]] \
+        || { echo "ASSERTION FAILED AC8b: SECURITY -- subshell was executed, PWNED file exists"; return 1; }
+}
+
+test_hg_ac_squote_literal_dollar_denied() {
+    arm_handoff
+    local cmd="cat '\$OMT_DIR/handoff-\$OMT_SESSION_ID.md'"
+    local out
+    out=$(printf '%s' "$(hg_bash_json "$cmd")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" || { echo "ASSERTION FAILED AC-SQUOTE: single-quoted literal \$ should deny. Got: $out"; return 1; }
+}
+
+test_hg_ac_env_full_honored_envelope() {
+    arm_handoff
+    local out
+    out=$(jq -n --arg fp "$HG_H" '{tool_name: "Write", tool_input: {file_path: $fp, content: "x"}}' \
+        | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    echo "$out" | jq -e . > /dev/null 2>&1 \
+        || { echo "ASSERTION FAILED AC-ENV: stdout should be valid JSON. Got: $out"; return 1; }
+    echo "$out" | grep -q '"hookEventName".*"PreToolUse"' \
+        || { echo "ASSERTION FAILED AC-ENV: missing hookEventName:PreToolUse. Got: $out"; return 1; }
+    echo "$out" | grep -q '"permissionDecision".*"deny"' \
+        || { echo "ASSERTION FAILED AC-ENV: missing permissionDecision:deny. Got: $out"; return 1; }
+}
+
+test_hg_ac_deny_nomark_marker_absent_on_deny() {
+    arm_handoff
+    local out
+
+    out=$(printf '%s' "$(hg_bash_json "cat \"$HG_H\" | tail -40")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" || { echo "ASSERTION FAILED AC-DENY-NOMARK: piped tail should deny. Got: $out"; return 1; }
+    assert_file_not_exists "$HG_M" "AC-DENY-NOMARK: marker must not exist after denied pipe" || return 1
+
+    out=$(jq -n --arg fp "$HG_H" '{tool_name: "Write", tool_input: {file_path: $fp, content: "x"}}' \
+        | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" || { echo "ASSERTION FAILED AC-DENY-NOMARK: Write should deny. Got: $out"; return 1; }
+    assert_file_not_exists "$HG_M" "AC-DENY-NOMARK: marker must not exist after denied Write" || return 1
+}
+
+test_hg_ac9_fully_expanded_path_allowed_and_marked() {
+    arm_handoff
+    local cmd="cat \"$HG_H\""
+    local out
+    out=$(printf '%s' "$(hg_bash_json "$cmd")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_allow "$out" || { echo "ASSERTION FAILED AC9: fully-expanded cat should allow. Got: $out"; return 1; }
+    assert_file_exists "$HG_M" "AC9: marker should be created on allowed cat" || return 1
+}
+
+test_hg_ac10_unexpanded_pointer_form_allowed_and_marked() {
+    arm_handoff
+    local cmd='cat "$OMT_DIR/handoff-$OMT_SESSION_ID.md"'
+    local out
+    out=$(printf '%s' "$(hg_bash_json "$cmd")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_allow "$out" || { echo "ASSERTION FAILED AC10: unexpanded pointer form should allow. Got: $out"; return 1; }
+    assert_file_exists "$HG_M" "AC10: marker should be created on allowed cat" || return 1
+}
+
+test_hg_ac11_leading_indent_allowed_and_marked() {
+    arm_handoff
+    local cmd='  cat "$OMT_DIR/handoff-$OMT_SESSION_ID.md"'
+    local out
+    out=$(printf '%s' "$(hg_bash_json "$cmd")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_allow "$out" || { echo "ASSERTION FAILED AC11: leading indent should allow. Got: $out"; return 1; }
+    assert_file_exists "$HG_M" "AC11: marker should be created on allowed cat" || return 1
+}
+
+test_hg_ac_partial_omtdir_expanded_sid_literal_allowed() {
+    arm_handoff
+    local cmd="cat \"$OMT_DIR/handoff-\$OMT_SESSION_ID.md\""
+    local out
+    out=$(printf '%s' "$(hg_bash_json "$cmd")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_allow "$out" || { echo "ASSERTION FAILED AC-PARTIAL: partially-substituted form should allow. Got: $out"; return 1; }
+    assert_file_exists "$HG_M" "AC-PARTIAL: marker should be created on allowed cat" || return 1
+}
+
+test_hg_ac_space_embedded_space_never_word_split() {
+    local base
+    base=$(mktemp -d)
+    export OMT_DIR="$base/dir with space"
+    mkdir -p "$OMT_DIR"
+    arm_handoff
+    local cmd="cat \"$OMT_DIR/handoff-$OMT_SESSION_ID.md\""
+    local out
+    out=$(printf '%s' "$(hg_bash_json "$cmd")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    if ! hg_is_allow "$out"; then
+        echo "ASSERTION FAILED AC-SPACE: quoted path with embedded space should allow. Got: $out"
+        rm -rf "$base"
+        return 1
+    fi
+    if [[ ! -f "$HG_M" ]]; then
+        echo "ASSERTION FAILED AC-SPACE: marker should be created on allowed cat"
+        rm -rf "$base"
+        return 1
+    fi
+    rm -rf "$base"
+}
+
+test_hg_ac13_symlink_omt_dir_byte_exact_allowed() {
+    local real link
+    real=$(mktemp -d)
+    link="${real}-link"
+    ln -s "$real" "$link"
+    export OMT_DIR="$link"
+    arm_handoff
+    local cmd="cat \"$OMT_DIR/handoff-$OMT_SESSION_ID.md\""
+    local out
+    out=$(printf '%s' "$(hg_bash_json "$cmd")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    if ! hg_is_allow "$out"; then
+        echo "ASSERTION FAILED AC13: symlinked OMT_DIR (byte-exact) should allow. Got: $out"
+        rm -f "$link"; rm -rf "$real"
+        return 1
+    fi
+    if [[ ! -f "$HG_M" ]]; then
+        echo "ASSERTION FAILED AC13: marker should be created on allowed cat"
+        rm -f "$link"; rm -rf "$real"
+        return 1
+    fi
+    rm -f "$link"; rm -rf "$real"
+}
+
+test_hg_ac14_marker_present_releases_gate() {
+    arm_handoff
+    : > "$HG_M"
+    local out
+    out=$(printf '%s' "$(hg_bash_json "ls")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_allow "$out" || { echo "ASSERTION FAILED AC14: gate should be released once marker present. Got: $out"; return 1; }
+}
+
+test_hg_ac15_handoff_absent_fail_open() {
+    rm -f "$OMT_DIR/handoff-$OMT_SESSION_ID.md" 2>/dev/null || true
+    local out
+    out=$(jq -n --arg fp "$OMT_DIR/x" '{tool_name: "Write", tool_input: {file_path: $fp, content: "x"}}' \
+        | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_allow "$out" || { echo "ASSERTION FAILED AC15: handoff absent should fail-open (allow). Got: $out"; return 1; }
+}
+
+test_hg_ac16_arms_via_stdin_derivation() {
+    local project_cwd="$SCRIPT_DIR"
+    local stdin_sid="hg-stdin-sid"
+    local fake_home="$TEST_TMP_DIR/home_hg16"
+    mkdir -p "$fake_home"
+
+    local derived_omt_dir
+    derived_omt_dir=$(
+        unset OMT_DIR
+        export HOME="$fake_home"
+        source "$SCRIPT_DIR/lib/omt-dir.sh" && resolve_omt_dir "$project_cwd"
+    )
+    mkdir -p "$derived_omt_dir"
+    : > "$derived_omt_dir/handoff-${stdin_sid}.md"
+    rm -f "$derived_omt_dir/handoff-consumed-${stdin_sid}"
+
+    local out
+    out=$(
+        unset OMT_DIR OMT_SESSION_ID
+        export HOME="$fake_home"
+        printf '%s' "{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"x\",\"content\":\"x\"},\"session_id\":\"$stdin_sid\",\"cwd\":\"$project_cwd\"}" \
+            | bash "$SCRIPT_DIR/pre-tool-enforcer.sh"
+    )
+    hg_is_deny "$out" || { echo "ASSERTION FAILED AC16: should arm via stdin-derived sid/cwd and deny. Got: $out"; return 1; }
+}
+
+test_hg_ac17_neither_env_nor_cwd_fail_open() {
+    local out
+    out=$(
+        unset OMT_DIR OMT_SESSION_ID
+        printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"x","content":"x"}}' \
+            | bash "$SCRIPT_DIR/pre-tool-enforcer.sh"
+    )
+    hg_is_allow "$out" || { echo "ASSERTION FAILED AC17: unresolvable sid+dir should fail-open (allow). Got: $out"; return 1; }
+}
+
+test_hg_ac18_unwritable_dir_no_livelock() {
+    arm_handoff
+    chmod -w "$OMT_DIR"
+
+    local cmd="cat \"$HG_H\""
+    local out exit_code=0
+    out=$(printf '%s' "$(hg_bash_json "$cmd")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh") || exit_code=$?
+    chmod +w "$OMT_DIR"
+
+    [[ "$exit_code" -eq 0 ]] \
+        || { echo "ASSERTION FAILED AC18a: hook should exit 0 under unwritable dir (exit=$exit_code)"; return 1; }
+    hg_is_allow "$out" \
+        || { echo "ASSERTION FAILED AC18a: allowed-cat under unwritable dir should allow. Got: $out"; return 1; }
+
+    chmod -w "$OMT_DIR"
+    local out2
+    out2=$(jq -n --arg fp "$OMT_DIR/x" '{tool_name: "Write", tool_input: {file_path: $fp, content: "x"}}' \
+        | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    chmod +w "$OMT_DIR"
+
+    hg_is_allow "$out2" \
+        || { echo "ASSERTION FAILED AC18b: Write under unwritable dir should allow (no-livelock). Got: $out2"; return 1; }
+}
+
+test_hg_ac_jq_missing_fail_open() {
+    arm_handoff
+    local payload
+    payload=$(jq -n --arg fp "$OMT_DIR/x" '{tool_name: "Write", tool_input: {file_path: $fp, content: "x"}}')
+
+    # Build a shim PATH: symlink every executable found on the real PATH
+    # EXCEPT jq (by filename, not by directory -- jq shares /usr/bin with
+    # grep/sed/dirname/basename, which the hook still needs).
+    local shim_dir p bin name
+    shim_dir=$(mktemp -d)
+    local oldifs="$IFS"
+    IFS=':'
+    for p in $PATH; do
+        IFS="$oldifs"
+        [[ -d "$p" ]] || continue
+        for bin in "$p"/*; do
+            [[ -x "$bin" && -f "$bin" ]] || continue
+            name=$(basename "$bin")
+            [[ "$name" == "jq" ]] && continue
+            [[ -e "$shim_dir/$name" ]] && continue
+            ln -s "$bin" "$shim_dir/$name" 2>/dev/null || true
+        done
+        IFS=':'
+    done
+    IFS="$oldifs"
+
+    local out exit_code=0
+    out=$(
+        export PATH="$shim_dir"
+        printf '%s' "$payload" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh"
+    ) || exit_code=$?
+    rm -rf "$shim_dir"
+
+    [[ "$exit_code" -eq 0 ]] \
+        || { echo "ASSERTION FAILED AC-JQ: hook should exit 0 when jq missing (exit=$exit_code)"; return 1; }
+    hg_is_allow "$out" \
+        || { echo "ASSERTION FAILED AC-JQ: jq missing should fail-open (allow). Got: $out"; return 1; }
+}
+
+test_hg_ac23_armed_prometheus_skill_denied_no_seed() {
+    arm_handoff
+    local state_file="$OMT_DIR/prometheus-state-$OMT_SESSION_ID.json"
+    rm -f "$state_file"
+    local out
+    out=$(printf '%s' '{"tool_name":"Skill","tool_input":{"skill":"prometheus"}}' \
+        | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" \
+        || { echo "ASSERTION FAILED AC23: armed Skill(prometheus) should deny. Got: $out"; return 1; }
+    assert_file_not_exists "$state_file" "AC23: prometheus-state must NOT be written while armed" || return 1
+}
+
+# =============================================================================
+# AC12 — drift-couple integration (TODO 3): the REAL session-start.sh emitter
+# and the REAL pre-tool-enforcer.sh gate must agree byte-for-byte. Runs
+# session-start.sh with source:compact + a >7000-char handoff under a clean
+# OMT_DIR (no prometheus/goal/qa/deep-interview restore-state present, HOME
+# sandboxed so real ~/.claude/todos can't inject a PENDING-TASKS message),
+# jq-decodes the emitted additionalContext, extracts the actual "cat ...
+# handoff-..." pointer line the emitter produced (no hand-fabricated string),
+# and feeds THAT literal env-unexpanded command to the gate.
+# =============================================================================
+
+test_ac12_drift_couple_session_start_emits_gate_accepts() {
+    local fake_home="$TEST_TMP_DIR/home_ac12"
+    mkdir -p "$fake_home/.claude"
+
+    local handoff_file="$OMT_DIR/handoff-$OMT_SESSION_ID.md"
+    rm -f "$OMT_DIR/handoff-consumed-$OMT_SESSION_ID"
+
+    # >7000-char handoff so session-start takes the pointer path (not the <=7000 inline path).
+    yes 'AC12_DRIFT_COUPLE_FILLER_LINE_1234567890_ABCDEFGHIJ' 2>/dev/null \
+        | head -c 7200 > "$handoff_file" 2>/dev/null || true
+    if [ ! -s "$handoff_file" ] || [ "$(wc -c < "$handoff_file" 2>/dev/null || echo 0)" -lt 7001 ]; then
+        python3 -c "print('X' * 7200)" > "$handoff_file" 2>/dev/null || true
+    fi
+
+    local output
+    output=$(
+        export HOME="$fake_home"
+        printf '%s' "{\"sessionId\":\"$OMT_SESSION_ID\",\"cwd\":\"$TEST_TMP_DIR\",\"source\":\"compact\"}" \
+            | bash "$SCRIPT_DIR/session-start.sh"
+    )
+
+    echo "$output" | jq -e . > /dev/null 2>&1 \
+        || { echo "ASSERTION FAILED AC12: session-start stdout must be valid JSON. Got: $output"; return 1; }
+
+    local ctx
+    ctx=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext // empty')
+    [[ -n "$ctx" ]] \
+        || { echo "ASSERTION FAILED AC12: additionalContext should be non-empty for a >7000-char compact handoff"; return 1; }
+
+    # Extract the emitter's actual pointer line -- derived, not fabricated.
+    local cat_cmd
+    cat_cmd=$(echo "$ctx" | grep -oE 'cat "[^"]*handoff-[^"]*"' | head -1)
+    [[ -n "$cat_cmd" ]] \
+        || { echo "ASSERTION FAILED AC12: could not find a handoff cat pointer in emitted additionalContext. ctx: ${ctx:0:400}"; return 1; }
+
+    # Feed the extracted command, env-UNexpanded, to the gate under the SAME OMT_DIR/OMT_SESSION_ID.
+    local gate_out
+    gate_out=$(printf '%s' "$(hg_bash_json "$cat_cmd")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+
+    hg_is_allow "$gate_out" \
+        || { echo "ASSERTION FAILED AC12: gate should allow the emitter's own pointer command. cmd='$cat_cmd' out=$gate_out"; return 1; }
+
+    assert_file_exists "$OMT_DIR/handoff-consumed-$OMT_SESSION_ID" \
+        "AC12: consumed marker should be written when the gate allows the emitter's pointer" || return 1
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -791,6 +1225,37 @@ main() {
     run_test test_ac8b_ii_missing_cwd_loud_failure
     run_test test_ac8b_iii_nonproject_cwd_falls_back_with_warning
     run_test test_ac8c_prometheus_and_di_seed_field_preservation
+
+    # Handoff-gate arm (TODO 1)
+    run_test test_hg_ac1_pipe_tail_denied
+    run_test test_hg_ac2_read_offset_denied_reason_mentions_cat
+    run_test test_hg_ac3_read_no_offset_denied
+    run_test test_hg_ac4a_write_denied_reason_mentions_handoff_or_cat
+    run_test test_hg_ac4b_bash_ls_denied
+    run_test test_hg_ac5_recognition_edge_cases_denied
+    run_test test_hg_ac6_wrong_path_denied_reason_redirects_to_handoff
+    run_test test_hg_ac7_other_state_file_denied_generic_reason
+    run_test test_hg_ac8a_command_substitution_denied
+    run_test test_hg_ac8b_command_substitution_never_executed
+    run_test test_hg_ac_squote_literal_dollar_denied
+    run_test test_hg_ac_env_full_honored_envelope
+    run_test test_hg_ac_deny_nomark_marker_absent_on_deny
+    run_test test_hg_ac9_fully_expanded_path_allowed_and_marked
+    run_test test_hg_ac10_unexpanded_pointer_form_allowed_and_marked
+    run_test test_hg_ac11_leading_indent_allowed_and_marked
+    run_test test_hg_ac_partial_omtdir_expanded_sid_literal_allowed
+    run_test test_hg_ac_space_embedded_space_never_word_split
+    run_test test_hg_ac13_symlink_omt_dir_byte_exact_allowed
+    run_test test_hg_ac14_marker_present_releases_gate
+    run_test test_hg_ac15_handoff_absent_fail_open
+    run_test test_hg_ac16_arms_via_stdin_derivation
+    run_test test_hg_ac17_neither_env_nor_cwd_fail_open
+    run_test test_hg_ac18_unwritable_dir_no_livelock
+    run_test test_hg_ac_jq_missing_fail_open
+    run_test test_hg_ac23_armed_prometheus_skill_denied_no_seed
+
+    # Drift-couple integration (TODO 3)
+    run_test test_ac12_drift_couple_session_start_emits_gate_accepts
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/pre-tool-enforcer_test.sh
+++ b/hooks/pre-tool-enforcer_test.sh
@@ -979,6 +979,32 @@ test_hg_ac_space_embedded_space_never_word_split() {
     rm -rf "$base"
 }
 
+test_hg_ac_unquoted_omtdir_space_denied_no_mark() {
+    # UNQUOTED pointer form under a space-bearing OMT_DIR. The hook's textual
+    # substitution matches the expected path (allow), but real bash word-splits
+    # the unquoted $OMT_DIR so `cat` never reads the handoff -- a false-allow
+    # that disarms the gate. The gate must DENY this form and leave no marker.
+    local base
+    base=$(mktemp -d)
+    export OMT_DIR="$base/dir with space"
+    mkdir -p "$OMT_DIR"
+    arm_handoff
+    local cmd='cat $OMT_DIR/handoff-$OMT_SESSION_ID.md'
+    local out
+    out=$(printf '%s' "$(hg_bash_json "$cmd")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    if ! hg_is_deny "$out"; then
+        echo "ASSERTION FAILED AC-UNQUOTED: unquoted \$OMT_DIR w/ space must deny (word-split false-allow). Got: $out"
+        rm -rf "$base"
+        return 1
+    fi
+    if [[ -f "$HG_M" ]]; then
+        echo "ASSERTION FAILED AC-UNQUOTED: marker must not exist after denied unquoted form"
+        rm -rf "$base"
+        return 1
+    fi
+    rm -rf "$base"
+}
+
 test_hg_ac13_symlink_omt_dir_byte_exact_allowed() {
     local real link
     real=$(mktemp -d)
@@ -1245,6 +1271,7 @@ main() {
     run_test test_hg_ac11_leading_indent_allowed_and_marked
     run_test test_hg_ac_partial_omtdir_expanded_sid_literal_allowed
     run_test test_hg_ac_space_embedded_space_never_word_split
+    run_test test_hg_ac_unquoted_omtdir_space_denied_no_mark
     run_test test_hg_ac13_symlink_omt_dir_byte_exact_allowed
     run_test test_hg_ac14_marker_present_releases_gate
     run_test test_hg_ac15_handoff_absent_fail_open

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -119,6 +119,29 @@ for handoff_file in "$OMT_DIR"/handoff-*.md; do
   fi
 done
 
+# GC arm: reap orphaned handoff-consumed-<sid> markers (D-9 marker contract).
+# Mirrors the handoff-*.md arm above: own current-sid skip, mtime TTL reuse of
+# TERMINAL_TTL. Separate arm (not folded into the .md arm above) because the
+# .md arm's sid-extraction (#handoff-/%.md) mis-parses a .md-less marker.
+# Explicit post-glob filter, NOT a glob property: handoff-consumed-* would
+# also match a handoff-consumed-*.md file if a sid literally started
+# "consumed-"; the filter guarantees this arm never reaps a .md handoff.
+for marker_file in "$OMT_DIR"/handoff-consumed-*; do
+  [ -e "$marker_file" ] || continue
+  case "$marker_file" in
+    *.md) continue ;;
+  esac
+  marker_base="${marker_file##*/}"
+  marker_sid="${marker_base#handoff-consumed-}"
+  [ "$marker_sid" = "$SESSION_ID" ] && continue
+  marker_mtime=$(stat -c %Y "$marker_file" 2>/dev/null || stat -f %m "$marker_file" 2>/dev/null || true)
+  [ -n "$marker_mtime" ] || continue
+  marker_age=$(( GC_NOW - marker_mtime ))
+  if [ "$marker_age" -gt "$HANDOFF_ORPHAN_TTL_SECS" ]; then
+    rm -f "$marker_file"
+  fi
+done
+
 # Check for active prometheus state (session-specific)
 if [ -f "$OMT_DIR/prometheus-state-${SESSION_ID}.json" ]; then
   PROMETHEUS_STATE=$(cat "$OMT_DIR/prometheus-state-${SESSION_ID}.json" 2>/dev/null)
@@ -240,12 +263,24 @@ if command -v jq &> /dev/null && [ "$SOURCE" = "compact" ]; then
       HANDOFF="$HANDOFF_RAW"
       rm -f "$HANDOFF_FILE"
     else
-      HANDOFF="[COMPACTION HANDOFF -- full continuation record on disk]
+      # Re-arm (D-10): a re-compaction on this same sid overwrites the handoff
+      # file above; a stale consumed-marker from a PRIOR read would leave the
+      # gate disarmed for the new content. Delete it before emitting the
+      # pointer so the gate re-arms.
+      rm -f "$OMT_DIR/handoff-consumed-${SESSION_ID}"
+      HANDOFF="CRITICAL [COMPACTION HANDOFF -- full continuation record on disk]
 
 Your context was just compacted. The COMPLETE session handoff (original request verbatim, the full arc of decisions/rejections/Q&A, exact stopping point, and all user messages) is on disk. Run this command NOW, BEFORE ANY OTHER ACTION:
   cat \"\$OMT_DIR/handoff-\$OMT_SESSION_ID.md\"
 (\$OMT_DIR and \$OMT_SESSION_ID are set in CLAUDE_ENV_FILE exported by this hook.)
-It is your only memory of this session -- do not trust your recollection of prior turns. Reconstructing it from memory is NOT reading it."
+It is your only memory of this session -- do not trust your recollection of prior turns. Reconstructing it from memory is NOT reading it.
+
+CRITICAL -- three exact rationalizations precede skipping this read. None of them holds:
+| Thought | Reality |
+|---|---|
+| \"The native compaction summary already covers this\" | The summary is compacted, lossy prose -- it does not substitute for the full on-disk record |
+| \"Only the new part since the last compaction is needed\" | The full handoff is needed, not a partial slice -- prior arc and decisions are required context |
+| \"Reading the whole file wastes tokens\" | Skipping it to save tokens costs far more later, recovering context lost through repeated back-and-forth |"
     fi
   fi
 fi

--- a/hooks/session-start_test.sh
+++ b/hooks/session-start_test.sh
@@ -1203,6 +1203,51 @@ EOF
 }
 
 # =============================================================================
+# Tests: re-arm deletion (ADR D-10) — a re-compaction on the same sid must
+# delete a stale handoff-consumed-<sid> marker BEFORE emitting a new
+# large-handoff pointer, so the gate re-arms for the fresh handoff.
+# =============================================================================
+
+# AC19: re-arm positive — stale marker present + a new >7000-char handoff on
+# the SAME sid, source=compact → the stale marker is deleted.
+test_session_start_rearm_deletes_stale_marker_on_new_large_handoff() {
+    local sid="rearm-positive"
+    local marker="$TEST_OMT_DIR/handoff-consumed-${sid}"
+    local handoff_file="$TEST_OMT_DIR/handoff-${sid}.md"
+
+    touch "$marker"
+    python3 -c "print('X' * 7200)" > "$handoff_file" 2>/dev/null \
+        || yes 'LARGE_HANDOFF_FILLER_LINE_1234567890_ABCDEFGHIJ' 2>/dev/null | head -c 7200 > "$handoff_file"
+
+    echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid"'", "source": "compact"}' \
+        | "$SCRIPT_DIR/session-start.sh" > /dev/null 2>&1 || true
+
+    if [ -f "$marker" ]; then
+        echo "ASSERTION FAILED (AC19): stale handoff-consumed marker should be deleted on re-arm but still exists"
+        return 1
+    fi
+    return 0
+}
+
+# AC20: re-arm negative — stale marker present, source=startup and no new
+# handoff → the marker is untouched (survives).
+test_session_start_rearm_marker_survives_without_new_handoff() {
+    local sid="rearm-negative"
+    local marker="$TEST_OMT_DIR/handoff-consumed-${sid}"
+
+    touch "$marker"
+
+    echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$sid"'", "source": "startup"}' \
+        | "$SCRIPT_DIR/session-start.sh" > /dev/null 2>&1 || true
+
+    if [ ! -f "$marker" ]; then
+        echo "ASSERTION FAILED (AC20): handoff-consumed marker should survive when no new large handoff is emitted"
+        return 1
+    fi
+    return 0
+}
+
+# =============================================================================
 # Tests: T3 — self-contained orphan-handoff GC arm (ADR D-8)
 # Globs $OMT_DIR/handoff-*.md, dash-safe sid extraction, own current-sid guard,
 # mtime age > HANDOFF_ORPHAN_TTL_SECS → rm -f. Does NOT call/modify
@@ -1337,6 +1382,40 @@ EOF
     # And the orphan handoff reaped by the new arm.
     if [ -f "$orphan" ]; then
         echo "ASSERTION FAILED: orphan handoff should be reaped alongside the *.json GC"
+        return 1
+    fi
+    return 0
+}
+
+# =============================================================================
+# Tests: marker-GC arm (ADR D-11a) — reaps orphaned handoff-consumed-* markers
+# by TTL, self-contained (own current-sid skip), and must NEVER touch a .md
+# handoff even if a marker's sid literally starts "consumed-" style basenames.
+# =============================================================================
+
+# AC22: marker-GC isolation — a past-TTL handoff-consumed-<OLD-SID> marker is
+# reaped, WHILE a co-present YOUNG non-current handoff-<OTHER-SID>.md (under
+# TTL) survives untouched by the marker-GC arm.
+test_gc_marker_consumed_orphan_reaped_young_handoff_survives() {
+    local current_sid="marker-gc-current"
+    local old_marker="$TEST_OMT_DIR/handoff-consumed-old-marker-sid"
+    local young_handoff="$TEST_OMT_DIR/handoff-other-young-sid.md"
+
+    touch "$old_marker"
+    _backdate_mtime_secs "$old_marker" 2000
+
+    printf 'young non-current handoff body' > "$young_handoff"
+    _backdate_mtime_secs "$young_handoff" 60
+
+    echo '{"cwd": "'"$TEST_TMP_DIR"'", "sessionId": "'"$current_sid"'"}' \
+        | "$SCRIPT_DIR/session-start.sh" > /dev/null 2>&1 || true
+
+    if [ -f "$old_marker" ]; then
+        echo "ASSERTION FAILED (AC22): past-TTL handoff-consumed marker should be reaped but still exists"
+        return 1
+    fi
+    if [ ! -f "$young_handoff" ]; then
+        echo "ASSERTION FAILED (AC22): young non-current .md handoff must SURVIVE the marker-GC arm"
         return 1
     fi
     return 0
@@ -1748,6 +1827,29 @@ test_cache_safe_handoff_large_pointer() {
         return 1
     fi
 
+    # (AC21) Red-flags hardening: CRITICAL marker + the 3 named rationalizations
+    if ! echo "$ctx" | grep -qF 'CRITICAL'; then
+        echo "ASSERTION FAILED (AC21): pointer must contain a CRITICAL marker"
+        return 1
+    fi
+    if ! echo "$ctx" | grep -qiF 'native compaction summary'; then
+        echo "ASSERTION FAILED (AC21): pointer must name the 'native compaction summary' rationalization"
+        return 1
+    fi
+    if ! echo "$ctx" | grep -qiF 'only the new part'; then
+        echo "ASSERTION FAILED (AC21): pointer must name the 'only the new part' rationalization"
+        return 1
+    fi
+    if ! echo "$ctx" | grep -qiF 'save tokens'; then
+        echo "ASSERTION FAILED (AC21): pointer must name the 'save tokens' rationalization"
+        return 1
+    fi
+    # (AC21) raw sid must never appear (session-invariant static bytes)
+    if echo "$ctx" | grep -qF "$sid"; then
+        echo "ASSERTION FAILED (AC21): pointer must NOT contain the raw session id"
+        return 1
+    fi
+
     # (iii) large-handoff file PRESERVED (not deleted)
     if [ ! -f "$handoff_file" ]; then
         echo "ASSERTION FAILED (AC5-iii): large handoff file must be preserved (delete fires only on <=7000 path)"
@@ -1900,6 +2002,10 @@ main() {
     run_test test_session_start_encoder_invariants_in_source
     run_test test_session_start_compact_no_handoff_equals_restore_only
 
+    # Re-arm deletion (ADR D-10)
+    run_test test_session_start_rearm_deletes_stale_marker_on_new_large_handoff
+    run_test test_session_start_rearm_marker_survives_without_new_handoff
+
     # T3: self-contained orphan-handoff GC arm (ADR D-8)
     run_test test_gc_handoff_orphan_old_reaped
     run_test test_gc_handoff_current_session_survives_when_old
@@ -1907,6 +2013,9 @@ main() {
     run_test test_gc_handoff_dash_sid_matched_exactly
     run_test test_gc_handoff_arm_does_not_call_is_current_session
     run_test test_gc_handoff_arm_does_not_disturb_json_state_gc
+
+    # Marker-GC arm (ADR D-11a)
+    run_test test_gc_marker_consumed_orphan_reaped_young_handoff_survives
 
     # Cache-safe restore — TODO 3 (AC2a–AC6)
     run_test test_cache_safe_prom_sentinel_not_in_stdout


### PR DESCRIPTION
## 📌 Summary

컴팩션 재시작 후 큰 핸드오프(>7000자)를 **문구가 아닌 기계적 게이트**로 전체 `cat` 읽게 강제한다. 무장 중에는 핸드오프를 byte-exact로 가리키는 clean `cat` 하나만 허용하고 그 외 모든 툴 호출을 `permissionDecision:"deny"`로 차단하며, 세션 절대 brick 없이·프로덕션 no-op 없이 동작한다.

---

## 🔧 Changes

### handoff-gate arm (`pre-tool-enforcer.sh`)

- TaskOutput arm과 Skill-seed arm 사이(라인 30)에 새 PreToolUse arm 삽입 — arm 순서 TaskOutput → handoff-gate → Skill-seed → allow.
- 무장 판정: `handoff-$sid.md` 존재 AND `handoff-consumed-$sid` 부재 AND 디렉터리 writable AND jq 가용. 하나라도 거짓이면 fail-open(무출력 통과).
- 인식: `jq`로 `.tool_input.command` 디코드 → 확장 전 메타문자/서브셸 fast-deny → quote-aware 토큰화로 인자 1개 검사 → `$OMT_DIR`/`$OMT_SESSION_ID`만 문자열 치환 후 핸드오프 경로와 byte-exact 비교.
- allow 분기에서만 0-byte consumed-marker 기록 후 기존 allow로 fall-through. deny 분기는 honored 봉투 emit 후 `exit 0`.

무장은 오직 컴팩션 재시작 + >7000자 핸드오프 상황에서만 성립하므로, 일반 세션은 동작 변화·jq 비용 0.

**영향 범위**
- 후방 호환: 비무장 세션은 기존과 동일(fail-open). 기존 TaskOutput arm·Skill-seed arm 미변경.
- 실패 안전: 강제 불가 상황 4종 전부 fail-open — 게이트가 세션을 brick하지 않음.
- 신규 의존: 무장 경로에서만 `jq` 호출(부재 시 fail-open, teeth 비활성).

### session-start 라이프사이클 + Red-flags (`session-start.sh`)

- **re-arm**: `>7000` 경로에서 포인터 emit 전에 stale `handoff-consumed-$sid` 삭제 — 동일 sid 재-컴팩션 시 게이트 재무장.
- **marker GC**: 기존 `handoff-*.md` GC arm을 미러링한 `handoff-consumed-*` orphan GC arm 추가 — 현재 sid skip, TTL reap, post-glob `*.md) continue` 필터로 `.md` 핸드오프 불훼손.
- **Red-flags**: 큰-핸드오프 포인터에 `CRITICAL` 마커 + Thought→Reality 표(3개 합리화: `native compaction summary`/`only the new part`/`save tokens`) 추가. 세션-불변 정적 바이트(cache-safe).

**영향 범위**
- `>7000` 임계·restore 블록·`handoff-*.md` GC arm 로직 미변경.
- 포인터 prefix에 가변 바이트 미추가(raw sid 부재) → KV 캐시 안전성 유지.

### drift-couple 통합 테스트 (`pre-tool-enforcer_test.sh`)

- 실제 `session-start.sh`가 방출하는 포인터 `cat` 라인을 게이트에 env-unexpanded로 먹여 allow + marker를 확인 — 게이트↔방출기 byte-exact 결합 보증.

**영향 범위**: 테스트 전용. 프로덕션 코드 무변경.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. deny 메커니즘 = `permissionDecision:"deny"` 정식 봉투 (≠ `continue:false`)

**배경 및 문제 상황:**
핸드오프 게이트는 툴 호출 **하나**를 막고, 모델에게 교정 지시를 먹이고, 에이전트 루프를 살려둬 그 다음 `cat`을 실행하게 해야 한다. 파일 내 기존 TaskOutput arm은 `{continue:false, reason}`을 쓰지만, 이 형태는 이 용도에 부적합하다.

**해결 방안:**
전체 honored 봉투 `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":...}}`를 emit한다.

**구현 세부사항:**
`continue:false`는 **턴 전체를 중단**시키고 그 메시지(`stopReason`)는 사용자에게만 노출돼 모델에 도달하지 않는다 → 에이전트가 이후 `cat`을 못 한다. 반면 `permissionDecision:"deny"`는 그 한 호출만 막고 이유를 모델에 전달하며 루프를 유지한다. 또한 `hookSpecificOutput` 래퍼 없는 맨 `{"permissionDecision":"deny"}`는 조용히 무시돼 프로덕션 no-op가 되므로, 전체 봉투가 필수다.

**선택과 트레이드오프:**
한 파일에 deny 관용구가 일시적으로 둘 공존(TaskOutput arm의 `continue:false`는 아래 4번 (b)로 수술적 유지). 신규 deny 지점에 왜 `permissionDecision:"deny"`(deny-one-continue)를 쓰는지 vs TaskOutput arm의 `continue:false`(halt-turn) 한 줄 주석으로 복붙-전파를 차단했다.

### 2. 명령 인식 = jq 디코드 + substitute-input byte-exact (≠ realpath)

**배경 및 문제 상황:**
`tool_input.command`에는 임베드된 이스케이프 따옴표·공백·메타문자가 흔하다. 기존 `extract_json_field`(grep/sed)는 첫 임베드 따옴표에서 명령을 절단한다. 또한 프로덕션 `OMT_DIR`는 심링크일 수 있다(macOS `/tmp`→`/private/tmp`).

**해결 방안:**
명령 필드는 `jq`로 디코드(quote-aware)하고, 인식은 `$OMT_DIR`/`$OMT_SESSION_ID`만 문자열 치환한 뒤 byte-exact 비교한다. realpath/심링크 해석은 하지 않는다.

**구현 세부사항:**
- `jq`는 무장 체크 **뒤**에 호출 → 비무장 hot path는 jq 비용 0, 부재 시 fail-open.
- 확장 **전**에 파이프/`tail`/`head`/`sed`/리다이렉트/체이닝/`$(`/백틱을 fast-deny — 서브셸은 결코 평가되지 않는다(`eval`/`bash -c`/`$(...)` 미사용).
- realpath를 쓰면 심링크 `OMT_DIR` 하에서 지시된 `cat` 인자는 `/private/...`로, 구성된 핸드오프 경로는 `/tmp/...`로 갈려 **게이트가 자기 지시 명령을 거부→복구 불능 brick**. byte-exact는 심링크-불변이라 이를 회피한다.

**관련 코드:**
```bash
# 확장 전 fast-deny (서브셸 미평가)
if ! echo "$_hg_cmd" | grep -qE '[|;<>&`]|\$\(|tail|head|sed'; then
  if _hg_tokenize "$_hg_cmd"; then
    if [[ "${#_hg_tokens[@]}" -eq 2 && "${_hg_tokens[0]}" == "cat" \
        && "${_hg_sqdollar[1]:-0}" != "1" ]]; then          # 홑따옴표 리터럴 $ → deny
      _hg_candidate="${_hg_tokens[1]//\$OMT_DIR/$_hg_omt_dir}"
      _hg_candidate="${_hg_candidate//\$OMT_SESSION_ID/$_hg_sid}"
      [[ "$_hg_candidate" == "$_hg_omt_dir/handoff-${_hg_sid}.md" ]] && _hg_allow=1
    fi
  fi
fi
```

**선택과 트레이드오프:**
비정규 따옴표/이스케이프 형태는 deny로 떨어진다(안전 — 정규 포인터 형태는 항상 allow라 모델 재시도 탈출구가 확실). 홑따옴표 안 리터럴 `$`는 셸이 확장 안 하므로 치환 시 존재하지 않는 파일을 가리키는 false-allow silent-skip이 되어, 이를 deny로 처리한다.

### 3. consumed 신호 = 전용 marker 파일 + orphan GC (≠ 핸드오프 삭제, ≠ 방치)

**배경 및 문제 상황:**
게이트에는 "에이전트가 핸드오프를 읽었나?" 해제 신호가 필요하다. 그런데 큰 핸드오프는 재-읽기 가능해야 하고(에이전트의 유일한 온-디스크 기억), PreToolUse는 실행 **전**에 발화한다.

**해결 방안:**
`handoff-consumed-$OMT_SESSION_ID`(`.md` 없음, `-state-` 없음) 전용 marker를 allow 분기에서만 기록하고, session-start의 신규 GC arm이 TTL로 reap한다.

**구현 세부사항:**
핸드오프 삭제를 신호로 쓰면 (a) 재-읽기 기록 파괴, (b) PreToolUse allow 시점 삭제 시 대기 중인 `cat`이 파일을 잃어 게이트가 막으려던 silent-skip 재발. dot-free sid regex(`^[A-Za-z0-9_-]{1,200}$`)가 marker 파일명을 `handoff-*.md` glob과 비충돌로 보장한다.

**선택과 트레이드오프:**
GC arm + AC 약 8줄 추가 비용. marker unwritable은 **무장 판정 단계**에서 감지돼 fail-open으로 빠지므로(deny 아님) livelock이 없다.

### 4. 열린 이슈 (리뷰어 논의 요청)

**(a) unquoted 포인터 폼 false-allow — PLAUSIBLE(비차단).**
현재 인식은 인자가 따옴표로 감싸였는지를 요구하지 않는다. 따라서 `cat $OMT_DIR/handoff-$OMT_SESSION_ID.md`(따옴표 없이)는 리터럴에 공백이 없어 1토큰으로 치환→byte-exact→**allow+mark**된다. 그러나 실제 Bash 실행 시 **공백 포함 `OMT_DIR`**에서 `$OMT_DIR`가 word-split → `cat`이 핸드오프를 못 읽음 → 게이트가 헛-무장해제되는 silent-skip. 발동에 "따옴표 이탈 + 공백 OMT_DIR" 동시 필요(방출되는 지시 명령은 항상 따옴표 폼이고 AC12가 이를 보증)라 happy-path 밖. **논의**: D-8에 "unquoted arg에 리터럴 `$` 포함 → deny" 규칙을 추가할지(현재 26 AC 표면 밖의 계약 확장).

**(b) TaskOutput arm `continue:false` 미이전 — 후속 항목.**
기존 TaskOutput arm도 1번과 같은 클래스의 latent-contract 이슈로 보이나 MEDIUM 확신이라, 수술적 원칙에 따라 이번 스코프에서 손대지 않고 별도 work-unit으로 남겼다. **논의**: 후속 PR에서 재검증 후 honored 봉투로 이전할지.

---

## ✅ Checklist

### handoff-gate
- [ ] 무장 상태에서 byte-exact clean `cat`만 allow, 그 외 모든 툴 호출 deny (26 AC RED→GREEN)
  - `hooks/pre-tool-enforcer.sh`
- [ ] 핸드오프 부재/sid 미해결/디렉터리 unwritable/jq 부재 4종에서 fail-open, no-livelock
  - `hooks/pre-tool-enforcer.sh`
- [ ] `$(...)`/백틱 서브셸 미평가 (AC8b: PWNED 파일 부재)
  - `hooks/pre-tool-enforcer_test.sh`
- [ ] marker는 allow 분기에서만 기록, deny는 게이트 무장 유지 (AC-DENY-NOMARK)
  - `hooks/pre-tool-enforcer.sh`

### session-start 라이프사이클
- [ ] 동일 sid 재-컴팩션 시 stale marker 삭제로 재무장 (AC19), 신규 핸드오프 없으면 marker 생존 (AC20)
  - `hooks/session-start.sh`
- [ ] orphan marker TTL reap 시 young `.md` 핸드오프 생존 (AC22)
  - `hooks/session-start.sh`
- [ ] 포인터에 `CRITICAL` + 3 앵커 포함, raw sid 부재 (AC21, cache-safe)
  - `hooks/cache-safe-guard_test.sh`

### 통합
- [ ] session-start 방출 포인터를 게이트가 byte-exact로 수용 + marker 기록 (AC12)
  - `hooks/pre-tool-enforcer_test.sh`
- [ ] 기존 스위트 + `make test` + `make validate` green (회귀 없음)