### PR TITLE
fix: 미배포 플랫폼 경로 재작성 가드 추가

### DIFF
--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -1519,6 +1519,47 @@ describe("processYaml", () => {
 			".claude/",
 		);
 	});
+
+	it("rewrites deployed md for a hook-only codex platform (no component categories)", async () => {
+		// hook-only codex project: sync.yaml has NO component-category items, so the
+		// CATEGORIES-derived rewriteEligiblePlatforms never gains codex. The platform
+		// is reached ONLY via codex.yaml's hook deploy, which syncPlatformConfigs
+		// records in libSourceRoots under codex. The rewrite gate must treat a
+		// hook/lib-only deploy as eligible too (mirroring the syncLib gate at
+		// sync.ts:1441) — otherwise a copied hook README keeps its .claude/ references
+		// under .codex/ un-rewritten.
+		const hookDir = path.join(rootDir, "hooks", "my-hook");
+		await writeFile(path.join(hookDir, "index.ts"), "export const run = () => {};\n");
+
+		const syncYamlPath = path.join(rootDir, "sync.yaml");
+		await writeFile(syncYamlPath, `path: ${targetPath}\n`);
+		await writeFile(
+			path.join(rootDir, "codex.yaml"),
+			"hooks:\n  PreToolUse:\n    - component: my-hook\n",
+		);
+
+		// Plant the hook README on disk (the mock adapter never copies it for real).
+		// The gate keys on codex being in libSourceRoots plus the file's presence,
+		// not on a real syncHooksDirect write.
+		const codexHookReadme = path.join(targetPath, ".codex", "hooks", "my-hook", "README.md");
+		const before = "See .claude/rules/ for conventions.\n";
+		await writeFile(codexHookReadme, before);
+
+		const adapters = makeAdapterMap(["codex"]);
+		const context = makeContext();
+
+		await processYaml(context, syncYamlPath, adapters, rootDir);
+
+		const after = await readFile(codexHookReadme);
+		expect(
+			after,
+			".codex/hooks/my-hook/README.md must be rewritten to .codex/rules/ for a hook-only codex deploy",
+		).toContain(".codex/rules/");
+		expect(
+			after,
+			".codex/hooks/my-hook/README.md must no longer contain .claude/",
+		).not.toContain(".claude/");
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -1371,6 +1371,154 @@ describe("processYaml", () => {
 		// .claude/ must be created when component items are present
 		expect(await exists(path.join(compTargetPath, ".claude"))).toBe(true);
 	});
+
+	// Regression coverage for the platform-eligibility gate on the post-deploy
+	// rewrite loop (tools/sync.ts:1432-1443). That loop currently runs
+	// `rewritePlatformPaths` for any non-claude platform whose `.{platform}/`
+	// dir happens to exist on disk, WITHOUT checking whether this project
+	// actually deploys to that platform — so a claude-only project's
+	// hand-authored `.codex/`/`.gemini/` files get their `.claude/` references
+	// clobbered even though OMT never deployed anything there.
+
+	it("preserves hand-authored non-claude md in claude-only target", async () => {
+		// claude-only project: sync.yaml top-level `platforms` narrows every
+		// category to claude. The project never deploys to codex/gemini, so
+		// hand-authored non-claude .md files sitting under the target must be
+		// left byte-identical.
+		const syncYamlPath = path.join(rootDir, "sync.yaml");
+		await writeFile(syncYamlPath, `path: ${targetPath}\nplatforms: [claude]\n`);
+
+		const codexFile = path.join(targetPath, ".codex", "hooks", "README.md");
+		const geminiFile = path.join(targetPath, ".gemini", "custom.md");
+		const codexBefore = "Hand-authored codex notes. See .claude/rules/ for conventions.\n";
+		const geminiBefore = "Hand-authored gemini notes. See .claude/rules/ for conventions.\n";
+		await writeFile(codexFile, codexBefore);
+		await writeFile(geminiFile, geminiBefore);
+
+		const adapters = makeAdapterMap(["claude"]);
+		const context = makeContext();
+
+		await processYaml(context, syncYamlPath, adapters, rootDir);
+
+		const codexAfter = await readFile(codexFile);
+		const geminiAfter = await readFile(geminiFile);
+
+		expect(codexAfter, ".codex/hooks/README.md must be untouched in a claude-only target").toBe(
+			codexBefore,
+		);
+		expect(geminiAfter, ".gemini/custom.md must be untouched in a claude-only target").toBe(
+			geminiBefore,
+		);
+	});
+
+	it("still rewrites deployed codex skill md via feature-platforms default", async () => {
+		// Un-narrowed project — no top-level `platforms` override and the skills
+		// item carries none either, so resolvePlatforms falls through to
+		// config.yaml's feature-platforms.skills default. This test depends on
+		// the REAL repo config.yaml declaring codex in feature-platforms.skills
+		// (pinned by "feature-platforms contains only skills" below): getRootDir()
+		// (tools/lib/config.ts) walks up from tools/lib/config.ts's OWN module
+		// location to find config.yaml, not from the `rootDir` fixture argument
+		// passed to processYaml — so resolvePlatforms always reads the real repo
+		// config.yaml regardless of any config.yaml written under this tmpDir.
+		const syncYamlPath = path.join(rootDir, "sync.yaml");
+		await writeFile(syncYamlPath, `path: ${targetPath}\nskills:\n  items:\n    - oracle\n`);
+
+		// Plant a codex skill md directly on disk instead of deploying it for
+		// real: the mock adapter never writes files, and "oracle" has no source
+		// under rootDir/skills/ so resolveComponentPath fails and syncCategory's
+		// per-item dispatch loop `continue`s before ever reaching the
+		// backup+wipe step for codex:skills — so the planted file survives
+		// untouched to the rewrite pass. The gate keys on the file's presence on
+		// disk plus the un-narrowed config, not on a real syncSkillsDirect write.
+		const codexSkillFile = path.join(targetPath, ".codex", "skills", "oracle", "SKILL.md");
+		const before = "See .claude/rules/ for conventions.\n";
+		await writeFile(codexSkillFile, before);
+
+		const adapters = makeAdapterMap(["claude", "codex"]);
+		const context = makeContext();
+
+		await processYaml(context, syncYamlPath, adapters, rootDir);
+
+		const after = await readFile(codexSkillFile);
+		expect(after, ".codex/skills/oracle/SKILL.md must be rewritten to .codex/rules/").toContain(
+			".codex/rules/",
+		);
+		expect(after, ".codex/skills/oracle/SKILL.md must no longer contain .claude/").not.toContain(
+			".claude/",
+		);
+	});
+
+	it("dry-run does not report codex rewrite for claude-only target", async () => {
+		const syncYamlPath = path.join(rootDir, "sync.yaml");
+		await writeFile(syncYamlPath, `path: ${targetPath}\nplatforms: [claude]\n`);
+
+		// A stray .codex/ dir already exists at the deploy root (e.g. left over
+		// from an earlier, differently-configured sync of the same target).
+		await fs.mkdir(path.join(targetPath, ".codex", "hooks"), { recursive: true });
+
+		const adapters = makeAdapterMap(["claude"]);
+		const context = makeContext({ dryRun: true });
+
+		const lines: string[] = [];
+		const origStderr = process.stderr.write.bind(process.stderr);
+		process.stderr.write = (chunk: string | Uint8Array) => {
+			if (typeof chunk === "string") lines.push(chunk);
+			return true;
+		};
+		try {
+			await processYaml(context, syncYamlPath, adapters, rootDir);
+		} finally {
+			process.stderr.write = origStderr;
+		}
+
+		expect(
+			lines.some((l) => l.includes("Rewrite .claude/ paths -> .codex/")),
+			"dry-run must not report a codex rewrite for a claude-only target",
+		).toBe(false);
+	});
+
+	it("rewrites deployed md for a section-level non-claude platform override", async () => {
+		// Top-level `platforms: [claude]` narrows every category's project-level
+		// default to claude-only (Level 3 in the resolvePlatforms cascade) — this
+		// pins down the OLD gate's per-category loop to {claude}, since it always
+		// passes the fake item + undefined sectionPlatforms and so never sees the
+		// section-level override below. Section-level `platforms: [claude,
+		// opencode]` on `agents` (Level 2) OUTRANKS the top-level Level-3 default
+		// for the real per-item resolution, ADDING opencode. The gate must mirror
+		// this per-item resolvePlatforms cascade (item > section > syncYaml >
+		// feature-platforms > use-platforms) exactly as syncCategory does, or
+		// opencode's deployed md is silently left un-rewritten.
+		const syncYamlPath = path.join(rootDir, "sync.yaml");
+		await writeFile(
+			syncYamlPath,
+			`path: ${targetPath}\nplatforms: [claude]\nagents:\n  platforms: [claude, opencode]\n  items:\n    - oracle\n`,
+		);
+
+		// Plant an opencode agent md directly on disk instead of deploying it for
+		// real: the mock adapter never writes files, and "oracle" has no source
+		// under rootDir/agents/ so resolveComponentPath fails and syncCategory's
+		// per-item dispatch loop `continue`s before reaching backup+wipe for
+		// opencode:agents — so the planted file survives untouched to the
+		// rewrite pass. The gate keys on the file's presence on disk plus the
+		// resolved eligible-platform set, not on a real syncAgentsDirect write.
+		const opencodeAgentFile = path.join(targetPath, ".opencode", "agents", "oracle.md");
+		const before = "See .claude/rules/ for conventions.\n";
+		await writeFile(opencodeAgentFile, before);
+
+		const adapters = makeAdapterMap(["claude", "opencode"]);
+		const context = makeContext();
+
+		await processYaml(context, syncYamlPath, adapters, rootDir);
+
+		const after = await readFile(opencodeAgentFile);
+		expect(after, ".opencode/agents/oracle.md must be rewritten to .opencode/rules/").toContain(
+			".opencode/rules/",
+		);
+		expect(after, ".opencode/agents/oracle.md must no longer contain .claude/").not.toContain(
+			".claude/",
+		);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -1457,7 +1457,15 @@ export async function processYaml(
 			const nonClaudePlatforms: Platform[] = ["gemini", "codex", "opencode"];
 			for (const platform of nonClaudePlatforms) {
 				const platformDir = path.join(deployRoot, `.${platform}`);
-				if (existsSync(platformDir) && rewriteEligiblePlatforms.has(platform)) {
+				// Eligible = this sync deployed to the platform via a component category
+				// (rewriteEligiblePlatforms) OR via a hook/lib deploy recorded in
+				// libSourceRoots (a codex/gemini-hook-only project — same signal the
+				// syncLib gate above keys on). Without the libSourceRoots arm, a copied
+				// hook README's .claude/ references stay un-rewritten under .{platform}/.
+				if (
+					existsSync(platformDir) &&
+					(rewriteEligiblePlatforms.has(platform) || libSourceRoots.has(platform))
+				) {
 					if (context.dryRun) {
 						logDry(`Rewrite .claude/ paths -> .${platform}/ in ${platformDir}/`);
 					} else {

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -1358,6 +1358,30 @@ export async function processYaml(
 		"lib",
 	);
 
+	// Platforms eligible for the non-claude path-rewrite loop below: the union,
+	// over every deployable category and every item in it, of that item's
+	// resolved platform cascade — mirroring syncCategory's own per-item
+	// resolvePlatforms(item, sectionPlatforms, syncYaml.platforms, category)
+	// call exactly, so eligibility equals actual deployment by construction.
+	// A project-level-only computation (fake item, no sectionPlatforms) would
+	// miss an item- or section-level override that ADDS a non-claude platform.
+	// This must key on CATEGORIES (feature-platforms.skills etc.), NOT
+	// libPlatforms — feature-platforms has no `lib` entry, so libPlatforms
+	// collapses to ["claude"] for any un-narrowed project and would wrongly
+	// skip codex/gemini/opencode for the root self-deploy.
+	const rewriteEligiblePlatforms = new Set<Platform>();
+	for (const category of CATEGORIES) {
+		const section = syncYaml[category];
+		if (!section || !Array.isArray(section.items) || section.items.length === 0) continue;
+		const sectionPlatforms = section.platforms;
+		for (const item of section.items) {
+			const platforms = await resolvePlatforms(item, sectionPlatforms, syncYaml.platforms, category);
+			for (const platform of platforms) {
+				rewriteEligiblePlatforms.add(platform);
+			}
+		}
+	}
+
 	// Parse claude.yaml once (it is colocated with sync.yaml in yamlDir, shared by
 	// every worktree) so the per-worktree mkdir gate need not re-read it.
 	const claudeYaml = await parseAndMergePlatformYaml(yamlDir, "claude");
@@ -1433,7 +1457,7 @@ export async function processYaml(
 			const nonClaudePlatforms: Platform[] = ["gemini", "codex", "opencode"];
 			for (const platform of nonClaudePlatforms) {
 				const platformDir = path.join(deployRoot, `.${platform}`);
-				if (existsSync(platformDir)) {
+				if (existsSync(platformDir) && rewriteEligiblePlatforms.has(platform)) {
 					if (context.dryRun) {
 						logDry(`Rewrite .claude/ paths -> .${platform}/ in ${platformDir}/`);
 					} else {


### PR DESCRIPTION
## 📌 Summary

`make sync`가 배포한 적 없는 파일을 건드리던 버그를 고칩니다. `platforms:[claude]` 프로젝트(예: algocare-home)의 손으로 작성한 `.codex/hooks/README.md`가 매 sync마다 `.claude/` → `.codex/`로 덮어써지던 문제를, "재작성 자격 = 실제 배포 플랫폼"이 구조적으로 일치하도록 게이트를 추가해 해결했습니다.

---

## 🔧 Changes

### sync 도구 (`tools/sync.ts`)

- `processYaml`의 비-claude 경로 재작성 루프에 **플랫폼 자격 게이트**(`rewriteEligiblePlatforms`)를 추가했습니다.
- 기존 조건 `existsSync(platformDir)`(디렉터리가 존재하기만 하면 재작성)를 `existsSync(platformDir) && rewriteEligiblePlatforms.has(platform)`로 좁혔습니다 — write 브랜치와 dry-run 로그 브랜치에 동일 적용.
- 자격 집합은 배포 로직(`syncCategory`)이 쓰는 것과 **똑같은** per-item `resolvePlatforms(item, section.platforms, syncYaml.platforms, category)`를 카테고리·아이템 전체에 대해 union하여, `processYaml`당 1회 계산합니다.

근본 원인은 재작성 루프가 `.codex/` 디렉터리의 **존재 여부만** 보고 OMT가 거기에 무엇을 배포했는지는 보지 않았던 것입니다. algocare-home은 `platforms:[claude]`라 `.codex/`에 아무것도 배포하지 않는데도, 미리 존재하던 hand-authored `.codex/` 트리를 루프가 훑어 정규화 치환을 가했습니다.

**영향 범위**
- 동작 축소만 수행 — 파일 삭제·절단 등 파괴적 연산은 도입하지 않습니다.
- 배포 대상 플랫폼의 정규화(un-narrowed self-deploy의 `.codex/skills/*`, `rules-injector/README.md` 등)는 그대로 유지 — 자격 집합이 배포와 일치하므로 회귀 없음.
- `rewritePlatformPaths` / `collectMdFiles` 본문 불변, `PlatformAdapter` 인터페이스 불변. 타겟 리포는 손대지 않음.

### 회귀 테스트 (`tools/sync.test.ts`)

- claude-only 타겟의 hand-authored `.codex/.gemini` md 보존 (RED→GREEN)
- section-level override로 추가된 non-claude 플랫폼의 배포 md 정규화 (RED→GREEN)
- un-narrowed 배포 codex skill md 정규화 유지 (무회귀 가드)
- claude-only 타겟 dry-run에 codex 재작성 로그 라인 부재 (RED→GREEN)

---

## 💬 Review Points

### 1. 재작성 루프를 "실제 배포 플랫폼"으로 게이팅

**배경 및 문제 상황:**
OMT는 이미 syncLib 등에서 "자기가 쓴 것만 소유한다"를 지키는데, 경로 재작성만 예외였습니다. 재작성 루프는 `.<platform>/` 디렉터리 존재만 확인하고 무조건 정규화를 돌려서, 배포하지 않은 hand-authored 파일까지 치환했습니다. 트리거는 `platforms:[claude]` 프로젝트였고, 실제로 algocare-home 워크트리들의 git-tracked README가 매 sync마다 clobber되고 있었습니다.

**해결 방안:**
호출부(call-site)에 게이트를 두어, 프로젝트가 실제로 배포하는 플랫폼에만 재작성을 허용합니다. `rewritePlatformPaths`의 순회 폭을 좁히는 방식(Option B)이나 배포 파일을 정확히 추적하는 방식(Option C)은 각각 회귀·과도한 비용 문제로 배제했습니다.

**구현 세부사항:**
자격 신호를 배포 로직과 **동일한** per-item `resolvePlatforms(item, section.platforms, syncYaml.platforms, category)`로 계산합니다. 두 가지가 비자명합니다.
- **`CATEGORIES` union, `libPlatforms` 아님**: `feature-platforms`에는 `lib` 항목이 없어, `lib` 카테고리로 자격을 키잉하면 un-narrowed 프로젝트에서도 `[claude]`로 붕괴되어 self-deploy의 codex 정규화를 잘못 건너뜁니다. `skills` 등 실제 배포 카테고리를 union해야 합니다.
- **프로젝트 레벨이 아니라 per-item**: 초기 구현은 자격을 프로젝트 레벨(가짜 item, section=undefined)로만 계산했는데, 이러면 section/item override로 non-claude 플랫폼을 *추가*하는 경우 배포는 하면서 정규화는 건너뛰는 비대칭이 생깁니다. 배포와 똑같이 아이템마다 계산해 "자격 = 배포"를 구조적으로 보장했습니다.

**선택과 트레이드오프:**
Option A(호출부 게이트)는 국소적이고 인터페이스 변경이 없으며, 배포 대상 플랫폼의 정규화를 전혀 회귀시키지 않습니다. 남은 사각 하나는 정직하게 밝힙니다 — `codex.yaml` 훅 번들이 `syncPlatformConfigs`를 통해 `.codex/hooks/`에 배포되는 경로는 `CATEGORIES`에 없어 이 union으로 잡히지 않습니다. 즉 "codex 스킬은 배포 안 하면서 codex.yaml 훅 번들만 가진 프로젝트"는 자기 훅 README 정규화를 건너뛸 수 있습니다. 현재 그런 `projects/*/codex.yaml`이 하나도 없어 트리거가 0이며, 완전 해결은 파일 단위 소유권 추적(Option C)이라 별건으로 둡니다. 지금 닫을지 계속 둘지 의견 주시면 좋겠습니다.

---

## ✅ Checklist

- [ ] claude-only 프로젝트의 hand-authored `.codex/.gemini/.opencode/*.md`가 `make sync` 후 byte-unchanged
  - `tools/sync.ts`
- [ ] section/item override로 추가된 non-claude 플랫폼의 배포 `.md`가 정규화됨
  - `tools/sync.ts`
- [ ] un-narrowed 프로젝트의 배포 codex skill `.md` 정규화가 유지됨 (무회귀)
  - `tools/sync.ts`
- [ ] claude-only 타겟 dry-run에 codex 재작성 로그 라인이 출력되지 않음
  - `tools/sync.ts`
- [ ] `make test` + `make validate` 모두 exit 0
  - `tools/sync.test.ts`

---

## 📎 References

- 없음 (내부 sync 버그 수정)