### PR TITLE
feat: docs first-class 컴포넌트 타입 추가

### DIFF
--- a/tools/lib/backup.test.ts
+++ b/tools/lib/backup.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
-import { mkdtemp, mkdir, writeFile, readdir, stat, chmod } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, readFile, readdir, stat, chmod } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -7,6 +7,7 @@ import {
 	generateBackupSessionId,
 	backupCategory,
 	backupConfigFile,
+	backupDocs,
 	cleanupOldBackups,
 } from "./backup.ts";
 
@@ -191,6 +192,59 @@ describe("backup 모듈", () => {
 			} finally {
 				await chmod(targetPath, 0o755);
 			}
+		});
+	});
+
+	describe("backupDocs", () => {
+		it("docs backup before mutate: copies the target file into .sync-backup/{sessionId}/docs/<relpath> preserving subdirectories", async () => {
+			const deployRoot = join(tmpDir, "docs-backup-basic");
+			const sessionId = "docs-sess-01";
+			const relPath = join("skills", "prometheus", "SKILL.md");
+			const targetFilePath = join(deployRoot, relPath);
+
+			await mkdir(join(deployRoot, "skills", "prometheus"), { recursive: true });
+			await writeFile(targetFilePath, "# Original content");
+
+			await backupDocs(targetFilePath, deployRoot, sessionId);
+
+			const backedUpFile = join(deployRoot, ".sync-backup", sessionId, "docs", relPath);
+			const content = await readFile(backedUpFile, "utf-8");
+			expect(content).toBe("# Original content");
+		});
+
+		it("does nothing when the target file does not exist yet", async () => {
+			const deployRoot = join(tmpDir, "docs-backup-missing");
+			await mkdir(deployRoot, { recursive: true });
+			const targetFilePath = join(deployRoot, "docs", "new-file.md");
+
+			// Should not throw
+			await backupDocs(targetFilePath, deployRoot, "docs-sess-missing");
+
+			// No .sync-backup directory should be created
+			let exists = true;
+			try {
+				await stat(join(deployRoot, ".sync-backup"));
+			} catch {
+				exists = false;
+			}
+			expect(exists).toBe(false);
+		});
+
+		it("docs backup retention: cleanupOldBackups(deployRoot, 0) removes the docs session dir", async () => {
+			const deployRoot = join(tmpDir, "docs-backup-retention");
+			const sessionId = "docs-sess-retention";
+			const relPath = "readme.md";
+			const targetFilePath = join(deployRoot, relPath);
+
+			await mkdir(deployRoot, { recursive: true });
+			await writeFile(targetFilePath, "content");
+
+			await backupDocs(targetFilePath, deployRoot, sessionId);
+
+			await cleanupOldBackups(deployRoot, 0);
+
+			const remaining = await readdir(join(deployRoot, ".sync-backup"));
+			expect(remaining).toHaveLength(0);
 		});
 	});
 

--- a/tools/lib/backup.ts
+++ b/tools/lib/backup.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { cp, mkdir, rm, readdir, stat } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join, relative } from "node:path";
 import { logWarn } from "./logger.ts";
 
 /**
@@ -67,6 +67,26 @@ export async function backupConfigFile(filePath: string, backupDir: string): Pro
 	const destFile = join(backupDir, fileName);
 
 	await cp(filePath, destFile);
+}
+
+/**
+ * Backs up a single docs target file before it is overwritten or deleted.
+ * Source: targetFilePath
+ * Destination: {deployRoot}/.sync-backup/{sessionId}/docs/<relpath>
+ *   where <relpath> is targetFilePath's path relative to deployRoot
+ *   (subdirectory structure preserved).
+ * Per-file only (never a directory copy), reusing backupConfigFile.
+ * Skips silently if the target file does not exist yet.
+ */
+export async function backupDocs(
+	targetFilePath: string,
+	deployRoot: string,
+	sessionId: string,
+): Promise<void> {
+	const relPath = relative(deployRoot, targetFilePath);
+	const backupDir = join(deployRoot, ".sync-backup", sessionId, "docs", dirname(relPath));
+
+	await backupConfigFile(targetFilePath, backupDir);
 }
 
 /**

--- a/tools/lib/overlay-keys.test.ts
+++ b/tools/lib/overlay-keys.test.ts
@@ -14,6 +14,10 @@ describe("hasRegistry", () => {
 		expect(hasRegistry("rules.items")).toBe(true);
 	});
 
+	it("docs.items 경로는 등록됨", () => {
+		expect(hasRegistry("docs.items")).toBe(true);
+	});
+
 	it("permissions 경로들은 등록됨", () => {
 		expect(hasRegistry("permissions.allow")).toBe(true);
 		expect(hasRegistry("permissions.deny")).toBe(true);
@@ -71,6 +75,29 @@ describe("getIdentityKey", () => {
 		it("문자열 항목은 자기 자신이 키", () => {
 			expect(getIdentityKey("agents.items", "oracle")).toBe("oracle");
 			expect(getIdentityKey("skills.items", "prometheus")).toBe("prometheus");
+		});
+	});
+
+	describe("docs.items 경로", () => {
+		it("객체 항목은 component 필드를 키로 반환", () => {
+			expect(getIdentityKey("docs.items", { component: "x" })).toBe("x");
+		});
+
+		it("문자열 항목은 자기 자신이 키", () => {
+			expect(getIdentityKey("docs.items", "architecture")).toBe("architecture");
+		});
+
+		it("동일 component를 가진 두 docs 항목은 같은 키로 dedup되어 overlay가 우선함", () => {
+			const global = { component: "architecture", path: "global/architecture.md" };
+			const overlay = { component: "architecture", path: "project/architecture.md" };
+			expect(getIdentityKey("docs.items", global)).toBe(getIdentityKey("docs.items", overlay));
+
+			const merged = new Map<string, unknown>();
+			for (const entry of [global, overlay]) {
+				merged.set(getIdentityKey("docs.items", entry), entry);
+			}
+			expect(merged.size).toBe(1);
+			expect(merged.get("architecture")).toEqual(overlay);
 		});
 	});
 

--- a/tools/lib/overlay-keys.ts
+++ b/tools/lib/overlay-keys.ts
@@ -7,6 +7,7 @@ const EXACT_REGISTRY = new Map<string, KeyExtractor>([
 	["skills.items", syncItemsKey],
 	["scripts.items", syncItemsKey],
 	["rules.items", syncItemsKey],
+	["docs.items", syncItemsKey],
 	["permissions.allow", selfKey],
 	["permissions.deny", selfKey],
 	["permissions.ask", selfKey],

--- a/tools/lib/path-utils.test.ts
+++ b/tools/lib/path-utils.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from "bun:test";
 import os from "os";
 import path from "path";
-import { expandTilde, isGlobalSync } from "./path-utils.ts";
+import {
+	expandTilde,
+	isGlobalSync,
+	resolveDocsTarget,
+	assertDocsTargetContained,
+	detectDocsTargetCollisions,
+} from "./path-utils.ts";
 
 describe("expandTilde", () => {
 	it("`~` 단독을 os.homedir()로 확장한다", () => {
@@ -56,5 +62,135 @@ describe("isGlobalSync", () => {
 
 	it("리터럴 환경변수 문자열 $HOME은 false", () => {
 		expect(isGlobalSync("$HOME")).toBe(false);
+	});
+});
+
+describe("resolveDocsTarget", () => {
+	it("sectionPath 미지정 시 base는 'docs' — nested componentName은 서브패스를 보존한다", () => {
+		expect(resolveDocsTarget("skills/authoring", undefined, undefined, undefined)).toBe(
+			"docs/skills/authoring",
+		);
+	});
+
+	it("itemPath가 주어지면 base와 join되어 componentName을 오버라이드한다", () => {
+		expect(resolveDocsTarget("ignored-component", "docs", "custom/file", undefined)).toBe(
+			"docs/custom/file",
+		);
+	});
+
+	it("as가 주어지면 최종 세그먼트 이름만 교체한다 (rename)", () => {
+		expect(resolveDocsTarget("skills/authoring", undefined, undefined, "renamed")).toBe(
+			"docs/skills/renamed",
+		);
+	});
+
+	describe("docs traversal matrix", () => {
+		const cases: Array<{
+			name: string;
+			componentName: string;
+			sectionPath: string | undefined;
+			itemPath: string | undefined;
+			as: string | undefined;
+			outcome: "reject" | string;
+		}> = [
+			{
+				name: "escape — leading .. past root는 거부된다",
+				componentName: "x",
+				sectionPath: "docs",
+				itemPath: "../../etc/passwd",
+				as: undefined,
+				outcome: "reject",
+			},
+			{
+				name: "absolute — sectionPath 자체가 절대경로면 거부된다",
+				componentName: "x",
+				sectionPath: "/etc",
+				itemPath: undefined,
+				as: undefined,
+				outcome: "reject",
+			},
+			{
+				name: "equals-root — 정규화 결과가 deployRoot('.')이면 거부된다",
+				componentName: ".",
+				sectionPath: ".",
+				itemPath: undefined,
+				as: undefined,
+				outcome: "reject",
+			},
+			{
+				name: "empty — 정규화 결과가 빈 경로면 거부된다",
+				componentName: "",
+				sectionPath: "",
+				itemPath: undefined,
+				as: undefined,
+				outcome: "reject",
+			},
+			{
+				name: "contained-but-leaves-base — ../other/x는 base를 벗어나지만 root 안에 머물러 허용된다",
+				componentName: "ignored-component",
+				sectionPath: "docs",
+				itemPath: "../other/x",
+				as: undefined,
+				outcome: "other/x",
+			},
+		];
+
+		for (const c of cases) {
+			it(c.name, () => {
+				if (c.outcome === "reject") {
+					expect(() =>
+						resolveDocsTarget(c.componentName, c.sectionPath, c.itemPath, c.as),
+					).toThrow();
+				} else {
+					expect(resolveDocsTarget(c.componentName, c.sectionPath, c.itemPath, c.as)).toBe(
+						c.outcome,
+					);
+				}
+			});
+		}
+	});
+});
+
+describe("assertDocsTargetContained", () => {
+	it("leading ..은 deployRoot 탈출로 간주해 거부한다", () => {
+		expect(() => assertDocsTargetContained("../etc/passwd")).toThrow();
+	});
+
+	it("절대경로는 거부한다", () => {
+		expect(() => assertDocsTargetContained("/etc/passwd")).toThrow();
+	});
+
+	it("빈 문자열은 거부한다", () => {
+		expect(() => assertDocsTargetContained("")).toThrow();
+	});
+
+	it("'.'(deployRoot 자체와 동일)는 거부한다", () => {
+		expect(() => assertDocsTargetContained(".")).toThrow();
+	});
+
+	it("정상적인 상대경로는 통과시킨다", () => {
+		expect(() => assertDocsTargetContained("docs/skills/authoring")).not.toThrow();
+	});
+
+	it("base를 벗어나지만 root 안에 머무는 경로는 통과시킨다", () => {
+		expect(() => assertDocsTargetContained("other/x")).not.toThrow();
+	});
+});
+
+describe("detectDocsTargetCollisions", () => {
+	it("docs case collision — Foo.md와 foo.md는 fs 조회 없이 케이스충돌로 감지된다", () => {
+		const collisions = detectDocsTargetCollisions(["docs/Foo.md", "docs/foo.md"]);
+		expect(collisions.length).toBe(1);
+		expect(collisions[0].kind).toBe("case-collision");
+	});
+
+	it("docs duplicate target — 동일 target으로 resolve된 두 아이템은 duplicate로 감지된다", () => {
+		const collisions = detectDocsTargetCollisions(["docs/skills/a", "docs/skills/a"]);
+		expect(collisions.length).toBe(1);
+		expect(collisions[0].kind).toBe("duplicate");
+	});
+
+	it("충돌 없는 targets 집합은 빈 배열을 반환한다", () => {
+		expect(detectDocsTargetCollisions(["docs/a", "docs/b"])).toEqual([]);
 	});
 });

--- a/tools/lib/path-utils.ts
+++ b/tools/lib/path-utils.ts
@@ -26,3 +26,127 @@ export function expandTilde(p: string): string {
 export function isGlobalSync(targetPath: string): boolean {
 	return path.resolve(expandTilde(targetPath)) === path.resolve(os.homedir());
 }
+
+// ---------------------------------------------------------------------------
+// Docs component target resolution (purely lexical — no filesystem access)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute a `docs` component item's final deploy target, relative to deployRoot.
+ * POSIX-normalized, no leading `./`. Does not append a file extension — that's
+ * the caller's concern.
+ *
+ * Resolution:
+ *   base = sectionPath ?? "docs"
+ *   itemPath given  → path.join(base, itemPath), overriding componentName.
+ *                     itemPath is root-relative in the sense that `..` segments
+ *                     can walk it back out of base — as long as the joined,
+ *                     normalized result stays under deployRoot, that's allowed
+ *                     (containment is about deployRoot, not about base).
+ *   itemPath absent → path.join(base, componentName) — a nested componentName
+ *                     like "skills/authoring" preserves its subpath under base.
+ *   as given        → replace the final path segment's name with `as`.
+ *
+ * Throws (via assertDocsTargetContained) if the resolved target escapes
+ * deployRoot, is absolute, is empty, or equals deployRoot itself.
+ *
+ * Lexical only — no realpath/lstat. The FS-level symlink-escape guard for
+ * intermediate directories is a separate, later runtime-only task.
+ */
+export function resolveDocsTarget(
+	componentName: string,
+	sectionPath: string | undefined,
+	itemPath: string | undefined,
+	as: string | undefined,
+): string {
+	const base = sectionPath ?? "docs";
+	const joined =
+		itemPath !== undefined ? path.posix.join(base, itemPath) : path.posix.join(base, componentName);
+
+	const renamed = as !== undefined ? path.posix.join(path.posix.dirname(joined), as) : joined;
+
+	const target = path.posix.normalize(renamed);
+	assertDocsTargetContained(target);
+	return target;
+}
+
+/**
+ * Reject a docs deploy target that escapes deployRoot as a trust-boundary check.
+ * Lexical only (path.normalize) — no realpath/lstat/existsSync.
+ *
+ * Rejects a relTarget that, after path.normalize:
+ *   - has a leading `..` segment (escapes deployRoot)
+ *   - is absolute
+ *   - is empty
+ *   - normalizes to `.` (equals deployRoot itself)
+ *
+ * A `..` that merely leaves the docs *base* but stays strictly under
+ * deployRoot (e.g. base "docs" + itemPath "../other/x" → "other/x") is NOT
+ * rejected here — that check already happened via normalize before this is
+ * called; this function only cares about escaping deployRoot.
+ */
+export function assertDocsTargetContained(relTarget: string): void {
+	const normalized = path.posix.normalize(relTarget);
+
+	if (normalized === "" || normalized === ".") {
+		throw new Error(`docs target must not resolve to deployRoot itself: ${JSON.stringify(relTarget)}`);
+	}
+	if (path.posix.isAbsolute(normalized)) {
+		throw new Error(`docs target must be relative to deployRoot, got absolute path: ${JSON.stringify(relTarget)}`);
+	}
+	if (normalized === ".." || normalized.startsWith("../")) {
+		throw new Error(`docs target escapes deployRoot: ${JSON.stringify(relTarget)}`);
+	}
+}
+
+export type DocsTargetCollision = {
+	kind: "duplicate" | "case-collision";
+	targets: string[];
+};
+
+/**
+ * Detect collisions among resolved docs deploy targets, purely by string
+ * comparison — no filesystem probe — so the result is identical on
+ * case-sensitive (Linux) and case-insensitive (macOS) filesystems.
+ *
+ *   - "duplicate": two or more targets normalize to the exact same string.
+ *   - "case-collision": two or more targets normalize to the same string
+ *     only after lowercasing (i.e. differ only in case).
+ */
+export function detectDocsTargetCollisions(targets: string[]): DocsTargetCollision[] {
+	const byLower = new Map<string, string[]>();
+
+	for (const raw of targets) {
+		const normalized = path.posix.normalize(raw);
+		const lower = normalized.toLowerCase();
+		const bucket = byLower.get(lower);
+		if (bucket) {
+			bucket.push(normalized);
+		} else {
+			byLower.set(lower, [normalized]);
+		}
+	}
+
+	const collisions: DocsTargetCollision[] = [];
+
+	for (const group of byLower.values()) {
+		if (group.length < 2) continue;
+
+		const countByExact = new Map<string, number>();
+		for (const t of group) {
+			countByExact.set(t, (countByExact.get(t) ?? 0) + 1);
+		}
+
+		for (const [exact, count] of countByExact) {
+			if (count > 1) {
+				collisions.push({ kind: "duplicate", targets: Array(count).fill(exact) });
+			}
+		}
+
+		if (countByExact.size > 1) {
+			collisions.push({ kind: "case-collision", targets: [...countByExact.keys()] });
+		}
+	}
+
+	return collisions;
+}

--- a/tools/lib/resolver.ts
+++ b/tools/lib/resolver.ts
@@ -178,9 +178,14 @@ export function tryResolveInDir(dir: string, name: string, category: string): st
 	const filePath = join(dir, `${name}.md`);
 	if (existsSync(filePath)) return filePath;
 
-	// 2. Folder with index.md
-	const indexPath = join(dir, name, "index.md");
-	if (existsSync(indexPath)) return indexPath;
+	// 2. Folder with index.md → the single entry file (skills-style single-entry
+	//    convention). Excluded for `docs`: a docs directory deploys as a WHOLE
+	//    tree (additive per-file), so collapsing it to index.md would silently
+	//    drop sibling files/assets. docs falls through to (4) → the directory.
+	if (category !== "docs") {
+		const indexPath = join(dir, name, "index.md");
+		if (existsSync(indexPath)) return indexPath;
+	}
 
 	// 3. Skills-specific SKILL.md → return the containing directory
 	if (category === "skills") {

--- a/tools/lib/types.docs.test.ts
+++ b/tools/lib/types.docs.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "bun:test";
+
+import type { SyncYaml, DeployCategory, SourceCategory } from "./types.ts";
+
+describe("docs 타입 확장", () => {
+	it("DeployCategory는 docs를 포함하지 않고 SourceCategory는 docs를 포함한다", () => {
+		const d: DeployCategory = "skills";
+		const c: SourceCategory = "docs";
+		expect(d).toBe("skills");
+		expect(c).toBe("docs");
+	});
+
+	it("SyncYaml.docs는 string 아이템과 object 아이템을 모두 담을 수 있다", () => {
+		const sy: SyncYaml = {
+			docs: {
+				path: "docs",
+				items: ["readme", { component: "spec", path: "spec.md", as: "renamed-spec", delete: true }],
+			},
+		};
+
+		expect(sy.docs?.items?.length).toBeGreaterThan(0);
+	});
+});

--- a/tools/lib/types.ts
+++ b/tools/lib/types.ts
@@ -13,7 +13,12 @@ export type PluginObjectItem = {
 	"pre-commands"?: string[];
 };
 
-export type Category = "agents" | "commands" | "skills" | "scripts" | "rules";
+export type DeployCategory = "agents" | "commands" | "skills" | "scripts" | "rules";
+
+/** Backward-compat alias — existing consumers bind `Category`; keep resolving to the same union. */
+export type Category = DeployCategory;
+
+export type SourceCategory = DeployCategory | "docs";
 
 export type SyncItem =
 	| string
@@ -30,6 +35,13 @@ export type SyncSection = {
 	items?: SyncItem[];
 };
 
+export type DocsItem = string | { component: string; path?: string; as?: string; delete?: true };
+
+export type DocsSection = {
+	path?: string;
+	items?: DocsItem[];
+};
+
 export type ProvisionItem = {
 	check?: string;
 	commands: string[];
@@ -44,6 +56,7 @@ export type SyncYaml = {
 	skills?: SyncSection;
 	scripts?: SyncSection;
 	rules?: SyncSection;
+	docs?: DocsSection;
 	provision?: ProvisionItem[];
 };
 

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -8,6 +8,7 @@ const parseYaml = Bun.YAML.parse;
 import {
 	syncCategory,
 	syncPlatformConfigs,
+	syncDocs,
 	processYaml,
 	syncLib,
 	rewritePlatformPaths,
@@ -3519,5 +3520,733 @@ describe("component fan-out", () => {
 		await expect(
 			runProjectsLoop(rootDir, adapters, context, effectiveFilter, false),
 		).rejects.toBeInstanceOf(DeployTargetsError);
+	});
+
+	// ---------------------------------------------------------------------
+	// TODO 11 — syncDocs wired into processYaml's per-deployRoot fan-out
+	// ---------------------------------------------------------------------
+
+	// AC2.6 (part 1) — docs fans out to every resolved worktree, same as any
+	// other component type.
+	it("docs fan-out: deploys the doc into every worktree", async () => {
+		const { container, worktrees } = makeBareTopology("repo", ["wt1", "wt2"]);
+		await writeFile(path.join(rootDir, "docs", "intro.md"), "# Intro\n");
+
+		const syncYamlPath = path.join(rootDir, "sync.yaml");
+		await writeFile(syncYamlPath, `path: ${container}\ndocs:\n  items:\n    - intro\n`);
+
+		const adapters = new Map<Platform, PlatformAdapter>([
+			["claude", new ClaudeAdapter()],
+		]) as AdapterMap;
+		const context = makeContext({ dryRun: false });
+
+		await processYaml(context, syncYamlPath, adapters, rootDir);
+
+		expect(await readFile(path.join(worktrees[0]!, "docs", "intro.md"))).toBe("# Intro\n");
+		expect(await readFile(path.join(worktrees[1]!, "docs", "intro.md"))).toBe("# Intro\n");
+	});
+
+	// AC2.6 (part 2) — a project sync.yaml and the root sync.yaml resolving to
+	// the same worktree must deploy the doc exactly once. syncDocs adds no
+	// dedup of its own; it inherits the existing processedPaths mechanism for
+	// free because it runs inside processYaml's per-deployRoot loop, same as
+	// every other component type (mirrors the "Bug3" dedup test above).
+	it("docs fan-out: a project sync.yaml and root sync.yaml resolving to the same worktree deploy the doc once", async () => {
+		const { container, worktrees } = makeBareTopology("repo", ["wt1"]);
+		await writeFile(path.join(rootDir, "docs", "intro.md"), "# Intro\n");
+
+		const projDir = path.join(rootDir, "projects", "proj-a");
+		await fs.mkdir(projDir, { recursive: true });
+		await writeFile(
+			path.join(projDir, "sync.yaml"),
+			`path: ${container}\nname: proj-a\ndocs:\n  items:\n    - intro\n`,
+		);
+
+		const adapters = new Map<Platform, PlatformAdapter>([
+			["claude", new ClaudeAdapter()],
+		]) as AdapterMap;
+		const context = makeContext({ dryRun: false });
+		const effectiveFilter = resolveProjectFilter(new Set(), undefined);
+
+		// Projects phase: deploys the doc into the container's worktree.
+		await runProjectsLoop(rootDir, adapters, context, effectiveFilter, false);
+
+		expect(await readFile(path.join(worktrees[0]!, "docs", "intro.md"))).toBe("# Intro\n");
+
+		// Root phase dedup: a sync.yaml whose path resolves to the same worktree
+		// is already processed, so the CLI skips calling processYaml (and thus
+		// syncDocs) again for it — single deploy.
+		expect(allTargetsProcessed(worktrees[0]!, context.processedPaths)).toBe(true);
+	});
+
+	// AC2.2 — a docs-only sync.yaml (no agents/skills/etc.) still deploys its
+	// docs: proves the call site is NOT gated behind shouldMkdirClaude.
+	it("docs-only deploys: a sync.yaml with only a docs section still deploys, with no .claude gate", async () => {
+		const plainTarget = path.join(tmpDir, "docs-only-target");
+		await fs.mkdir(plainTarget, { recursive: true });
+		await writeFile(path.join(rootDir, "docs", "intro.md"), "# Intro\n");
+
+		const syncYamlPath = path.join(rootDir, "sync.yaml");
+		await writeFile(syncYamlPath, `path: ${plainTarget}\ndocs:\n  items:\n    - intro\n`);
+
+		const adapters = new Map<Platform, PlatformAdapter>([
+			["claude", new ClaudeAdapter()],
+		]) as AdapterMap;
+		const context = makeContext({ dryRun: false });
+
+		await processYaml(context, syncYamlPath, adapters, rootDir);
+
+		expect(await readFile(path.join(plainTarget, "docs", "intro.md"))).toBe("# Intro\n");
+		// No component sections and no claude.yaml → shouldMkdirClaude is false;
+		// docs must still deploy without a .claude/ directory ever appearing.
+		expect(await exists(path.join(plainTarget, ".claude"))).toBe(false);
+	});
+
+	// AC2.1 — a syncDocs throw routes the whole worktree to failedTargets, same
+	// as any other deploy-step failure in the per-deployRoot try/catch.
+	it("docs failure routes failedTargets: a syncDocs throw records the worktree as failed", async () => {
+		const { worktrees } = makeBareTopology("repo", ["wt1"]);
+
+		// Two items resolving to the identical real leaf trip syncDocs's
+		// pre-flight collision guard — a clean, deterministic way to force a
+		// docs failure without touching fs modes. The collision check now keys
+		// off the REAL leaf (post-extension), so the source must actually exist
+		// for both items to resolve and collide.
+		await writeFile(path.join(rootDir, "docs", "intro.md"), "# Intro\n");
+		const container = path.dirname(worktrees[0]!);
+		const syncYamlPath = path.join(rootDir, "sync.yaml");
+		await writeFile(syncYamlPath, `path: ${container}\ndocs:\n  items:\n    - intro\n    - intro\n`);
+
+		const adapters = new Map<Platform, PlatformAdapter>([
+			["claude", new ClaudeAdapter()],
+		]) as AdapterMap;
+		const context = makeContext({ dryRun: false });
+
+		await processYaml(context, syncYamlPath, adapters, rootDir);
+
+		expect(context.failedTargets).toContain(worktrees[0]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Suite: syncDocs
+// ---------------------------------------------------------------------------
+
+describe("syncDocs", () => {
+	let tmpDir: string;
+	let rootDir: string;
+	let deployRoot: string;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "sync-docs-test-"));
+		rootDir = path.join(tmpDir, "root");
+		deployRoot = path.join(tmpDir, "deploy");
+		await fs.mkdir(rootDir, { recursive: true });
+		await fs.mkdir(deployRoot, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("is a no-op when the docs section is absent", async () => {
+		const syncYaml: SyncYaml = { path: deployRoot };
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await exists(path.join(deployRoot, "docs"))).toBe(false);
+	});
+
+	it("is a no-op when docs.items is empty", async () => {
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: [] } };
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await exists(path.join(deployRoot, "docs"))).toBe(false);
+	});
+
+	// --- AC2.3: docs path/as resolution ---
+
+	it("docs path/as resolution: deploys under the default 'docs' base for a plain string item", async () => {
+		await writeFile(path.join(rootDir, "docs", "intro.md"), "# Intro\n");
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["intro"] } };
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await readFile(path.join(deployRoot, "docs", "intro.md"))).toBe("# Intro\n");
+	});
+
+	it("docs path/as resolution: item `path` can walk back out of the section base while staying under deployRoot", async () => {
+		await writeFile(path.join(rootDir, "docs", "intro.md"), "# Intro\n");
+		const syncYaml: SyncYaml = {
+			path: deployRoot,
+			docs: { items: [{ component: "intro", path: "../top-level.md" }] },
+		};
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await readFile(path.join(deployRoot, "top-level.md"))).toBe("# Intro\n");
+		expect(await exists(path.join(deployRoot, "docs", "intro.md"))).toBe(false);
+	});
+
+	it("docs path/as resolution: `as` renames the final file segment", async () => {
+		await writeFile(path.join(rootDir, "docs", "intro.md"), "# Intro\n");
+		const syncYaml: SyncYaml = {
+			path: deployRoot,
+			docs: { items: [{ component: "intro", as: "README" }] },
+		};
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await readFile(path.join(deployRoot, "docs", "README.md"))).toBe("# Intro\n");
+	});
+
+	it("docs path/as resolution: `as` renames a dir-form target directory", async () => {
+		await writeFile(path.join(rootDir, "docs", "guide", "a.md"), "# A\n");
+		await writeFile(path.join(rootDir, "docs", "guide", "b.md"), "# B\n");
+		const syncYaml: SyncYaml = {
+			path: deployRoot,
+			docs: { items: [{ component: "guide", as: "renamed-guide" }] },
+		};
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await readFile(path.join(deployRoot, "docs", "renamed-guide", "a.md"))).toBe("# A\n");
+		expect(await readFile(path.join(deployRoot, "docs", "renamed-guide", "b.md"))).toBe("# B\n");
+		expect(await exists(path.join(deployRoot, "docs", "guide"))).toBe(false);
+	});
+
+	// --- AC2.4: nested component name ---
+
+	it("docs nested name: component 'skills/authoring' deploys to docs/skills/authoring.md", async () => {
+		await writeFile(path.join(rootDir, "docs", "skills", "authoring.md"), "# Authoring\n");
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["skills/authoring"] } };
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await readFile(path.join(deployRoot, "docs", "skills", "authoring.md"))).toBe(
+			"# Authoring\n",
+		);
+	});
+
+	// F5: `path.extname` on a DOTTED stem like "api.v2" reports ".v2" as an
+	// extension already present, wrongly suppressing the real source extension
+	// append — the fix compares against the SOURCE's own extension instead.
+	it("docs dotted stem: a dotted component name still gets the source's extension appended", async () => {
+		await writeFile(path.join(rootDir, "docs", "api.v2.md"), "# API v2\n");
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["api.v2"] } };
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await readFile(path.join(deployRoot, "docs", "api.v2.md"))).toBe("# API v2\n");
+		expect(await exists(path.join(deployRoot, "docs", "api.v2"))).toBe(false);
+	});
+
+	// --- AC2.5: hybrid form ---
+
+	it("docs hybrid form: a file-form source deploys as a single file", async () => {
+		await writeFile(path.join(rootDir, "docs", "single.md"), "# Single\n");
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["single"] } };
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await readFile(path.join(deployRoot, "docs", "single.md"))).toBe("# Single\n");
+	});
+
+	it("docs hybrid form: a dir-form source deploys additively", async () => {
+		await writeFile(path.join(rootDir, "docs", "bundle", "one.md"), "# One\n");
+		await writeFile(path.join(rootDir, "docs", "bundle", "sub", "two.md"), "# Two\n");
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["bundle"] } };
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await readFile(path.join(deployRoot, "docs", "bundle", "one.md"))).toBe("# One\n");
+		expect(await readFile(path.join(deployRoot, "docs", "bundle", "sub", "two.md"))).toBe("# Two\n");
+	});
+
+	// --- AC3.1: overwrite ---
+
+	it("docs overwrite: a declared item overwrites the existing target unconditionally", async () => {
+		await writeFile(path.join(rootDir, "docs", "intro.md"), "# New\n");
+		await writeFile(path.join(deployRoot, "docs", "intro.md"), "# Old\n");
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["intro"] } };
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await readFile(path.join(deployRoot, "docs", "intro.md"))).toBe("# New\n");
+	});
+
+	// --- AC3.2: delete idempotent ---
+
+	it("docs delete idempotent: delete:true removes an existing target", async () => {
+		await writeFile(path.join(deployRoot, "docs", "old.md"), "# Old\n");
+		const syncYaml: SyncYaml = {
+			path: deployRoot,
+			docs: { items: [{ component: "old", as: "old.md", delete: true }] },
+		};
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await exists(path.join(deployRoot, "docs", "old.md"))).toBe(false);
+	});
+
+	it("docs delete idempotent: delete:true is a no-op when the target is already absent", async () => {
+		const syncYaml: SyncYaml = {
+			path: deployRoot,
+			docs: { items: [{ component: "missing", delete: true }] },
+		};
+		const context = makeContext();
+
+		await expect(syncDocs(context, syncYaml, rootDir, deployRoot)).resolves.toBeUndefined();
+	});
+
+	// F2: a delete item has no source, so resolveDocsTarget only gives its bare,
+	// pre-extension stem ("docs/intro") — the real on-disk leaf ("docs/intro.md")
+	// must be discovered by basename, not assumed to equal the bare stem.
+	it("docs delete real leaf: delete:true with a bare component name removes the real extensioned leaf on disk", async () => {
+		await writeFile(path.join(deployRoot, "docs", "intro.md"), "# Old\n");
+		const syncYaml: SyncYaml = {
+			path: deployRoot,
+			docs: { items: [{ component: "intro", delete: true }] },
+		};
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await exists(path.join(deployRoot, "docs", "intro.md"))).toBe(false);
+
+		// Idempotent: a second run against the now-absent leaf is a no-op.
+		await expect(syncDocs(context, syncYaml, rootDir, deployRoot)).resolves.toBeUndefined();
+	});
+
+	it("docs delete real leaf: a similarly-named file is never treated as a tombstone candidate", async () => {
+		await writeFile(path.join(deployRoot, "docs", "introduction.md"), "keep me\n");
+		const syncYaml: SyncYaml = {
+			path: deployRoot,
+			docs: { items: [{ component: "intro", delete: true }] },
+		};
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await readFile(path.join(deployRoot, "docs", "introduction.md"))).toBe("keep me\n");
+	});
+
+	// The extension-branch match (`${base}.` prefix) must require a FILE: a
+	// human DIRECTORY sharing that dot-prefix (e.g. "intro.assets/" for stem
+	// "intro") is not a file-form candidate for the "intro" tombstone and must
+	// never be resolved — let alone recursively removed — by delete:true.
+	it("docs delete candidate: a human directory sharing the stem's dot-prefix is never a delete candidate", async () => {
+		await writeFile(path.join(deployRoot, "docs", "intro.assets", "diagram.png"), "binary\n");
+		const syncYaml: SyncYaml = {
+			path: deployRoot,
+			docs: { items: [{ component: "intro", delete: true }] },
+		};
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await exists(path.join(deployRoot, "docs", "intro.assets", "diagram.png"))).toBe(true);
+	});
+
+	it("docs delete candidate control: a real intro.md file-form leaf is still removed by delete:true", async () => {
+		await writeFile(path.join(deployRoot, "docs", "intro.md"), "# Old\n");
+		await writeFile(path.join(deployRoot, "docs", "intro.assets", "diagram.png"), "binary\n");
+		const syncYaml: SyncYaml = {
+			path: deployRoot,
+			docs: { items: [{ component: "intro", delete: true }] },
+		};
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await exists(path.join(deployRoot, "docs", "intro.md"))).toBe(false);
+		expect(await exists(path.join(deployRoot, "docs", "intro.assets", "diagram.png"))).toBe(true);
+	});
+
+	it("docs delete ambiguous tombstone: a file-form AND a dir-form candidate matching the same stem throws and touches neither", async () => {
+		await writeFile(path.join(deployRoot, "docs", "intro.md"), "# Old\n");
+		await writeFile(path.join(deployRoot, "docs", "intro", "nested.md"), "stale\n");
+		const syncYaml: SyncYaml = {
+			path: deployRoot,
+			docs: { items: [{ component: "intro", delete: true }] },
+		};
+		const context = makeContext();
+
+		await expect(syncDocs(context, syncYaml, rootDir, deployRoot)).rejects.toThrow(/ambiguous tombstone/);
+		expect(await readFile(path.join(deployRoot, "docs", "intro.md"))).toBe("# Old\n");
+		expect(await readFile(path.join(deployRoot, "docs", "intro", "nested.md"))).toBe("stale\n");
+	});
+
+	// --- AC3.3: anti-wipe ---
+
+	it("docs anti-wipe: an undeclared sibling file survives a sync", async () => {
+		await writeFile(path.join(rootDir, "docs", "intro.md"), "# Intro\n");
+		await writeFile(path.join(deployRoot, "docs", "human-note.md"), "human content\n");
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["intro"] } };
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await readFile(path.join(deployRoot, "docs", "human-note.md"))).toBe("human content\n");
+	});
+
+	it("docs anti-wipe: an undeclared file inside a dir-form target survives", async () => {
+		await writeFile(path.join(rootDir, "docs", "foo", "a.md"), "# A\n");
+		await writeFile(path.join(deployRoot, "docs", "foo", "human.md"), "human content\n");
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["foo"] } };
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await readFile(path.join(deployRoot, "docs", "foo", "human.md"))).toBe(
+			"human content\n",
+		);
+		expect(await readFile(path.join(deployRoot, "docs", "foo", "a.md"))).toBe("# A\n");
+	});
+
+	// --- AC3.4 vs anti-wipe: form-morph never recursively wipes a directory ---
+	//
+	// F4 reconciliation: a file-form item's real write leaf carries an appended
+	// extension (docs/foo.md), so a pre-existing DIRECTORY sitting at the bare,
+	// pre-extension stem (docs/foo/) never actually collides with it on disk —
+	// anti-wipe wins, and that directory (however "stale"-looking) survives.
+
+	it("docs form-morph: a file-form deploy coexists with a stale dir-form entry at the bare stem (anti-wipe wins)", async () => {
+		await writeFile(path.join(rootDir, "docs", "foo.md"), "# Foo\n");
+		await writeFile(path.join(deployRoot, "docs", "foo", "old.md"), "stale\n");
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["foo"] } };
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await readFile(path.join(deployRoot, "docs", "foo", "old.md"))).toBe("stale\n");
+		expect(await readFile(path.join(deployRoot, "docs", "foo.md"))).toBe("# Foo\n");
+	});
+
+	it("docs form-morph: a dir-form deploy removes a single stale squatting FILE at its exact target, never a directory", async () => {
+		await writeFile(path.join(rootDir, "docs", "bundle", "one.md"), "# One\n");
+		await writeFile(path.join(deployRoot, "docs", "bundle"), "stale file\n");
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["bundle"] } };
+		const context = makeContext({ backupSession: "form-morph-sess" });
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await readFile(path.join(deployRoot, "docs", "bundle", "one.md"))).toBe("# One\n");
+		const backupFile = path.join(
+			deployRoot,
+			".sync-backup",
+			"form-morph-sess",
+			"docs",
+			"docs",
+			"bundle",
+		);
+		expect(await readFile(backupFile)).toBe("stale file\n");
+	});
+
+	it("docs form-morph: a different sibling target is untouched by a flip", async () => {
+		await writeFile(path.join(rootDir, "docs", "foo.md"), "# Foo\n");
+		await writeFile(path.join(deployRoot, "docs", "foo", "old.md"), "stale\n");
+		await writeFile(path.join(deployRoot, "docs", "bar", "keep.md"), "keep me\n");
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["foo"] } };
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await readFile(path.join(deployRoot, "docs", "bar", "keep.md"))).toBe("keep me\n");
+	});
+
+	// --- AC4.3/4.4: pre-flight collision rejection ---
+
+	it("docs duplicate target: two items resolving to the same target throws before mutating anything", async () => {
+		await writeFile(path.join(rootDir, "docs", "a.md"), "# A\n");
+		await writeFile(path.join(rootDir, "docs", "b.md"), "# B\n");
+		const syncYaml: SyncYaml = {
+			path: deployRoot,
+			docs: {
+				items: [
+					{ component: "a", as: "same" },
+					{ component: "b", as: "same" },
+				],
+			},
+		};
+		const context = makeContext();
+
+		await expect(syncDocs(context, syncYaml, rootDir, deployRoot)).rejects.toThrow();
+		expect(await exists(path.join(deployRoot, "docs"))).toBe(false);
+	});
+
+	it("docs case collision: two items differing only by case throws before mutating anything", async () => {
+		await writeFile(path.join(rootDir, "docs", "a.md"), "# A\n");
+		await writeFile(path.join(rootDir, "docs", "b.md"), "# B\n");
+		const syncYaml: SyncYaml = {
+			path: deployRoot,
+			docs: {
+				items: [
+					{ component: "a", as: "Same" },
+					{ component: "b", as: "same" },
+				],
+			},
+		};
+		const context = makeContext();
+
+		await expect(syncDocs(context, syncYaml, rootDir, deployRoot)).rejects.toThrow();
+		expect(await exists(path.join(deployRoot, "docs"))).toBe(false);
+	});
+
+	// F3: a collision that only appears AFTER extension resolution — the bare
+	// stems ("docs/intro" vs "docs/intro.md") differ lexically, so a
+	// pre-extension check would miss this, but both resolve to the identical
+	// real write leaf "docs/intro.md" once each source's extension is applied.
+	it("docs post-extension collision: two items whose bare stems differ but whose real leaves match throws before mutating anything", async () => {
+		await writeFile(path.join(rootDir, "docs", "intro.md"), "# Intro\n");
+		await writeFile(path.join(rootDir, "docs", "guide.md"), "# Guide\n");
+		const syncYaml: SyncYaml = {
+			path: deployRoot,
+			docs: { items: ["intro", { component: "guide", as: "intro.md" }] },
+		};
+		const context = makeContext();
+
+		await expect(syncDocs(context, syncYaml, rootDir, deployRoot)).rejects.toThrow();
+		expect(await exists(path.join(deployRoot, "docs"))).toBe(false);
+	});
+
+	// finding6 (defensive): an item resolving to the docs base directory itself
+	// would let a single item treat the ENTIRE shared docs folder as one
+	// write/delete target — e.g. {component: '.', delete: true} would otherwise
+	// resolve to the bare stem "docs" and, discovered as a lone on-disk
+	// candidate, recursively wipe every human file already under it.
+	it("docs base-wipe guard: an item resolving to the docs base directory throws instead of wiping the folder", async () => {
+		await writeFile(path.join(deployRoot, "docs", "human-note.md"), "human content\n");
+		const syncYaml: SyncYaml = {
+			path: deployRoot,
+			docs: { items: [{ component: ".", delete: true }] },
+		};
+		const context = makeContext();
+
+		await expect(syncDocs(context, syncYaml, rootDir, deployRoot)).rejects.toThrow();
+		expect(await readFile(path.join(deployRoot, "docs", "human-note.md"))).toBe("human content\n");
+	});
+
+	// A trailing slash on section.path must not bypass the base-wipe guard: the
+	// guard compares a normalized base against the item's bare stem, and
+	// path.posix.normalize preserves a trailing slash while resolveDocsTarget's
+	// bare stem never carries one — a naive string `===` would then miss this
+	// and let a schema-valid `{path: "docs/"}` config recursively wipe docs/.
+	it("docs base-wipe guard: a trailing slash on section.path still triggers the guard instead of wiping the folder", async () => {
+		await writeFile(path.join(deployRoot, "docs", "human-note.md"), "human content\n");
+		const syncYaml: SyncYaml = {
+			path: deployRoot,
+			docs: { path: "docs/", items: [{ component: ".", delete: true }] },
+		};
+		const context = makeContext();
+
+		await expect(syncDocs(context, syncYaml, rootDir, deployRoot)).rejects.toThrow();
+		expect(await readFile(path.join(deployRoot, "docs", "human-note.md"))).toBe("human content\n");
+	});
+
+	// --- AC4.1/4.2: FS-level symlink-escape guards (runtime, beyond lexical containment) ---
+	//
+	// `docs` is NO-WIPE and human-co-authored, so it can preserve a human-planted
+	// symlink that a plain cp/rm would follow straight out of the docs tree.
+	// Lexical containment (resolveDocsTarget) cannot see a symlinked directory —
+	// these guards are the actual escape-prevention layer at runtime.
+
+	it("docs traversal runtime: an item path escaping deployRoot is rejected before mutating anything", async () => {
+		await writeFile(path.join(rootDir, "docs", "intro.md"), "# Intro\n");
+		const syncYaml: SyncYaml = {
+			path: deployRoot,
+			docs: { items: [{ component: "intro", path: "../../outside.md" }] },
+		};
+		const context = makeContext();
+
+		await expect(syncDocs(context, syncYaml, rootDir, deployRoot)).rejects.toThrow();
+		expect(await exists(path.join(deployRoot, "docs"))).toBe(false);
+	});
+
+	it("docs source symlink: a symlinked source file is rejected and nothing is deployed", async () => {
+		const externalFile = path.join(tmpDir, "external.md");
+		await writeFile(externalFile, "external content\n");
+		await fs.mkdir(path.join(rootDir, "docs"), { recursive: true });
+		await fs.symlink(externalFile, path.join(rootDir, "docs", "linked.md"));
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["linked"] } };
+		const context = makeContext();
+
+		await expect(syncDocs(context, syncYaml, rootDir, deployRoot)).rejects.toThrow();
+		expect(await exists(path.join(deployRoot, "docs", "linked.md"))).toBe(false);
+	});
+
+	it("docs source symlink: a symlinked file inside a dir-form source is rejected and nothing is deployed", async () => {
+		await writeFile(path.join(rootDir, "docs", "bundle", "one.md"), "# One\n");
+		const externalFile = path.join(tmpDir, "external-two.md");
+		await writeFile(externalFile, "external content\n");
+		await fs.symlink(externalFile, path.join(rootDir, "docs", "bundle", "two.md"));
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["bundle"] } };
+		const context = makeContext();
+
+		await expect(syncDocs(context, syncYaml, rootDir, deployRoot)).rejects.toThrow();
+		expect(await exists(path.join(deployRoot, "docs", "bundle"))).toBe(false);
+	});
+
+	it("docs target symlink: a pre-existing leaf symlink to an external file is not followed on overwrite", async () => {
+		await writeFile(path.join(rootDir, "docs", "intro.md"), "# New\n");
+		const externalFile = path.join(tmpDir, "external-leaf.md");
+		await writeFile(externalFile, "external content\n");
+		await fs.mkdir(path.join(deployRoot, "docs"), { recursive: true });
+		await fs.symlink(externalFile, path.join(deployRoot, "docs", "intro.md"));
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["intro"] } };
+		const context = makeContext();
+
+		await expect(syncDocs(context, syncYaml, rootDir, deployRoot)).rejects.toThrow();
+		expect(await readFile(externalFile)).toBe("external content\n");
+	});
+
+	it("docs intermediate symlink: a symlinked intermediate target directory refuses the write", async () => {
+		await writeFile(path.join(rootDir, "docs", "api", "x.md"), "# X\n");
+		const externalDir = path.join(tmpDir, "external-dir");
+		await fs.mkdir(externalDir, { recursive: true });
+		await fs.mkdir(path.join(deployRoot, "docs"), { recursive: true });
+		await fs.symlink(externalDir, path.join(deployRoot, "docs", "api"));
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["api"] } };
+		const context = makeContext();
+
+		await expect(syncDocs(context, syncYaml, rootDir, deployRoot)).rejects.toThrow();
+		expect(await fs.readdir(externalDir)).toEqual([]);
+	});
+
+	// F1: the coarse guard above only reaches the item's own bare stem
+	// (deployRoot/docs/foo); a dir-form deploy also writes NESTED files below
+	// that stem (deployRoot/docs/foo/sub/x.md), and a symlink planted at that
+	// deeper intermediate segment is a write-escape the coarse guard cannot see.
+	it("docs nested intermediate symlink: a symlink under a dir-form target's own subdirectory refuses the write", async () => {
+		await writeFile(path.join(rootDir, "docs", "foo", "sub", "x.md"), "# X\n");
+		const externalDir = path.join(tmpDir, "external-sub-dir");
+		await fs.mkdir(externalDir, { recursive: true });
+		await fs.mkdir(path.join(deployRoot, "docs", "foo"), { recursive: true });
+		await fs.symlink(externalDir, path.join(deployRoot, "docs", "foo", "sub"));
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["foo"] } };
+		const context = makeContext();
+
+		await expect(syncDocs(context, syncYaml, rootDir, deployRoot)).rejects.toThrow();
+		expect(await fs.readdir(externalDir)).toEqual([]);
+	});
+
+	// --- Backup evidence: every mutation is recoverable ---
+
+	it("backs up the pre-existing file before an overwrite", async () => {
+		await writeFile(path.join(rootDir, "docs", "intro.md"), "# New\n");
+		await writeFile(path.join(deployRoot, "docs", "intro.md"), "# Old\n");
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["intro"] } };
+		const context = makeContext({ backupSession: "sess1" });
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		// backupDocs preserves the FULL deployRoot-relative path (including the
+		// docs section's own "docs/" segment) under the fixed .sync-backup/<session>/docs/
+		// namespace — so a target already living at deployRoot/docs/intro.md backs
+		// up to .sync-backup/sess1/docs/docs/intro.md (see lib/backup.ts:backupDocs).
+		const backupFile = path.join(deployRoot, ".sync-backup", "sess1", "docs", "docs", "intro.md");
+		expect(await readFile(backupFile)).toBe("# Old\n");
+	});
+
+	// --- AC5.2: dry-run preview branch ---
+
+	it("docs dry run: previews write/delete plans and an advisory list, and writes nothing to disk", async () => {
+		await writeFile(path.join(rootDir, "docs", "intro.md"), "# Intro\n");
+		await writeFile(path.join(deployRoot, "docs", "old.md"), "# Old\n");
+		await writeFile(path.join(deployRoot, "docs", "human-note.md"), "human content\n");
+		const syncYaml: SyncYaml = {
+			path: deployRoot,
+			docs: { items: ["intro", { component: "old", as: "old.md", delete: true }] },
+		};
+		const context = makeContext({ dryRun: true });
+
+		const lines: string[] = [];
+		const origStderr = process.stderr.write.bind(process.stderr);
+		process.stderr.write = (chunk: string | Uint8Array) => {
+			if (typeof chunk === "string") lines.push(chunk);
+			return true;
+		};
+		try {
+			await syncDocs(context, syncYaml, rootDir, deployRoot);
+		} finally {
+			process.stderr.write = origStderr;
+		}
+
+		// AC5.2a: write plan for the declared (non-delete) item.
+		const writeLines = lines.filter((l) => l.includes("write"));
+		expect(writeLines.some((l) => l.includes(path.join(deployRoot, "docs", "intro.md")))).toBe(
+			true,
+		);
+
+		// AC5.2b: delete plan for the delete:true item.
+		const removeLines = lines.filter((l) => l.includes("remove"));
+		expect(removeLines.some((l) => l.includes(path.join(deployRoot, "docs", "old.md")))).toBe(true);
+
+		// AC5.2c: advisory line for the undeclared file — but NOT for the
+		// delete:true item's own target (its removal is already reported above;
+		// it must not also read as unmanaged drift).
+		const advisoryLines = lines.filter((l) => l.includes("advisory"));
+		expect(
+			advisoryLines.some((l) => l.includes(path.join(deployRoot, "docs", "human-note.md"))),
+		).toBe(true);
+		expect(advisoryLines.some((l) => l.includes("old.md"))).toBe(false);
+
+		// AC5.2d: write nothing — filesystem is byte-identical to before.
+		expect(await exists(path.join(deployRoot, "docs", "intro.md"))).toBe(false);
+		expect(await readFile(path.join(deployRoot, "docs", "old.md"))).toBe("# Old\n");
+		expect(await readFile(path.join(deployRoot, "docs", "human-note.md"))).toBe(
+			"human content\n",
+		);
+		expect(await exists(path.join(deployRoot, ".sync-backup"))).toBe(false);
+	});
+
+	it("docs dry run: dir-form item previews each source file's destination", async () => {
+		await writeFile(path.join(rootDir, "docs", "bundle", "one.md"), "# One\n");
+		await writeFile(path.join(rootDir, "docs", "bundle", "sub", "two.md"), "# Two\n");
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["bundle"] } };
+		const context = makeContext({ dryRun: true });
+
+		const lines: string[] = [];
+		const origStderr = process.stderr.write.bind(process.stderr);
+		process.stderr.write = (chunk: string | Uint8Array) => {
+			if (typeof chunk === "string") lines.push(chunk);
+			return true;
+		};
+		try {
+			await syncDocs(context, syncYaml, rootDir, deployRoot);
+		} finally {
+			process.stderr.write = origStderr;
+		}
+
+		const output = lines.join("");
+		expect(output).toContain(path.join(deployRoot, "docs", "bundle", "one.md"));
+		expect(output).toContain(path.join(deployRoot, "docs", "bundle", "sub", "two.md"));
+		expect(await exists(path.join(deployRoot, "docs", "bundle"))).toBe(false);
+	});
+
+	it("docs dry guards: a pre-existing leaf symlink target is rejected in preview, never previewed as a successful write", async () => {
+		await writeFile(path.join(rootDir, "docs", "intro.md"), "# New\n");
+		const externalFile = path.join(tmpDir, "external-leaf.md");
+		await writeFile(externalFile, "external content\n");
+		await fs.mkdir(path.join(deployRoot, "docs"), { recursive: true });
+		await fs.symlink(externalFile, path.join(deployRoot, "docs", "intro.md"));
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["intro"] } };
+		const context = makeContext({ dryRun: true });
+
+		await expect(syncDocs(context, syncYaml, rootDir, deployRoot)).rejects.toThrow();
+		expect(await readFile(externalFile)).toBe("external content\n");
 	});
 });

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -3774,6 +3774,23 @@ describe("syncDocs", () => {
 		expect(await readFile(path.join(deployRoot, "docs", "bundle", "sub", "two.md"))).toBe("# Two\n");
 	});
 
+	// A docs directory that happens to contain index.md must still deploy as a
+	// WHOLE directory (additive per-file), not collapse to a single docs/<name>.md
+	// via the generic resolver's skills-style index.md single-entry rule — that
+	// collapse would silently drop sibling files/assets under the docs directory.
+	it("docs hybrid form: a dir-form source containing index.md copies the whole directory, not just index.md", async () => {
+		await writeFile(path.join(rootDir, "docs", "guide", "index.md"), "# Guide\n");
+		await writeFile(path.join(rootDir, "docs", "guide", "advanced.md"), "# Advanced\n");
+		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["guide"] } };
+		const context = makeContext();
+
+		await syncDocs(context, syncYaml, rootDir, deployRoot);
+
+		expect(await readFile(path.join(deployRoot, "docs", "guide", "index.md"))).toBe("# Guide\n");
+		expect(await readFile(path.join(deployRoot, "docs", "guide", "advanced.md"))).toBe("# Advanced\n");
+		expect(await exists(path.join(deployRoot, "docs", "guide.md"))).toBe(false);
+	});
+
 	// --- AC3.1: overwrite ---
 
 	it("docs overwrite: a declared item overwrites the existing target unconditionally", async () => {

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -21,12 +21,14 @@ import type {
 	SyncYaml,
 	SyncContext,
 	PluginScope,
+	DocsItem,
 } from "./lib/types.ts";
 import { getRootDir, getBackupRetentionDays, getEnabledProjects } from "./lib/config.ts";
 import { readAndExpandSyncYaml } from "./lib/parse-sync-yaml.ts";
 import { parseAndMergePlatformYaml } from "./lib/parse-platform-yaml.ts";
 import { resolvePlatforms, resolveComponentPath, setProjectContext } from "./lib/resolver.ts";
-import { generateBackupSessionId, backupCategory, cleanupOldBackups } from "./lib/backup.ts";
+import { generateBackupSessionId, backupCategory, backupDocs, cleanupOldBackups } from "./lib/backup.ts";
+import { resolveDocsTarget, detectDocsTargetCollisions } from "./lib/path-utils.ts";
 import { logInfo, logWarn, logError, logDry, logSuccess } from "./lib/logger.ts";
 import { ProjectKeyError } from "./lib/git-key.ts";
 import { resolveDeployTargets, DeployTargetsError } from "./lib/resolve-deploy-targets.ts";
@@ -410,6 +412,474 @@ export async function syncPlatformConfigs(
 
 		if (result.modelMap) {
 			context.modelMaps.set(platform, result.modelMap);
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// syncDocs
+// ---------------------------------------------------------------------------
+
+/** Read a docs item's declared fields uniformly for both the string shorthand and the object form. */
+function docsItemFields(item: DocsItem): {
+	componentName: string;
+	itemPath: string | undefined;
+	as: string | undefined;
+	isDelete: boolean;
+} {
+	if (typeof item === "string") {
+		return { componentName: item, itemPath: undefined, as: undefined, isDelete: false };
+	}
+	return {
+		componentName: item.component,
+		itemPath: item.path,
+		as: item.as,
+		isDelete: item.delete === true,
+	};
+}
+
+/** Recursively list every FILE (not directory) under `dir`, as absolute paths. [] if `dir` is absent. */
+async function listFilesRecursive(dir: string): Promise<string[]> {
+	const results: string[] = [];
+	let entries: import("fs").Dirent[];
+	try {
+		entries = await fs.readdir(dir, { withFileTypes: true });
+	} catch {
+		return results;
+	}
+	for (const entry of entries) {
+		const fullPath = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			results.push(...(await listFilesRecursive(fullPath)));
+		} else if (entry.isFile()) {
+			results.push(fullPath);
+		}
+	}
+	return results;
+}
+
+/**
+ * Recursively search `dir` for the first symlinked entry (file or directory),
+ * without following it. Returns its absolute path, or null if the tree is
+ * symlink-free. Used to reject a dir-form docs source that contains a
+ * human-planted symlink pointing outside the docs tree.
+ */
+async function findSymlinkInTree(dir: string): Promise<string | null> {
+	let entries: import("fs").Dirent[];
+	try {
+		entries = await fs.readdir(dir, { withFileTypes: true });
+	} catch {
+		return null;
+	}
+	for (const entry of entries) {
+		const fullPath = path.join(dir, entry.name);
+		if (entry.isSymbolicLink()) return fullPath;
+		if (entry.isDirectory()) {
+			const found = await findSymlinkInTree(fullPath);
+			if (found) return found;
+		}
+	}
+	return null;
+}
+
+/**
+ * Back up every file currently under `targetDir` (recursively), preserving
+ * substructure. `backupDocs` only ever copies a single file, so a whole-tree
+ * backup is this per-file loop over it. No-op if targetDir is absent/empty.
+ */
+async function backupDocsTree(targetDir: string, deployRoot: string, sessionId: string): Promise<void> {
+	for (const file of await listFilesRecursive(targetDir)) {
+		await backupDocs(file, deployRoot, sessionId);
+	}
+}
+
+/**
+ * Reject a docs deploy/delete target whose path — walked segment by segment
+ * from just under deployRoot down to and including absTarget itself — passes
+ * through a symlink anywhere along the way.
+ *
+ * Lexical containment (assertDocsTargetContained) is a string check and
+ * cannot see what's actually on disk: a human-planted symlink at an
+ * intermediate directory, or at the leaf target itself, would otherwise be
+ * silently followed by mkdir/copyFile/rm — escaping the docs tree entirely.
+ * This is the runtime-only counterpart that closes that gap.
+ *
+ * Only EXISTING segments are checked; a segment that doesn't exist yet means
+ * nothing below it can exist either, so the walk stops there.
+ */
+async function assertNoSymlinkInTargetPath(absTarget: string, deployRoot: string): Promise<void> {
+	const rel = path.relative(deployRoot, absTarget);
+	const segments = rel.split(path.sep).filter((segment) => segment.length > 0);
+
+	let current = deployRoot;
+	for (const segment of segments) {
+		current = path.join(current, segment);
+		let st: import("fs").Stats;
+		try {
+			st = await fs.lstat(current);
+		} catch {
+			return; // Doesn't exist yet — nothing below it can exist either.
+		}
+		if (st.isSymbolicLink()) {
+			throw new Error(`docs: refusing to write through symlink at ${current}`);
+		}
+	}
+}
+
+/**
+ * Compute a file-form docs item's real write path: `absTarget`, with the
+ * source's extension appended unless `absTarget` already ends with that same
+ * extension — avoids `x.md.md`. Checking `absTarget`'s OWN extname (the old
+ * approach) misfires on a dotted stem like `api.v2`: `path.extname` reports
+ * `.v2` as an extension already present and wrongly suppresses the append,
+ * losing `.md` entirely. Comparing against the SOURCE's extension specifically
+ * (via endsWith) is what correctly distinguishes "already has this extension"
+ * from "has an unrelated dot in the name".
+ */
+function docsFileFinalTarget(absTarget: string, sourceFile: string): string {
+	const sourceExt = path.extname(sourceFile);
+	return absTarget.endsWith(sourceExt) ? absTarget : absTarget + sourceExt;
+}
+
+/**
+ * Remove a single stale FILE squatting at a dir-form docs item's own
+ * (pre-extension) target path, backing it up first — otherwise the
+ * mkdir/copyFile in deployDocsDir would ENOTDIR trying to write files under a
+ * path that's currently a file. Only ever inspects `absTarget` itself; a
+ * sibling item's target is never touched.
+ *
+ * File-form has NO equivalent call: its real write leaf carries an appended
+ * extension (docsFileFinalTarget), so a directory sitting at the bare,
+ * pre-extension stem never collides with it on disk — anti-wipe wins, that
+ * directory is simply left alone (AC3.4 vs anti-wipe reconciliation).
+ *
+ * NEVER removes a directory — that would be an undeclared-human-dir wipe. If
+ * a directory sits at the exact leaf being deployed (e.g. a directory
+ * literally named `foo.md` squatting a file-form leaf), this function is not
+ * called for that path at all; copyFile is left to fail loudly instead.
+ */
+async function cleanStaleDocsForm(absTarget: string, deployRoot: string, sessionId: string): Promise<void> {
+	let existing: import("fs").Stats;
+	try {
+		existing = await fs.stat(absTarget);
+	} catch {
+		return; // Nothing there — no stale form to clean.
+	}
+	if (existing.isDirectory()) return; // Already the right form — additive merge handles it.
+
+	await backupDocs(absTarget, deployRoot, sessionId);
+	await fs.rm(absTarget, { force: true }); // Non-recursive: a single file, never a directory.
+}
+
+/**
+ * Write one docs FILE target at its real, already-resolved leaf
+ * (`finalTarget` — post-extension, computed once by the caller via
+ * docsFileFinalTarget): back up whatever currently sits there, then copy the
+ * source over it unconditionally (declared items always overwrite). No
+ * opposite-form cleaning here — see cleanStaleDocsForm's doc comment for why
+ * file-form never needs it.
+ */
+async function deployDocsFile(
+	sourceFile: string,
+	finalTarget: string,
+	deployRoot: string,
+	sessionId: string,
+): Promise<void> {
+	await backupDocs(finalTarget, deployRoot, sessionId);
+	await fs.mkdir(path.dirname(finalTarget), { recursive: true });
+	await fs.copyFile(sourceFile, finalTarget);
+}
+
+/**
+ * Write one docs DIRECTORY target: clean a stale squatting file at the
+ * target (see cleanStaleDocsForm), then additively copy every precomputed
+ * source→dest pair — the caller's own read-only Pass 1 enumeration, shared
+ * with the dry-run preview and the collision check, never re-derived here —
+ * backing up each destination file before overwrite. NEVER wipes/mirrors the
+ * target dir — an undeclared file already inside it is never enumerated
+ * here, so it survives untouched.
+ *
+ * Guards EACH destination file individually right before its own mkdir/
+ * copyFile: the coarse guard the caller already ran against `absTarget` only
+ * reaches the item's own bare stem, not a symlink planted deeper at some
+ * nested intermediate segment (e.g. `absTarget/sub` when the real write is
+ * `absTarget/sub/x.md`) — only a per-file, full deployRoot→destFile walk
+ * catches that write-escape.
+ */
+async function deployDocsDir(
+	absTarget: string,
+	files: { source: string; dest: string }[],
+	deployRoot: string,
+	sessionId: string,
+): Promise<void> {
+	await cleanStaleDocsForm(absTarget, deployRoot, sessionId);
+
+	for (const { source, dest } of files) {
+		await assertNoSymlinkInTargetPath(dest, deployRoot);
+		await backupDocs(dest, deployRoot, sessionId);
+		await fs.mkdir(path.dirname(dest), { recursive: true });
+		await fs.copyFile(source, dest);
+	}
+}
+
+/** Delete one docs target (file or directory), backing it up first. Idempotent: no-op if already absent. */
+async function deleteDocsTarget(absTarget: string, deployRoot: string, sessionId: string): Promise<void> {
+	let st: import("fs").Stats;
+	try {
+		st = await fs.stat(absTarget);
+	} catch {
+		return;
+	}
+	if (st.isDirectory()) {
+		await backupDocsTree(absTarget, deployRoot, sessionId);
+	} else {
+		await backupDocs(absTarget, deployRoot, sessionId);
+	}
+	await fs.rm(absTarget, { recursive: true, force: true });
+}
+
+/**
+ * Discover on-disk delete candidates for a delete:true item's bare stem. A
+ * delete item has no source file, so — unlike a write item — its real leaf
+ * isn't computable ahead of time; it must be discovered by basename directly
+ * under the stem's parent directory.
+ *
+ * An entry matches when its name is EXACTLY the stem's basename (a dir-form
+ * or extensionless-file candidate) or the stem's basename plus a literal `.`
+ * AND the entry is a regular file (a file-form candidate carrying an
+ * extension — stem `intro` matches `intro.md` but never `introduction.md`: a
+ * bare `startsWith(base)` without the trailing dot would wrongly treat an
+ * unrelated longer name as the same tombstone; the file-type check keeps a
+ * human directory like `intro.assets/` from matching too).
+ */
+async function findDocsDeleteCandidates(absStem: string): Promise<string[]> {
+	const dir = path.dirname(absStem);
+	const base = path.basename(absStem);
+	let entries: import("fs").Dirent[];
+	try {
+		entries = await fs.readdir(dir, { withFileTypes: true });
+	} catch {
+		return [];
+	}
+	return entries
+		.filter((entry) => entry.name === base || (entry.name.startsWith(`${base}.`) && entry.isFile()))
+		.map((entry) => path.join(dir, entry.name));
+}
+
+/**
+ * Deploy the `docs` component type: a NO-WIPE merge-patch onto a
+ * human-co-authored folder. Unlike the OMT-owned CATEGORIES (which
+ * backup+wipe+redeploy their whole target dir — see syncCategory above),
+ * docs is additive per-file only: an undeclared file already present at or
+ * under a docs target must always survive a sync. There is no per-platform
+ * dispatch either — docs lands directly under deployRoot.
+ *
+ * Resolve-then-mutate, in passes, because `resolveDocsTarget` only returns a
+ * BARE STEM (e.g. `docs/intro`, no extension) — the real materialized leaf
+ * differs per form (file-form appends the source's extension via
+ * docsFileFinalTarget; dir-form nests the source's files under the stem).
+ * Collision detection, the symlink guard, and delete all have to key off that
+ * REAL leaf, or they silently miss the path actually being written:
+ *
+ *   PASS 0 (lexical, no I/O): resolve each item's bare stem, and reject one
+ *     that resolves to the docs base directory itself (finding6 — otherwise a
+ *     single item could treat the whole shared folder as one target).
+ *   PASS 1 (resolve, READ-ONLY): compute each item's REAL leaf(s) — stat/
+ *     lstat/readdir only, no writes — so the collision check below still
+ *     throws before any mutation, including dry-run. This is why collision
+ *     detection can no longer be "purely lexical, no I/O" as it once was: the
+ *     real leaf depends on the source's extension, which requires resolving
+ *     and stat-ing the source. The property that survives is "before
+ *     mutation", not "I/O-free".
+ *   COLLISION: detectDocsTargetCollisions runs on the union of every real
+ *     leaf (file leaves + dir-form destination files + delete candidates).
+ *   PASS 2 (guard + mutate): for each real leaf, the runtime symlink guard
+ *     fires — in dry-run too — immediately before that leaf would be written
+ *     or removed.
+ *
+ * Under context.dryRun, every guard below still runs unconditionally — an
+ * unsafe item is rejected, never previewed as a would-succeed write — but no
+ * mutation happens: write/delete actions are logged via logDry instead of
+ * executed, followed by an advisory pass listing every file already sitting
+ * under the docs base that no item's write/delete plan would touch (the
+ * operator's only stateless drift signal, since docs never wipes on its own).
+ */
+export async function syncDocs(
+	context: SyncContext,
+	syncYaml: SyncYaml,
+	rootDir: string,
+	deployRoot: string,
+): Promise<void> {
+	const section = syncYaml.docs;
+	if (!section || !Array.isArray(section.items) || section.items.length === 0) {
+		return;
+	}
+
+	const items = section.items;
+	const docsBase = path.posix.normalize(section.path ?? "docs");
+
+	// PASS 0 (lexical, no I/O).
+	const relStems = items.map((item) => {
+		const { componentName, itemPath, as } = docsItemFields(item);
+		const relStem = resolveDocsTarget(componentName, section.path, itemPath, as);
+		// finding6 (defensive): an item resolving to the base directory itself
+		// would let one item (e.g. `{component: '.', delete: true}`) treat the
+		// ENTIRE shared docs folder as a single write/delete target — every
+		// human file under it would be wiped. (Resolving to deployRoot itself
+		// is already unreachable here: assertDocsTargetContained, called
+		// inside resolveDocsTarget above, rejects a normalized "." before
+		// returning.) Trailing slash(es) stripped before comparing: normalize
+		// alone preserves a trailing slash on docsBase (e.g. "docs/" stays
+		// "docs/") while relStem never carries one, so a raw string compare
+		// would miss that case and let `{path: "docs/"}` bypass this guard.
+		if (relStem.replace(/\/+$/, "") === docsBase.replace(/\/+$/, "")) {
+			throw new Error(`docs: target resolves to the docs base directory itself — refusing: ${relStem}`);
+		}
+		return relStem;
+	});
+
+	// PASS 1 (resolve, READ-ONLY): each item's REAL materialized leaf(s).
+	type DocsItemPlan =
+		| { kind: "delete"; absTarget: string; candidates: string[] }
+		| { kind: "file"; sourceFile: string; absTarget: string; finalTarget: string }
+		| { kind: "dir"; absTarget: string; files: { source: string; dest: string }[] };
+
+	const plans: (DocsItemPlan | null)[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		const item = items[i];
+		const { componentName, isDelete } = docsItemFields(item);
+		const absTarget = path.join(deployRoot, relStems[i]);
+
+		if (isDelete) {
+			const candidates = await findDocsDeleteCandidates(absTarget);
+			if (candidates.length > 1) {
+				throw new Error(
+					`docs: ambiguous tombstone — multiple candidates match ${relStems[i]}: [${candidates.join(", ")}]`,
+				);
+			}
+			plans.push({ kind: "delete", absTarget, candidates });
+			continue;
+		}
+
+		const resolved = resolveComponentPath(componentName, "docs", rootDir, context.projectDir || undefined);
+		if ("error" in resolved) {
+			logWarn(`docs/${componentName}: ${resolved.error}`);
+			plans.push(null);
+			continue;
+		}
+
+		// Runtime FS guard: refuse a source that is itself a symlink — never
+		// materialize external content into the docs tree.
+		const sourceLstat = await fs.lstat(resolved.path);
+		if (sourceLstat.isSymbolicLink()) {
+			throw new Error(`docs/${componentName}: source is a symlink — refusing to materialize external content`);
+		}
+
+		const sourceStat = await fs.stat(resolved.path);
+		if (sourceStat.isDirectory()) {
+			// Runtime FS guard: refuse a dir-form source containing a symlinked file.
+			const symlinkPath = await findSymlinkInTree(resolved.path);
+			if (symlinkPath) {
+				throw new Error(
+					`docs/${componentName}: source contains a symlink (${symlinkPath}) — refusing to materialize external content`,
+				);
+			}
+			const files = (await listFilesRecursive(resolved.path)).map((source) => ({
+				source,
+				dest: path.join(absTarget, path.relative(resolved.path, source)),
+			}));
+			plans.push({ kind: "dir", absTarget, files });
+		} else {
+			const finalTarget = docsFileFinalTarget(absTarget, resolved.path);
+			plans.push({ kind: "file", sourceFile: resolved.path, absTarget, finalTarget });
+		}
+	}
+
+	// COLLISION: real leaves only (file leaves + dir-form destination files +
+	// delete candidates) — a bare-stem check would miss a collision that only
+	// appears post-extension (e.g. `intro` and `guide` renamed to `intro.md`
+	// both landing on `docs/intro.md`).
+	const leafSet: string[] = [];
+	for (const plan of plans) {
+		if (!plan) continue;
+		if (plan.kind === "file") leafSet.push(plan.finalTarget);
+		else if (plan.kind === "dir") leafSet.push(...plan.files.map((f) => f.dest));
+		else leafSet.push(...plan.candidates);
+	}
+	const collisions = detectDocsTargetCollisions(leafSet);
+	if (collisions.length > 0) {
+		const detail = collisions.map((c) => `${c.kind}: [${c.targets.join(", ")}]`).join("; ");
+		throw new Error(`docs: target collision detected — ${detail}`);
+	}
+
+	// PASS 2 (guard + mutate). Every target file any item resolves to touch
+	// (write or delete) — dry-run only, feeds the advisory unmanaged-file pass
+	// below. A delete:true item's own target counts as managed too: its
+	// removal is already reported via its own dry-run line, so it must not
+	// also surface as advisory drift.
+	const managedTargets = new Set<string>();
+
+	for (const plan of plans) {
+		if (!plan) continue;
+
+		if (plan.kind === "delete") {
+			// Coarse guard on the bare stem, mirroring the file/dir branches below
+			// — usually a no-op (the bare stem rarely exists on disk verbatim),
+			// but defends the case where it happens to coincide with the real
+			// on-disk candidate (e.g. an explicit `as` already carrying the
+			// extension).
+			await assertNoSymlinkInTargetPath(plan.absTarget, deployRoot);
+
+			const [candidate] = plan.candidates;
+			if (candidate === undefined) continue; // No on-disk match — idempotent no-op.
+
+			await assertNoSymlinkInTargetPath(candidate, deployRoot);
+			if (context.dryRun) {
+				managedTargets.add(candidate);
+				logDry(`docs: would remove ${candidate}`);
+			} else {
+				await deleteDocsTarget(candidate, deployRoot, context.backupSession);
+			}
+			continue;
+		}
+
+		if (plan.kind === "file") {
+			await assertNoSymlinkInTargetPath(plan.absTarget, deployRoot); // coarse: bare stem
+			await assertNoSymlinkInTargetPath(plan.finalTarget, deployRoot); // real leaf
+			if (context.dryRun) {
+				managedTargets.add(plan.finalTarget);
+				logDry(`docs: would write ${plan.finalTarget}`);
+			} else {
+				await deployDocsFile(plan.sourceFile, plan.finalTarget, deployRoot, context.backupSession);
+			}
+			continue;
+		}
+
+		// plan.kind === "dir"
+		await assertNoSymlinkInTargetPath(plan.absTarget, deployRoot); // coarse: the item's own bare stem
+		if (context.dryRun) {
+			for (const { dest } of plan.files) {
+				await assertNoSymlinkInTargetPath(dest, deployRoot); // fine-grained: fires in dry-run too
+				managedTargets.add(dest);
+				logDry(`docs: would write ${dest}`);
+			}
+		} else {
+			await deployDocsDir(plan.absTarget, plan.files, deployRoot, context.backupSession);
+		}
+	}
+
+	if (!context.dryRun) return;
+
+	// Advisory unmanaged-file list (AC5.2c): every file already sitting under
+	// the docs base that no item above would write or delete. NOT an error and
+	// NOT swept — docs is no-wipe, so this is the only stateless signal that a
+	// target has drifted from what sync.yaml declares (human-added, or the
+	// operator deleted the source out from under a stale target).
+	const docsBaseAbs = path.join(deployRoot, docsBase);
+	for (const existingFile of (await listFilesRecursive(docsBaseAbs)).sort()) {
+		if (!managedTargets.has(existingFile)) {
+			logDry(`docs: advisory (unmanaged): ${existingFile}`);
 		}
 	}
 }
@@ -947,6 +1417,11 @@ export async function processYaml(
 			if (shouldMkdirClaude || libSourceRoots.size > 0) {
 				await syncLib(context, deployRoot, rootDir, libPlatforms, libSourceRoots);
 			}
+
+			// Sync docs — unconditional (not gated on shouldMkdirClaude): docs is
+			// platform-agnostic and lands directly under deployRoot, so a docs-only
+			// project (no CATEGORIES items, no .claude) must still deploy its docs.
+			await syncDocs(context, syncYaml, rootDir, deployRoot);
 
 			// Record this worktree as a backup root ONLY after all sync steps succeeded.
 			// Registering before the steps (or on failure) would let retention cleanup

--- a/tools/validators/components.test.ts
+++ b/tools/validators/components.test.ts
@@ -441,6 +441,55 @@ agents:
 			expect(result.errors.some((e) => e.includes("missing-agent"))).toBe(true);
 		});
 	});
+
+	describe("docs existence 검증", () => {
+		it("returns error for missing docs component with no source", async () => {
+			const syncPath = writeYaml(
+				root,
+				"sync.yaml",
+				`
+path: ${root}
+docs:
+  items:
+    - component: gone
+`,
+			);
+			const result = await validateSyncYamlComponents(syncPath, root);
+			expect(result.errors.some((e) => e.includes("gone"))).toBe(true);
+		});
+
+		it("skips existence check for docs item with delete:true and no source", async () => {
+			const syncPath = writeYaml(
+				root,
+				"sync.yaml",
+				`
+path: ${root}
+docs:
+  items:
+    - component: gone
+      delete: true
+`,
+			);
+			const result = await validateSyncYamlComponents(syncPath, root);
+			expect(result.errors.filter((e) => e.includes("gone"))).toHaveLength(0);
+		});
+
+		it("produces no errors for existing docs component", async () => {
+			touch(join(root, "docs", "adr-001.md"));
+			const syncPath = writeYaml(
+				root,
+				"sync.yaml",
+				`
+path: ${root}
+docs:
+  items:
+    - component: adr-001
+`,
+			);
+			const result = await validateSyncYamlComponents(syncPath, root);
+			expect(result.errors.filter((e) => e.includes("adr-001"))).toHaveLength(0);
+		});
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/tools/validators/components.ts
+++ b/tools/validators/components.ts
@@ -25,7 +25,7 @@ import {
 	isArray,
 } from "../lib/validation.ts";
 import { resolveComponentPath, setProjectContext } from "../lib/resolver.ts";
-import type { SyncYaml } from "../lib/types.ts";
+import type { SyncItem, SyncYaml } from "../lib/types.ts";
 import { readAndExpandSyncYaml } from "../lib/parse-sync-yaml.ts";
 import { parseAndMergePlatformYaml } from "../lib/parse-platform-yaml.ts";
 import { deploysToClaudeDotDir } from "../sync.ts";
@@ -277,7 +277,7 @@ export async function validateSyncYamlComponents(
 
 	// Category definitions: [category, extension]
 	type CategoryDef = {
-		category: "agents" | "commands" | "skills" | "scripts" | "rules";
+		category: "agents" | "commands" | "skills" | "scripts" | "rules" | "docs";
 		ext: string;
 	};
 	const categories: CategoryDef[] = [
@@ -286,6 +286,7 @@ export async function validateSyncYamlComponents(
 		{ category: "skills", ext: "" },
 		{ category: "scripts", ext: "" },
 		{ category: "rules", ext: ".md" },
+		{ category: "docs", ext: "" },
 	];
 
 	for (const { category } of categories) {
@@ -299,6 +300,10 @@ export async function validateSyncYamlComponents(
 			const item = items[i];
 			const component = getItemComponent(item);
 			if (!component) continue;
+
+			// docs: a delete:true item is a tombstone naming a target to REMOVE, so
+			// its source may legitimately no longer exist — skip the existence check.
+			if (category === "docs" && isObject(item) && item.delete === true) continue;
 
 			// Agents: try flat path first for non-scoped refs
 			if (category === "agents" && !component.includes(":")) {
@@ -315,8 +320,10 @@ export async function validateSyncYamlComponents(
 
 		// hooks: also validate add-hooks in agent items
 		if (category === "agents") {
-			for (let i = 0; i < items.length; i++) {
-				const item = items[i];
+			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- category === "agents" guarantees sectionData was SyncSection, so items is SyncItem[]; the shared `items` variable's static type widens across the CategoryDef union now that "docs" (→ DocsItem[]) is a member
+			const agentItems = items as SyncItem[];
+			for (let i = 0; i < agentItems.length; i++) {
+				const item = agentItems[i];
 				if (!isObject(item)) continue;
 
 				// add-skills

--- a/tools/validators/schema.test.ts
+++ b/tools/validators/schema.test.ts
@@ -1646,6 +1646,175 @@ provision:
 });
 
 // ---------------------------------------------------------------------------
+// Suite: validateSyncYaml — docs 섹션 검증
+// ---------------------------------------------------------------------------
+
+describe("validateSyncYaml — docs 섹션 검증", () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = makeTempDir();
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	describe("docs section validated", () => {
+		it("유효한 docs 섹션은 오류 없이 통과한다", () => {
+			const path = writeYaml(
+				dir,
+				"sync.yaml",
+				`
+path: /target
+docs:
+  path: guides
+  items:
+    - component: intro
+      as: index
+`,
+			);
+			const result = validateSyncYaml(path);
+			expect(result.errors).toHaveLength(0);
+		});
+	});
+
+	describe("docs rejects platforms", () => {
+		it("item에 platforms 필드가 있으면 오류를 반환한다", () => {
+			const path = writeYaml(
+				dir,
+				"sync.yaml",
+				`
+path: /target
+docs:
+  items:
+    - component: intro
+      platforms: [claude]
+`,
+			);
+			const result = validateSyncYaml(path);
+			expect(result.errors.some((e) => e.includes("platforms"))).toBe(true);
+		});
+	});
+
+	describe("docs rejects unsafe path", () => {
+		it("item.path가 상위 디렉토리를 벗어나면 오류를 반환한다", () => {
+			const path = writeYaml(
+				dir,
+				"sync.yaml",
+				`
+path: /target
+docs:
+  items:
+    - component: intro
+      path: "../x"
+`,
+			);
+			const result = validateSyncYaml(path);
+			expect(result.errors.some((e) => e.includes("deployRoot"))).toBe(true);
+		});
+	});
+
+	describe("docs item shape", () => {
+		it("component 필드가 없으면 오류를 반환한다", () => {
+			const path = writeYaml(
+				dir,
+				"sync.yaml",
+				`
+path: /target
+docs:
+  items:
+    - path: guides/x
+`,
+			);
+			const result = validateSyncYaml(path);
+			expect(result.errors.some((e) => e.includes("component 필드가 필요합니다"))).toBe(true);
+		});
+
+		it("delete가 false이면 오류를 반환한다", () => {
+			const path = writeYaml(
+				dir,
+				"sync.yaml",
+				`
+path: /target
+docs:
+  items:
+    - component: intro
+      delete: false
+`,
+			);
+			const result = validateSyncYaml(path);
+			expect(result.errors.some((e) => e.includes("delete"))).toBe(true);
+		});
+
+		it("알 수 없는 item 필드가 있으면 오류를 반환한다", () => {
+			const path = writeYaml(
+				dir,
+				"sync.yaml",
+				`
+path: /target
+docs:
+  items:
+    - component: intro
+      unknown-field: value
+`,
+			);
+			const result = validateSyncYaml(path);
+			expect(result.errors.some((e) => e.includes("unknown-field"))).toBe(true);
+		});
+	});
+
+	describe("docs rejects section platforms", () => {
+		it("섹션에 platforms 필드가 있으면 오류를 반환한다", () => {
+			const path = writeYaml(
+				dir,
+				"sync.yaml",
+				`
+path: /target
+docs:
+  platforms: [claude]
+  items:
+    - component: intro
+`,
+			);
+			const result = validateSyncYaml(path);
+			expect(result.errors.some((e) => e.includes("platforms"))).toBe(true);
+		});
+
+		it("섹션에 알 수 없는 필드가 있으면 오류를 반환한다", () => {
+			const path = writeYaml(
+				dir,
+				"sync.yaml",
+				`
+path: /target
+docs:
+  unknown-section-field: value
+`,
+			);
+			const result = validateSyncYaml(path);
+			expect(result.errors.some((e) => e.includes("unknown-section-field"))).toBe(true);
+		});
+	});
+
+	describe("docs component name traversal", () => {
+		it("component 이름이 상위 디렉토리를 벗어나면 오류를 반환한다", () => {
+			const path = writeYaml(
+				dir,
+				"sync.yaml",
+				`
+path: /target
+docs:
+  items:
+    - component: "../../etc/x"
+`,
+			);
+			const result = validateSyncYaml(path);
+			expect(result.errors.some((e) => e.includes("deployRoot"))).toBe(true);
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
 // Suite: validateAll — local yaml 파일 탐색
 // ---------------------------------------------------------------------------
 

--- a/tools/validators/schema.test.ts
+++ b/tools/validators/schema.test.ts
@@ -1698,7 +1698,9 @@ docs:
 	});
 
 	describe("docs rejects unsafe path", () => {
-		it("item.path가 상위 디렉토리를 벗어나면 오류를 반환한다", () => {
+		it("item.path가 deployRoot를 벗어나면 오류를 반환한다", () => {
+			// "../../x" from the default "docs" base normalizes to "../x" — it
+			// escapes deployRoot itself (not merely the docs base), so it is rejected.
 			const path = writeYaml(
 				dir,
 				"sync.yaml",
@@ -1707,11 +1709,31 @@ path: /target
 docs:
   items:
     - component: intro
-      path: "../x"
+      path: "../../x"
 `,
 			);
 			const result = validateSyncYaml(path);
 			expect(result.errors.some((e) => e.includes("deployRoot"))).toBe(true);
+		});
+
+		it("item.path가 docs base만 벗어나고 deployRoot 안이면 통과한다", () => {
+			// "../shared/x" from the "docs" base resolves to "shared/x" — under
+			// deployRoot. The runtime (resolveDocsTarget/syncDocs) allows this per
+			// AC4.1, so the validator must NOT reject it: containment is asserted on
+			// the COMBINED target, never on the raw item.path fragment in isolation.
+			const path = writeYaml(
+				dir,
+				"sync.yaml",
+				`
+path: /target
+docs:
+  items:
+    - component: intro
+      path: "../shared/x"
+`,
+			);
+			const result = validateSyncYaml(path);
+			expect(result.errors).toHaveLength(0);
 		});
 	});
 

--- a/tools/validators/schema.ts
+++ b/tools/validators/schema.ts
@@ -369,16 +369,25 @@ function validateDocsPathField(
 	value: unknown,
 	fieldCtx: string,
 	result: ValidationResult,
+	assertContainment = false,
 ): string | undefined {
 	if (value === undefined) return undefined;
 	if (typeof value !== "string") {
 		result.errors.push(`${fieldCtx}: string이어야 합니다 (got ${typeof value})`);
 		return undefined;
 	}
-	try {
-		assertDocsTargetContained(value);
-	} catch (e) {
-		result.errors.push(`${fieldCtx}: ${e instanceof Error ? e.message : String(e)}`);
+	// `item.path`/`item.as` are FRAGMENTS joined onto the base — a leading `..`
+	// that stays under deployRoot once combined is legitimate (matches the
+	// runtime resolveDocsTarget + AC4.1: "leaving the docs base but under
+	// deployRoot is allowed"). Containment is asserted on the COMBINED target
+	// below, so per-field containment only applies to the section base `path`,
+	// whose own `..` genuinely escapes deployRoot.
+	if (assertContainment) {
+		try {
+			assertDocsTargetContained(value);
+		} catch (e) {
+			result.errors.push(`${fieldCtx}: ${e instanceof Error ? e.message : String(e)}`);
+		}
 	}
 	return value;
 }
@@ -400,7 +409,7 @@ function validateDocsSection(sectionData: unknown, result: ValidationResult): vo
 		}
 	}
 
-	const sectionPath = validateDocsPathField(sectionData.path, "docs.path", result);
+	const sectionPath = validateDocsPathField(sectionData.path, "docs.path", result, true);
 
 	const items = sectionData.items;
 	if (items !== undefined && !isArray(items)) {

--- a/tools/validators/schema.ts
+++ b/tools/validators/schema.ts
@@ -18,6 +18,7 @@
 import { existsSync, readdirSync } from "fs";
 import { join, dirname, basename } from "path";
 import { getRootDir } from "../lib/config.ts";
+import { resolveDocsTarget, assertDocsTargetContained } from "../lib/path-utils.ts";
 import {
 	type ValidationResult,
 	makeResult,
@@ -51,6 +52,7 @@ const VALID_SYNC_TOP_LEVEL = new Set([
 	"skills",
 	"scripts",
 	"rules",
+	"docs",
 	"provision",
 ]);
 
@@ -82,6 +84,12 @@ const VALID_ADD_HOOK_ITEM_FIELDS = new Set([
 const VALID_GENERIC_ITEM_FIELDS = new Set(["component", "platforms"]);
 
 const VALID_PROVISION_ITEM_FIELDS = new Set(["check", "commands"]);
+
+// docs is platform-agnostic (no per-section/per-item `platforms`) and has a
+// shape distinct from the generic sections (`path` instead of `platforms`,
+// item-level `path`/`as`/`delete` instead of `add-skills`/`add-hooks`).
+const VALID_DOCS_SECTION_FIELDS = new Set(["path", "items"]);
+const VALID_DOCS_ITEM_FIELDS = new Set(["component", "path", "as", "delete"]);
 
 const VALID_EVENTS = new Set([
 	"SessionStart",
@@ -348,6 +356,123 @@ function validateProvision(provision: unknown, result: ValidationResult): void {
 	}
 }
 
+/**
+ * Validate a `docs` item's `path`/`as`/section's `path` field: must be a
+ * string when present, and must itself be a relative, contained path
+ * (rejects absolute paths, empty, `.`, and any leading `..` escape) via the
+ * shared `assertDocsTargetContained` — no re-implementation of containment.
+ * Returns the string value (even if it failed containment) so the caller can
+ * still feed it into `resolveDocsTarget` for the combined-target check, or
+ * `undefined` when the field is absent or of the wrong type.
+ */
+function validateDocsPathField(
+	value: unknown,
+	fieldCtx: string,
+	result: ValidationResult,
+): string | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value !== "string") {
+		result.errors.push(`${fieldCtx}: string이어야 합니다 (got ${typeof value})`);
+		return undefined;
+	}
+	try {
+		assertDocsTargetContained(value);
+	} catch (e) {
+		result.errors.push(`${fieldCtx}: ${e instanceof Error ? e.message : String(e)}`);
+	}
+	return value;
+}
+
+function validateDocsSection(sectionData: unknown, result: ValidationResult): void {
+	if (sectionData === null || sectionData === undefined) return;
+
+	if (!isObject(sectionData)) {
+		result.errors.push(`docs: object 형식이어야 합니다`);
+		return;
+	}
+
+	// Section-level fields: docs is platform-agnostic — no `platforms` key.
+	for (const key of Object.keys(sectionData)) {
+		if (!VALID_DOCS_SECTION_FIELDS.has(key)) {
+			result.errors.push(
+				`docs: 알 수 없는 필드 '${key}' (지원: ${[...VALID_DOCS_SECTION_FIELDS].join(", ")})`,
+			);
+		}
+	}
+
+	const sectionPath = validateDocsPathField(sectionData.path, "docs.path", result);
+
+	const items = sectionData.items;
+	if (items !== undefined && !isArray(items)) {
+		result.errors.push(`docs.items: 배열 형식이어야 합니다`);
+		return;
+	}
+	if (!isArray(items)) return;
+
+	for (let i = 0; i < items.length; i++) {
+		const item = items[i];
+		const itemCtx = `docs.items[${i}]`;
+
+		if (typeof item === "string") {
+			validateComponentRef(item, itemCtx, result);
+			if (item.trim()) {
+				try {
+					resolveDocsTarget(item, sectionPath, undefined, undefined);
+				} catch (e) {
+					result.errors.push(`${itemCtx}: ${e instanceof Error ? e.message : String(e)}`);
+				}
+			}
+			continue;
+		}
+
+		if (!isObject(item)) {
+			result.errors.push(`${itemCtx}: string 또는 object 이어야 합니다`);
+			continue;
+		}
+
+		// Item-level fields: no `platforms`, no `add-skills`/`add-hooks` — docs
+		// items only ever carry component/path/as/delete.
+		for (const key of Object.keys(item)) {
+			if (!VALID_DOCS_ITEM_FIELDS.has(key)) {
+				result.errors.push(
+					`${itemCtx}: 알 수 없는 필드 '${key}' (지원: ${[...VALID_DOCS_ITEM_FIELDS].join(", ")})`,
+				);
+			}
+		}
+
+		const component = item.component;
+		let validComponent: string | undefined;
+		if (!("component" in item)) {
+			result.errors.push(`${itemCtx}: component 필드가 필요합니다`);
+		} else if (typeof component !== "string") {
+			result.errors.push(`${itemCtx}.component: string이어야 합니다 (got ${typeof component})`);
+		} else if (!component.trim()) {
+			result.errors.push(`${itemCtx}.component: 빈 문자열은 허용되지 않습니다`);
+		} else {
+			validateComponentRef(component, `${itemCtx}.component`, result);
+			validComponent = component;
+		}
+
+		const itemPath = validateDocsPathField(item.path, `${itemCtx}.path`, result);
+		const itemAs = validateDocsPathField(item.as, `${itemCtx}.as`, result);
+
+		if ("delete" in item && item.delete !== true) {
+			result.errors.push(`${itemCtx}.delete: true만 허용됩니다 (got ${JSON.stringify(item.delete)})`);
+		}
+
+		// Combined containment: catches escapes that only manifest once
+		// component/section.path/item.path/as are joined together (e.g. a
+		// traversal hidden in the component name itself).
+		if (validComponent !== undefined) {
+			try {
+				resolveDocsTarget(validComponent, sectionPath, itemPath, itemAs);
+			} catch (e) {
+				result.errors.push(`${itemCtx}: ${e instanceof Error ? e.message : String(e)}`);
+			}
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // sync.yaml validator
 // ---------------------------------------------------------------------------
@@ -378,6 +503,7 @@ function validateSyncYamlData(
 	validateSection(data.skills, "skills", result, VALID_GENERIC_ITEM_FIELDS);
 	validateSection(data.scripts, "scripts", result, VALID_GENERIC_ITEM_FIELDS);
 	validateSection(data.rules, "rules", result, VALID_GENERIC_ITEM_FIELDS);
+	validateDocsSection(data.docs, result);
 	validateProvision(data.provision, result);
 }
 


### PR DESCRIPTION
## 📌 Summary

`docs`를 OMT의 first-class 소스 컴포넌트 타입으로 추가합니다. 소스 머시너리(리졸버·오버레이·스키마·검증)는 기존 `skills`와 공유하지만, `docs/`는 **인간이 공동저작하는 공유 폴더**라서 배포는 플랫폼 팬아웃(`CATEGORIES`)에 넣지 않고 `hooks` 선례처럼 전용 `syncDocs`로 분리했습니다. 배포는 디렉토리 wipe 없이 파일 단위 merge-patch(선언=덮어쓰기 / 미선언=보존 / `delete:true`=제거)로 동작하며, 미선언 인간 파일은 어떤 코드 경로로도 삭제되지 않습니다.

---

## 🔧 Changes

### 타입 시스템 — `DeployCategory` / `SourceCategory` 분리

- `Category` 단일 유니온을 `DeployCategory`(agents·commands·skills·scripts·rules)와 `SourceCategory`(= `DeployCategory | "docs"`)로 분리
- `Category = DeployCategory` 하위호환 별칭 유지 → 기존 배포측 소비자(`pull.ts`, `pull-utils.ts`, `SUPPORTED_CATEGORIES`) 무수정 컴파일
- `DocsSection`/`DocsItem` 형태와 `SyncYaml.docs?` 추가

**영향 범위**
`tools/lib/types.ts`만 신규 타입 추가. 기존 소비자는 별칭으로 무변경. docs가 배포 유니온에 들어가면 `make typecheck` 실패(컴파일 타임 seam 강제).

### 경로 해석·안전 헬퍼 (lexical)

- `resolveDocsTarget()` — `component-name + section.path + path + as`로 최종 상대 타깃 계산
- containment 단언(정규화 후 leading `..`/절대경로/deployRoot 자기자신 거부), host-FS 무관 케이스충돌·중복타깃 검출
- FS 접근 없는 순수 lexical (심링크 방어는 런타임 가드가 담당 — Review Point 4)

**영향 범위**
`tools/lib/path-utils.ts`. 순수 함수라 validate/runtime/dry-run 3층이 동일 규칙을 공유. 기존 path-utils 동작 무변경.

### 소스측 등록 (배포측 아님)

- `schema.ts`: `VALID_SYNC_TOP_LEVEL`에 `"docs"` + per-section 디스패치에 `validateDocsSection` (섹션/아이템 형태·`delete` 리터럴 `true`·경로 안전 검증)
- `components.ts`: `CategoryDef`에 `{category:"docs", ext:""}` + `delete:true` 아이템은 소스 존재 검증 skip(툼스톤)
- `overlay-keys.ts`: `docs.items` → `syncItemsKey` 등록 (`.local.yaml` 오버레이가 `component` 기준 dedup)

**영향 범위**
`docs`는 소스 검증·존재확인·오버레이만 참여. `CATEGORIES`/`SUPPORTED_CATEGORIES`/adapter/`FILE_BASED_CATEGORIES`/`COMPONENT_DIRS`에는 부재(grep 확인 완료).

### 파일 단위 백업

- `backupDocs()` — 덮어쓰기/삭제 직전 각 타깃 파일을 `.sync-backup/{sessionId}/docs/<relpath>`로 백업, `backupConfigFile` 재사용
- 리텐션은 `cleanupOldBackups`가 `.sync-backup/` 트리 전체를 관리하므로 별도 배선 없이 상속

**영향 범위**
`tools/lib/backup.ts`. `backupCategory`(platform×category 경로)는 재사용 불가라 신규 함수. 디렉토리 단위가 아닌 파일 단위(EISDIR 회피).

### 배포 — 전용 `syncDocs`

- `processYaml`의 per-`deployRoot` try에서 **마지막 배포 단계**로 호출(`CATEGORIES` 루프·`syncLib` 이후, `backupRoots.add` 직전) → docs 오류가 검증된 `.claude` 경로를 중단시키지 않음
- merge-patch: 선언 아이템 파일 단위 덮어쓰기 / `delete:true` 제거(부재 시 멱등 no-op) / form-morph 자기 정리
- 런타임 경로 안전 가드(Review Point 4), dry-run write/delete/advisory 미리보기(디스크 미변경)

**영향 범위**
`tools/sync.ts`. 기존 카테고리 배포 경로·wipe 시맨틱 무변경. docs-only 프로젝트도 배포(`shouldMkdirClaude` 게이트 없음). 실패는 worktree 단위로 `failedTargets` 라우팅(기존 best-effort 시맨틱과 일관).

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 소스 정체성과 배포 정체성의 분리

**배경 및 문제 상황:**
`docs/`는 사람이 직접 파일을 추가·수정하는 공유 폴더입니다. 기존 6개 카테고리는 `.claude/` 같은 OMT 소유 디렉토리로 플랫폼별 팬아웃되며 배포 시 대상 디렉토리를 `fs.rm` 후 재생성합니다. 이 wipe를 `docs/`에 적용하면 사람이 넣은 파일이 사라집니다.

**해결 방안:**
`docs`를 first-class *소스* 카테고리로만 합류시키고, 배포는 `CATEGORIES` 팬아웃 루프에서 제외한 뒤 전용 `syncDocs`로 단일 플랫폼-무관 위치에 merge-patch합니다. 이는 새로 발명한 패턴이 아니라 이미 리포에 있는 `hooks` 선례(first-class 소스지만 `CATEGORIES`에서 의도적으로 빠지고 별도 경로로 배포)를 그대로 따른 것입니다.

**구현 세부사항:**
`syncDocs`는 `processYaml`의 per-`deployRoot` try 안에서 마지막 배포 단계로 배치했습니다. 이 위치 덕분에 docs 오류가 나도 그 시점엔 `.claude` 카테고리와 `syncLib`가 이미 완료돼 있어, 잘 검증된 경로를 오염시키지 않습니다. 대신 dedup·backup-root 등록·`failedTargets` 라우팅을 caller로부터 무상속받습니다.

**선택과 트레이드오프:**
대안 B(가짜 플랫폼 "shared")는 `Platform` 유니온·경로 재작성·벤더링을 오염시키고 wipe가 `.shared/docs`를 지웁니다. 대안 C(adapter 라우팅)는 4개 어댑터 중 3개를 no-op으로 만들고 게이트 플랫폼 제외 시 docs가 조용히 사라지는 잠재 버그가 있습니다. 채택안의 비용은 배포 경로가 둘(`syncCategory` + `syncDocs`)로 늘어나는 것 — N=2가 되면 `mergePatchDeploy` 헬퍼로 추출하는 것이 상환 지점입니다(현재는 YAGNI).

### 2. per-file 소유 = anti-wipe 불변식

**배경 및 문제 상황:**
docs 아이템은 디렉토리 형태(`foo/` → `docs/foo/`)일 수 있습니다. "리졸버 + `syncDirectory` 재사용"이라는 자명한 메커니즘은 rsync `--delete`로 타깃 디렉토리 안의 orphan을 쓸어내는데, 이는 사람이 `docs/foo/`에 추가한 파일을 파괴합니다.

**해결 방안:**
아이템은 자신이 배포하는 파일만 소유합니다(파일형=1개, 디렉토리형=소스 디렉토리의 파일 집합). 배포는 파일 단위 additive copy로 대응 파일만 덮어쓰고, 타깃 안의 미선언 파일은 — 디렉토리형 타깃 내부라도 — 보존됩니다. 삭제는 오직 명시적 `delete:true`로만 일어납니다.

**구현 세부사항:**
`syncDirectory --delete`는 docs 경로에서 절대 사용하지 않습니다. 이미 리포의 `rules` 카테고리가 동일한 no-wipe·additive 동작(`sync.ts`가 wipe에서 제외)이라, `hooks`(config-merge)보다 더 강한 동종 선례입니다.

**선택과 트레이드오프:**
대안 C(매니페스트 추적 소유)는 진짜 mirror 시맨틱을 주지만 영속 상태와 stale/corrupt 매니페스트라는 새 실패 모드를 더합니다. 사람이 공동저작하는 폴더에는 **명시적·수동 삭제**(`sync.yaml` diff에 보임)가 **암묵적·자동 sweep**(아무도 이 diff에서 명명하지 않은 파일 삭제)보다 안전합니다. 대가: 소스→타깃 발산(운영자 자신의 소스 삭제 포함)은 자동 mirror가 아니라 `delete:true`로 조정해야 하며, 이 발산은 dry-run advisory 목록으로 표면화됩니다.

### 3. `DeployCategory` / `SourceCategory` 타입 분리

**배경 및 문제 상황:**
`Category`를 단일 유니온으로 두고 `docs`를 추가하면, docs가 배포 팬아웃 루프에 타입 레벨로 흘러들어 "조용히 팬아웃되거나 사라지는" 버그 클래스가 런타임 관례로만 막히게 됩니다.

**해결 방안:**
유니온을 둘로 쪼개 배포 사이트는 `DeployCategory`(docs 불가능), 소스 사이트는 `SourceCategory`(docs 포함)로 타이핑합니다. seam이 컴파일러로 강제됩니다.

**선택과 트레이드오프:**
`Category`를 리터럴 rename하면 모든 배포측 소비자를 건드려야 합니다. 대신 `Category = DeployCategory` 별칭을 남겨 소비자 churn을 0으로 만들었습니다. 비용은 스레드할 타입 이름이 하나 늘어난 것뿐이고, docs가 배포 사이트에 추가되는 순간 `make typecheck`가 실패합니다.

### 4. 2층 경로 안전 (lexical containment + 런타임 심링크 가드)

**배경 및 문제 상황:**
T1 데이터 파괴 리스크. 세 가지 탈출 벡터가 있습니다 — (a) component 이름을 통한 traversal(`../../etc/x`), (b) 사람이 심은 심링크 intermediate 디렉토리(`docs/api → ../../generated`)를 `cp`가 따라가 외부 파일 clobber, (c) 케이스 충돌.

**해결 방안:**
검증 시점 lexical containment(순수 문자열, FS 무접근)와 런타임 per-segment 심링크 가드를 **합성**합니다. 어느 하나만으로는 불충분합니다.

**구현 세부사항:**
lexical 층이 lexical한 이유: validate 시점엔 타깃이 아직 없어 `realpath` 불가하고, `realpath`는 macOS/Linux 간 케이스 민감도 의존성을 만듭니다. FS 층은 덮어쓰기/삭제 전에 최종 타깃의 존재하는 조상 세그먼트를 `lstat`로 걸어 심링크면 거부합니다. 이 FS 가드가 **필요한** 이유는 docs가 no-wipe이기 때문입니다 — 팬아웃 카테고리는 타깃을 `fs.rm`+`mkdir`해서 심은 심링크를 못 물려받지만, docs는 사람이 심은 심링크를 보존해 `cp`가 따라갈 수 있습니다.

**선택과 트레이드오프:**
containment를 입력 사이트별 문자열 검사로 두는 대안은 component 이름이라는 4번째 타깃 결정 입력을 빠뜨립니다 — *해석된 출력*을 가드하면 모든 입력을 포섭합니다. dir-form 타깃 자신의 하위 디렉토리에 심긴 nested intermediate 심링크까지 거부하도록 확장했습니다.

---

## ✅ Checklist

### 타입 seam
- [ ] `DeployCategory`/`SourceCategory`가 분리되고 docs를 배포 사이트에 추가하면 typecheck 실패
  - `tools/lib/types.ts`
- [ ] 기존 배포측 소비자가 `Category` 별칭으로 무수정 컴파일
  - `tools/pull.ts`, `tools/lib/pull-utils.ts`, `tools/sync.ts`

### 경로 안전
- [ ] escape(`..`)/절대경로/deployRoot 자기자신 타깃이 검증·런타임·dry-run 모두에서 거부됨
  - `tools/lib/path-utils.ts`, `tools/sync.ts`
- [ ] 소스 심링크·타깃 leaf 심링크·intermediate 심링크가 모두 거부되고 외부 위치는 미변경
  - `tools/sync.ts`
- [ ] 케이스 충돌·중복 타깃이 FS 조회 없이 mutation 전에 거부됨
  - `tools/lib/path-utils.ts`

### anti-wipe 배포
- [ ] 디렉토리형 타깃 내부의 미선언 인간 파일이 sync 후 생존
  - `tools/sync.ts`
- [ ] `delete:true`가 부재 타깃에서 멱등 no-op이고, 선언 아이템은 무조건 덮어쓰기
  - `tools/sync.ts`
- [ ] 덮어쓰기/삭제 직전 타깃 파일이 `.sync-backup/{sessionId}/docs/`로 백업됨
  - `tools/lib/backup.ts`
- [ ] dry-run이 write/delete/advisory 계획을 출력하고 디스크에 아무것도 쓰지 않음
  - `tools/sync.ts`

### 배포 격리
- [ ] `docs`가 `CATEGORIES`/`SUPPORTED_CATEGORIES`/adapter/`FILE_BASED_CATEGORIES`/`COMPONENT_DIRS`에 부재
  - `tools/sync.ts`, `tools/adapters/*.ts`, `tools/lib/pull-utils.ts`, `tools/validators/components.ts`
- [ ] docs-only 프로젝트가 `.claude` 게이트 없이 배포되고, worktree 팬아웃 시 중복 배포 없음
  - `tools/sync.ts`
