### PR TITLE
feat: 불투명 라벨 금지 소통 규칙·강제 훅 도입

### DIFF
--- a/claude.yaml
+++ b/claude.yaml
@@ -2,6 +2,14 @@ hooks:
   PreCompact:
     - component: pre-compact.sh
       timeout: 1200
+  PreToolUse:
+    - component: label-commit-gate.sh
+      matcher: "Bash"
+      timeout: 5
+  PostToolUse:
+    - component: label-edit-warn.sh
+      matcher: "Write|Edit|MultiEdit"
+      timeout: 5
 
 config:
   language: "한국어"

--- a/hooks/label-commit-gate.sh
+++ b/hooks/label-commit-gate.sh
@@ -35,24 +35,38 @@ if [[ ! "$cmd" =~ $_commit_gate_re ]]; then
     exit 0
 fi
 
-# Extract the commit MESSAGE. Human paths (editor-driven commit, bare
-# --amend, -F -) leave message empty → passthrough.
+# Extract the commit MESSAGE across ALL documented forms, then scan their
+# union. Human paths (editor-driven commit, bare --amend, -F -) leave the
+# message empty → passthrough. First-match-only extraction previously let
+# documented forms (--message, repeated -m as subject/body, --file <path>)
+# bypass the hard block (Codex PR #161 P2).
 message=""
 
-if [[ "$cmd" =~ -[a-zA-Z]*m[[:space:]]*\'([^\']*)\' ]]; then
-    message="${BASH_REMATCH[1]}"
-elif [[ "$cmd" =~ -[a-zA-Z]*m[[:space:]]*\"([^\"]*)\" ]]; then
-    message="${BASH_REMATCH[1]}"
-elif [[ "$cmd" =~ -F[[:space:]]+([^[:space:]]+) ]]; then
-    file_path="${BASH_REMATCH[1]}"
-    if [[ "$file_path" != "-" && -f "$file_path" ]]; then
-        message=$(cat "$file_path")
-    fi
-elif [[ "$cmd" =~ --file=([^[:space:]]+) ]]; then
-    file_path="${BASH_REMATCH[1]}"
-    if [[ -f "$file_path" ]]; then
-        message=$(cat "$file_path")
-    fi
+# Every -m / -am / --message value (space or = form, single or double
+# quoted). git treats repeated -m as subject/body paragraphs, so all values
+# are collected. Iterated because bash =~ captures only the leftmost match
+# per call; each pass strips through the matched value and re-scans the rest.
+# The leading (^|[[:space:]]) pins the flag to a token boundary so
+# -[a-zA-Z]*m never mis-binds to the "-m" substring inside "--message".
+_msg_re='(^|[[:space:]])(-[a-zA-Z]*m|--message)[[:space:]]*=?[[:space:]]*('\''[^'\'']*'\''|"[^"]*")'
+_rest="$cmd"
+while [[ "$_rest" =~ $_msg_re ]]; do
+    _val="${BASH_REMATCH[3]}"
+    _val="${_val#[\'\"]}"; _val="${_val%[\'\"]}"   # strip the surrounding quotes
+    message="$message$_val"$'\n'
+    _rest="${_rest#*"${BASH_REMATCH[0]}"}"          # advance past this match
+done
+
+# -F/--file message file: space form (-F <path>, --file <path>) or
+# --file=<path>. -F - (stdin) is a human path → left unread.
+file_path=""
+if [[ "$cmd" =~ (^|[[:space:]])(-F|--file)[[:space:]]+([^[:space:]]+) ]]; then
+    file_path="${BASH_REMATCH[3]}"
+elif [[ "$cmd" =~ (^|[[:space:]])--file=([^[:space:]]+) ]]; then
+    file_path="${BASH_REMATCH[2]}"
+fi
+if [[ -n "$file_path" && "$file_path" != "-" && -f "$file_path" ]]; then
+    message="$message$(cat "$file_path")"$'\n'
 fi
 
 if [[ -z "$message" ]]; then

--- a/hooks/label-commit-gate.sh
+++ b/hooks/label-commit-gate.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# =============================================================================
+# Label Commit Gate (PreToolUse hook)
+# Hard-blocks a `git commit` whose commit MESSAGE (message only — never
+# staged content) contains a clean-economics invented label. Message-only
+# by design: scanning staged content would collide with legitimate
+# `### D-1:` ADR headings.
+# matcher: "Bash"
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Fail-open source guard: this is a style gate, not a security gate — a
+# deploy drift must never wedge the user's commits.
+source "$SCRIPT_DIR/lib/label-patterns.sh" 2>/dev/null || {
+    echo "WARNING: label-patterns.sh missing — commit-gate disabled" >&2
+    exit 0
+}
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+
+# Fast path: not a git commit → passthrough. Tolerates git GLOBAL options
+# between `git` and `commit` (e.g. `git -C <path> commit`), bounded to a
+# single line: the between-run excludes shell operators (&/|/;) AND
+# newline/CR — a newline is also a command separator, so a `git <x>` on
+# one line must never bleed into an unrelated `commit` token on a later
+# line. The two inter-token gaps use [[:blank:]] (space/tab only, never
+# newline) so `git` and `commit` must share one line. Still guards
+# against `git commit-graph`/`commit-tree` by requiring a space or
+# end-of-string after "commit".
+_commit_gate_nl=$'\n\r'
+_commit_gate_re='git[[:blank:]]([^\&\|\;'"$_commit_gate_nl"']*[[:blank:]])?commit([[:space:]]|$)'
+if [[ ! "$cmd" =~ $_commit_gate_re ]]; then
+    exit 0
+fi
+
+# Extract the commit MESSAGE. Human paths (editor-driven commit, bare
+# --amend, -F -) leave message empty → passthrough.
+message=""
+
+if [[ "$cmd" =~ -[a-zA-Z]*m[[:space:]]*\'([^\']*)\' ]]; then
+    message="${BASH_REMATCH[1]}"
+elif [[ "$cmd" =~ -[a-zA-Z]*m[[:space:]]*\"([^\"]*)\" ]]; then
+    message="${BASH_REMATCH[1]}"
+elif [[ "$cmd" =~ -F[[:space:]]+([^[:space:]]+) ]]; then
+    file_path="${BASH_REMATCH[1]}"
+    if [[ "$file_path" != "-" && -f "$file_path" ]]; then
+        message=$(cat "$file_path")
+    fi
+elif [[ "$cmd" =~ --file=([^[:space:]]+) ]]; then
+    file_path="${BASH_REMATCH[1]}"
+    if [[ -f "$file_path" ]]; then
+        message=$(cat "$file_path")
+    fi
+fi
+
+if [[ -z "$message" ]]; then
+    exit 0
+fi
+
+if label_match_hard "$message"; then
+    # Best-effort extraction of the offending token so the reason names it.
+    matched_token=$(printf '%s\n' "$message" \
+        | LABEL_RE="$_LABEL_PATTERN_HARD" perl -ne 'if (/($ENV{LABEL_RE})/) { print $1; exit }')
+    reason="Invented label in commit message (see rules/communication-style.md). Reword to name the thing, not '${matched_token}'."
+    jq -n --arg reason "$reason" '{decision:"deny",reason:$reason}' >&2
+    exit 2
+fi
+
+exit 0

--- a/hooks/label-commit-gate_test.sh
+++ b/hooks/label-commit-gate_test.sh
@@ -270,6 +270,79 @@ test_multiline_real_git_commit_on_second_line_denies() {
 }
 
 # =============================================================================
+# Documented-message-form coverage (Codex PR #161 P2): the hard block must
+# scan the actual commit text across ALL documented `git commit` message
+# forms, not just the first short quoted `-m`. Each of these creates a
+# message carrying a forbidden label and must → exit 2.
+# =============================================================================
+test_dash_dash_message_space_denies() {
+    local exit_code=0 stderr_out
+    local cmd="git commit --message 'fix D-36'"
+    stderr_out=$(jq -n --arg c "$cmd" '{tool_input:{command:$c}}' \
+        | bash "$HOOK" 2>&1 >/dev/null) || exit_code=$?
+
+    [[ "$exit_code" -eq 2 ]] \
+        || { echo "ASSERTION FAILED: --message <space> form should deny (exit=$exit_code)"; return 1; }
+    echo "$stderr_out" | grep -q "D-36" \
+        || { echo "ASSERTION FAILED: stderr should name 'D-36'. Got: '$stderr_out'"; return 1; }
+}
+
+test_dash_dash_message_equals_denies() {
+    local exit_code=0 stderr_out
+    local cmd="git commit --message='fix D-36'"
+    stderr_out=$(jq -n --arg c "$cmd" '{tool_input:{command:$c}}' \
+        | bash "$HOOK" 2>&1 >/dev/null) || exit_code=$?
+
+    [[ "$exit_code" -eq 2 ]] \
+        || { echo "ASSERTION FAILED: --message= form should deny (exit=$exit_code)"; return 1; }
+    echo "$stderr_out" | grep -q "D-36" \
+        || { echo "ASSERTION FAILED: stderr should name 'D-36'. Got: '$stderr_out'"; return 1; }
+}
+
+# Repeated -m (subject + body): git accepts multiple -m as paragraphs; the
+# label lives in the SECOND value, which the first-match-only extractor missed.
+test_repeated_dash_m_label_in_body_denies() {
+    local exit_code=0 stderr_out
+    local cmd="git commit -m 'clean subject' -m 'fix D-36'"
+    stderr_out=$(jq -n --arg c "$cmd" '{tool_input:{command:$c}}' \
+        | bash "$HOOK" 2>&1 >/dev/null) || exit_code=$?
+
+    [[ "$exit_code" -eq 2 ]] \
+        || { echo "ASSERTION FAILED: repeated -m (label in 2nd) should deny (exit=$exit_code)"; return 1; }
+    echo "$stderr_out" | grep -q "D-36" \
+        || { echo "ASSERTION FAILED: stderr should name 'D-36'. Got: '$stderr_out'"; return 1; }
+}
+
+# --file <space> path (long-flag space form of -F): only --file=<path> was
+# handled; the space-separated documented form left the message unscanned.
+test_dash_dash_file_space_denies() {
+    local exit_code=0 stderr_out
+    local msg_file="$TEST_TMP_DIR/msg3.txt"
+    printf 'fix D-36\n' > "$msg_file"
+
+    local cmd="git commit --file $msg_file"
+    stderr_out=$(jq -n --arg c "$cmd" '{tool_input:{command:$c}}' \
+        | bash "$HOOK" 2>&1 >/dev/null) || exit_code=$?
+
+    [[ "$exit_code" -eq 2 ]] \
+        || { echo "ASSERTION FAILED: --file <space> form should deny (exit=$exit_code)"; return 1; }
+    echo "$stderr_out" | grep -q "D-36" \
+        || { echo "ASSERTION FAILED: stderr should name 'D-36'. Got: '$stderr_out'"; return 1; }
+}
+
+# Guard: repeated -m where NO value carries a label must still passthrough
+# (subject + body both clean) → exit 0.
+test_repeated_dash_m_all_clean_passthrough() {
+    local exit_code=0
+    local cmd="git commit -m 'add enrich flag' -m 'covers retries and timeouts'"
+    jq -n --arg c "$cmd" '{tool_input:{command:$c}}' \
+        | bash "$HOOK" >/dev/null 2>&1 || exit_code=$?
+
+    [[ "$exit_code" -eq 0 ]] \
+        || { echo "ASSERTION FAILED: repeated -m all-clean should passthrough (exit=$exit_code)"; return 1; }
+}
+
+# =============================================================================
 # Fail-open source guard: missing lib must never wedge a commit (exit 0)
 # =============================================================================
 test_fail_open_when_lib_missing() {
@@ -308,6 +381,11 @@ main() {
     run_test test_editor_driven_commit_passthrough
     run_test test_bare_amend_no_message_passthrough
     run_test test_dash_dash_file_equals_shape_denies
+    run_test test_dash_dash_message_space_denies
+    run_test test_dash_dash_message_equals_denies
+    run_test test_repeated_dash_m_label_in_body_denies
+    run_test test_dash_dash_file_space_denies
+    run_test test_repeated_dash_m_all_clean_passthrough
     run_test test_combined_short_flag_am_denies
     run_test test_git_global_option_before_commit_denies
     run_test test_commit_graph_still_passthrough

--- a/hooks/label-commit-gate_test.sh
+++ b/hooks/label-commit-gate_test.sh
@@ -1,0 +1,328 @@
+#!/bin/bash
+# =============================================================================
+# Label Commit Gate Hook Tests
+# Covers AC-EH1a / AC-EH1b / AC-EH1c / AC-EH2 for hooks/label-commit-gate.sh —
+# a PreToolUse (Bash matcher) hook that hard-blocks a `git commit` whose
+# commit MESSAGE (message only, never staged content) contains a
+# clean-economics invented label (hooks/lib/label-patterns.sh label_match_hard).
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/label-commit-gate.sh"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# -----------------------------------------------------------------------------
+# mktemp -d + cleanup trap (OMT shell-test convention)
+# -----------------------------------------------------------------------------
+TEST_TMP_DIR=$(mktemp -d)
+cleanup() {
+    rm -rf "$TEST_TMP_DIR"
+}
+trap cleanup EXIT
+
+run_hook() {
+    local cmd_json="$1"
+    printf '{"tool_input":{"command":%s}}' "$cmd_json" | bash "$HOOK"
+}
+
+run_test() {
+    local test_name="$1"
+    if "$test_name"; then
+        echo "[PASS] $test_name"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "[FAIL] $test_name"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+# =============================================================================
+# AC-EH1a — hard-tier label in -m message → exit 2, stderr names the token
+# =============================================================================
+test_ac_eh1a_hard_label_in_dash_m_denies() {
+    local exit_code=0
+    local stderr_out
+    stderr_out=$(printf '{"tool_input":{"command":"git commit -m '"'"'fix D-36'"'"'"}}' \
+        | bash "$HOOK" 2>&1 >/dev/null) || exit_code=$?
+
+    [[ "$exit_code" -eq 2 ]] \
+        || { echo "ASSERTION FAILED: exit code should be 2 (exit=$exit_code)"; return 1; }
+
+    echo "$stderr_out" | grep -q "D-36" \
+        || { echo "ASSERTION FAILED: stderr should name 'D-36'. Got: '$stderr_out'"; return 1; }
+
+    echo "$stderr_out" | grep -q '"decision"[[:space:]]*:[[:space:]]*"deny"' \
+        || { echo "ASSERTION FAILED: stderr should carry decision:deny JSON. Got: '$stderr_out'"; return 1; }
+}
+
+# =============================================================================
+# AC-EH1b — clean message (no invented label) → exit 0
+# =============================================================================
+test_ac_eh1b_clean_message_allows() {
+    local exit_code=0
+    printf '{"tool_input":{"command":"git commit -m '"'"'add enrich flag'"'"'"}}' \
+        | bash "$HOOK" >/dev/null 2>&1 || exit_code=$?
+
+    [[ "$exit_code" -eq 0 ]] \
+        || { echo "ASSERTION FAILED: exit code should be 0 for clean message (exit=$exit_code)"; return 1; }
+}
+
+# =============================================================================
+# AC-EH1c — FULL-tier-only pattern ("Phase 2") in message must NOT hard-block
+# (label_match_hard must be used, never label_match_full)
+# =============================================================================
+test_ac_eh1c_full_tier_only_pattern_allows() {
+    local exit_code=0
+    printf '{"tool_input":{"command":"git commit -m '"'"'feat: Phase 2 rollout'"'"'"}}' \
+        | bash "$HOOK" >/dev/null 2>&1 || exit_code=$?
+
+    [[ "$exit_code" -eq 0 ]] \
+        || { echo "ASSERTION FAILED: exit code should be 0 for 'Phase 2' message (exit=$exit_code)"; return 1; }
+}
+
+# =============================================================================
+# AC-EH1 (-F variant) — hard-tier label read from a -F file path → exit 2
+# =============================================================================
+test_ac_eh1_dash_capital_f_file_denies() {
+    local exit_code=0
+    local stderr_out
+    local msg_file="$TEST_TMP_DIR/msg.txt"
+    printf 'fix D-36\n' > "$msg_file"
+
+    local cmd
+    cmd="git commit -F $msg_file"
+    stderr_out=$(jq -n --arg c "$cmd" '{tool_input:{command:$c}}' \
+        | bash "$HOOK" 2>&1 >/dev/null) || exit_code=$?
+
+    [[ "$exit_code" -eq 2 ]] \
+        || { echo "ASSERTION FAILED: exit code should be 2 for -F file with hard label (exit=$exit_code)"; return 1; }
+
+    echo "$stderr_out" | grep -q "D-36" \
+        || { echo "ASSERTION FAILED: stderr should name 'D-36'. Got: '$stderr_out'"; return 1; }
+}
+
+# =============================================================================
+# Non-commit Bash passthrough — .tool_input.command = "ls" → exit 0
+# =============================================================================
+test_non_commit_bash_passthrough() {
+    local exit_code=0
+    printf '{"tool_input":{"command":"ls"}}' | bash "$HOOK" >/dev/null 2>&1 || exit_code=$?
+
+    [[ "$exit_code" -eq 0 ]] \
+        || { echo "ASSERTION FAILED: exit code should be 0 for non-commit Bash (exit=$exit_code)"; return 1; }
+}
+
+# =============================================================================
+# AC-EH2 — message-only proof: clean MESSAGE passes even though the hook
+# never reads staged content (no real git repo/staging is set up here — the
+# absence of any git-diff read is the point being proven).
+# =============================================================================
+test_ac_eh2_message_only_clean_message_allows() {
+    local exit_code=0
+    printf '{"tool_input":{"command":"git commit -m '"'"'add ADR'"'"'"}}' \
+        | bash "$HOOK" >/dev/null 2>&1 || exit_code=$?
+
+    [[ "$exit_code" -eq 0 ]] \
+        || { echo "ASSERTION FAILED: exit code should be 0 for clean-message commit regardless of staged content (exit=$exit_code)"; return 1; }
+}
+
+# =============================================================================
+# Human paths must never be blocked: -F -, editor-driven, bare --amend
+# =============================================================================
+test_stdin_message_dash_f_dash_passthrough() {
+    local exit_code=0
+    printf '{"tool_input":{"command":"git commit -F -"}}' \
+        | bash "$HOOK" >/dev/null 2>&1 || exit_code=$?
+
+    [[ "$exit_code" -eq 0 ]] \
+        || { echo "ASSERTION FAILED: exit code should be 0 for -F - (stdin message) (exit=$exit_code)"; return 1; }
+}
+
+test_editor_driven_commit_passthrough() {
+    local exit_code=0
+    printf '{"tool_input":{"command":"git commit"}}' \
+        | bash "$HOOK" >/dev/null 2>&1 || exit_code=$?
+
+    [[ "$exit_code" -eq 0 ]] \
+        || { echo "ASSERTION FAILED: exit code should be 0 for editor-driven commit (exit=$exit_code)"; return 1; }
+}
+
+test_bare_amend_no_message_passthrough() {
+    local exit_code=0
+    printf '{"tool_input":{"command":"git commit --amend"}}' \
+        | bash "$HOOK" >/dev/null 2>&1 || exit_code=$?
+
+    [[ "$exit_code" -eq 0 ]] \
+        || { echo "ASSERTION FAILED: exit code should be 0 for bare --amend (exit=$exit_code)"; return 1; }
+}
+
+# =============================================================================
+# --file=<path> shape (long-flag form of -F) → exit 2 on hard label
+# =============================================================================
+test_dash_dash_file_equals_shape_denies() {
+    local exit_code=0
+    local stderr_out
+    local msg_file="$TEST_TMP_DIR/msg2.txt"
+    printf 'fix D-36\n' > "$msg_file"
+
+    local cmd
+    cmd="git commit --file=$msg_file"
+    stderr_out=$(jq -n --arg c "$cmd" '{tool_input:{command:$c}}' \
+        | bash "$HOOK" 2>&1 >/dev/null) || exit_code=$?
+
+    [[ "$exit_code" -eq 2 ]] \
+        || { echo "ASSERTION FAILED: exit code should be 2 for --file= with hard label (exit=$exit_code)"; return 1; }
+
+    echo "$stderr_out" | grep -q "D-36" \
+        || { echo "ASSERTION FAILED: stderr should name 'D-36'. Got: '$stderr_out'"; return 1; }
+}
+
+# =============================================================================
+# Combined short-flag form `-am` — message must still be extracted → exit 2
+# =============================================================================
+test_combined_short_flag_am_denies() {
+    local exit_code=0
+    local stderr_out
+    stderr_out=$(printf '{"tool_input":{"command":"git commit -am '"'"'fix D-36'"'"'"}}' \
+        | bash "$HOOK" 2>&1 >/dev/null) || exit_code=$?
+
+    [[ "$exit_code" -eq 2 ]] \
+        || { echo "ASSERTION FAILED: exit code should be 2 for -am combined flag (exit=$exit_code)"; return 1; }
+
+    echo "$stderr_out" | grep -q "D-36" \
+        || { echo "ASSERTION FAILED: stderr should name 'D-36'. Got: '$stderr_out'"; return 1; }
+}
+
+# =============================================================================
+# `git -C <path> commit -m '...'` — git global option before commit must
+# still trigger detection → exit 2
+# =============================================================================
+test_git_global_option_before_commit_denies() {
+    local exit_code=0
+    local stderr_out
+    local cmd="git -C /tmp/x commit -m 'see D-1'"
+    stderr_out=$(jq -n --arg c "$cmd" '{tool_input:{command:$c}}' \
+        | bash "$HOOK" 2>&1 >/dev/null) || exit_code=$?
+
+    [[ "$exit_code" -eq 2 ]] \
+        || { echo "ASSERTION FAILED: exit code should be 2 for 'git -C <path> commit -m' (exit=$exit_code)"; return 1; }
+
+    echo "$stderr_out" | grep -q "D-1\b" \
+        || { echo "ASSERTION FAILED: stderr should name 'D-1'. Got: '$stderr_out'"; return 1; }
+}
+
+# =============================================================================
+# Guard-preserving negative: broadened detection must NOT match
+# `git commit-graph` (a distinct git subcommand, not a commit) → exit 0
+# =============================================================================
+test_commit_graph_still_passthrough() {
+    local exit_code=0
+    printf '{"tool_input":{"command":"git commit-graph write"}}' \
+        | bash "$HOOK" >/dev/null 2>&1 || exit_code=$?
+
+    [[ "$exit_code" -eq 0 ]] \
+        || { echo "ASSERTION FAILED: exit code should be 0 for 'git commit-graph write' (exit=$exit_code)"; return 1; }
+}
+
+# =============================================================================
+# Newline boundary — detection must be single-line only. A `git <x>` on one
+# line must never let the between-run match across the newline into an
+# unrelated later line that happens to contain a bare `commit` token.
+# =============================================================================
+test_multiline_git_diff_then_prose_commit_mention_passthrough() {
+    local exit_code=0
+    local cmd
+    cmd=$(printf 'git diff --staged\necho "ready to commit with -m '\''D-1'\''"')
+    jq -n --arg c "$cmd" '{tool_input:{command:$c}}' \
+        | bash "$HOOK" >/dev/null 2>&1 || exit_code=$?
+
+    [[ "$exit_code" -eq 0 ]] \
+        || { echo "ASSERTION FAILED: exit code should be 0 for multi-line 'git diff' followed by unrelated prose mentioning commit (exit=$exit_code)"; return 1; }
+}
+
+test_multiline_bare_commit_word_on_own_line_passthrough() {
+    local exit_code=0
+    local cmd
+    cmd=$(printf 'git status\ncommit -m '\''D-1'\''')
+    jq -n --arg c "$cmd" '{tool_input:{command:$c}}' \
+        | bash "$HOOK" >/dev/null 2>&1 || exit_code=$?
+
+    [[ "$exit_code" -eq 0 ]] \
+        || { echo "ASSERTION FAILED: exit code should be 0 for 'git status' followed by a bare 'commit' on a later, unrelated line (exit=$exit_code)"; return 1; }
+}
+
+test_multiline_real_git_commit_on_second_line_denies() {
+    local exit_code=0
+    local stderr_out
+    local cmd
+    cmd=$(printf 'git add -A\ngit commit -m '\''D-1'\''')
+    stderr_out=$(jq -n --arg c "$cmd" '{tool_input:{command:$c}}' \
+        | bash "$HOOK" 2>&1 >/dev/null) || exit_code=$?
+
+    [[ "$exit_code" -eq 2 ]] \
+        || { echo "ASSERTION FAILED: exit code should be 2 for a genuine 'git commit' on its own line (exit=$exit_code)"; return 1; }
+
+    echo "$stderr_out" | grep -q "D-1" \
+        || { echo "ASSERTION FAILED: stderr should name 'D-1'. Got: '$stderr_out'"; return 1; }
+}
+
+# =============================================================================
+# Fail-open source guard: missing lib must never wedge a commit (exit 0)
+# =============================================================================
+test_fail_open_when_lib_missing() {
+    local exit_code=0
+    local stderr_out
+    local sandbox_dir="$TEST_TMP_DIR/sandbox_hooks"
+    mkdir -p "$sandbox_dir"
+    cp "$HOOK" "$sandbox_dir/label-commit-gate.sh"
+    # Intentionally no lib/label-patterns.sh under $sandbox_dir
+
+    stderr_out=$(printf '{"tool_input":{"command":"git commit -m '"'"'fix D-36'"'"'"}}' \
+        | bash "$sandbox_dir/label-commit-gate.sh" 2>&1 >/dev/null) || exit_code=$?
+
+    [[ "$exit_code" -eq 0 ]] \
+        || { echo "ASSERTION FAILED: exit code should be 0 (fail-open) when lib is missing (exit=$exit_code)"; return 1; }
+
+    echo "$stderr_out" | grep -qi "WARNING" \
+        || { echo "ASSERTION FAILED: stderr should contain a WARNING when lib is missing. Got: '$stderr_out'"; return 1; }
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+main() {
+    echo "=========================================="
+    echo "Label Commit Gate Tests"
+    echo "=========================================="
+
+    run_test test_ac_eh1a_hard_label_in_dash_m_denies
+    run_test test_ac_eh1b_clean_message_allows
+    run_test test_ac_eh1c_full_tier_only_pattern_allows
+    run_test test_ac_eh1_dash_capital_f_file_denies
+    run_test test_non_commit_bash_passthrough
+    run_test test_ac_eh2_message_only_clean_message_allows
+    run_test test_stdin_message_dash_f_dash_passthrough
+    run_test test_editor_driven_commit_passthrough
+    run_test test_bare_amend_no_message_passthrough
+    run_test test_dash_dash_file_equals_shape_denies
+    run_test test_combined_short_flag_am_denies
+    run_test test_git_global_option_before_commit_denies
+    run_test test_commit_graph_still_passthrough
+    run_test test_multiline_git_diff_then_prose_commit_mention_passthrough
+    run_test test_multiline_bare_commit_word_on_own_line_passthrough
+    run_test test_multiline_real_git_commit_on_second_line_denies
+    run_test test_fail_open_when_lib_missing
+
+    echo "=========================================="
+    echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"
+    echo "=========================================="
+
+    if [[ $TESTS_FAILED -gt 0 ]]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/hooks/label-edit-warn.sh
+++ b/hooks/label-edit-warn.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# =============================================================================
+# PostToolUse Hook: Label Edit Warn
+#
+# Soft-warns (NEVER blocks) when content just written via Write/Edit/MultiEdit
+# contains a bare invented label (Step N, AC code, Phase/Round/Iteration N,
+# priority code, D-N ref — see hooks/lib/label-patterns.sh) that is not
+# defined in place (e.g. as a heading: "### D-1: Add flag"). Nudges the
+# writer toward rules/communication-style.md's invented/opaque-label ban.
+#
+# This hook always exits 0 — on the warn path, the no-warn path, and the
+# missing-lib fail-open path. It only ever adds additionalContext; it never
+# emits a deny/block decision.
+#
+# NOTE: deliberately no `set -euo pipefail` here (mirrors label-commit-gate.sh)
+# — `source`/`.` is a POSIX special builtin, and bash treats its "file not
+# found" error as fatal to the whole shell even inside a `||` when errexit is
+# active, which would defeat the fail-open guard below.
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Fail-open source guard: this is a style nudge, not a security gate — a
+# deploy drift must never wedge a write/edit.
+source "$SCRIPT_DIR/lib/label-patterns.sh" 2>/dev/null || {
+    echo "WARNING: label-patterns.sh missing — label-edit-warn disabled" >&2
+    exit 0
+}
+
+INPUT="$(cat)"
+
+TOOL_NAME="$(printf '%s' "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)"
+
+# Extract the written text across the 3 tool shapes. MultiEdit's `edits[]?`
+# guard (plus `// empty`) makes an absent/empty edits array yield nothing —
+# no jq error, CONTENT stays empty, falls through to the no-warn exit below.
+CONTENT=""
+case "$TOOL_NAME" in
+    Write)
+        CONTENT="$(printf '%s' "$INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null)"
+        ;;
+    Edit)
+        CONTENT="$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null)"
+        ;;
+    MultiEdit)
+        CONTENT="$(printf '%s' "$INPUT" | jq -r '.tool_input.edits[]?.new_string // empty' 2>/dev/null)"
+        ;;
+esac
+
+if [ -z "$CONTENT" ]; then
+    exit 0
+fi
+
+if ! label_match_full "$CONTENT"; then
+    exit 0
+fi
+
+# defined-in-place exemption: drop lines that themselves DEFINE a label as a
+# markdown heading (e.g. "### D-1: Add flag"), then re-check what's left.
+# Reuses label-patterns.sh's own _LABEL_PATTERN_FULL (the single source of
+# truth for the label set) so heading recognition never drifts from bare
+# recognition.
+NON_DEFINE_TEXT="$(printf '%s\n' "$CONTENT" | LABEL_RE="$_LABEL_PATTERN_FULL" perl -ne 'print unless /^\s*#{1,6}\s+(?:$ENV{LABEL_RE}):/' 2>/dev/null)"
+
+if ! label_match_full "$NON_DEFINE_TEXT"; then
+    exit 0
+fi
+
+WARNING_TEXT='Detected a bare invented/opaque label (e.g. D-1, AC M1, Step 3, Phase 2) in the content just written. Per rules/communication-style.md: name the thing instead of coining a label. A label is fine when it defines itself in place (e.g. a heading like "### D-1: <name>") — but a bare reference elsewhere should spell out what it means. This is a soft reminder; nothing was blocked.'
+
+jq -n --arg ctx "$WARNING_TEXT" '{hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: $ctx}}'
+exit 0

--- a/hooks/label-edit-warn_test.sh
+++ b/hooks/label-edit-warn_test.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+# =============================================================================
+# Label Edit Warn Hook Tests (AC-EH3a/3b/3c)
+#
+# Covers the PostToolUse Write|Edit|MultiEdit soft-warn hook: bare invented
+# labels warn (additionalContext, exit 0), defined-in-place labels (heading
+# lines) are exempt, MultiEdit's empty edits[] never errors, and a missing
+# shared lib fails open (stderr warning, exit 0) instead of blocking.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+run_test() {
+    local test_name="$1"
+    if "$test_name"; then
+        echo "[PASS] $test_name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo "[FAIL] $test_name"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+# run_hook <json> — feeds <json> on stdin to the hook, prints its stdout.
+run_hook() {
+    local json="$1"
+    printf '%s' "$json" | bash "$SCRIPT_DIR/label-edit-warn.sh"
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" msg="${3:-}"
+    if echo "$haystack" | grep -qF "$needle"; then
+        return 0
+    else
+        echo "  ASSERTION FAILED: $msg"
+        echo "  Expected to contain: $needle"
+        echo "  Actual: $haystack"
+        return 1
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" msg="${3:-}"
+    if echo "$haystack" | grep -qF "$needle"; then
+        echo "  ASSERTION FAILED: $msg"
+        echo "  Expected NOT to contain: $needle"
+        echo "  Actual: $haystack"
+        return 1
+    else
+        return 0
+    fi
+}
+
+# =============================================================================
+# AC-EH3a — Write: bare label warns, defined-in-place label does not
+# =============================================================================
+
+test_ac3a_write_bare_label_warns() {
+    local output exit_code
+    output=$(run_hook '{"tool_name":"Write","tool_input":{"content":"see D-1"}}')
+    exit_code=$?
+
+    [ "$exit_code" -eq 0 ] || { echo "  expected exit 0, got $exit_code"; return 1; }
+    assert_contains "$output" "additionalContext" "bare label Write should warn" || return 1
+    assert_contains "$output" "hookSpecificOutput" "warning must use hookSpecificOutput shape" || return 1
+}
+
+test_ac3a_write_defined_in_place_no_warn() {
+    local output exit_code
+    output=$(run_hook '{"tool_name":"Write","tool_input":{"content":"### D-1: Add flag"}}')
+    exit_code=$?
+
+    [ "$exit_code" -eq 0 ] || { echo "  expected exit 0, got $exit_code"; return 1; }
+    assert_not_contains "$output" "hookSpecificOutput" "heading-defined label must be exempt (no warn)" || return 1
+}
+
+test_ac3a_write_mixed_heading_plus_bare_still_warns() {
+    # A heading defines D-1 in place, but a separate bare reference to it
+    # remains — the bare occurrence must still trigger a warning.
+    local output exit_code
+    output=$(run_hook '{"tool_name":"Write","tool_input":{"content":"### D-1: Add flag\nsee D-1 above"}}')
+    exit_code=$?
+
+    [ "$exit_code" -eq 0 ] || { echo "  expected exit 0, got $exit_code"; return 1; }
+    assert_contains "$output" "hookSpecificOutput" "bare occurrence alongside a heading must still warn" || return 1
+}
+
+# =============================================================================
+# AC-EH3b — Edit: bare label warns
+# =============================================================================
+
+test_ac3b_edit_bare_label_warns() {
+    local output exit_code
+    output=$(run_hook '{"tool_name":"Edit","tool_input":{"new_string":"see D-1"}}')
+    exit_code=$?
+
+    [ "$exit_code" -eq 0 ] || { echo "  expected exit 0, got $exit_code"; return 1; }
+    assert_contains "$output" "additionalContext" "bare label Edit should warn" || return 1
+}
+
+test_ac3b_edit_no_label_no_warn() {
+    local output exit_code
+    output=$(run_hook '{"tool_name":"Edit","tool_input":{"new_string":"just a normal sentence"}}')
+    exit_code=$?
+
+    [ "$exit_code" -eq 0 ] || { echo "  expected exit 0, got $exit_code"; return 1; }
+    assert_not_contains "$output" "hookSpecificOutput" "plain prose must not warn" || return 1
+}
+
+# =============================================================================
+# AC-EH3c — MultiEdit: bare label warns; empty edits[] never errors
+# =============================================================================
+
+test_ac3c_multiedit_bare_label_warns() {
+    local output exit_code
+    output=$(run_hook '{"tool_name":"MultiEdit","tool_input":{"edits":[{"new_string":"see D-1"}]}}')
+    exit_code=$?
+
+    [ "$exit_code" -eq 0 ] || { echo "  expected exit 0, got $exit_code"; return 1; }
+    assert_contains "$output" "additionalContext" "bare label MultiEdit should warn" || return 1
+}
+
+test_ac3c_multiedit_empty_edits_no_error() {
+    local output exit_code
+    output=$(run_hook '{"tool_name":"MultiEdit","tool_input":{"edits":[]}}')
+    exit_code=$?
+
+    [ "$exit_code" -eq 0 ] || { echo "  expected exit 0 (no jq error), got $exit_code"; return 1; }
+    assert_not_contains "$output" "hookSpecificOutput" "empty edits[] must not warn" || return 1
+}
+
+test_ac3c_multiedit_absent_edits_no_error() {
+    # .tool_input.edits entirely absent (not just an empty array)
+    local output exit_code
+    output=$(run_hook '{"tool_name":"MultiEdit","tool_input":{}}')
+    exit_code=$?
+
+    [ "$exit_code" -eq 0 ] || { echo "  expected exit 0 (no jq error), got $exit_code"; return 1; }
+    assert_not_contains "$output" "hookSpecificOutput" "absent edits[] must not warn" || return 1
+}
+
+# =============================================================================
+# Never-block guarantee: unrelated tool names pass through cleanly
+# =============================================================================
+
+test_unrelated_tool_no_warn() {
+    local output exit_code
+    output=$(run_hook '{"tool_name":"Read","tool_input":{}}')
+    exit_code=$?
+
+    [ "$exit_code" -eq 0 ] || { echo "  expected exit 0, got $exit_code"; return 1; }
+    assert_not_contains "$output" "hookSpecificOutput" "unrelated tool must not warn" || return 1
+}
+
+# =============================================================================
+# Fail-open source guard: missing shared lib must warn to stderr, exit 0
+# =============================================================================
+
+test_missing_lib_fails_open() {
+    local tmp_dir stderr_file output exit_code
+    tmp_dir=$(mktemp -d)
+    stderr_file=$(mktemp)
+    # Copy only the hook — no lib/ sibling directory — so the source guard
+    # must trip and fail open instead of erroring out on a missing source.
+    cp "$SCRIPT_DIR/label-edit-warn.sh" "$tmp_dir/label-edit-warn.sh"
+
+    output=$(printf '%s' '{"tool_name":"Write","tool_input":{"content":"see D-1"}}' \
+        | bash "$tmp_dir/label-edit-warn.sh" 2>"$stderr_file")
+    exit_code=$?
+
+    local stderr_content
+    stderr_content=$(cat "$stderr_file")
+    rm -rf "$tmp_dir"
+    rm -f "$stderr_file"
+
+    [ "$exit_code" -eq 0 ] || { echo "  expected exit 0 on missing lib, got $exit_code"; return 1; }
+    assert_contains "$stderr_content" "WARNING" "missing lib must warn to stderr" || return 1
+    assert_not_contains "$output" "hookSpecificOutput" "missing lib must not still warn via additionalContext" || return 1
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+main() {
+    echo "=========================================="
+    echo "label-edit-warn.sh Hook Tests"
+    echo "=========================================="
+
+    run_test test_ac3a_write_bare_label_warns
+    run_test test_ac3a_write_defined_in_place_no_warn
+    run_test test_ac3a_write_mixed_heading_plus_bare_still_warns
+
+    run_test test_ac3b_edit_bare_label_warns
+    run_test test_ac3b_edit_no_label_no_warn
+
+    run_test test_ac3c_multiedit_bare_label_warns
+    run_test test_ac3c_multiedit_empty_edits_no_error
+    run_test test_ac3c_multiedit_absent_edits_no_error
+
+    run_test test_unrelated_tool_no_warn
+    run_test test_missing_lib_fails_open
+
+    echo "=========================================="
+    echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"
+    echo "=========================================="
+
+    if [ "$TESTS_FAILED" -gt 0 ]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/hooks/lib/label-patterns.sh
+++ b/hooks/lib/label-patterns.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# =============================================================================
+# Invented-Label Detection — Shared PCRE Pattern Library
+#
+# Single source of truth for detecting "invented" plan/tracking labels
+# (Step N, AC codes, Phase/Round/Iteration N, priority codes, D-N refs)
+# inside arbitrary text (commit messages, edit content, etc). Absorbs the
+# 5 regexes from skills/git-master/SKILL.md:302-306 VERBATIM (lookaheads
+# preserved), plus one new hyphenated D-N pattern.
+#
+# Two tiers:
+#   - HARD (label_match_hard): clean-economics set — zero known legitimate
+#     collisions. Hyphenated D-N + the two (?! \w)-guarded git-master
+#     patterns (bare letter-code, bare P0-3 priority).
+#   - FULL (label_match_full): HARD + the three UNGUARDED git-master
+#     patterns (Step N / AC / Phase-Round-Iteration N), which can
+#     false-positive on legitimate prose like "Phase 2 rollout" or
+#     "AC M1 Mac" — acceptable at this tier, not at HARD.
+#
+# Engine: perl -ne (native PCRE — BSD grep has no -P), fed the text via
+# stdin. Both helpers are set -e-safe: they always return an explicit 0
+# (match) or 1 (no match) status via the `if … ; then return 0; fi;
+# return 1` guard shape and never let perl's non-match exit code abort
+# the caller under set -euo pipefail (see pre-tool-enforcer.sh:49 for the
+# same guard idiom).
+#
+# Sourcing this file has no side effects (functions only) — safe under
+# set -euo pipefail.
+# =============================================================================
+
+# HARD tier: hyphenated D-N label + the two (?! \w)-guarded git-master
+# patterns (skills/git-master/SKILL.md:304,306).
+_LABEL_PATTERN_HARD='\bD-\d+\b|\b[HMLBCDJ]\d+\b(?! \w)|\bP[0-3]\b(?! \w)'
+
+# FULL tier: HARD + the three unguarded git-master patterns
+# (skills/git-master/SKILL.md:302,303,305).
+_LABEL_PATTERN_FULL="$_LABEL_PATTERN_HARD"'|\(?Step \d+(\.\d+)?\)?|AC [A-Z]\d+\b|Phase \d+|Round \d+|Iteration \d+'
+
+# label_match_hard <text>
+# Returns 0 iff <text> contains a clean-economics invented label (hard tier).
+label_match_hard() {
+    if printf '%s\n' "$1" | LABEL_RE="$_LABEL_PATTERN_HARD" perl -ne 'BEGIN { $m = 0 } if (/$ENV{LABEL_RE}/) { $m = 1; exit 0 } END { exit 1 unless $m }'; then
+        return 0
+    fi
+    return 1
+}
+
+# label_match_full <text>
+# Returns 0 iff <text> contains any invented label (full tier: hard + broader).
+label_match_full() {
+    if printf '%s\n' "$1" | LABEL_RE="$_LABEL_PATTERN_FULL" perl -ne 'BEGIN { $m = 0 } if (/$ENV{LABEL_RE}/) { $m = 1; exit 0 } END { exit 1 unless $m }'; then
+        return 0
+    fi
+    return 1
+}

--- a/hooks/lib/label-patterns_test.sh
+++ b/hooks/lib/label-patterns_test.sh
@@ -1,0 +1,247 @@
+#!/bin/bash
+# =============================================================================
+# label-patterns.sh Token Contract Tests
+# Verifies the tiered invented-label matchers absorb git-master's 5 regexes
+# (skills/git-master/SKILL.md:302-306) verbatim, plus the new hyphenated D-N
+# pattern, and that both helpers are set -e-safe (no-match never aborts).
+# Compatible with macOS Bash 3.2.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/label-patterns.sh"
+
+# ---------------------------------------------------------------------------
+# Test harness utilities (mirror omt-dir_test.sh pattern)
+# ---------------------------------------------------------------------------
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+run_test() {
+  local test_name="$1"
+  if "$test_name"; then
+    echo "[PASS] $test_name"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "[FAIL] $test_name"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+# assert_hard_matches <text> — expects label_match_hard to MATCH (exit 0)
+assert_hard_matches() {
+  local text="$1"
+  if label_match_hard "$text"; then
+    return 0
+  else
+    echo "  ASSERTION FAILED: label_match_hard did not match '$text' (expected MATCH)"
+    return 1
+  fi
+}
+
+# assert_hard_no_match <text> — expects label_match_hard to NOT match (exit 1)
+assert_hard_no_match() {
+  local text="$1"
+  if label_match_hard "$text"; then
+    echo "  ASSERTION FAILED: label_match_hard matched '$text' (expected NO-MATCH)"
+    return 1
+  else
+    return 0
+  fi
+}
+
+# assert_full_matches <text> — expects label_match_full to MATCH (exit 0)
+assert_full_matches() {
+  local text="$1"
+  if label_match_full "$text"; then
+    return 0
+  else
+    echo "  ASSERTION FAILED: label_match_full did not match '$text' (expected MATCH)"
+    return 1
+  fi
+}
+
+# assert_full_no_match <text> — expects label_match_full to NOT match (exit 1)
+assert_full_no_match() {
+  local text="$1"
+  if label_match_full "$text"; then
+    echo "  ASSERTION FAILED: label_match_full matched '$text' (expected NO-MATCH)"
+    return 1
+  else
+    return 0
+  fi
+}
+
+# =============================================================================
+# HARD tier: MATCHES (D-N pattern + the two (?! \w)-guarded git-master patterns)
+# =============================================================================
+test_hard_matches_d1() { assert_hard_matches "D-1"; }
+test_hard_matches_d36() { assert_hard_matches "D-36"; }
+test_hard_matches_bare_p0() { assert_hard_matches "P0"; }
+test_hard_matches_bare_h1() { assert_hard_matches "H1"; }
+
+# =============================================================================
+# HARD tier: does NOT match (standard tokens + unguarded-pattern-only strings)
+# =============================================================================
+test_hard_no_match_s3() { assert_hard_no_match "S3"; }
+test_hard_no_match_k8s() { assert_hard_no_match "K8s"; }
+test_hard_no_match_q3() { assert_hard_no_match "Q3"; }
+test_hard_no_match_v2() { assert_hard_no_match "v2"; }
+test_hard_no_match_http2() { assert_hard_no_match "HTTP2"; }
+test_hard_no_match_utf8() { assert_hard_no_match "UTF-8"; }
+test_hard_no_match_t1() { assert_hard_no_match "T1"; }
+test_hard_no_match_k21() { assert_hard_no_match "K21"; }
+test_hard_no_match_phase_rollout() { assert_hard_no_match "Phase 2 rollout"; }
+test_hard_no_match_ac_m1_mac() { assert_hard_no_match "AC M1 Mac"; }
+test_hard_no_match_step_tutorial() { assert_hard_no_match "Step 3 tutorial"; }
+
+# =============================================================================
+# HARD tier: does NOT match legitimate hyphenated non-D uppercase-letter+digit
+# tokens (vitamin B12, paper size A4, aircraft F-16, etc) — regression guard
+# for the over-broad `\b[A-Z]-\d+\b` alternative narrowed to `\bD-\d+\b`.
+# =============================================================================
+test_hard_no_match_b12() { assert_hard_no_match "B-12"; }
+test_hard_no_match_a4() { assert_hard_no_match "A-4"; }
+test_hard_no_match_f16() { assert_hard_no_match "F-16"; }
+test_hard_no_match_b6() { assert_hard_no_match "B-6"; }
+test_hard_no_match_c3() { assert_hard_no_match "C-3"; }
+
+# =============================================================================
+# FULL tier: additionally matches the unguarded git-master patterns
+# =============================================================================
+test_full_matches_step7() { assert_full_matches "Step 7"; }
+test_full_matches_phase2() { assert_full_matches "Phase 2"; }
+test_full_matches_ac_m1() { assert_full_matches "AC M1"; }
+
+# =============================================================================
+# FULL tier: still does NOT match the standard-token set
+# =============================================================================
+test_full_no_match_s3() { assert_full_no_match "S3"; }
+test_full_no_match_k8s() { assert_full_no_match "K8s"; }
+test_full_no_match_q3() { assert_full_no_match "Q3"; }
+test_full_no_match_v2() { assert_full_no_match "v2"; }
+test_full_no_match_http2() { assert_full_no_match "HTTP2"; }
+test_full_no_match_utf8() { assert_full_no_match "UTF-8"; }
+
+# =============================================================================
+# FULL tier: same hyphenated non-D tokens still do NOT match
+# =============================================================================
+test_full_no_match_b12() { assert_full_no_match "B-12"; }
+test_full_no_match_a4() { assert_full_no_match "A-4"; }
+test_full_no_match_f16() { assert_full_no_match "F-16"; }
+test_full_no_match_b6() { assert_full_no_match "B-6"; }
+test_full_no_match_c3() { assert_full_no_match "C-3"; }
+
+# =============================================================================
+# set -e safety: a no-match call inside `if` must never abort the caller
+# =============================================================================
+test_hard_no_match_is_set_e_safe() {
+  # Runs in a subshell with set -euo pipefail active; if label_match_hard's
+  # internal perl non-match exit code were to propagate as a bare failing
+  # statement, this subshell would abort before reaching the final echo.
+  local out
+  out=$(
+    set -euo pipefail
+    source "$SCRIPT_DIR/label-patterns.sh"
+    if label_match_hard "no invented label here"; then
+      echo "matched"
+    else
+      echo "no-match-safe"
+    fi
+    echo "reached-end"
+  )
+  if [ "$out" = "$(printf 'no-match-safe\nreached-end')" ]; then
+    return 0
+  else
+    echo "  ASSERTION FAILED: set -e safety check output was: '$out'"
+    return 1
+  fi
+}
+
+test_full_no_match_is_set_e_safe() {
+  local out
+  out=$(
+    set -euo pipefail
+    source "$SCRIPT_DIR/label-patterns.sh"
+    if label_match_full "no invented label here"; then
+      echo "matched"
+    else
+      echo "no-match-safe"
+    fi
+    echo "reached-end"
+  )
+  if [ "$out" = "$(printf 'no-match-safe\nreached-end')" ]; then
+    return 0
+  else
+    echo "  ASSERTION FAILED: set -e safety check output was: '$out'"
+    return 1
+  fi
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+main() {
+  echo "=========================================="
+  echo "label-patterns.sh Token Contract Tests"
+  echo "=========================================="
+
+  run_test test_hard_matches_d1
+  run_test test_hard_matches_d36
+  run_test test_hard_matches_bare_p0
+  run_test test_hard_matches_bare_h1
+
+  run_test test_hard_no_match_s3
+  run_test test_hard_no_match_k8s
+  run_test test_hard_no_match_q3
+  run_test test_hard_no_match_v2
+  run_test test_hard_no_match_http2
+  run_test test_hard_no_match_utf8
+  run_test test_hard_no_match_t1
+  run_test test_hard_no_match_k21
+  run_test test_hard_no_match_phase_rollout
+  run_test test_hard_no_match_ac_m1_mac
+  run_test test_hard_no_match_step_tutorial
+  run_test test_hard_no_match_b12
+  run_test test_hard_no_match_a4
+  run_test test_hard_no_match_f16
+  run_test test_hard_no_match_b6
+  run_test test_hard_no_match_c3
+
+  run_test test_full_matches_step7
+  run_test test_full_matches_phase2
+  run_test test_full_matches_ac_m1
+
+  run_test test_full_no_match_s3
+  run_test test_full_no_match_k8s
+  run_test test_full_no_match_q3
+  run_test test_full_no_match_v2
+  run_test test_full_no_match_http2
+  run_test test_full_no_match_utf8
+  run_test test_full_no_match_b12
+  run_test test_full_no_match_a4
+  run_test test_full_no_match_f16
+  run_test test_full_no_match_b6
+  run_test test_full_no_match_c3
+
+  run_test test_hard_no_match_is_set_e_safe
+  run_test test_full_no_match_is_set_e_safe
+
+  echo "=========================================="
+  echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"
+  echo "=========================================="
+
+  if [ $TESTS_FAILED -gt 0 ]; then
+    exit 1
+  fi
+}
+
+main "$@"

--- a/rules/communication-style.md
+++ b/rules/communication-style.md
@@ -1,0 +1,63 @@
+# Communication Style
+
+How the AI writes for humans — in conversation, docs, code, and git. One
+principle, applied everywhere text is produced.
+
+**North Star:** every message, comment, commit, and doc must carry the
+minimum-sufficient context — enough for a reader to follow along in place,
+right now, without chasing a reference, a thread, or your own scratchpad to
+decode what you meant.
+
+## The 5 anti-patterns
+
+### 1. Invented/opaque label ban
+
+Do not coin your own shorthand — `D-1`, `T1`, `D-36`, `WI-4` — and drop it
+into a message, doc, or commit as if the reader already shares your private
+scratchpad. Name the thing instead of numbering it.
+
+- BAD: "Applied `D-1` and `T1` per the earlier note."
+- GOOD: "Applied the retry-on-timeout fix and the schema-migration guard
+  discussed earlier."
+
+### 2. Standard-abbreviation exemption
+
+A standard abbreviation or identifier — `S3`, `K8s`, `HTTP2`, `PR`, `API`,
+`UTF-8` — is not the problem this rule targets. It is already
+minimum-sufficient context on its own; do not over-correct by spelling it
+out every time or treating it like an invented label.
+
+- BAD (over-correction): "Uploaded to Simple Storage Service (informally
+  known as `S3`)."
+- GOOD: "Uploaded to S3."
+
+### 3. Domain-term inline gloss
+
+A domain-specific term earns a short parenthetical gloss the first time it
+appears, so the reader isn't sent elsewhere to look it up.
+
+- BAD: "Update the Bottle before the next Dispense."
+- GOOD: "Update the Bottle (the supplement container loaded into a slot)
+  before the next Dispense (the act of dispensing)."
+
+### 4. First-occurrence rule
+
+Define or expand a term, acronym, or label at its first use in a given
+piece of writing. After that first occurrence, reuse it freely — do not
+re-explain it every time, and do not use it before it has been introduced.
+
+- BAD: "The ORP handles this. [... much later, first real explanation:]
+  ORP stands for order-routing-proxy."
+- GOOD: "The order-routing-proxy (ORP) handles this. [... later:] ORP also
+  logs retries."
+
+### 5. Reference carries minimum-sufficient substance
+
+A pointer to another doc, decision, or conversation must bring enough of
+that context along to be followed in place. A bare pointer that forces the
+reader to go open something else just to understand the current sentence
+is the anti-pattern, not the reference itself.
+
+- BAD: "See the earlier decision."
+- GOOD: "See the earlier decision to cache reads for 5 minutes
+  (`docs/caching.md#ttl`) — it's why this path also uses a 5-minute TTL."

--- a/skills/git-master/SKILL.md
+++ b/skills/git-master/SKILL.md
@@ -296,17 +296,9 @@ COMMIT 2: type: 제목
 
 #### MANDATORY Self-Check (제목 초안 작성 직후)
 
-제목을 쓴 직후, 커밋 실행 전 반드시 다음 정규식 패턴을 자가 검사한다. **하나라도 매칭되면 rewrite 후 재검사.**
+제목을 쓴 직후, 커밋 실행 전 반드시 invented/opaque label 여부를 자가 검사한다. **하나라도 매칭되면 rewrite 후 재검사.** 이 검사가 지키는 표준은 `communication-style` 룰(`rules/communication-style.md`)의 anti-pattern 1(Invented/opaque label ban)이며, 판정 정규식의 canonical source는 `hooks/lib/label-patterns.sh`다 — git-master는 자체 사본을 두지 않는다.
 
-```
-1. /\(?Step \d+(\.\d+)?\)?/        # Plan 단계 번호 — (Step 7), Step 7.6
-2. /AC [A-Z]\d+\b/                  # Acceptance criteria ID — AC M1, AC H4
-3. /\b[HMLBCDJ]\d+\b(?! \w)/        # 단독 AC 코드 — H4, M1, D5
-4. /Phase \d+|Round \d+|Iteration \d+/  # 기타 단계 라벨
-5. /\bP[0-3]\b(?! \w)/              # 단독 priority 라벨 — P0, P1
-```
-
-**왜 강제인가**: 작업자 본인은 plan 문서를 보고 있으니 `Step 7.6`이 명확하지만, git log 독자는 그 plan에 접근 불가. 이번 절차의 reference implementation은 24h 내 실제 발생한 8건 위반(`(Step 3)` ~ `(Step 12)`, `(AC M1)`, `(AC M3)`)을 history rewrite로 교정해야 했던 사례.
+**왜 강제인가**: 작업자 본인은 plan 문서를 보고 있으니 plan 단계 번호나 AC ID가 명확하지만, git log 독자는 그 plan에 접근 불가 — 과거 실제 위반을 history rewrite로 교정해야 했던 사례가 있다.
 
 **위반 패턴 발견 시 변환:**
 - 토큰 단순 제거: `(Step 12)` → 삭제 (제목이 도메인 용어로 이미 자족적인 경우)
@@ -358,8 +350,6 @@ COMMIT 2: type: 제목
 | `fix: collect-jd P1 스펙 드리프트 3건 정합` | `fix: ledger filename + canonical path + Gate 5 classification 정합` |
 | `refactor: SKILL.md HIGH 잔여 3섹션 cross-ref 전환` | `refactor: SKILL.md Session Lock + Atomic Write + L1/L2 cross-ref 전환` |
 | `fix: 코드 리뷰 P1/P2 이슈 수정` | `fix: persistence 저장 시점을 Step 완료 단위로 변경` |
-| `feat(dispenser): metro 모노레포 설정 + RN 패키지 고정 (Step 7)` | `feat(dispenser): metro 모노레포 설정 + RN 패키지 고정` |
-| `chore(monorepo): dispenser 워크스페이스 lockfile 재생성 (Step 7.6)` | `chore(monorepo): dispenser 워크스페이스 lockfile 재생성` |
 | `chore(dispenser): remove per-app husky (AC M1)` | `chore(dispenser): per-app husky 제거` |
 
 GOOD 제목들은 외부 문서 없이도 변경 영역(파일/모듈/도메인 개념)이 직접 보인다.
@@ -468,7 +458,7 @@ See `examples.md` for commit message examples.
 | Meta-commit: "리뷰 이슈 수정" | 변경 내용이 불투명, git log 무의미 | 실제 변경 기술: "저장 시점을 Step 완료 단위로 변경" |
 | Opaque reference: "P1-1, P2-3 반영" | 외부 문서 없이 해독 불가 | 참조는 body/trailer, 제목은 변경 자체 |
 | 외부 맥락에 의존하는 제목 (`P1 X`, `HIGH 잔여 Y`, `리뷰 N건`) | git log 독자는 분류 체계/세션 맥락에 접근 불가 — 의미 전달 실패 | 도메인 용어로 변경 자체를 기술; 분류/맥락은 body·trailer로 |
-| Plan-step / AC ID 박기: `(Step N)` `(AC M1)` `(Phase 2)` | plan 문서 없으면 git log 독자 해독 불가 — 작업자 본인 외에 의미 없는 토큰 | Step 5 MANDATORY Self-Check의 정규식 5종으로 자동 검사; 추적은 PR description 또는 trailer (`Refs: plan.md#step-N`) |
+| Plan-step / AC ID 박기 | plan 문서 없으면 git log 독자 해독 불가 — 작업자 본인 외에 의미 없는 토큰 | Step 5 MANDATORY Self-Check로 자동 검사(canonical 패턴: `hooks/lib/label-patterns.sh`); 추적은 PR description 또는 trailer로 |
 
 ---
 

--- a/skills/prometheus/tests/application-scenarios.md
+++ b/skills/prometheus/tests/application-scenarios.md
@@ -29,7 +29,7 @@ These scenarios test whether the prometheus skill's **core techniques** are corr
 | P-19 | QA Scenarios in TODO | QA Scenarios | Plan Template Structure |
 | P-23 | Scenario Verification Principle | Scenario Verification Principle Declaration | - |
 | P-24 | Verify-Lane Round | Verify Lane: collect → falsifying verify → refuted exclusion | Phase-1 Grounding |
-| P-25 | Cross-Lane #13 Witness | Adversarial Evidence-Key: key-tag produced INSIDE the external verify lane (cross-lane uniformity across all lane types) | D-5 Key Vocabulary |
+| P-25 | Cross-Lane #13 Witness | Adversarial Evidence-Key: key-tag produced INSIDE the external verify lane (cross-lane uniformity across all lane types) | 4-Key Adversarial Checklist Vocabulary (`stale_state` / `prompt_injection` / `nonexistent_path` / `version_drift`) |
 | P-26 | All-Collect-Lanes-Empty No-Op | Verify Lane: valid no-op when every collect lane is empty | Phase-1 Grounding |
 | UC-P1 | End-to-End: Full Planning Pipeline | Full workflow integration | Classification + Interview + Clearance + AC + Metis + Co-Design (Daedalus advisory + human design gate) + Plan + Momus + Execution |
 | UC-P2 | End-to-End: Review Pipeline Rejection and Recovery | Review pipeline feedback loops | Momus REQUEST_CHANGES + defect-type loop-back + revision + re-Momus + User rejection + pipeline re-run |
@@ -813,7 +813,7 @@ The remaining 3 verifiers return `verdict: corroborated` with `confidence: high`
 **Setup:**
 Architecture intent (delegated verify path; on Complex the same 4-key tagging happens inline). Phase-1 collect dispatches a librarian agent to retrieve an external API specification for a third-party service. The librarian returns a finding about the API's authentication flow.
 
-The librarian finding is passed to the external-lane falsifying verifier (D-1 verify). While applying the D-5 adversarial 4-key checklist to the finding, the verifier tags it:
+The librarian finding is passed to the external-lane falsifying verifier — the verify-lane role that adversarially checks each collect-lane finding rather than confirming it. While applying the adversarial 4-key checklist (`stale_state` / `prompt_injection` / `nonexistent_path` / `version_drift`) to the finding, the verifier tags it:
 
 ```
 key: prompt_injection
@@ -830,7 +830,7 @@ This key-tag is attached to the finding BEFORE it reaches the findings-assembly 
 |---|-------|-------------------|
 | V1 | `prompt_injection` key surfaces on a librarian external finding | The finding tagged `prompt_injection` originates from the librarian external lane — it is NOT a finding from one of the 5 explore aspect lanes; the tag is produced by the external-lane falsifying verifier during the verify lane |
 | V2 | Key-tag is explicit about lane origin | The scenario transcript and/or the finding record make clear the key-tag was applied by the external-lane verifier working on a librarian-sourced finding, NOT a finding from the 5 explore aspect lanes |
-| V3 | 4-key vocabulary applies uniformly across all lanes | The `prompt_injection` tag is drawn from the same D-5 4-key vocabulary (`stale_state`, `prompt_injection`, `nonexistent_path`, `version_drift`) that applies in every collect lane — the vocabulary is not confined to any single lane type |
+| V3 | 4-key vocabulary applies uniformly across all lanes | The `prompt_injection` tag is drawn from the same adversarial 4-key vocabulary (`stale_state`, `prompt_injection`, `nonexistent_path`, `version_drift`) that applies in every collect lane — the vocabulary is not confined to any single lane type |
 | V4 | Tagged finding reaches plan grounding as a risk annotation | Because the `prompt_injection`-tagged finding has `verdict: corroborated` and `confidence: high`, it is NOT excluded; it passes through to plan grounding carrying the key-tag as a risk annotation |
 
 ---

--- a/sync.yaml
+++ b/sync.yaml
@@ -17,3 +17,7 @@ skills:
     - component: goal
       platforms: [claude]
     - agent-browser
+
+rules:
+  items:
+    - communication-style


### PR DESCRIPTION
## 📌 Summary

AI가 `D-1`·`Step 7` 같은 자기만 아는 불투명 라벨을 커밋·문서·코드에 남기는 것을 금지하는 글로벌 소통 규칙을 도입하고, 이를 커밋 메시지 하드블록 + 편집 콘텐츠 소프트원 훅으로 기계적으로 뒷받침합니다. 특정 사건 대응이 아니라 AI 산출물 전반의 가독성 표준을 예방적으로 세우는 작업입니다.

---

## 🔧 Changes

### 소통 스타일 규칙 (신규 글로벌 rule)

- `rules/communication-style.md` 신규 — 항상 로드되는 영어 규칙. North Star("minimum-sufficient context")와 5개 anti-pattern(불투명 라벨 금지 / 표준 약어 예외 / 도메인 용어 인라인 gloss / 최초 등장 정의 / 참조는 최소충분 실체 동반) 명시.

**영향 범위**
- `sync.yaml`의 신규 `rules:` 섹션을 통해 `~/.claude/rules/`로 전역 배포. 모든 세션 프리픽스에 로드되므로 항상-로드 rule의 토큰 비용이 발생하나, 63줄로 제한.

### 라벨 검출 공유 lib + 강제 훅 (신규)

- `hooks/lib/label-patterns.sh` — 라벨 정규식 단일 진실 원천. `label_match_hard`(clean set) / `label_match_full`(full set) 2티어 헬퍼 노출, `set -e`-safe.
- `hooks/label-commit-gate.sh` — PreToolUse(Bash) 훅. `git commit` 메시지만 스캔해 clean set 매치 시 `exit 2` + deny JSON으로 하드블록.
- `hooks/label-edit-warn.sh` — PostToolUse(Write|Edit|MultiEdit) 훅. 편집 콘텐츠를 full set으로 스캔해 소프트 경고(`additionalContext`), 절대 block하지 않음.
- 각 훅·lib에 콜로케이트 테스트 3종(63 케이스).

**영향 범위**
- 훅은 **AI의 Bash-tool 커밋**에만 발동 — 사용자 터미널 커밋은 무관. `--no-verify`로 우회 불가(Claude Code PreToolUse).
- 두 훅 모두 fail-open: lib 유실 시 커밋/편집을 막지 않고 경고만 남김.

### git-master 흡수 (기존 스킬 정합)

- `skills/git-master/SKILL.md` — 인라인 정규식 5종 블록과 구체 BAD 예시를 제거하고, canonical source를 공유 lib로 이관. 산문 self-check 지시문은 유지하고 `communication-style` 규칙을 참조하도록 변경.

**영향 범위**
- claude에서는 훅이 teeth, gemini/codex에서는 산문 지시문이 fallback(훅 미배포 플랫폼). 문서화된 부분 회귀.

### prometheus 댕글링 참조 교정

- `skills/prometheus/tests/application-scenarios.md` — 외부 plan에만 존재하던 `D-N` 백포인터 3곳을 자족적 서술로 교체(예: `D-5 Key Vocabulary` → `4-Key Adversarial Checklist Vocabulary (stale_state/prompt_injection/nonexistent_path/version_drift)`).

**영향 범위**
- `SKILL.md`/`plan-template.md`의 `D-N` ADR 헤딩과 `adr-log-contract.test.ts`는 byte-intact(테스트가 핀). 변경은 테스트 문서 3줄로 국한.

### 글로벌 배포 배선

- `sync.yaml` — 루트에 `rules:` 섹션 신규(규칙 전역 배포 경로).
- `claude.yaml` — 두 훅을 `PreToolUse`/`PostToolUse`에 등록. sync 시 공유 lib(`label-patterns.sh`)가 dep으로 함께 랜딩.

**영향 범위**
- 아직 미배포 상태(`~/.claude/`에 미랜딩). 실제 반영은 `make sync` 필요.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 강제 표면을 둘로 분리 — 메시지 하드블록 vs 콘텐츠 소프트원 (열린 질문)

**배경 및 문제 상황:**
같은 어휘 형태(`D-1`)가 커밋 메시지에서는 위반이지만 문서에서는 정당한 ADR 헤딩(`### D-1:`)입니다. 콘텐츠를 순진하게 하드블록하면 prometheus의 ADR 파일과 규칙 파일 자신의 BAD 예시가 커밋 불가능해집니다.

**해결 방안:**
표면별로 반대인 오탐 경제를 각기 다른 경로에 배치했습니다. 커밋 **메시지**는 하드블록(복구 불가·인간에겐 in-flight 불가, AI에겐 reword로 복구 가능)이라 오탐 0인 **clean set**만 스캔. 편집 **콘텐츠**는 소프트원(dismissible)이라 넓은 **full set**을 쓰되 defined-in-place 휴리스틱(`### D-1: <title>` 면제)만 얹었습니다.

**선택과 트레이드오프:**
- clean set(하드) = 하이픈 `D-N` + `(?! \w)` 가드된 bare `P0-3`·letter-code. full set(소프트) = clean + unguarded `Step N`/`AC [A-Z]\d`/`Phase·Round·Iteration N`. 후자는 "Phase 2 rollout" 같은 정당한 산문에 오탐하나 경고 티어에서는 허용치.
- **열린 질문**: 이 AFK-기본 티어링(메시지=clean만 하드블록)을 유지할지, 아니면 메시지도 full set으로 강하게 막을지 리뷰어 의견을 구합니다. 후자는 "feat: Phase 2 rollout" 같은 정당한 글로벌 메시지를 오차단하는 대가가 있습니다.
- **Residual(수용)**: Write/Edit/MultiEdit 외 도구(Bash heredoc, `sed -i`, `echo >>`)로 쓴 콘텐츠는 라벨이 커밋 메시지에 안 나타나면 양쪽 표면 모두 미스캔. AI는 파일 콘텐츠를 거의 Write/Edit로만 쓰므로 좁은 잔여로 판단.

### 2. 하이픈 라벨 커버리지를 `D-N`으로 좁힌 이유 (열린 질문)

**배경 및 문제 상황:**
"모든 하이픈-숫자 라벨"을 잡으려 `[A-Z]-\d+`로 넓히면 `B-12`(비타민)·`M-5`(설정) 같은 **정당한 도메인 토큰**을 오차단합니다. 이 저장소 개발 중 실제로 이 오탐이 관측되어 좁혔습니다.

**해결 방안:**
새로 추가하는 하이픈 패턴을 `\bD-\d+\b` 하나로 한정하고, `H1`/`M1` 등은 하이픈 없는 bare letter-code(`\b[HMLBCDJ]\d+\b`, git-master verbatim 흡수)로만 매치합니다.

**관련 코드:**
```bash
# hooks/lib/label-patterns.sh
_LABEL_PATTERN_HARD='\bD-\d+\b|\b[HMLBCDJ]\d+\b(?! \w)|\bP[0-3]\b(?! \w)'
_LABEL_PATTERN_FULL="$_LABEL_PATTERN_HARD"'|\(?Step \d+(\.\d+)?\)?|AC [A-Z]\d+\b|Phase \d+|Round \d+|Iteration \d+'
```

**선택과 트레이드오프:**
- **정착 확인**: 이 PR에 대해 훅을 실제 stdin으로 구동한 결과 `B-12`/`M-5`/`A-1`은 두 티어 모두 무매치(오차단 없음), `D-1`/`D-36`은 하드블록.
- **알려진 간극(열린 질문)**: 규칙 산문은 `WI-4`를 대표 BAD 예시로 들지만, 좁은 패턴 탓에 `WI-4`·`H-5`·`T-1`은 **양 티어 모두 통과**합니다. 이는 `B-12` 안전성과 맞바꾼 의도된 tradeoff입니다(넓히면 비타민 오차단 재발). 규칙 예시를 `D-N`형으로 좁힐지, 화이트리스트 접두(`WI-`)만 좁게 추가할지 리뷰어 판단을 구합니다.

### 3. 매처 엔진을 `perl -ne`로 선택

**배경 및 문제 상황:**
git-master의 원본 정규식은 `(?! \w)` 룩어헤드(PCRE)를 씁니다. 그러나 이 BSD 머신에서 `/usr/bin/grep -P`가 실패하고, 인터랙티브 `grep`은 훅 서브프로세스에 상속되지 않는 ugrep 셸함수입니다.

**해결 방안:**
`/usr/bin/perl`의 네이티브 PCRE를 `perl -ne`로 사용해 룩어헤드를 verbatim 보존. 텍스트는 stdin으로, 패턴은 env(`LABEL_RE`)로 주입해 인젝션 경계를 분리했습니다.

**선택과 트레이드오프:**
- 두 헬퍼는 `if … perl …; then return 0; fi; return 1` 형태로 `set -euo pipefail`에서 perl의 non-match exit가 caller를 abort하지 않도록 보장.
- 커밋 메시지·편집 콘텐츠가 stdin 데이터로만 흐르고 정규식은 lib 상수라, 커밋 메시지에 `$(...)`·백틱을 넣어도 실행되지 않음(QA에서 canary로 확인).

### 4. fail-open + canonical source 단일화

**배경 및 문제 상황:**
훅이 sourcing하는 공유 lib가 배포 드리프트로 유실될 수 있고, git-master는 자체 정규식 사본을 갖고 있어 드리프트 위험이 있었습니다.

**해결 방안:**
정규식 canonical source를 `hooks/lib/label-patterns.sh` 하나로 모으고(git-master는 사본 제거·참조만), 두 훅은 `source … || { echo WARNING >&2; exit 0; }` fail-open 가드를 둡니다.

**선택과 트레이드오프:**
- 이건 보안 게이트가 아니라 스타일 게이트이므로, lib 유실이 사용자 커밋을 wedge하는 것보다 조용히 비활성화되는 편이 낫다고 판단(fail-open).
- 두 훅은 의도적으로 `set -euo pipefail`을 생략 — `source`가 POSIX special builtin이라 errexit 하에서 파일 미존재가 `||` 안에서도 셸 전체를 죽여 fail-open 가드를 무력화하기 때문.

---

## ✅ Checklist

### 커밋 메시지 하드블록
- [ ] clean set(`D-N`/bare `P0-3`/`[HMLBCDJ]\d`) 매치 시 `exit 2` + `{"decision":"deny"}` JSON에 위반 토큰 명시
  - `hooks/label-commit-gate.sh`
- [ ] 표준 토큰(`S3`/`K8s`/`HTTP2`)·`B-12`·`Phase 2 rollout`·`Step 3`은 통과(exit 0)
  - `hooks/label-commit-gate.sh`
- [ ] `commit-graph`/`commit-tree`·비-commit Bash는 passthrough, `git -C`·`--amend`·`-F <file>`는 정상 처리
  - `hooks/label-commit-gate.sh`

### 편집 콘텐츠 소프트원
- [ ] full set 매치 시 `additionalContext` 경고 + 항상 `exit 0`(절대 block 안 함)
  - `hooks/label-edit-warn.sh`
- [ ] `### D-1: <title>` defined-in-place는 면제, 빈 `edits[]`·미지 tool·malformed JSON에서 jq 에러 없이 exit 0
  - `hooks/label-edit-warn.sh`

### 공유 lib 티어 계약
- [ ] `label_match_hard`/`label_match_full`이 티어 토큰 계약을 만족하고 `set -euo pipefail`에서 안전하게 source
  - `hooks/lib/label-patterns.sh`

### 스킬 정합
- [ ] git-master가 self-check 지시문을 유지하며 `communication-style`을 참조하고 인라인 정규식 블록은 제거됨
  - `skills/git-master/SKILL.md`
- [ ] `application-scenarios.md`의 `D-[0-9]+` 카운트 0, prometheus `SKILL.md`/`plan-template.md`/`adr-log-contract.test.ts`는 byte-intact + 테스트 green
  - `skills/prometheus/tests/application-scenarios.md`

### 배포 배선
- [ ] `make sync-dry`가 `communication-style.md`·두 훅·`label-patterns.sh`를 모두 `~/.claude/`로 랜딩
  - `sync.yaml`, `claude.yaml`
- [ ] `make validate` exit 0, `make test` 전량 green(신규 훅·lib 테스트 63건 포함)
