### PR TITLE
feat(examiner): interview_hints 4-요소 스캐폴드 격상

### DIFF
--- a/agents/tech-claim-examiner.md
+++ b/agents/tech-claim-examiner.md
@@ -20,6 +20,7 @@ Technical Evaluation Request:
 - `bullet_text`: resume bullet to evaluate
 - `candidate_context`: `{ years, position, target_company }`
 - (Optional) Cross-entry context for R-Cross check
+- (Optional) `## Proposed Alternatives`: re-dispatch 시 review-resume이 전달하는 후보 수정안 블록. first dispatch에는 `None — initial evaluation`.
 
 ---
 
@@ -219,7 +220,7 @@ THEN final_verdict := "REQUEST_CHANGES"
 ```
 
 이 rule은 R-Phys, R-Cross 후 다음 순서로 체크. P1 누적이 3개 이상이면 개별 FAIL 없이도 REQUEST_CHANGES.
-**Note**: R-Phys 또는 R-Cross가 triggered되어 early return하더라도, P1 cumulative count는 `interview_hints` 생성을 위해 계산하고 기록한다.
+**Note**: R-Phys 또는 R-Cross가 triggered되어 early return하더라도, 그 시점까지 평가된 A1-A4 축의 pending P1 verdict는 count 기록에 그치지 않고 `interview_hints`에 4-라벨 스캐폴드(§Output Format 참조)로 실제 emit한다.
 
 #### final_verdict Decision Sequence
 
@@ -227,8 +228,8 @@ THEN final_verdict := "REQUEST_CHANGES"
 1. Evaluate all 5 axes (A1-A5)
 2. Assign structural_verdict = verdicts.a5_scanability.verdict
 3. Check critical_rule_flags:
-   a. If r_phys triggered → final_verdict = REQUEST_CHANGES (early return)
-   b. If r_cross triggered → final_verdict = REQUEST_CHANGES (early return)
+   a. If r_phys triggered → final_verdict = REQUEST_CHANGES (early return); 그 시점까지 평가된 A1-A4 pending P1 verdict(및 r_phys 자체가 구동한 hint 포함)를 interview_hints에 4-라벨 스캐폴드로 emit
+   b. If r_cross triggered → final_verdict = REQUEST_CHANGES (early return); 그 시점까지 평가된 A1-A4 pending P1 verdict(및 r_cross 자체가 구동한 hint 포함)를 interview_hints에 4-라벨 스캐폴드로 emit
 4. Check P1 cumulative: if count(P1 across A1-A4) >= 3 → final_verdict = REQUEST_CHANGES (early return)
 5. If any A1-A4 FAIL → final_verdict = REQUEST_CHANGES
 6. If structural_verdict == FAIL AND all A1-A4 PASS/P1 AND count(P1 across A1-A4) < 3 → final_verdict = REQUEST_CHANGES (readability-fix lane)
@@ -241,10 +242,10 @@ THEN final_verdict := "REQUEST_CHANGES"
 
 ## Output Format
 
-다음 YAML template로 응답 (output-schema.md v4.0 contract와 정확히 일치):
+다음 YAML template로 응답 (output-schema.md v4.1 contract와 정확히 일치):
 
 ```yaml
-schema_version: "v4.0"
+schema_version: "v4.1"
 bullet_text: <원본 bullet>
 candidate_context:
   years: <int>
@@ -286,16 +287,27 @@ critical_rule_flags:
 final_verdict: APPROVE | REQUEST_CHANGES
 structural_verdict: PASS | P1 | FAIL   # A5 scanability axis verdict — FAIL triggers final_verdict = REQUEST_CHANGES (readability-fix lane)
 interview_hints:
-  - <hint 1>
-  - <hint 2>
-  - ...
+  - |
+    인용: «bullet 본문에서 직접 발췌한 verbatim substring»
+    문제: <그 인용 구간의 구체적 결함>
+    이유: <왜 문제인지 — 평이한 서술, axis 이름 없이>
+    제안: <구체적·실행가능한 수정안>
+  - |
+    인용: «...»
+    문제: ...
+    이유: ...
+    제안: ...
 ```
 
-**Language hint rule (bidirectional)**: `interview_hints` 언어는 source bullet의 언어를 따른다 — 한국어 bullet → 한국어 hint; English bullet → English hint.
+**Scaffold rule**: interview_hints에 surface되는 모든 hint는 위 4-라벨(`인용:` / `문제:` / `이유:` / `제안:`) 스캐폴드로 emit한다 — content axis(A1-A4)의 P1/FAIL 구동 hint, structural axis(A5)의 P1 구동 hint, critical-rule(r_phys/r_cross) 구동 hint 등을 포함하되, 이 열거는 예시일 뿐이다: surface되는 어떤 hint든 이 스캐폴드를 입는다. `인용:`의 내용은 항상 «»로 감싼다. A5 P1 hint의 `인용:`은 파묻힌·뒤바뀐 구절을, `제안:`은 재배치·압축 fix를 담는다. 완전 clean(P1 없음, structural PASS)이면 `interview_hints: []`.
+
+**Dispatch-state branch (`제안:` 줄)**: `## Input`의 `Proposed Alternatives`에 실제 후보 대안이 있으면 `제안:` 줄은 그 대안을 근거로 작성(near-verbatim 인용, 새로 지어내지 않음). `None — initial evaluation`이면 examiner가 자체 생성.
+
+**Language hint rule (bidirectional)**: `interview_hints` 언어는 source bullet의 언어를 따른다 — 한국어 bullet → 한국어 hint; English bullet → English hint. `인용:` 줄은 원문 verbatim이므로 자동 충족.
 
 ### interview_hints Constraints
 
-Follow `skills/tech-claim-rubric/output-schema.md` §interview_hints Constraints (Vocabulary / Actionability / P1 coverage rules). Do not duplicate rule bodies here.
+Follow `skills/tech-claim-rubric/output-schema.md` §interview_hints Constraints (Vocabulary / Actionability / P1 coverage / scaffold rules). `문제:` / `이유:` / `제안:` 세 줄에는 `A[1-5]` 코드도 axis name도 등장하지 않는다 — `인용:` 줄은 verbatim 인용이라 면제. Do not duplicate rule bodies here.
 
 ---
 
@@ -319,5 +331,6 @@ Follow `skills/tech-claim-rubric/output-schema.md` §interview_hints Constraints
 - [ ] interview_hints 언어가 source bullet 언어와 일치 (한국어 bullet → 한국어 hint, English bullet → English hint)
 - [ ] interview_hints에 axis identifier (A1-A5) 또는 axis name 포함되지 않음 (Vocabulary rule)
 - [ ] 각 hint가 구체적이고 실행 가능함 — generic 표현 없음 (Actionability rule)
-- [ ] P1 verdict가 어느 axis(A1-A4)에라도 존재할 경우 final_verdict가 APPROVE여도 interview_hints에 개선 제안 포함됨 (P1 coverage rule)
+- [ ] P1 verdict가 content axis(A1-A4) 또는 structural axis(A5)에라도 존재할 경우, final_verdict나 조기 종료 여부와 무관하게 interview_hints에 개선 제안 포함됨 (P1 coverage rule)
+- [ ] 모든 hint가 4-라벨 스캐폴드(`인용:`/`문제:`/`이유:`/`제안:`)를 따르며, `인용:`은 bullet 본문에서 직접 발췌한 verbatim substring임 (paraphrase 금지)
 - [ ] final_verdict 결정됨 (APPROVE | REQUEST_CHANGES)

--- a/agents/tech-claim-examiner.md
+++ b/agents/tech-claim-examiner.md
@@ -298,16 +298,21 @@ interview_hints:
     이유: ...
     제안: ...
 ```
+<!-- English bullet example: labels switch to the English set, «» rule unchanged —
+  Quote: «...»
+  Problem: ...
+  Why: ...
+  Suggestion: ... -->
 
-**Scaffold rule**: interview_hints에 surface되는 모든 hint는 위 4-라벨(`인용:` / `문제:` / `이유:` / `제안:`) 스캐폴드로 emit한다 — content axis(A1-A4)의 P1/FAIL 구동 hint, structural axis(A5)의 P1 구동 hint, critical-rule(r_phys/r_cross) 구동 hint 등을 포함하되, 이 열거는 예시일 뿐이다: surface되는 어떤 hint든 이 스캐폴드를 입는다. `인용:`의 내용은 항상 «»로 감싼다. A5 P1 hint의 `인용:`은 파묻힌·뒤바뀐 구절을, `제안:`은 재배치·압축 fix를 담는다. 완전 clean(P1 없음, structural PASS)이면 `interview_hints: []`.
+**Scaffold rule**: interview_hints에 surface되는 모든 hint는 4-라벨 스캐폴드로 emit한다 — content axis(A1-A4)의 P1/FAIL 구동 hint, structural axis(A5)의 P1 구동 hint, critical-rule(r_phys/r_cross) 구동 hint 등을 포함하되, 이 열거는 예시일 뿐이다: surface되는 어떤 hint든 이 스캐폴드를 입는다. 라벨 자체가 source bullet 언어를 따른다 — 한국어 bullet이면 `인용:` / `문제:` / `이유:` / `제안:`, English bullet이면 `Quote:` / `Problem:` / `Why:` / `Suggestion:` (콜론 뒤 한 칸 공백). `인용:`/`Quote:`의 내용은 언어와 무관하게 항상 «»로 감싼다. A5 P1 hint의 `인용:`/`Quote:`은 파묻힌·뒤바뀐 구절을, `제안:`/`Suggestion:`은 재배치·압축 fix를 담는다. 완전 clean(P1 없음, structural PASS)이면 `interview_hints: []`.
 
-**Dispatch-state branch (`제안:` 줄)**: `## Input`의 `Proposed Alternatives`에 실제 후보 대안이 있으면 `제안:` 줄은 그 대안을 근거로 작성(near-verbatim 인용, 새로 지어내지 않음). `None — initial evaluation`이면 examiner가 자체 생성.
+**Dispatch-state branch (`제안:`/`Suggestion:` 줄)**: `## Input`의 `Proposed Alternatives`에 실제 후보 대안이 있으면 `제안:`/`Suggestion:` 줄은 그 대안을 근거로 작성(near-verbatim 인용, 새로 지어내지 않음). `None — initial evaluation`이면 examiner가 자체 생성.
 
-**Language hint rule (bidirectional)**: `interview_hints` 언어는 source bullet의 언어를 따른다 — 한국어 bullet → 한국어 hint; English bullet → English hint. `인용:` 줄은 원문 verbatim이므로 자동 충족.
+**Language hint rule (bidirectional)**: `interview_hints`는 라벨과 본문 모두 source bullet의 언어를 따른다 — 한국어 bullet → 한국어 라벨(인용/문제/이유/제안) + 한국어 hint 본문; English bullet → English 라벨(Quote/Problem/Why/Suggestion) + English hint 본문. 라벨 매핑: 인용=Quote, 문제=Problem, 이유=Why, 제안=Suggestion. `인용:`/`Quote:` 줄은 원문 verbatim이므로 본문 언어 일치가 자동 충족.
 
 ### interview_hints Constraints
 
-Follow `skills/tech-claim-rubric/output-schema.md` §interview_hints Constraints (Vocabulary / Actionability / P1 coverage / scaffold rules). `문제:` / `이유:` / `제안:` 세 줄에는 `A[1-5]` 코드도 axis name도 등장하지 않는다 — `인용:` 줄은 verbatim 인용이라 면제. Do not duplicate rule bodies here.
+Follow `skills/tech-claim-rubric/output-schema.md` §interview_hints Constraints (Vocabulary / Actionability / P1 coverage / scaffold rules). `문제:` / `이유:` / `제안:` 세 줄(English bullet에서는 `Problem:` / `Why:` / `Suggestion:` — 동일 규칙 적용)에는 `A[1-5]` 코드도 axis name도 등장하지 않는다 — `인용:`/`Quote:` 줄은 verbatim 인용이라 면제. Do not duplicate rule bodies here.
 
 ---
 
@@ -328,9 +333,9 @@ Follow `skills/tech-claim-rubric/output-schema.md` §interview_hints Constraints
 - [ ] P1 cumulative meta-rule 적용: count(P1 across A1-A4) ≥ 3이면 final_verdict = REQUEST_CHANGES
 - [ ] final_verdict 도출 시 A1-A4 FAIL/P1-cumulative 외에 structural_verdict == FAIL 게이트도 적용됨
 - [ ] structural_verdict 작성됨 (A5 scanability 결과 직접 반영)
-- [ ] interview_hints 언어가 source bullet 언어와 일치 (한국어 bullet → 한국어 hint, English bullet → English hint)
+- [ ] interview_hints 언어가 source bullet 언어와 일치 — 4-라벨과 hint 본문 모두 (한국어 bullet → 한국어 라벨+hint, English bullet → English 라벨+hint)
 - [ ] interview_hints에 axis identifier (A1-A5) 또는 axis name 포함되지 않음 (Vocabulary rule)
 - [ ] 각 hint가 구체적이고 실행 가능함 — generic 표현 없음 (Actionability rule)
 - [ ] P1 verdict가 content axis(A1-A4) 또는 structural axis(A5)에라도 존재할 경우, final_verdict나 조기 종료 여부와 무관하게 interview_hints에 개선 제안 포함됨 (P1 coverage rule)
-- [ ] 모든 hint가 4-라벨 스캐폴드(`인용:`/`문제:`/`이유:`/`제안:`)를 따르며, `인용:`은 bullet 본문에서 직접 발췌한 verbatim substring임 (paraphrase 금지)
+- [ ] 모든 hint가 4-라벨 스캐폴드(한국어 bullet: `인용:`/`문제:`/`이유:`/`제안:`, English bullet: `Quote:`/`Problem:`/`Why:`/`Suggestion:`)를 따르며, `인용:`/`Quote:`은 bullet 본문에서 직접 발췌한 verbatim substring임 (paraphrase 금지)
 - [ ] final_verdict 결정됨 (APPROVE | REQUEST_CHANGES)

--- a/skills/review-resume/tests/phase9-loop-scenarios.md
+++ b/skills/review-resume/tests/phase9-loop-scenarios.md
@@ -139,3 +139,280 @@ interview_hints:
 - Internal struct (`verdicts.`, `critical_rule_flags.`, `evidence_quote`, `reasoning:`) → 0 matches
 
 Pattern 본문은 `skills/tech-claim-rubric/output-schema.md §Prohibited Token Patterns for review-resume`에서 canonical 관리. 축 이름 변경 시 그 표만 갱신하면 SCN-6은 자동으로 따라간다.
+
+---
+
+# Rich-Hint Scaffold Scenarios (4-element anchored scaffold, 구현됨)
+
+아래 SCN-7~13은 `interview_hints`가 (이전의 "한 줄 제안" 대신) **4-요소 앵커드 스캐폴드**를 방출하는 명세다. `agents/tech-claim-examiner.md` Output Format과 `output-schema.md` §interview_hints Constraints가 이 4-요소 스캐폴드를 emit하도록 구현되었으며, 아래 mock YAML은 그 기대 출력이다.
+
+## Rich-Hint Scaffold Format (A′) — pinned physical format
+
+각 `interview_hints` 원소는 **하나의 문자열**이며, 4개 라벨이 각각 **별도 줄**(newline-delimited, `/`-delimited 아님)에 온다:
+
+```
+인용: «원본 bullet의 verbatim substring»
+문제: <그 인용 구간의 구체적 결함>
+이유: <왜 문제인지 — 평이한 소스언어, 축 이름 절대 없음>
+제안: <구체적·실행가능한 수정안>
+```
+
+- `인용:` 라인의 `«»` 내부는 원본 bullet에서 **글자 그대로** 뽑은 substring (paraphrase 금지). noleak 검증 시 이 줄만 라인 단위로 제외하고 나머지 3줄을 검사한다.
+- `문제:` / `이유:` / `제안:` 라인에는 axis identifier(`A[1-5]`)도 axis name(Technical Credibility / Causal Honesty / Outcome Presence & Clarity / Ownership & Scope / Scanability)도 등장하지 않는다. "이유"는 평이한 한국어 서술.
+- 이 포맷은 `output-schema.md §interview_hints Constraints`(Vocabulary/Actionability/P1 coverage)의 상위 호환이다 — 기존 제약을 완화하지 않고 물리적 구조만 4-라인으로 pin한다.
+
+### Fixture Index
+
+| Fixture | 코드 경로 | 겨냥하는 것 |
+|---------|-----------|-------------|
+| `FX-RC` | first dispatch, examiner 자체 생성 제안 | vague scale/ownership REQUEST_CHANGES |
+| `FX-RC-redispatch` | re-dispatch, user 제공 alternative 반영 | 제안이 sentinel을 인용하는지 |
+| `FX-P1-APPROVE` | APPROVE + P1 hint surface | P1 coverage rule (APPROVE여도 hint 노출) |
+| `FX-STRUCT-P1` | structural P1, content 전부 PASS | 구조 hint 전용, structural_verdict 필드 불변 |
+| `FX-CLEAN` | 완전 clean APPROVE | `interview_hints == []` 회귀 방지 (SCN-1과 정합) |
+| `FX-RPHYS` | r_phys early-return + pending content P1 | early-return에도 실제 emit (count만 아님) |
+| `FX-TECH-ECHO` | bullet 본문에 `A[1-5]`-모양 토큰 | noleak false-positive 방지 (`인용:` 줄 제외 후 검사) |
+
+---
+
+## SCN-7: Rich-hint scaffold — first dispatch, examiner-생성 제안 (FX-RC)
+
+**Target Rule:** REQUEST_CHANGES hint는 4-요소 스캐폴드(인용/문제/이유/제안)로 emit되며, first dispatch(대안 없음)에서는 `제안`을 examiner가 자체 생성한다.
+
+**Setup:**
+
+Fixture `FX-RC` bullet:
+```
+대규모 마이그레이션을 주도하여 레거시 시스템을 성공적으로 개선함
+```
+
+Dispatch payload (first dispatch):
+```
+## Bullet
+대규모 마이그레이션을 주도하여 레거시 시스템을 성공적으로 개선함
+
+## Proposed Alternatives
+None — initial evaluation
+```
+
+examiner 기대 output (GREEN mock, PUBLIC fields만):
+```yaml
+final_verdict: REQUEST_CHANGES
+interview_hints:
+  - |
+    인용: «대규모 마이그레이션을 주도하여»
+    문제: 규모(팀 수, 서비스 수, 기간)와 소유권(단독 주도인지 공동 참여인지)이 전혀 명시되지 않음
+    이유: 성과의 크기와 본인 기여도를 가늠할 근거가 없어 임팩트가 와닿지 않음
+    제안: "3개 팀, 40개 서비스 마이그레이션을 단독 설계·주도"처럼 규모와 역할을 구체적 수치로 명시
+```
+
+**Expected:** review-resume이 이 hint를 그대로 user에게 표시. `인용:` 줄은 원본 bullet의 verbatim substring, `제안:` 줄은 (대안이 없었으므로) examiner가 독자적으로 생성한 구체안.
+
+**Verification:**
+- `인용:` / `문제:` / `이유:` / `제안:` 4개 라벨이 hint 문자열 내 각각 별도 줄로 1회씩 등장 — `grep -c '^인용: '` 등 라인 단위 grep으로 각 1.
+- `인용:` 라인의 `«...»` 내부 문자열이 원본 bullet의 substring: `grep -F '대규모 마이그레이션을 주도하여' <<< "$bullet"` → match.
+- `인용:` 라인을 제외한 나머지 3줄에 대해 canonical noleak 정규식 3종(`\bA[1-5]\b` / axis name alternation / `verdicts\.|critical_rule_flags\.|evidence_quote|reasoning:`) 각각 0 matches.
+- dispatch payload에 `Proposed Alternatives: None — initial evaluation`이 있었음 — 이 fixture의 `제안:` 줄은 SENTINEL 패턴을 포함하지 않는다 (SCN-8과의 대조 지점).
+
+---
+
+## SCN-8: Rich-hint scaffold — re-dispatch, user 대안 반영 (FX-RC-redispatch)
+
+**Target Rule:** re-dispatch payload에 `## Proposed Alternatives`가 존재하면, `제안:` 줄은 그 대안 내용을 근거로 작성되어야 한다 (examiner가 무시하고 새로 지어내지 않는다).
+
+**Setup:**
+
+Fixture `FX-RC-redispatch` — SCN-7과 **동일 bullet**:
+```
+대규모 마이그레이션을 주도하여 레거시 시스템을 성공적으로 개선함
+```
+
+Re-dispatch payload (SCN-7의 REQUEST_CHANGES 이후, 사용자 인터뷰로 확보한 대안 포함):
+```
+## Bullet
+대규모 마이그레이션을 주도하여 레거시 시스템을 성공적으로 개선함
+
+## Proposed Alternatives
+SENTINEL-ALT-7f3a: 3개 팀 40개 서비스로 규모 명시
+```
+
+examiner 기대 output (GREEN mock):
+```yaml
+final_verdict: REQUEST_CHANGES
+interview_hints:
+  - |
+    인용: «대규모 마이그레이션을 주도하여»
+    문제: 규모(팀 수, 서비스 수, 기간)와 소유권이 여전히 불명확
+    이유: 제안된 대안에도 기간 정보가 빠져 있어 성과의 지속 기간을 알 수 없음
+    제안: SENTINEL-ALT-7f3a: 3개 팀 40개 서비스로 규모 명시 — 여기에 진행 기간(예: 6개월)까지 추가해 재작성
+```
+
+**Expected:** `제안:` 줄이 payload의 `SENTINEL-ALT-7f3a` 대안 내용을 near-verbatim으로 인용/반영. examiner가 대안을 무시하고 독자적 문구를 새로 지어내지 않는다.
+
+**Verification:**
+- `grep -F 'SENTINEL-ALT-7f3a'`를 hint 문자열 전체에 실행 → match (SCN-7의 동일 hint에는 no match — 대조로 first-dispatch/re-dispatch 차이를 증명).
+- 4라벨 존재 및 noleak 검증은 SCN-7과 동일하게 반복 적용 (`인용:` 줄 제외 remainder에 axis 토큰/이름/internal struct 0 matches).
+- `인용:` 라인은 여전히 원본 bullet의 substring — 대안 반영이 `제안:` 줄에만 영향을 주고 `인용:` 줄의 anchor 규칙을 깨지 않음을 확인.
+
+---
+
+## SCN-9: APPROVE인데 P1 hint surface (FX-P1-APPROVE)
+
+**Target Rule:** `output-schema.md §interview_hints Constraints` #3 (P1 coverage) — P1 verdict는 `final_verdict == APPROVE`여도 스캐폴드 hint로 emit된다.
+
+**Setup:**
+
+Fixture `FX-P1-APPROVE` bullet (A1 depth 충분(PASS), A3만 정량 부재로 content P1, 나머지 PASS, structural PASS → count(P1) < 3, no FAIL → APPROVE):
+```
+결제 PG 동기 호출의 스레드 풀 고갈 병목을, 단순 풀 증설 대신 Kafka 비동기 큐와 서킷브레이커로 분리하고 at-least-once 중복을 idempotency key로 흡수해(개인 설계·구현), 결제 확정 지연과 실패율을 낮춤
+```
+
+`candidate_context`: `years: 5, position: Backend engineer, target_company: 핀테크 기업`
+
+examiner 기대 output (GREEN mock):
+```yaml
+final_verdict: APPROVE
+interview_hints:
+  - |
+    인용: «결제 확정 지연과 실패율을 낮춤»
+    문제: 결과가 수치 없이 서술되어 개선 폭을 가늠할 수 없음
+    이유: before/after나 % 변화가 없으면 이 결과가 유의미한 개선인지 판단할 근거가 없음
+    제안: "결제 확정 p99를 820ms에서 140ms로, 실패율을 2.1%에서 0.3%로 낮춤"처럼 정량 지표를 추가
+```
+
+**Expected:** review-resume 관점에서 `final_verdict == APPROVE`이므로 Phase 9 gate는 통과(다음 bullet 진행)하지만, `interview_hints`는 비어있지 않고 P1 스캐폴드 hint를 user에게 참고용으로 노출한다 (SCN-1의 완전 clean 케이스와 달리 `[]`가 아님).
+
+**Verification:**
+- `final_verdict == "APPROVE"` AND `len(interview_hints) >= 1` — 둘 다 동시 성립 (APPROVE라고 hint가 자동으로 `[]`이 되지 않음을 확인, SCN-11/FX-CLEAN과의 대조 지점).
+- hint가 4라벨 스캐폴드 형식 준수, `인용:` 줄이 bullet의 verbatim substring.
+- `인용:` 줄 제외 remainder에 noleak 정규식 3종 0 matches.
+
+---
+
+## SCN-10: structural-only P1 hint, structural_verdict 필드 불변 (FX-STRUCT-P1)
+
+**Target Rule:** A1-A4 전부 PASS + `structural_verdict == P1` → `final_verdict == APPROVE`, `interview_hints`에 **구조(readability) hint** 1개가 스캐폴드 형식으로 emit되며, `structural_verdict` PUBLIC 필드 값 자체는 이 작업으로 변경되지 않는다.
+
+**Setup:**
+
+Fixture `FX-STRUCT-P1` bullet (핵심 성과가 문장 후반부에 파묻힘):
+```
+여러 팀과 협업하며 다양한 업무를 수행했고 그 과정에서 결제 시스템 마이그레이션을 담당하여 장애율을 40% 감소시켰음
+```
+
+examiner 기대 output (GREEN mock):
+```yaml
+final_verdict: APPROVE
+structural_verdict: P1
+interview_hints:
+  - |
+    인용: «그 과정에서 결제 시스템 마이그레이션을 담당하여 장애율을 40% 감소시켰음»
+    문제: 핵심 정량 성과가 문장 후반부에 묻혀 있어 훑어볼 때 놓치기 쉬움
+    이유: 채용 담당자는 bullet을 빠르게 훑어보는데, 성과가 문두에 없으면 그냥 지나칠 수 있음
+    제안: 핵심 성과를 문두로 재배치 — "결제 시스템 마이그레이션을 담당해 장애율을 40% 감소 (여러 팀과 협업)"
+```
+
+**Expected:** `structural_verdict` PUBLIC 필드는 그대로 `"P1"` — 이 후속 작업은 hint 포맷만 바꾸고 verdict 도출 로직을 건드리지 않는다 (`output-schema.md §A5 Co-failure Disambiguation` 우선순위 6 라우팅 불변).
+
+**Verification:**
+- `structural_verdict` 필드 값이 정확히 `"P1"` (문자열 리터럴 불변 — 이 fixture로 인해 `PASS`나 `FAIL`로 바뀌지 않음을 확인).
+- `인용:` 줄이 bullet 후반부의 "파묻힌" 구절을 정확히 anchor (bullet 앞부분 "여러 팀과 협업하며 다양한 업무를 수행했고"는 인용되지 않음 — 핵심 성과 구절만 quote).
+- `제안:` 줄이 재배치/압축 방향의 수정안 (source extraction 요구 아님 — readability 성격의 제안이되 `structural_verdict == P1`이므로 우선순위 6(APPROVE lane) 라우팅과 정합, `output-schema.md §A5 Co-failure Disambiguation` 참조).
+- `인용:` 줄 제외 remainder에 canonical axis name 정규식(`Technical Credibility|Causal Honesty|Outcome Presence & Clarity|Ownership & Scope|Scanability`) 0 matches — 특히 `Scanability` 문자열 자체가 `문제:`/`이유:`/`제안:` 어느 줄에도 등장하지 않음.
+
+---
+
+## SCN-11: Clean APPROVE — `interview_hints == []` 회귀 방지 (FX-CLEAN)
+
+**Target Rule:** A1-A4 전부 PASS, `structural_verdict == PASS`, P1 없음 → `interview_hints == []` (SCN-1 계약과 동일하게 유지 — 스캐폴드 포맷 도입이 강점(strength) 코멘트를 새로 만들어내지 않는다).
+
+**Setup:**
+
+Fixture `FX-CLEAN` bullet (제약·기술 선택·메커니즘·트레이드오프·근거·인과·정량 결과·소유권·가독성 모두 충족):
+```
+결제 PG 동기 호출의 스레드 풀 고갈 병목을, 단순 풀 증설 대신 Kafka 비동기 큐와 서킷브레이커로 분리하고 at-least-once 중복을 idempotency key로 흡수해(개인 설계·구현), 결제 확정 p99를 820ms에서 140ms로, 실패율을 2.1%에서 0.3%로 낮춤
+```
+
+`candidate_context`: `years: 7, position: Staff backend engineer, target_company: 핀테크 기업`
+
+examiner 기대 output (GREEN mock):
+```yaml
+final_verdict: APPROVE
+structural_verdict: PASS
+interview_hints: []
+```
+
+**Expected:** 4-요소 스캐폴드 포맷이 도입되어도, P1이 하나도 없는 완전 clean 케이스에서는 `interview_hints`가 여전히 빈 배열이다 — "잘했다"류의 강점 hint를 새로 만들어 채우지 않는다.
+
+**Verification:**
+- `interview_hints == []` (SCN-1의 Verification "user에게 hint 표시 안 함"과 동일 판정).
+- 이 fixture는 회귀 테스트로만 존재 — 스캐폴드 포맷을 이 케이스에 강제로 채워 넣는 구현은 REQUEST_CHANGES 대상.
+
+---
+
+## SCN-12: r_phys early-return에도 pending content P1이 실제 emit (FX-RPHYS)
+
+**Target Rule:** `critical_rule_flags.r_phys.triggered == true`로 인한 early-return(`output-schema.md §Critical Rule → Verdict Invariant`, 우선순위 1)이 발생해도, 별개로 pending 중인 content-axis P1이 있다면 그 hint도 **실제로 스캐폴드 형태로 emit**된다 (단순히 "문제가 더 있다"는 카운트/요약이 아니라 완전한 4-라벨 hint).
+
+**Setup:**
+
+Fixture `FX-RPHYS` bullet — 물리적으로 불가능한 수치(r_phys trigger) + 별개의 얕은 outcome 주장(pending A3 P1)이 공존:
+```
+매일 30시간씩 근무하며 시스템 성능을 개선함
+```
+
+examiner 기대 output (GREEN mock):
+```yaml
+final_verdict: REQUEST_CHANGES
+interview_hints:
+  - |
+    인용: «매일 30시간씩 근무하며»
+    문제: 하루는 24시간이므로 "30시간 근무"는 물리적으로 성립할 수 없는 수치
+    이유: 명백히 불가능한 숫자가 하나라도 있으면 이력서 전체의 신뢰도가 깎임
+    제안: 과장된 표현을 제거 — 실제 근무 강도(예: "주 60시간, 마감 기간엔 야근 잦음")로 수정
+  - |
+    인용: «시스템 성능을 개선함»
+    문제: 무엇을 얼마나 개선했는지 수치가 전혀 없음
+    이유: 정량적 근거 없이는 개선의 크기를 가늠할 수 없어 설득력이 떨어짐
+    제안: "응답 시간을 800ms→200ms로 단축"처럼 구체적 before/after 수치를 추가
+```
+
+**Expected:** r_phys가 최우선순위로 REQUEST_CHANGES를 확정짓지만(critical rule invariant), examiner는 여기서 멈추지 않고 pending 중이던 content-axis P1(막연한 성과 주장)도 별도 hint로 실제 방출한다.
+
+**Verification:**
+- `interview_hints` 길이 >= 2 — "critical issue가 더 있음" 류의 단일 요약 문자열이 아니라, 서로 다른 `인용:` anchor를 가진 두 개의 완전한 4-라벨 스캐폴드.
+- 첫 hint의 `인용:` 줄이 물리적으로 불가능한 수치 구절(`매일 30시간씩 근무하며`)을 anchor.
+- 두 번째 hint의 `인용:` 줄이 별개의 막연한 outcome 구절(`시스템 성능을 개선함`)을 anchor — 서로 다른 substring, 서로 다른 결함.
+- 두 hint 모두 `인용:` 줄 제외 remainder에 canonical noleak 정규식 3종 0 matches.
+
+---
+
+## SCN-13: bullet 본문에 axis-모양 토큰 — 인용 라인만 매치, remainder는 clean (FX-TECH-ECHO)
+
+**Target Rule:** noleak 검증은 `인용:` 라인을 제외한 remainder에 대해서만 수행된다 — 원본 bullet 자체가 우연히 `A[1-5]` 모양 토큰(예: 기술/인스턴스명)을 포함하면 `인용:` 라인에는 그 토큰이 그대로(verbatim) 등장할 수 있지만, 이것은 noleak 위반이 아니다.
+
+**Setup:**
+
+Fixture `FX-TECH-ECHO` bullet (AWS 인스턴스 패밀리명 `A1`이 본문에 등장):
+```
+AWS A1 instances로 배치 처리 파이프라인을 최적화하여 비용을 30% 절감함
+```
+
+examiner 기대 output (GREEN mock):
+```yaml
+final_verdict: REQUEST_CHANGES
+interview_hints:
+  - |
+    인용: «AWS A1 instances로 배치 처리 파이프라인을 최적화»
+    문제: 사용한 인스턴스 유형과 조치는 언급했지만 어떤 병목을 해결했는지가 빠져 있음
+    이유: 무엇이 느렸고 무엇을 바꿨는지 알아야 기술적 판단력을 평가할 수 있음
+    제안: "ARM 기반 저비용 인스턴스로 전환하고 배치 크기를 조정해 비용을 30% 절감"처럼 병목과 해결책을 구체화
+```
+
+**Expected:** `인용:` 라인에는 원본 bullet의 verbatim substring인 `AWS A1 instances로 배치 처리 파이프라인을 최적화`가 그대로 들어가며, 여기엔 `A1` 토큰이 포함된다. 이것은 candidate가 실제로 쓴 기술명이 인용된 것일 뿐, examiner가 axis identifier를 누출한 것이 아니다.
+
+**Verification:**
+- 전체 hint 문자열에 `grep -E '\bA[1-5]\b'`를 그대로 돌리면 `인용:` 라인에서 1 match가 나는 것이 **정상** (naive 전체-문자열 검사는 false positive를 낸다는 것을 이 fixture로 증명).
+- `인용:` 라인을 제거한 나머지 3줄(`문제:`/`이유:`/`제안:`)에만 `grep -E '\bA[1-5]\b'`를 적용하면 0 matches — 이것이 실제 noleak 판정 기준.
+- 나머지 두 canonical 정규식(axis name alternation, internal struct)도 `인용:` 줄 제외 remainder에서 0 matches.
+- 이 fixture는 SCN-6(HTML report noleak)의 실행 방식과 구분된다: SCN-6은 렌더된 HTML 전체를 검사하는 반면, 이 fixture는 raw hint 문자열 레벨에서 "`인용:` 줄 제외" 전처리가 선행되어야 함을 규정한다 — review-resume의 HTML 렌더러는 `인용:` 라인을 별도 마크업(예: blockquote)으로 렌더링하고 noleak 검사기는 그 라인을 알고 제외해야 한다.

--- a/skills/review-resume/tests/phase9-loop-scenarios.md
+++ b/skills/review-resume/tests/phase9-loop-scenarios.md
@@ -148,7 +148,7 @@ Pattern 본문은 `skills/tech-claim-rubric/output-schema.md §Prohibited Token 
 
 ## Rich-Hint Scaffold Format (A′) — pinned physical format
 
-각 `interview_hints` 원소는 **하나의 문자열**이며, 4개 라벨이 각각 **별도 줄**(newline-delimited, `/`-delimited 아님)에 온다:
+각 `interview_hints` 원소는 **하나의 문자열**이며, 4개 라벨이 각각 **별도 줄**(newline-delimited, `/`-delimited 아님)에 온다. 라벨 자체가 source bullet 언어를 따른다 — 한국어 bullet:
 
 ```
 인용: «원본 bullet의 verbatim substring»
@@ -157,8 +157,10 @@ Pattern 본문은 `skills/tech-claim-rubric/output-schema.md §Prohibited Token 
 제안: <구체적·실행가능한 수정안>
 ```
 
-- `인용:` 라인의 `«»` 내부는 원본 bullet에서 **글자 그대로** 뽑은 substring (paraphrase 금지). noleak 검증 시 이 줄만 라인 단위로 제외하고 나머지 3줄을 검사한다.
-- `문제:` / `이유:` / `제안:` 라인에는 axis identifier(`A[1-5]`)도 axis name(Technical Credibility / Causal Honesty / Outcome Presence & Clarity / Ownership & Scope / Scanability)도 등장하지 않는다. "이유"는 평이한 한국어 서술.
+English bullet은 동일 구조에 영어 라벨셋을 쓴다: `Quote:` / `Problem:` / `Why:` / `Suggestion:` (콜론 뒤 한 칸 공백). 라벨 매핑: 인용=Quote, 문제=Problem, 이유=Why, 제안=Suggestion.
+
+- `인용:`/`Quote:` 라인의 `«»` 내부는 원본 bullet에서 **글자 그대로** 뽑은 substring (paraphrase 금지), 언어와 무관하게 항상 «»로 감싼다. noleak 검증 시 «»로 감싼 이 verbatim 줄만 라인 단위로 제외하고 나머지 3줄을 검사한다 — «»는 인용 줄에만 존재하므로 라벨 언어와 무관하게 식별 가능하다.
+- `문제:` / `이유:` / `제안:` 라인(English bullet에서는 `Problem:` / `Why:` / `Suggestion:` — 동일 규칙)에는 axis identifier(`A[1-5]`)도 axis name(Technical Credibility / Causal Honesty / Outcome Presence & Clarity / Ownership & Scope / Scanability)도 등장하지 않는다. "이유"/"Why"는 평이한 소스언어 서술.
 - 이 포맷은 `output-schema.md §interview_hints Constraints`(Vocabulary/Actionability/P1 coverage)의 상위 호환이다 — 기존 제약을 완화하지 않고 물리적 구조만 4-라인으로 pin한다.
 
 ### Fixture Index
@@ -172,6 +174,7 @@ Pattern 본문은 `skills/tech-claim-rubric/output-schema.md §Prohibited Token 
 | `FX-CLEAN` | 완전 clean APPROVE | `interview_hints == []` 회귀 방지 (SCN-1과 정합) |
 | `FX-RPHYS` | r_phys early-return + pending content P1 | early-return에도 실제 emit (count만 아님) |
 | `FX-TECH-ECHO` | bullet 본문에 `A[1-5]`-모양 토큰 | noleak false-positive 방지 (`인용:` 줄 제외 후 검사) |
+| `FX-EN` | English bullet, unquantified outcome | 영어 라벨(Quote/Problem/Why/Suggestion) emit + noleak |
 
 ---
 
@@ -389,7 +392,7 @@ interview_hints:
 
 ## SCN-13: bullet 본문에 axis-모양 토큰 — 인용 라인만 매치, remainder는 clean (FX-TECH-ECHO)
 
-**Target Rule:** noleak 검증은 `인용:` 라인을 제외한 remainder에 대해서만 수행된다 — 원본 bullet 자체가 우연히 `A[1-5]` 모양 토큰(예: 기술/인스턴스명)을 포함하면 `인용:` 라인에는 그 토큰이 그대로(verbatim) 등장할 수 있지만, 이것은 noleak 위반이 아니다.
+**Target Rule:** noleak 검증은 «»로 감싼 verbatim 줄(즉 `인용:`/`Quote:` 라벨 줄)을 제외한 remainder에 대해서만 수행된다 — 원본 bullet 자체가 우연히 `A[1-5]` 모양 토큰(예: 기술/인스턴스명)을 포함하면 그 인용 줄에는 그 토큰이 그대로(verbatim) 등장할 수 있지만, 이것은 noleak 위반이 아니다.
 
 **Setup:**
 
@@ -416,3 +419,46 @@ interview_hints:
 - `인용:` 라인을 제거한 나머지 3줄(`문제:`/`이유:`/`제안:`)에만 `grep -E '\bA[1-5]\b'`를 적용하면 0 matches — 이것이 실제 noleak 판정 기준.
 - 나머지 두 canonical 정규식(axis name alternation, internal struct)도 `인용:` 줄 제외 remainder에서 0 matches.
 - 이 fixture는 SCN-6(HTML report noleak)의 실행 방식과 구분된다: SCN-6은 렌더된 HTML 전체를 검사하는 반면, 이 fixture는 raw hint 문자열 레벨에서 "`인용:` 줄 제외" 전처리가 선행되어야 함을 규정한다 — review-resume의 HTML 렌더러는 `인용:` 라인을 별도 마크업(예: blockquote)으로 렌더링하고 noleak 검사기는 그 라인을 알고 제외해야 한다.
+
+---
+
+## SCN-14: English bullet — English-label scaffold, «» language-agnostic noleak (FX-EN)
+
+**Target Rule:** source bullet이 영어면 4개 라벨이 영어(`Quote:`/`Problem:`/`Why:`/`Suggestion:`)로 emit되고, noleak 검증은 «» verbatim 줄 제외 후 나머지에 정준 3정규식 0 matches.
+
+**Setup:**
+
+Fixture `FX-EN` bullet:
+```
+Built a Scanability monitoring dashboard on AWS A1 instances and greatly improved service response time.
+```
+
+Dispatch payload (first dispatch):
+```
+## Bullet
+Built a Scanability monitoring dashboard on AWS A1 instances and greatly improved service response time.
+
+## Proposed Alternatives
+None — initial evaluation
+```
+
+examiner 기대 output (GREEN mock, PUBLIC fields만):
+```yaml
+final_verdict: REQUEST_CHANGES
+interview_hints:
+  - |
+    Quote: «greatly improved service response time»
+    Problem: The result is stated only qualitatively with "greatly" and carries no before/after figures.
+    Why: "Greatly" cannot be verified or compared — a reader has no sense of how large the improvement was.
+    Suggestion: Replace "greatly" with a concrete before→after metric, e.g., "reduced p95 response time from 800ms to 200ms (75% faster)."
+```
+
+**Expected:** review-resume이 이 hint를 그대로 user에게 표시. 라벨이 English(`Quote:`/`Problem:`/`Why:`/`Suggestion:`)로 emit되며 한국어 라벨(인용/문제/이유/제안)은 등장하지 않는다. `Quote:` 줄은 원본 bullet의 verbatim substring이며 «»로 감싼다.
+
+**Verification:**
+- `Quote:` / `Problem:` / `Why:` / `Suggestion:` 4개 라벨이 hint 문자열 내 각각 별도 줄로 1회씩 등장.
+- `Quote:` 줄(«» 줄)에는 "AWS A1"/"Scanability" 같은 토큰이 원본 bullet에서 온 것이라면 정당하게 등장할 수 있다.
+- «» 줄 제외 remainder(`Problem:`/`Why:`/`Suggestion:` 3줄)에 canonical noleak 정규식 3종(`\bA[1-5]\b` / axis name alternation / `verdicts\.|critical_rule_flags\.|evidence_quote|reasoning:`) 각각 0 matches.
+- 한국어 라벨(인용/문제/이유/제안)이 hint 문자열 어디에도 등장하지 않는다.
+
+---

--- a/skills/tech-claim-rubric/SKILL.md
+++ b/skills/tech-claim-rubric/SKILL.md
@@ -204,7 +204,7 @@ The examiner's full output schema is defined in `output-schema.md`. Key fields:
 
 | Field | Description |
 |-------|-------------|
-| `schema_version` | `string` — output schema contract version (e.g., `v4.0`) |
+| `schema_version` | `string` — output schema contract version (e.g., `v4.1`) |
 | `final_verdict` | `APPROVE` or `REQUEST_CHANGES` |
 | `structural_verdict` | `PASS`/`P1`/`FAIL` — A5 axis verdict, readability routing key |
 | `interview_hints` | `string[]` — actionable improvement suggestions |

--- a/skills/tech-claim-rubric/output-schema.md
+++ b/skills/tech-claim-rubric/output-schema.md
@@ -1,6 +1,6 @@
-# Examiner Output Schema (v4.0)
+# Examiner Output Schema (v4.1)
 
-<!-- schema_version: "v4.0" -->
+<!-- schema_version: "v4.1" -->
 <!-- v4.0 changes:
   - structural_verdict (PUBLIC) 필드 추가: A5 scanability 축의 PASS/P1/FAIL을 PUBLIC으로 노출.
     review-resume readability-fix routing trigger 및 resume-forge Loop 2 gate에서 사용.
@@ -8,6 +8,11 @@
     (v3까지는 A1-A5 모두 PASS 조건; v4는 P1 최대 2개까지 허용하는 permissive 기준)
   - ownership-scope critical_rule_flag 제거: A4 ownership-scope axis의 P1 verdict로 대체됨.
     (see a4-ownership-scope.md integrity_suspected)
+-->
+<!-- v4.1 changes:
+  - interview_hints content가 4-요소 앵커드 스캐폴드(인용/문제/이유/제안, newline-delimited)로 격상.
+    type은 여전히 string[]; final_verdict/structural_verdict 필드 및 도출 로직 불변.
+    Vocabulary rule 확장: 문제/이유/제안 줄에 A[1-5] 코드·영문 axis name(Scanability 포함) 금지. 인용: 줄은 면제.
 -->
 
 ## Purpose
@@ -23,7 +28,7 @@
 모든 필드에 PUBLIC / INTERNAL 태그 부여. INTERNAL 필드는 orchestrator(resume-forge)만 접근 가능.
 
 ```yaml
-schema_version: string              # PUBLIC. ex: "v4.0"
+schema_version: string              # PUBLIC. ex: "v4.1"
 bullet_text: string                 # INTERNAL (debugging context)
 candidate_context:                  # INTERNAL
   years: int
@@ -149,11 +154,21 @@ downstream skill들이 v1 examiner output 참조를 v4로 갱신할 때 사용:
 
 ## interview_hints Constraints
 
-1. **Vocabulary rule**: hint 본문에 axis identifier (A1-A5) 또는 axis name (Technical Credibility, Causal Honesty, Outcome Presence & Clarity, Ownership & Scope, Scanability) 포함 금지. 자연스러운 서술로만.
+1. **Scaffold format rule**: 각 `interview_hints` 원소는 하나의 문자열이며, 4개 라벨이 각각 별도 줄(newline-delimited, `/`-delimited 아님)에 온다:
+   ```
+   인용: «원본 bullet의 verbatim substring»
+   문제: <그 인용 구간의 구체적 결함>
+   이유: <왜 문제인지 — 평이한 소스언어, 축 이름 없음>
+   제안: <구체적·실행가능한 수정안>
+   ```
+   - `인용:` 라인의 `«»` 내부는 원본 bullet의 글자 그대로 substring(paraphrase 금지). noleak 검증 시 이 줄만 라인 단위로 제외.
+   - 이 스캐폴드는 surface되는 모든 hint에 적용된다 — REQUEST_CHANGES hint, APPROVE 시 P1 개선 hint, 그리고 구조(A5) P1 readability hint(`resume-forge/SKILL.md:210` — structural_verdict가 A1-A4와 동일하게 uniform하게 surface)도 포함.
+   - 예외: 완전 clean APPROVE는 여전히 `interview_hints: []` (스캐폴드를 억지로 채우지 않음).
+2. **Vocabulary rule**: `문제:`/`이유:`/`제안:` 세 줄에는 axis identifier(`A[1-5]`, 즉 A1-A5) 또는 영문 axis name (Technical Credibility, Causal Honesty, Outcome Presence & Clarity, Ownership & Scope, Scanability) 포함 금지 — 자연스러운 서술로만. "이유:"는 평이한 소스언어로 설명한다. `인용:` 라인은 원본 bullet의 verbatim substring이므로 이 규칙에서 면제(후보 기술명에 A1 등이 우연히 들어갈 수 있음).
    - OK: "사용한 시스템과 선택 이유를 추가하면 기술 깊이가 더 잘 드러납니다"
    - 금지: "A1 Technical Credibility FAIL — 시스템 명시 필요"
-2. **Actionability rule**: 각 hint는 구체적이고 실행 가능해야 함. "add more technical detail"처럼 generic한 hint 금지.
-3. **P1 coverage**: P1 verdict는 final_verdict가 APPROVE여도 interview_hints에 improvement suggestion으로 포함.
+3. **Actionability rule**: 각 hint는 구체적이고 실행 가능해야 함. "add more technical detail"처럼 generic한 hint 금지.
+4. **P1 coverage**: P1 verdict는 final_verdict가 APPROVE여도 interview_hints에 improvement suggestion으로 포함.
 
 이 규칙들은 `agents/tech-claim-examiner.md` prompt에서 본문 복제 없이 참조된다.
 
@@ -183,7 +198,7 @@ review-resume가 생성하는 HTML report의 user-facing surface에 examiner int
 | Axis name | `Technical Credibility\|Causal Honesty\|Outcome Presence & Clarity\|Ownership & Scope\|Scanability` | 5축 정식 이름 누출. `Ownership & Scope`는 일반 `Ownership`과 구분하기 위해 정확 매치 |
 | Internal struct | `verdicts\.\|critical_rule_flags\.\|evidence_quote\|reasoning:` | examiner output schema의 field key 누출 |
 
-**Verification usage**: `grep -E '<pattern>' <rendered-html>`을 3개 pattern 각각에 대해 실행. 모두 0 matches이면 noleak 통과.
+**Verification usage**: rendered 내용이 §interview_hints Constraints의 4-요소 스캐폴드 hint(`인용:`/`문제:`/`이유:`/`제안:`)를 포함하는 경우, 먼저 각 hint의 `인용:` 라인(원본 bullet의 verbatim substring — 후보 기술명 "AWS A1 instances"처럼 `A[1-5]`-모양 토큰이 정당하게 들어갈 수 있음)을 라인 단위로 제외한다. 그 뒤 남은 라인에 대해 `grep -E '<pattern>' <rendered-html>`을 3개 pattern 각각 실행하여 모두 0 matches이면 noleak 통과. `인용:` 줄 제외 전처리 없이 whole-HTML에 naive하게 돌리면 `인용:` 라인의 후보 토큰에서 false-positive가 난다(`tests/phase9-loop-scenarios.md` SCN-13 `FX-TECH-ECHO` 참조). `인용:` 라인을 포함하지 않는 terse 출력(스캐폴드 이전 형태)에는 이 전처리가 불필요하며, 그 경우 기존 whole-content grep이 그대로 유효하다.
 
 **Canonical regex** (shell에서 직접 사용, escape 없이):
 ```

--- a/skills/tech-claim-rubric/output-schema.md
+++ b/skills/tech-claim-rubric/output-schema.md
@@ -76,8 +76,8 @@ structural_verdict: PASS | P1 | FAIL       # PUBLIC. A5 scanability axis의 verd
                                            #   - resume-forge: Loop 2 gate readability-fix path
                                            #     (A1-A4 no FAIL AND count(P1 across A1-A4) < 3 AND structural_verdict ∈ {PASS, P1} → APPROVE)
 interview_hints: string[]                  # PUBLIC (APPROVE/REQUEST_CHANGES 모두 user-facing — P1 hints는 항상 surface)
-                                           # language constraint: source bullet의 언어 = hint 언어.
-                                           # 한국어 bullet → 한국어 hint; English bullet → English hint. (bidirectional)
+                                           # language constraint: source bullet의 언어 = hint 언어 — 4-라벨 + hint 본문 모두.
+                                           # 한국어 bullet → 한국어 라벨(인용/문제/이유/제안)+hint; English bullet → English 라벨(Quote/Problem/Why/Suggestion)+hint. (bidirectional)
 ```
 
 ---
@@ -154,17 +154,18 @@ downstream skill들이 v1 examiner output 참조를 v4로 갱신할 때 사용:
 
 ## interview_hints Constraints
 
-1. **Scaffold format rule**: 각 `interview_hints` 원소는 하나의 문자열이며, 4개 라벨이 각각 별도 줄(newline-delimited, `/`-delimited 아님)에 온다:
+1. **Scaffold format rule**: 각 `interview_hints` 원소는 하나의 문자열이며, 4개 라벨이 각각 별도 줄(newline-delimited, `/`-delimited 아님)에 온다. 라벨 자체가 source bullet 언어를 따른다 — 한국어 bullet:
    ```
    인용: «원본 bullet의 verbatim substring»
    문제: <그 인용 구간의 구체적 결함>
    이유: <왜 문제인지 — 평이한 소스언어, 축 이름 없음>
    제안: <구체적·실행가능한 수정안>
    ```
-   - `인용:` 라인의 `«»` 내부는 원본 bullet의 글자 그대로 substring(paraphrase 금지). noleak 검증 시 이 줄만 라인 단위로 제외.
+   English bullet은 동일 구조에 영어 라벨셋을 쓴다: `Quote:` / `Problem:` / `Why:` / `Suggestion:` (콜론 뒤 한 칸 공백). 라벨 매핑: 인용=Quote, 문제=Problem, 이유=Why, 제안=Suggestion.
+   - `인용:`/`Quote:` 라인의 `«»` 내부는 원본 bullet의 글자 그대로 substring(paraphrase 금지), 언어와 무관하게 항상 «»로 감싼다. noleak 검증 시 «»로 감싼 이 verbatim 줄만 라인 단위로 제외한다.
    - 이 스캐폴드는 surface되는 모든 hint에 적용된다 — REQUEST_CHANGES hint, APPROVE 시 P1 개선 hint, 그리고 구조(A5) P1 readability hint(`resume-forge/SKILL.md:210` — structural_verdict가 A1-A4와 동일하게 uniform하게 surface)도 포함.
    - 예외: 완전 clean APPROVE는 여전히 `interview_hints: []` (스캐폴드를 억지로 채우지 않음).
-2. **Vocabulary rule**: `문제:`/`이유:`/`제안:` 세 줄에는 axis identifier(`A[1-5]`, 즉 A1-A5) 또는 영문 axis name (Technical Credibility, Causal Honesty, Outcome Presence & Clarity, Ownership & Scope, Scanability) 포함 금지 — 자연스러운 서술로만. "이유:"는 평이한 소스언어로 설명한다. `인용:` 라인은 원본 bullet의 verbatim substring이므로 이 규칙에서 면제(후보 기술명에 A1 등이 우연히 들어갈 수 있음).
+2. **Vocabulary rule**: `문제:`/`이유:`/`제안:` 세 줄(English bullet에서는 `Problem:`/`Why:`/`Suggestion:` — 동일 규칙)에는 axis identifier(`A[1-5]`, 즉 A1-A5) 또는 영문 axis name (Technical Credibility, Causal Honesty, Outcome Presence & Clarity, Ownership & Scope, Scanability) 포함 금지 — 자연스러운 서술로만. "이유:"/"Why:"는 평이한 소스언어로 설명한다. `인용:`/`Quote:` 라인은 원본 bullet의 verbatim substring이므로 이 규칙에서 면제(후보 기술명에 A1 등이 우연히 들어갈 수 있음).
    - OK: "사용한 시스템과 선택 이유를 추가하면 기술 깊이가 더 잘 드러납니다"
    - 금지: "A1 Technical Credibility FAIL — 시스템 명시 필요"
 3. **Actionability rule**: 각 hint는 구체적이고 실행 가능해야 함. "add more technical detail"처럼 generic한 hint 금지.
@@ -198,7 +199,7 @@ review-resume가 생성하는 HTML report의 user-facing surface에 examiner int
 | Axis name | `Technical Credibility\|Causal Honesty\|Outcome Presence & Clarity\|Ownership & Scope\|Scanability` | 5축 정식 이름 누출. `Ownership & Scope`는 일반 `Ownership`과 구분하기 위해 정확 매치 |
 | Internal struct | `verdicts\.\|critical_rule_flags\.\|evidence_quote\|reasoning:` | examiner output schema의 field key 누출 |
 
-**Verification usage**: rendered 내용이 §interview_hints Constraints의 4-요소 스캐폴드 hint(`인용:`/`문제:`/`이유:`/`제안:`)를 포함하는 경우, 먼저 각 hint의 `인용:` 라인(원본 bullet의 verbatim substring — 후보 기술명 "AWS A1 instances"처럼 `A[1-5]`-모양 토큰이 정당하게 들어갈 수 있음)을 라인 단위로 제외한다. 그 뒤 남은 라인에 대해 `grep -E '<pattern>' <rendered-html>`을 3개 pattern 각각 실행하여 모두 0 matches이면 noleak 통과. `인용:` 줄 제외 전처리 없이 whole-HTML에 naive하게 돌리면 `인용:` 라인의 후보 토큰에서 false-positive가 난다(`tests/phase9-loop-scenarios.md` SCN-13 `FX-TECH-ECHO` 참조). `인용:` 라인을 포함하지 않는 terse 출력(스캐폴드 이전 형태)에는 이 전처리가 불필요하며, 그 경우 기존 whole-content grep이 그대로 유효하다.
+**Verification usage**: rendered 내용이 §interview_hints Constraints의 4-요소 스캐폴드 hint(한국어: `인용:`/`문제:`/`이유:`/`제안:`, English: `Quote:`/`Problem:`/`Why:`/`Suggestion:`)를 포함하는 경우, 먼저 «»로 감싼 verbatim 줄(즉 `인용:`/`Quote:` 라벨 줄 — 원본 bullet의 verbatim substring이며, 후보 기술명 "AWS A1 instances"처럼 `A[1-5]`-모양 토큰이 정당하게 들어갈 수 있음)을 라인 단위로 제외한다. «»는 인용 줄에만 존재하므로 라벨 언어(한국어/영어)와 무관하게 이 줄을 식별할 수 있다. 그 뒤 남은 라인에 대해 `grep -E '<pattern>' <rendered-html>`을 3개 pattern 각각 실행하여 모두 0 matches이면 noleak 통과. «» 줄 제외 전처리 없이 whole-HTML에 naive하게 돌리면 인용 줄의 후보 토큰에서 false-positive가 난다(`tests/phase9-loop-scenarios.md` SCN-13 `FX-TECH-ECHO` 참조). «»로 감싼 인용 줄을 포함하지 않는 terse 출력(스캐폴드 이전 형태)에는 이 전처리가 불필요하며, 그 경우 기존 whole-content grep이 그대로 유효하다.
 
 **Canonical regex** (shell에서 직접 사용, escape 없이):
 ```


### PR DESCRIPTION
## 무엇을

tech-claim-examiner 에이전트의 `interview_hints`를 얇은 한 줄 제안에서 **4-요소 앵커드 스캐폴드**로 격상.

각 hint가 4줄 고정 구조를 가짐:
```
인용: «지원자가 실제로 쓴 문장 그대로»
문제: 이 문장이 왜 약한지
이유: 근거(측정 부재 / 인과 비약 등)
제안: 어떻게 고칠지
```

## 왜

기존 한 줄 hint는 "무엇이 약한지"만 지목하고 "지원자 원문의 어디를, 왜, 어떻게"를 연결하지 못해, 면접관이 hint만 보고는 실제 bullet의 어느 부분을 고쳐야 하는지 되짚어야 했음. 4-요소 스캐폴드는 인용(앵커)→문제→이유→제안을 한 hint 안에서 자기완결적으로 제공.

## 핵심 제약 — 축명 이중표면 noleak

축 이름(A1~A5, "Scanability" 등 5축 정식 명칭)이 **두 표면 어디에도** 누출되지 않음:
1. emit되는 `interview_hints` 필드 자체
2. review-resume가 파생하는 `.hint-category` 라벨

`인용:` 줄은 지원자 원문 verbatim이라 후보 기술명("AWS A1 instances")에 축-모양 토큰이 정당하게 들어갈 수 있으므로, noleak 검증 시 line 단위로 제외 후 나머지 `문제/이유/제안` 줄에 정준 정규식 적용.

## 불변 보존

- `final_verdict` / `structural_verdict` FIELD 불변
- `interview_hints: string[]` 타입 보존
- clean APPROVE는 여전히 `[]` 반환 (hint 날조 없음)
- 정준 noleak 정규식(`\bA[1-5]\b` 등) 코드블록 불변
- A1~A5 채점 로직 불변
- `schema_version` v4.0 → v4.1

## 검증

- **RED→GREEN**: 7 픽스처 라이브 opus 디스패치 (stochastic 에이전트라 정적 grep 불가)
- **code-review 3라운드**: CONFIRMED 0 (round 2에서 독립 reviewer가 §Verification usage의 `인용:`-줄 제외 누락 모순 포착 → 수정)
- **qa 적대 검증 APPROVE**: 신규 3 픽스처(injection-noleak / clean-APPROVE / R-Phys 경계) 전부 PASS, noleak 0/0/0, 스캐폴드 4-라벨 균형·«» 래핑 100%
- `make validate` exit 0, `make test` 3221 pass / 0 fail

## 잔여 (out-of-scope, 비차단)

`content-quality-gate.md:489`의 스캐폴드 렌더러가 미배선. 이번 작업의 Non-Goal("review-resume 재설계 금지")이라 의도적으로 제외. 스캐폴드를 UI에 실제 렌더링하려면 별도 작업 필요.