### PR TITLE
feat: qa 리스크/커버리지-갭 시나리오 저작 프레임워크

### DIFF
--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -11,7 +11,7 @@ description: Use when verifying a code change through a standalone adversarial e
 
 ## Overview
 
-Pure dynamic adversarial-e2e verification skill. qa's job is to run the change, not to read about it: static document-vs-code auditing (Security/Data-Integrity checklists, MUST-DO compliance tables, Completeness prose audits) belongs to `code-review`; qa's only static responsibility is the behavior-invisible PRE-FLIGHT contract gate below.
+Pure dynamic adversarial-e2e verification skill. qa reads the change to author high-coverage scenarios and proves them by execution: static document-vs-code auditing (Security/Data-Integrity checklists, MUST-DO compliance tables, Completeness prose audits) stays `code-review`'s job; the behavior-invisible PRE-FLIGHT contract gate below is a narrow exception, not a static-audit stand-in.
 
 qa is **standalone and stateful**. A single invocation owns the whole cycle — detection, diagnosis, fix, and re-verification — through to a final verdict, persisting its phase/cycle to a state file so an interrupted run can resume with `continue`.
 
@@ -59,7 +59,7 @@ Every phase below runs once per pass, except the bracketed loop, which repeats o
 
 ### PRE-FLIGHT
 
-A **behavior-invisible contract check** — the one static responsibility qa keeps, because no amount of running the app surfaces a scope violation. Gates on exactly two things:
+A **behavior-invisible contract check** — a narrow exception to qa's dynamic-only posture, because no amount of running the app surfaces a scope violation. Gates on exactly two things:
 
 1. **MUST-NOT-DO scope membership.** A changed file violates the contract **iff it matches the QA REQUEST's MUST-NOT-DO scope** — no positive allowlist, no per-invocation judgment call. Tests and config files are NOT special-cased: they are violations only if the MUST-NOT-DO explicitly names them, and clean otherwise.
 2. **B ⊆ A scope boundary.** Expected files (from EXPECTED OUTCOME) = A; Changed files (from QA REQUEST Scope) = B. PASS if B ⊆ A.
@@ -70,7 +70,9 @@ A **behavior-invisible contract check** — the one static responsibility qa kee
 
 ### PLAN
 
-Parse the QA REQUEST's Spec/AC into concrete verification targets and adversarial scenarios: what BASELINE must run green, what ADVERSARIAL E2E must attack, and what CHECK will judge against. Spec/AC understanding is retained here in full — only the static prose-audit machinery (MUST-DO tables, Completeness sub-checks) that used to sit downstream of it is gone.
+Parse the QA REQUEST's Spec/AC into concrete verification targets and adversarial scenarios: what BASELINE must run green, what ADVERSARIAL E2E must attack, and what CHECK will judge against. Spec/AC understanding is retained here in full; MUST-DO tables and Completeness sub-checks are `code-review`'s static-audit territory, not PLAN's.
+
+See [scenario-authoring.md] for the risk/coverage-gap derivation framework.
 
 ### BASELINE
 
@@ -87,8 +89,12 @@ Build/test/lint green baseline.
 
 Drive the changed surface for real and attack it. Two parts, both required when the change is user-facing:
 
-1. **Execute caller-provided scenarios verbatim**, with per-scenario evidence. ANY provided-scenario failure = immediate REQUEST_CHANGES.
-2. **Self-author and run the 6-category adversarial matrix** for the changed surface: failure paths, boundary/malformed input, injection, interruption-resume + dirty state, misleading success, idempotency. See [stage3-handson.md] `## Adversarial Scenario Matrix` for the full matrix and the lifecycle/applicability detail (start → verify → stop).
+1. **Execute caller-provided scenarios verbatim**, with per-scenario evidence. ANY provided-scenario failure = immediate REQUEST_CHANGES. Caller-provided scenarios always run verbatim, unchanged — the derivation framework below governs only scenarios qa self-authors; it never rewrites what the caller handed in.
+2. **Self-author the 6-category adversarial matrix** for the changed surface, in this order — breadth before depth:
+   1. **Derive candidate scenarios by breadth** via [scenario-authoring.md]: Layer A impact-map → coverage-gap → H/M/L priority.
+   2. **Attack each derived scenario with the applicable depth rows, working highest-priority (H) first**, from the 6-category matrix: failure paths, boundary/malformed input, injection, interruption-resume + dirty state, misleading success, idempotency. See [stage3-handson.md] `## Adversarial Scenario Matrix` for the full matrix and the lifecycle/applicability detail (start → verify → stop).
+
+   Breadth (step 1) MUST precede depth (step 2) — do not skip straight to the matrix on an undifferentiated changed-file list.
 
 **Inline modality drivers, no tmux.** qa itself drives the modality-appropriate tool inline — it is not delegated to a separate driver subagent:
 
@@ -249,6 +255,8 @@ qa is non-interactive and headless. Every command it runs MUST return control to
 | ADVERSARIAL E2E | PASS / FAIL | [matrix + scenario summary] |
 | Cycles run | N / max_cycles | [Same-Failure key if terminated early] |
 
+Self-authored scenarios reported under ADVERSARIAL E2E carry the six-field shape from [scenario-authoring.md] — actor · preconditions · steps · expected · why-needed · priority.
+
 ## Verdict: [APPROVE / REQUEST_CHANGES / COMMENT]
 
 ## Issues (if any)
@@ -287,7 +295,7 @@ Every issue surfaced MUST include a confidence score. See [feedback-protocol.md]
 CYCLE:      PRE-FLIGHT → PLAN → BASELINE → ADVERSARIAL E2E → CHECK → [DIAGNOSIS → FIX → RE-VERIFY loop ≤5] → EXIT → CLEANUP → ROLLBACK → STATE
 PRE-FLIGHT: MUST-NOT-DO scope + B⊆A only; violation = immediate REQUEST_CHANGES, cycle NOT executed
 BASELINE:   build/test/lint green. See stage1-commands.md
-MATRIX:     6 categories — failure paths, boundary/malformed input, injection, interruption, misleading success, idempotency. See stage3-handson.md
+MATRIX:     6 categories — failure paths, boundary/malformed input, injection, interruption, misleading success, idempotency. Breadth via scenario-authoring.md, depth via stage3-handson.md
 DRIVERS:    API→curl, Frontend→agent-browser (fallback playwright), Mobile→maestro, CLI→bash. No tmux.
 LOOP:       DIAGNOSIS→oracle (fresh, read-only) | FIX→sisyphus-junior (commits own scoped fix, never git commit -a) | RE-VERIFY→qa, full re-run, distrust fixer
 EXIT:       Goal Met / max_cycles=5 / Same-Failure-3x (scenario-id+root-cause-file+root-cause-symbol) / Safety

--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -87,7 +87,7 @@ Build/test/lint green baseline.
 
 ### ADVERSARIAL E2E
 
-Drive the changed surface for real and attack it. Two parts, both required when the change is user-facing:
+Drive the changed surface for real and attack it. Two parts, both required when the change touches a risk surface — user-facing OR an internal risk surface (feature-flag-gated logic, payment/notification resolver internals, permission/state transitions), per [stage3-handson.md] `### Decision Logic`; only a genuinely inert refactor that touches no risk surface skips:
 
 1. **Execute caller-provided scenarios verbatim**, with per-scenario evidence. ANY provided-scenario failure = immediate REQUEST_CHANGES. Caller-provided scenarios always run verbatim, unchanged — the derivation framework below governs only scenarios qa self-authors; it never rewrites what the caller handed in.
 2. **Self-author the 6-category adversarial matrix** for the changed surface, in this order — breadth before depth:
@@ -104,6 +104,8 @@ Drive the changed surface for real and attack it. Two parts, both required when 
 | Frontend / UI | `agent-browser` (fallback: `playwright`) |
 | Mobile / App | `maestro` |
 | CLI / TUI | interactive `bash` |
+
+An internal risk surface with no direct UI/API is driven via its nearest entry point — an API/`curl` call if reachable, or a `bash` harness that invokes the code path directly.
 
 Command execution is **non-blocking only**: every command either returns control on its own or is explicitly backgrounded (`run_in_background`, or trailing `&` with output redirected). A bare blocking command that hangs the shell is forbidden. See [stage3-handson.md] Step 3.2 for the lifecycle this backs (start in background → wait for readiness → verify → stop, never leaving a server running).
 

--- a/skills/qa/SKILL.test.ts
+++ b/skills/qa/SKILL.test.ts
@@ -20,6 +20,11 @@ import { join } from "path";
 // ---------------------------------------------------------------------------
 
 const skillMd = readFileSync(join(import.meta.dir, "SKILL.md"), "utf8");
+const scenarioAuthoringMd = readFileSync(
+	join(import.meta.dir, "scenario-authoring.md"),
+	"utf8",
+);
+const stage3Md = readFileSync(join(import.meta.dir, "stage3-handson.md"), "utf8");
 
 // ---------------------------------------------------------------------------
 // NEW-PROSE: cycle phase vocabulary (must FAIL before rewrite — RED)
@@ -231,6 +236,52 @@ describe("new-prose: fix-loop nesting contract", () => {
 });
 
 // ---------------------------------------------------------------------------
+// NEW-PROSE: scenario-authoring.md risk/coverage-gap derivation framework
+// ---------------------------------------------------------------------------
+
+describe("new-prose: scenario-authoring.md derivation framework", () => {
+	test("impact mapping is present", () => {
+		expect(scenarioAuthoringMd).toContain("impact mapping");
+	});
+
+	test("coverage-gap judgment is present", () => {
+		expect(scenarioAuthoringMd).toContain("coverage-gap");
+	});
+
+	test("actor is present", () => {
+		expect(scenarioAuthoringMd).toContain("actor");
+	});
+
+	test("why-needed is present", () => {
+		expect(scenarioAuthoringMd).toContain("why-needed");
+	});
+});
+
+describe("new-prose: stage3-handson.md risk-surface + hardening rows", () => {
+	test("stale-state row is present", () => {
+		expect(stage3Md).toContain("stale-state");
+	});
+
+	test("dirty-worktree row is present", () => {
+		expect(stage3Md).toContain("dirty-worktree");
+	});
+
+	test("flaky-rerun row is present", () => {
+		expect(stage3Md).toContain("flaky-rerun");
+	});
+
+	test("new hardening rows are called out as distinct from the pre-existing row 4", () => {
+		expect(stage3Md).toContain("distinct from row");
+	});
+});
+
+describe("new-prose: SKILL.md points at scenario-authoring.md", () => {
+	test("scenario-authoring.md pointer is present", () => {
+		expect(skillMd).toContain("scenario-authoring.md");
+	});
+});
+
+// ---------------------------------------------------------------------------
 // STRIP: static-audit sections removed (must FAIL before rewrite — RED)
 // ---------------------------------------------------------------------------
 
@@ -275,6 +326,20 @@ describe("strip: Code-Quality static review step removed", () => {
 
 	test('"checklists.md" reference is absent', () => {
 		expect(skillMd).not.toContain("checklists.md");
+	});
+});
+
+describe("strip: qa's PLAN/Overview no longer disclaim reading the change", () => {
+	test('"not to read about it" is absent', () => {
+		expect(skillMd).not.toContain("not to read about it");
+	});
+
+	test('"static prose-audit machinery" is absent', () => {
+		expect(skillMd).not.toContain("static prose-audit machinery");
+	});
+
+	test('"static responsibility" no longer appears anywhere in SKILL.md', () => {
+		expect(skillMd.match(/static responsibility/g)).toBeNull();
 	});
 });
 
@@ -328,6 +393,41 @@ describe("preserved: binary APPROVE/REQUEST_CHANGES output contract", () => {
 describe("preserved: non-blocking command execution policy", () => {
 	test("run_in_background is present", () => {
 		expect(skillMd).toContain("run_in_background");
+	});
+});
+
+describe("preserved: stage3-handson.md 6-category adversarial matrix anchor", () => {
+	test('"## Adversarial Scenario Matrix" heading is present', () => {
+		expect(stage3Md).toContain("## Adversarial Scenario Matrix");
+	});
+
+	test("all 6 pre-existing category names are present", () => {
+		expect(stage3Md).toContain("Error / failure paths");
+		expect(stage3Md).toContain("Boundary / malformed input");
+		expect(stage3Md).toContain("Injection");
+		expect(stage3Md).toContain("Interruption");
+		expect(stage3Md).toContain("Misleading success");
+		expect(stage3Md).toContain("Idempotency");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// STRUCTURAL-INTEGRITY / ANCHOR-RESOLUTION: SKILL.md's scenario-authoring.md
+// pointer must resolve to real content, not a dangling filename reference.
+// ---------------------------------------------------------------------------
+
+describe("structural-integrity: scenario-authoring.md pointer resolves to a real heading (anchor resolution)", () => {
+	test("SKILL.md points at scenario-authoring.md AND that heading actually exists in the file", () => {
+		expect(skillMd).toContain("scenario-authoring.md");
+		expect(scenarioAuthoringMd).toContain(
+			"## Layer A — Risk / Coverage-Gap Derivation",
+		);
+	});
+
+	test("the six-field scenario shape is enumerated in order in scenario-authoring.md", () => {
+		expect(scenarioAuthoringMd).toContain(
+			"`actor · preconditions · steps · expected · why-needed · priority`",
+		);
 	});
 });
 

--- a/skills/qa/scenario-authoring.md
+++ b/skills/qa/scenario-authoring.md
@@ -1,0 +1,97 @@
+# Scenario Authoring — Risk / Coverage-Gap Derivation
+
+> **Scope**: This framework governs scenarios the qa cycle **self-authors** for a QA REQUEST. It does not apply to caller-provided scenarios — those run verbatim, unchanged, exactly as handed in. Self-author scenarios are the ones this file teaches you to derive; the six-field shape and the three layers below exist to make derivation systematic instead of a mechanical sweep of the hostile-category matrix.
+
+Reading the changed code to derive scenarios and identify reproduction conditions is setup intelligence, not static audit. Static audit — comparing a document's claims against the code to produce findings (Security/Data-Integrity checklists, MUST-DO compliance tables, completeness prose) — stays `code-review`'s job. Here, reading code only feeds scenario derivation; every derived scenario is still proven by actual execution (curl / agent-browser / maestro / bash), never by reasoning on paper.
+
+---
+
+## Layer A — Risk / Coverage-Gap Derivation
+
+Derive scenarios from risk and coverage gaps, not from a fixed attack-category checklist alone. Three sub-steps, in order:
+
+### A1. Impact mapping
+
+For each change, map:
+- **Domain area** — which part of the system does this touch (dispenser control, program/recipe computation, payment, notification delivery, household/membership, auth, onboarding/consent)?
+- **Change type** — new logic, modified branch, config/flag toggle, schema/data shape change, integration point?
+- **High-risk-domain weighting** — weight the scenario set toward domains where a silent failure is expensive or hard to detect after the fact: payment, notification, dispenser/device, auth, and household/membership carry more derivation weight than a purely cosmetic UI change.
+
+### A2. Coverage-gap judgment
+
+For each candidate scenario, ask explicitly: **does automation / e2e already catch this?** If an existing automated test or e2e suite already exercises this exact path with equivalent assertions, it is not a coverage gap — do not re-author it as a self-authored scenario. Derivation exists to fill the gap between what automation proves and what a real user/attacker/operator path would actually exercise, not to duplicate what is already proven.
+
+### A3. Risk priority (H/M/L)
+
+Assign each surviving scenario a `H/M/L` priority based on the impact-mapping weight and the coverage-gap judgment: a high-risk domain with no automated coverage is `H`; a moderate-risk domain with partial coverage is `M`; a low-risk, low-blast-radius path with some existing coverage is `L`. Priority governs derivation output, not a depth budget — every derived scenario still gets a full six-field shape (see below) regardless of its priority letter.
+
+**Applicability note**: impact mapping is not gated by "is this surface user-facing." A change that looks purely internal — logic hidden behind a feature flag, a resolver inside payment or notification, a permission/state-transition branch — still gets impact-mapped and derived if it touches a risk surface. Only a genuinely inert internal refactor that touches no risk surface is skipped.
+
+---
+
+## Layer B — Reproduction Conditions
+
+Every derived scenario needs a reproduction gate: the condition that must hold for the scenario to actually manifest, identified from the changed code itself (setup intelligence, not static audit).
+
+Reproduction-gate categories:
+
+| Category | Examples |
+|----------|----------|
+| **Feature flag + time window** | global / group / user-level override, KST/UTC-scoped rollout window |
+| **Env · deploy** | stg vs prd, canary vs full rollout, migration-not-yet-run state |
+| **Account · state · role** | owner vs payer household role, subscription state, onboarding/consent stage |
+| **Device · mobile** | dispenser firmware version, simulator vs real device, OS/app version skew |
+| **Time · async** | KST/UTC boundary, delayed/async job completion, race between two async paths |
+
+**Explicit "none" rule**: when no gate applies to a scenario — it reproduces unconditionally, every time, on any account/state/time — write the gate field as the literal word `none`. An empty or omitted gate value is forbidden. Silence about the gate is not the same claim as "no gate exists"; a missing field reads as an oversight, while `none` reads as a checked and confirmed absence.
+
+---
+
+## Layer C — Actor
+
+Name the actor for every derived scenario. The actor is who is performing the steps, and it changes what "expected" means:
+
+- **Normal user** — following the intended path, no ill intent, may still hit an edge case.
+- **Malicious user** — actively trying to break, bypass, or exploit the change.
+- **Careless user** — ignores instructions, skips fields, pastes garbage, double-clicks, retries impatiently.
+- **Specific role** — a named role in the system (household owner vs payer, admin vs member) whose permissions or state the scenario specifically probes.
+
+Every scenario must name its actor explicitly — do not leave it implicit as "the user."
+
+---
+
+## Unified Scenario Shape
+
+Every self-authored scenario is written in this six-field shape, in this order:
+
+`actor · preconditions · steps · expected · why-needed · priority`
+
+1. **actor** — from Layer C.
+2. **preconditions** — the reproduction gate from Layer B (or the literal `none`).
+3. **steps** — the concrete action sequence to execute.
+4. **expected** — the observable outcome that proves pass or fail.
+5. **why-needed** — **mandatory.** States the reason this scenario exists — mostly "what automation/e2e already misses" from the Layer A2 coverage-gap judgment. A scenario without a `why-needed` field is incomplete; this is what separates a derived scenario from a mechanically-generated one.
+6. **priority** — the `H/M/L` value from Layer A3.
+
+Omitting any of the six fields, or leaving `why-needed` blank, makes the scenario non-conformant — go back and fill it before running it.
+
+---
+
+## Worked Example (algocare high-risk domain)
+
+**Change**: a new discount-percentage branch in the payment checkout flow, gated behind a feature flag rolled out to a `group` cohort during a KST business-hours time window (09:00–18:00 KST), affecting Smart Subscription resupply orders.
+
+- **actor**: specific role — a household `payer` (not the `owner`) completing a Smart Subscription resupply checkout.
+- **preconditions**: `feature flag` = `payment.discount_v2` enabled for the payer's cohort group; `time window` = request issued at 17:55 KST (5 minutes before the window closes) to probe the boundary.
+- **steps**: log in as the payer, trigger a Smart Subscription resupply checkout while the flag is enabled and the clock is inside the window, then repeat the same checkout request 6 minutes later (after 18:00 KST, window closed).
+- **expected**: the discount applies and the payment succeeds at 17:55 KST; at 18:06 KST the discount no longer applies and the checkout falls back to full price without erroring or double-charging.
+- **why-needed**: the existing payment e2e suite only exercises the flag-enabled, mid-window case — it never asserts the flag/window boundary transition, so a silent "discount still applies after the window closes" bug (double-honoring an expired promotion) would ship undetected.
+- **priority**: `H` — payment + feature-flag + time-window intersection, no existing automated coverage of the boundary transition.
+
+(The same shape applies to a dispenser-surface example — e.g., a `feature flag` + `time window`-gated firmware behavior change — or a notification-surface example — e.g., a flag-gated reminder message rollout that must not double-send across a KST/UTC boundary. Instantiate all six fields and a real gate the same way.)
+
+---
+
+## Breadth Then Depth
+
+Author in two passes, in this order. **Breadth first**: walk Layer A → B → C for the change under review to derive the full set of risk-covering scenarios — this is what guarantees the scenario set covers the risk surface, not just the files that changed. **Depth second**: once a scenario is derived with its six fields, subject it to the 6-category `Adversarial Scenario Matrix` in `stage3-handson.md` — that matrix is the hostile-**depth** dimension applied to each scenario this file derives, not a replacement for derivation. Do not skip straight to the matrix on an undifferentiated changed-file list; derive first, then harden each derived scenario against the matrix's categories.

--- a/skills/qa/stage3-handson.md
+++ b/skills/qa/stage3-handson.md
@@ -12,14 +12,17 @@ Verify user-facing behavior by actually running the changed code. This is not op
 
 ### Decision Logic
 
+The applicability gate is not "is the surface user-facing?" — it is **does the change touch a risk surface?** A change with no UI/API entry point can still touch a risk surface (a feature-flag-gated branch, a payment/notification resolver internal, a permission/state-transition path) and must not be waved through on "internal-only" grounds alone. Only a change that touches no risk surface at all — a genuinely inert pure refactor — is safe to skip.
+
 | Signal in Prompt | Change Type | Action |
 |------------------|-------------|--------|
 | API endpoint, route, handler, REST, HTTP | API | Verify with `curl` |
 | UI, page, component, frontend, render | Frontend | Verify with `agent-browser` (fallback: `playwright`) |
 | Mobile, app, iOS, Android, simulator, emulator | Mobile | Verify with `maestro` |
 | CLI command, terminal output, TUI, interactive | CLI / TUI | Verify with interactive Bash |
-| Refactoring, internal logic, utility, helper, config | Internal only | **Skip ADVERSARIAL E2E** — unless caller-provided executable scenarios are present; in that case, run them verbatim (no adversarial matrix — non-user-facing surface) |
-| Documentation, markdown, comments only | Non-code | **Skip ADVERSARIAL E2E** — unless caller-provided executable scenarios are present; in that case, run them verbatim (no adversarial matrix — non-user-facing surface) |
+| Feature-flag-gated logic, payment/notification resolver internals, permission/state-transition branch — no direct UI/API entry point but touches a **risk surface** | Internal / risk surface | Do NOT skip — derive scenarios via [scenario-authoring.md] Layer A→B→C, then verify hands-on |
+| Refactoring, internal logic, utility, helper, config that touches **no risk surface** (pure refactor, no behavior/branch change) | Internal only | **Skip ADVERSARIAL E2E** — unless caller-provided executable scenarios are present; in that case, run them verbatim (no adversarial matrix — no risk surface touched) |
+| Documentation, markdown, comments only | Non-code | **Skip ADVERSARIAL E2E** — unless caller-provided executable scenarios are present; in that case, run them verbatim (no adversarial matrix — no risk surface touched) |
 
 ### When Multiple Types Apply
 
@@ -278,11 +281,11 @@ Skip teardown only when boot was idempotent and the device was reused, not creat
 
 **Applicability:** [API / Frontend / Mobile / CLI / SKIPPED (reason)]
 
-| Verification | Status | Details |
-|--------------|--------|---------|
-| Server start | PASS / FAIL | [startup details] |
-| [Endpoint/Page/Command] | PASS / FAIL | [response/behavior summary] |
-| Server stop | PASS / FAIL | [cleanup details] |
+| Verification | Why-Needed | Status | Details |
+|--------------|-----------|--------|---------|
+| Server start | - | PASS / FAIL | [startup details] |
+| [Endpoint/Page/Command] | [why this scenario exists — the coverage gap it fills, from the derived scenario's `why-needed` field] | PASS / FAIL | [response/behavior summary] |
+| Server stop | - | PASS / FAIL | [cleanup details] |
 
 **ADVERSARIAL E2E Result:** PASS -> Proceed to CHECK / FAIL -> REQUEST_CHANGES / SKIPPED -> Proceed to CHECK
 ```
@@ -318,6 +321,8 @@ If ANY verification fails:
 
 ## Adversarial Scenario Matrix
 
+This matrix is the **hostile-depth** dimension of scenario verification — it is not where scenario derivation starts. Scenarios are first derived by **breadth** in [scenario-authoring.md]: walk that framework's Layer A → B → C for the change under review to produce the full six-field scenario set (`actor · preconditions · steps · expected · why-needed · priority`) covering the risk surface. Only after breadth derivation is done does **depth** apply — subject each derived scenario to the rows below as the hostile attack layer. Breadth first, depth second: do not skip straight to this matrix on an undifferentiated changed-file list.
+
 Hands-on verification is not "run the happy path once." A change is only verified when it survives hostile probing. When running these checks, adopt the mindset of a malicious or careless user: someone who ignores documentation, pastes garbage data, skips required fields, and actively tries to confuse or break the system. After the modality procedures above confirm the happy path, run the adversarial checks below. Each category names what a hostile check looks like so a verifier running hands-on knows what to probe — pick the rows that apply to the change under review and actually execute them, do not reason about them on paper.
 
 | # | Category | What the adversarial check probes |
@@ -328,3 +333,6 @@ Hands-on verification is not "run the happy path once." A change is only verifie
 | 4 | **Interruption–cancel–resume + dirty initial state** | Kill or cancel the operation mid-flight, then re-run it; trigger concurrent executions, rapid repeated calls, and out-of-order sequencing; also start it from a dirty/partial prior state (leftover lock file, half-written record, stale session). Assert it recovers to a consistent state rather than compounding corruption. |
 | 5 | **Misleading success** (OWASP LLM09) | Distrust a green check / `200` / `"done"` that does not reflect real success. Verify the *actual effect* — the row was written, the file changed on disk, the message was delivered — not the success signal the system reports. An overconfident success claim is itself the bug. |
 | 6 | **Idempotency / re-run** | Run the operation twice with identical inputs and assert no duplicate records, double charges, or corruption. **By-design exception**: some operations are intentionally non-idempotent (append-only logs, "send another reminder", incrementing counters). When the spec marks an operation as intended to differ on re-run, repeated effects are an acceptable exception, not a defect — confirm against the intended behavior rather than flagging it. |
+| 7 | **stale-state** (source vs. packaged / build-artifact staleness) | Verify against the actually deployed/packaged artifact — build cache, bundled dist, compiled binary, container image — not just the source tree; a source-correct change can still ship stale bytes. This is distinct from row 4: row 4 is a dirty *runtime* state (a corrupted mid-operation record inside the running system); row 7 is stale *build artifacts* (the wrong bytes were packaged/deployed in the first place). |
+| 8 | **dirty-worktree** (git / harness debris) | Check the repo/worktree the verification run itself leaves behind — a stray test file, an uncommitted debug print, a leftover git stash, a temporary branch the harness created. Temporary-harness debris is not a product defect, but it must be noticed and cleaned up, not silently committed. This is distinct from row 4: row 4 is dirty *application* state; row 8 is debris the *harness/verifier* leaves in the repo. |
+| 9 | **flaky-rerun** (non-deterministic pass/fail) | Run the identical check 2-3 times with identical inputs and assert the pass/fail verdict is stable across runs. A verdict that flips between runs (race condition, order-dependent test, timing-sensitive assertion) is itself a defect. This is distinct from row 6: row 6 asks whether re-running produces duplicate/corrupted *effects*; row 9 asks whether re-running produces a consistent *verdict* on the same effects. |

--- a/skills/qa/tests/scenario-authoring-derivation-scenario.md
+++ b/skills/qa/tests/scenario-authoring-derivation-scenario.md
@@ -1,0 +1,127 @@
+# Scenario Authoring Derivation — Applicability Discrimination + Field-Shape Rubric
+
+**Purpose**: RED-phase test for the qa skill's scenario-authoring framework (`skills/qa/scenario-authoring.md`, Layer A/B/C + the six-field `actor · preconditions · steps · expected · why-needed · priority` shape). It measures whether a verifier that self-authors scenarios for a QA REQUEST actually (1) derives scenarios for an internal-but-risky, feature-flag-gated change while correctly skipping a pure refactor on the same surface, and (2) fills every derived scenario's `actor`, `why-needed`, and reproduction-gate fields per the framework's requirements — rather than mechanically sweeping a hostile-category checklist or authoring scenarios for code that carries no risk.
+
+**Origin**: qa scenario-authoring derivation framework (`skills/qa/scenario-authoring.md`, Layer A "Applicability note" + Layer B "Explicit none rule" + Layer C actor taxonomy + "Unified Scenario Shape"). Human/agent-run documentation form; no automated Claude-API harness exists in this repo — this asset, together with the automated `SKILL.test.ts` regression guard covering the framework's static shape, substitutes for the plan's behavioral AC1 (see `Substitution Note` below). This asset mirrors the structure of `skills/qa/tests/regression-capture-scenario.md`: staged code change(s) + a Scenario Prompt handed verbatim to a fresh subagent + expected verdict with-and-without the mechanism + human-scored compliance rubric.
+
+---
+
+## Architecture Intent
+
+The failure mode this scenario targets has two layers, and they are **not equally weighted**.
+
+The **primary** failure mode is misjudged applicability: a verifier that either (a) skips deriving scenarios for a change that only *looks* internal — a resolver hidden behind a feature flag, invoked from a scheduler, never touched by a UI — because it never made it past a superficial "is this user-facing" filter, or (b) over-eagerly authors scenarios for a change that carries no risk at all, such as a pure refactor, diluting the scenario set with noise and burning verification budget on nothing. `scenario-authoring.md`'s Layer A1/A3 "Applicability note" exists precisely to prevent both: impact-mapping is not gated by surface visibility, but a genuinely inert refactor is still skipped.
+
+The **secondary** failure mode is field-shape drift: a derived scenario that omits its `actor`, leaves `why-needed` blank, or never names its reproduction gate (or the literal `none`). This is graded too, but it is deliberately weighted below applicability-discrimination, because the **old** (pre-framework) guidance already seeds a generic actor ("malicious or careless user") and an implied why-needed ("to find security/robustness gaps") by default — a verifier that never adopted the new framework at all can still limp through a field-presence check by reusing that old boilerplate. Field-presence alone is therefore a soft, easily-gamed signal; a verifier could paste the same generic actor/why-needed onto every scenario, including ones for the pure refactor, and still pass a naive field-presence check. Applicability-discrimination cannot be gamed the same way: it requires the verifier to have actually read the two code changes below, recognized which one sits inside a real risk domain (notification delivery, gated by a feature flag and a KST time window), and recognized which one changes nothing observable at all.
+
+---
+
+## How to Run
+
+**Trigger**: run this rubric before or after editing `skills/qa/scenario-authoring.md` or the Stage 3 `Adversarial Scenario Matrix` in `stage3-handson.md` — any change to either file can silently shift derivation behavior, and this doc is how that drift gets caught since no automated harness exercises it.
+
+1. Spawn a **fresh subagent** (no memory of this test's design) with the qa skill loaded, or paste the scenario to a clean top-level session.
+2. Hand it the **Sample QA REQUEST** below verbatim — both code changes, unlabeled as "risky" or "refactor." Do not tell it which one warrants scenarios; that judgment is exactly what is being measured.
+3. Let it run its normal scenario-authoring pass (Layer A → B → C, breadth before depth) and produce its self-authored scenario set.
+4. Apply the **Compliance Rubric** to the scenarios it produces.
+5. Compare against **Expected Verdicts** to confirm the test still reproduces the discrimination/field-shape failure (RED) or that the framework is honored (GREEN).
+
+**Test discipline**: do not hint which of the two changes is the risky one. If the verifier authors scenarios for both, or for neither, or authors thin/generic scenarios for the risky one while skipping the field-shape entirely, record that as the measurement — not as a mis-run of the test.
+
+---
+
+## Sample QA REQUEST
+
+Hand this to the subagent verbatim, together with both code changes:
+
+> algocare Home App 백엔드에 두 개의 변경사항이 있어. 둘 다 같은 PR에 포함돼 있는데, QA 시나리오를 자체적으로 도출해서 검증해줘.
+
+### Change 1 — evening restock reminder, feature-flag + KST time-window gated (notification surface)
+
+```ts
+// src/notifications/eveningReminder.ts
+async function maybeSendEveningReminder(user: User): Promise<void> {
+  if (!isFlagEnabled('notification.evening_reminder_v2', user.cohortGroup)) {
+    return;
+  }
+  const nowKst = toKst(new Date());
+  if (nowKst.hour < 20 || nowKst.hour >= 22) {
+    return; // outside 20:00-22:00 KST rollout window
+  }
+  if (user.stockDaysRemaining > 3) {
+    return;
+  }
+  await sendPush(user.deviceToken, buildRestockReminderPayload(user));
+}
+```
+
+This is a new gate on an existing notification path: previously `maybeSendEveningReminder` only checked `stockDaysRemaining`; this change adds a `notification.evening_reminder_v2` feature-flag cohort check and a 20:00–22:00 KST time-window check, as part of a staged rollout to a `group` cohort. There is no UI change — this function is invoked from a backend scheduler, not from any screen a designer touched. It looks internal. It is not risk-free: notification delivery is a high-risk domain (silent double-send or silent non-delivery across the flag/window boundary is hard to detect after the fact), and the change introduces exactly the `feature flag + time window` reproduction-gate category Layer B names.
+
+### Change 2 — restock reminder payload builder, pure refactor (no behavior change)
+
+```diff
+ // src/notifications/templates.ts
+ function buildRestockReminderPayload(user: User) {
+-  return { title: '리필이 필요해요', body: `${user.name}님, 재고가 얼마 남지 않았어요.` };
++  const title = '리필이 필요해요';
++  const body = `${user.name}님, 재고가 얼마 남지 않았어요.`;
++  return { title, body };
+ }
+```
+
+This extracts two local variables before returning the same object literal. No branch, no condition, no gate, no externally observable difference — the function returns byte-identical output for every input, before and after. There is no feature flag, no time window, no role, no state transition; it is a genuinely inert internal refactor, the one case Layer A1's Applicability note says to skip.
+
+---
+
+## Compliance Rubric
+
+Score each line from the verifier's self-authored scenario set. Score: PASS / PARTIAL / FAIL.
+
+### Primary — Applicability discrimination (the rubric's teeth)
+
+| # | Category | Observable Signal (PASS) | Failure Signal (FAIL) |
+|---|----------|---------------------------|------------------------|
+| P1 | **Risky-but-internal change gets scenarios** — Change 1 (feature-flag + KST-window gated notification) yields at least one derived scenario | Verifier derives ≥1 scenario for `maybeSendEveningReminder`, addressing the flag-cohort and/or the 20:00/22:00 KST boundary. | Verifier produces zero scenarios for Change 1, reasoning (explicitly or by omission) that it is "internal" or "not user-facing" and therefore out of scope. |
+| P2 | **Pure refactor gets skipped** — Change 2 (variable-extraction refactor) yields zero derived scenarios | Verifier explicitly states or visibly treats Change 2 as out of scope for scenario derivation — no behavior changed, nothing to reproduce. | Verifier authors one or more scenarios for Change 2 (e.g., re-testing that the payload still contains the same title/body), diluting the scenario set with a scenario that proves nothing new. |
+| P3 | **Discrimination is reasoned, not coincidental** — the verifier's own stated reasoning distinguishes the two changes on risk/gate/behavior grounds | Verifier's visible reasoning names the feature flag + time window as the reason Change 1 warrants scenarios, and names "no behavior change" / "no gate" as the reason Change 2 does not. | Verifier reaches the correct P1/P2 outcome by accident (e.g., only derives scenarios for the file it happened to read first) without stating the applicability distinction. |
+
+### Secondary — Field-shape presence (soft signal, gameable by old-guidance boilerplate)
+
+| # | Category | Observable Signal (PASS) | Failure Signal (FAIL) |
+|---|----------|---------------------------|------------------------|
+| S1 | **Actor named from taxonomy** | Every derived scenario for Change 1 names an actor from Layer C's taxonomy (normal user / malicious user / careless user / specific role) — e.g., "normal user, household owner, evening notification recipient." | A scenario leaves the actor implicit ("the user"), or reuses the generic old-guidance actor ("malicious or careless user") without adapting it to the notification-cohort context. |
+| S2 | **`why-needed` non-empty and coverage-gap-grounded** | Every derived scenario states a `why-needed` that names a concrete coverage gap — e.g., "existing notification e2e never asserts the flag/window boundary transition." | `why-needed` is blank, or is a generic placeholder ("to check security") not tied to what automation actually misses for this change. |
+| S3 | **Reproduction gate identified, or explicit `none`** | Every derived scenario for Change 1 names `feature flag = notification.evening_reminder_v2` + `time window = 20:00-22:00 KST` (or the specific boundary instant it probes) as its precondition/gate. | Gate field is omitted, left blank, or vaguely stated ("some flag is involved") instead of naming the specific flag and window. |
+
+**GREEN requires**: every self-authored scenario (for Change 1) satisfies S1 + S2 + S3 — this is the field-presence baseline from `MUST DO` (b). But GREEN on S1–S3 alone, with P1/P2/P3 FAILing, is **not** sufficient for an overall GREEN verdict — see Expected Verdicts.
+
+---
+
+## Expected Verdicts
+
+**WITH the applicability-discrimination + field-shape framework honored → GREEN.**
+
+The verifier reads both changes, recognizes that Change 1 sits inside the notification risk domain and carries a real `feature flag + time window` gate despite having no UI surface (P1, P3 PASS), and recognizes Change 2 as a behavior-preserving refactor that earns no scenarios (P2 PASS). Every scenario it derives for Change 1 names its actor from the taxonomy, states a concrete `why-needed`, and names the flag + window gate explicitly (S1–S3 PASS). This is the target state: the framework's Layer A "Applicability note" and the six-field shape are both doing real work, not decorative compliance.
+
+**WITHOUT the mechanism → RED, in either of two failure shapes.**
+
+*Shape 1 (applicability failure, primary)*: the verifier either skips Change 1 because it looks internal/backend-only ("no UI, no scenarios needed" — P1 FAILs), or wastes derivation effort re-scenario-ing Change 2's inert refactor (P2 FAILs). Either failure means the discrimination the framework's Applicability note exists to produce did not happen — this is the dominant failure mode this test is built to catch, regardless of how S1–S3 score.
+
+*Shape 2 (field-shape failure, secondary)*: the verifier does correctly derive scenarios only for Change 1, but those scenarios carry a generic, unadapted actor ("malicious or careless user," verbatim from old guidance) and/or an empty or boilerplate `why-needed`, and/or never name the specific flag + window gate (S1/S2/S3 FAIL) — even though P1–P3 pass. This is a real failure but a softer one: it indicates the framework's mechanics were not fully adopted even though the risk judgment landed correctly by other means (e.g., old guidance's default actor happened to still be present).
+
+A verdict is only GREEN when **both** the primary (P1, P2, P3) and secondary (S1, S2, S3) rows pass. A verdict where only S1–S3 pass while P1 or P2 fails must be scored RED — field-presence alone is not proof the new derivation framework is in effect, per the weighting stated in Architecture Intent.
+
+---
+
+## Substitution Note
+
+This document, together with the automated `SKILL.test.ts` regression guard that asserts `scenario-authoring.md`'s static shape (Layer A/B/C headings, the six-field list, the "Explicit none rule" text) is present and unmodified, substitutes for the plan's behavioral AC1. No automated Claude-API harness exists in this repo capable of actually invoking a subagent, observing its self-authored scenario set, and scoring applicability discrimination — that judgment can only be exercised by a human or agent reading a live subagent's output against the rubric above. `SKILL.test.ts` proves the framework's text has not silently regressed; this document proves (when someone actually runs it) that the framework's text produces the intended behavior.
+
+---
+
+## Notes
+
+- Documentation-only and human-run. Not wired into `make test` — there is no automated Claude-API harness in this repo to drive a live subagent and score its output; a human or agent scores the rubric from the verifier's visible scenario output, exactly as a real reviewer would.
+- The two changes are staged as already-written code, not as a live diff the subagent must produce itself — this keeps the QA REQUEST deterministic and independent of any prior session's judgment about which files changed.
+- Do not add a third change, and do not label the two changes "risky" / "refactor" in the prompt handed to the subagent — the whole point is that the subagent must reach that discrimination on its own from reading the code, exactly as `scenario-authoring.md`'s Applicability note requires.
+- If `scenario-authoring.md`'s Applicability note or six-field shape is edited, re-run this rubric before relying on its RED/GREEN outcome — see `How to Run`'s trigger.


### PR DESCRIPTION
## 📌 Summary

qa 스킬의 시나리오 저작을 "6-범주 적대적 매트릭스 기계적 스윕"에서 **리스크/커버리지-갭 도출 프레임워크**로 강화합니다. 이제 qa는 actor·재현조건·why-needed·우선순위를 갖춘 고커버리지 시나리오를 **breadth로 먼저 도출**한 뒤, 기존 6-범주 매트릭스를 각 시나리오의 **hostile-depth 차원**으로 적용합니다. 매트릭스는 삭제가 아니라 **포섭**됩니다.

---

## 🔧 Changes

### `scenario-authoring.md` (신규) — 도출 프레임워크 (deep-module)

- **Layer A**: 영향매핑(도메인·변경유형·고위험 가중) → 커버리지-갭 판단("자동화가 이미 잡는가?") → H/M/L 우선순위
- **Layer B**: 재현 게이트 분류(feature flag+time window / env·deploy / account·role / device / time·async), 게이트 없을 시 **명시적 `none` 강제**(빈 값 금지)
- **Layer C**: actor 분류(normal / malicious / careless / specific role)
- 통합 **6필드 shape** `actor · preconditions · steps · expected · why-needed · priority`, why-needed **필수**
- breadth-then-depth 저작 루프 + algocare 고위험 예시(결제 flag+KST window)
- **self-author 전용** 스코프 명시(caller 제공 시나리오는 verbatim 유지)

**영향 범위**: 신규 참조 프로즈. qa 소비 에이전트의 self-author 행동에만 영향, 런타임/사이클/verdict 계약 불변.

### `stage3-handson.md` — 매트릭스 재프레이밍 + applicability 확장

- 6-범주 매트릭스를 **hostile-depth 차원**으로 재프레이밍(heading·6 원본 행 보존)
- 신규 3행 `stale-state`/`dirty-worktree`/`flaky-rerun`, 각 `distinct from row 4|6` 차별자로 MECE 보장
- applicability 게이트를 **"user-facing?" → "risk surface 접촉?"**으로 확장(순수 refactor는 여전히 skip)
- Output Format에 why-needed 슬롯

**영향 범위**: 기존 6행 검증 동작 불변, 내부-but-risky 변경(flag-gated 등)이 이제 skip되지 않고 도출 대상.

### `SKILL.md` — framing 제거 + 포인터 + 불변식

- 정적감사 framing 제거/완화(Overview·PLAN에서 제거, PRE-FLIGHT는 "narrow exception"으로 완화) — **PRE-FLIGHT 게이트 의미 보존**(behavior-invisible contract check / MUST-NOT-DO / B⊆A)
- PLAN 포인터 + ADVERSARIAL **breadth-then-depth 스파인** + Quick-Ref 링크
- Output Format six-field 슬롯 + caller-verbatim 불변식

**영향 범위**: frontmatter description·pinned 토큰 보존(트리거/캐시 안정). 사이클 phase 순서 불변.

### `SKILL.test.ts` — prose-contract 회귀 가드

- new-prose / strip(LIVE-string 타깃, genuine RED) / preserved / **structural-integrity(anchor-resolution)** 블록. scenario-authoring.md·stage3 두 파일 read 추가.

**영향 범위**: `make test`에 회귀 게이트 편입. 기존 pinned-token 단언 불변.

### `tests/scenario-authoring-derivation-scenario.md` (신규) — 수동 behavioral 루브릭

- 실제 게이트(feature flag+KST window)를 가진 sample QA REQUEST + 컴플라이언스 루브릭 + How-to-Run. `make test` 미편입(수동 문서) 명시.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.

### 1. no-Claude-API-harness 제약 하의 이중 검증층

**배경 및 문제 상황:** 원 스펙은 "behavioral RED→GREEN" 테스트를 요구합니다. 그러나 이 repo엔 서브에이전트를 실제로 구동해 산출물을 채점하는 Claude-API harness가 없습니다. prose-presence grep만으로 테스트하면 "어휘를 타이핑하는 순간 GREEN"이 되는 **null-RED 함정**에 빠집니다.

**해결 방안:** 두 층으로 분리. **자동층**(`SKILL.test.ts`)은 prose-contract 회귀 가드로 두되 정직하게 "behavioral 증명이 아님"이라 라벨합니다. **수동층**(`tests/scenario-authoring-derivation-scenario.md`)이 진짜 behavioral RED→GREEN을 담당합니다.

**구현 세부사항:** 자동층은 strip 단언을 LIVE 문자열에 겨눠 genuine RED를 보장하고(pre-edit에서 실제 실패), anchor-resolution 단언으로 포인터가 실재 heading으로 resolve됨을 기계적으로 검사합니다(단순 키워드 존재보다 고가치). plan-AC7(자동)+AC8(수동)이 spec-AC1(behavioral)을 대체합니다.

**선택과 트레이드오프:** 핵심 가치(고커버리지 시나리오 저작)에는 자동 behavioral 회귀 게이트가 **없습니다** — no-harness 제약의 본질적 결과로 knowingly 수용했고, 방어는 수동 루브릭+구조 assert입니다. Claude-API harness가 생기면 수동 루브릭을 자동 behavioral 테스트로 승격하는 게 follow-up입니다. **이 대체가 수용 가능한지 리뷰 요청.**

### 2. 프레임워크 두 축의 검증 비대칭 — field-shape는 검증됨, applicability-discrimination은 미검증 (open question)

**배경 및 문제 상황:** 이 프레임워크는 두 축을 강화합니다 — ① **field-shape**(모든 시나리오가 six-field를 갖도록) ② **applicability-discrimination**(surface 가시성이 아니라 risk-surface 접촉으로 도출 여부 판단). 수동 루브릭의 Architecture Intent는 ②를 "primary teeth"로 가중합니다.

**해결 방안:** 배포 후 subagent A/B(무압박 baseline, 동일 QA REQUEST·guidance만 상이)로 두 축을 실측했습니다.

**구현 세부사항:**
- **field-shape 축 = 검증됨.** control(옛 guidance) 0/N → treatment(새 guidance) N/N으로 깨끗이 분리, reps 강수렴. six-field 강제가 실제 행동을 만듭니다.
- **applicability-discrimination 축 = RED 재현 실패.** 유능한 baseline 에이전트는 "순수 backend, no UI"라 명시된 변경조차 다운스트림 리스크로 추적해 이미 in-scope로 판정합니다. 무압박 상태에선 "user-facing?" gate가 약한 strawman라 프레임워크 없이도 정답에 도달합니다.

**선택과 트레이드오프:** 루브릭이 "primary"로 주장한 축(②)의 가중치가 무압박 데이터와 **반대**입니다. 두 해석이 가능합니다 — (a) baseline gate가 약한 strawman이라 애초에 고칠 게 없다(micro-test 규칙: control이 실패 안 하면 고칠 게 없음), 또는 (b) applicability 실패는 time+exhaustion 압박 하에서만 유효(discipline/shortcut 실패 모드)라 pressure scenario로 재검해야 한다. **열린 질문: ②축을 pressure scenario로 재검할지, 아니면 루브릭의 "primary" 가중 주장을 하향할지 리뷰어 의견 요청.**

---

## ✅ Checklist

### 검증 (자동)
- [ ] `make validate` + `make test` 모두 exit 0
  - `Makefile`
- [ ] SKILL.md의 scenario-authoring.md 포인터가 실재 heading으로 resolve (anchor-resolution 블록 green)
  - `skills/qa/SKILL.test.ts`

### 매트릭스 포섭 (삭제 아님)
- [ ] `## Adversarial Scenario Matrix` heading + 6 원본 행 전부 보존
  - `skills/qa/stage3-handson.md`
- [ ] 신규 3행이 각각 올바른 원본 행으로 차별(stale-state→4, dirty-worktree→4, flaky-rerun→6)
  - `skills/qa/stage3-handson.md`

### 계약 불변식 보존
- [ ] PRE-FLIGHT 게이트 문구(behavior-invisible contract check / MUST-NOT-DO / B⊆A) 보존
  - `skills/qa/SKILL.md`
- [ ] frontmatter description + pinned 토큰(6범주 / stage3-handson.md / Adversarial Scenario Matrix) 불변
  - `skills/qa/SKILL.md`, `skills/qa/SKILL.test.ts`
- [ ] `stage1-commands.md`의 Linter/Static Analysis 미변경
  - `skills/qa/stage1-commands.md`
