### PR TITLE
feat(qa): 검증 누락을 드러내는 시나리오 로스터 출력계약

### DIFF
--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -286,7 +286,7 @@ Close the table with exactly one coverage-delta line naming the impact-map domai
 
 ## Approval Decision
 
-1. **Issuance precondition.** A `## Scenarios Executed` section is a precondition for issuing a verdict — when it is absent, the `## Verdict` heading is omitted rather than a verdict being issued. This reads as an unfinished cycle, never as a third value alongside the `{APPROVE, REQUEST_CHANGES, COMMENT}` domain below. The single exception is the PRE-FLIGHT fail-fast, which legitimately issues **REQUEST_CHANGES** with no cycle run and therefore no `## Scenarios Executed` section.
+1. **Issuance precondition.** A `## Scenarios Executed` section is a precondition for issuing a verdict. When it is absent, the `## Verdict` heading is omitted rather than a verdict being issued — this reads as an unfinished cycle, never as a fourth value alongside the `{APPROVE, REQUEST_CHANGES, COMMENT}` domain below. The single exception to this absence rule is the PRE-FLIGHT fail-fast, which legitimately issues **REQUEST_CHANGES** with no cycle run and therefore no `## Scenarios Executed` section. A section that is *present* with zero rows is a separate case, not an omission: when ADVERSARIAL E2E was skipped because the change is a genuinely inert refactor touching no risk surface (`### ADVERSARIAL E2E` above), the cycle is complete, its coverage-delta line states the change touched no risk surface, and a verdict **is** issued per the table below.
 
 | Condition | Verdict |
 |-----------|---------|

--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -257,7 +257,14 @@ qa is non-interactive and headless. Every command it runs MUST return control to
 | ADVERSARIAL E2E | PASS / FAIL | [matrix + scenario summary] |
 | Cycles run | N / max_cycles | [Same-Failure key if terminated early] |
 
-Self-authored scenarios reported under ADVERSARIAL E2E carry the six-field shape from [scenario-authoring.md] — actor · preconditions · steps · expected · why-needed · priority.
+## Scenarios Executed
+
+| # | source | actor | preconditions | steps | expected | result | why-needed | priority |
+|---|---|---|---|---|---|---|---|---|
+
+Every row's `source` is either `self-authored` or `caller-provided`. A `self-authored` row carries the six-field shape from [scenario-authoring.md] — actor · preconditions · steps · expected · why-needed · priority — filled in full; a `caller-provided` row carries whatever shape the caller supplied. This table is the canonical scenario record for the cycle: `result` maps to `Status` and `why-needed` maps to `Why-Needed` in the four-column working table [stage3-handson.md] mandates for hands-on execution — the column-count divergence is declared here, not fixed there.
+
+Close the table with exactly one coverage-delta line naming the impact-map domains from [scenario-authoring.md], which of those domains the rows above cover, and which are left uncovered.
 
 ## Verdict: [APPROVE / REQUEST_CHANGES / COMMENT]
 
@@ -278,6 +285,8 @@ Self-authored scenarios reported under ADVERSARIAL E2E carry the six-field shape
 ---
 
 ## Approval Decision
+
+1. **Issuance precondition.** A `## Scenarios Executed` section is a precondition for issuing a verdict — when it is absent, the `## Verdict` heading is omitted rather than a verdict being issued. This reads as an unfinished cycle, never as a third value alongside the `{APPROVE, REQUEST_CHANGES, COMMENT}` domain below. The single exception is the PRE-FLIGHT fail-fast, which legitimately issues **REQUEST_CHANGES** with no cycle run and therefore no `## Scenarios Executed` section.
 
 | Condition | Verdict |
 |-----------|---------|
@@ -304,5 +313,6 @@ EXIT:       Goal Met / max_cycles=5 / Same-Failure-3x (scenario-id+root-cause-fi
 ROLLBACK:   git revert fix_head_before..HEAD only, NEVER git reset --hard; 3 guards: linear-descendant, non-empty-range=ERROR, post-revert disjointness on user_dirty_set; REFUSE the cycle on user_dirty_set overlap; rm -rf/force auto-deny honored
 STATE:      bun ${CLAUDE_SKILL_DIR}/scripts/qa-state.ts <sub>; continue resumes at last phase/cycle
 NESTING:    qa's fix-loop must NOT be called inside another fix-loop (e.g. goal) — doc contract, YAGNI; upgrade trigger: add a code guard when qa gains its first fix-loop-owning caller
+ROSTER:     ## Scenarios Executed is a precondition for verdict issuance; absent → verdict not issued, cycle incomplete
 FEEDBACK:   feedback-protocol.md for Confidence Scoring; CONFIDENCE 0-49 discard, 50-79 nitpick, 80+ report
 ```

--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -313,6 +313,6 @@ EXIT:       Goal Met / max_cycles=5 / Same-Failure-3x (scenario-id+root-cause-fi
 ROLLBACK:   git revert fix_head_before..HEAD only, NEVER git reset --hard; 3 guards: linear-descendant, non-empty-range=ERROR, post-revert disjointness on user_dirty_set; REFUSE the cycle on user_dirty_set overlap; rm -rf/force auto-deny honored
 STATE:      bun ${CLAUDE_SKILL_DIR}/scripts/qa-state.ts <sub>; continue resumes at last phase/cycle
 NESTING:    qa's fix-loop must NOT be called inside another fix-loop (e.g. goal) — doc contract, YAGNI; upgrade trigger: add a code guard when qa gains its first fix-loop-owning caller
-ROSTER:     ## Scenarios Executed is a precondition for verdict issuance; absent → verdict not issued, cycle incomplete
+ROSTER:     ## Scenarios Executed is a precondition for verdict issuance; absent → verdict not issued, cycle incomplete. Exception: PRE-FLIGHT fail-fast issues REQUEST_CHANGES with no roster — never synthesize an empty one there; present+0 rows means inert refactor, a completed cycle
 FEEDBACK:   feedback-protocol.md for Confidence Scoring; CONFIDENCE 0-49 discard, 50-79 nitpick, 80+ report
 ```

--- a/skills/qa/SKILL.test.ts
+++ b/skills/qa/SKILL.test.ts
@@ -473,13 +473,18 @@ describe("new-prose: Scenarios Executed roster (roster axis)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// NEW-PROSE: issuance precondition names the inert-refactor carve-out
+// NEW-PROSE: issuance precondition names both carve-outs
 // (Finding 1 fix — a zero-row roster from a genuinely inert refactor is a
 // complete cycle and still issues a verdict; must FAIL before the SKILL.md
 // edit — RED)
+//
+// Both carve-outs are load-bearing and each one's absence deadlocks a distinct
+// path: without the inert-refactor carve-out a pure refactor can never be
+// approved; without the PRE-FLIGHT one a contract-violating change can never be
+// rejected. Guard them symmetrically.
 // ---------------------------------------------------------------------------
 
-describe("new-prose: issuance precondition names the inert-refactor carve-out", () => {
+describe("new-prose: issuance precondition names both carve-outs", () => {
 	test("the Approval Decision guard prose names the inert-refactor carve-out", () => {
 		const guardStart = skillMd.indexOf("## Approval Decision");
 		expect(guardStart).not.toBe(-1);
@@ -490,6 +495,18 @@ describe("new-prose: issuance precondition names the inert-refactor carve-out", 
 		expect(tableStart).not.toBe(-1);
 		const guardSection = skillMd.slice(guardStart, tableStart);
 		expect(guardSection).toContain("inert refactor");
+	});
+
+	test("the Approval Decision guard prose names the PRE-FLIGHT fail-fast carve-out", () => {
+		const guardStart = skillMd.indexOf("## Approval Decision");
+		expect(guardStart).not.toBe(-1);
+		const tableStart = skillMd.indexOf(
+			"| Condition | Verdict |",
+			guardStart + 1,
+		);
+		expect(tableStart).not.toBe(-1);
+		const guardSection = skillMd.slice(guardStart, tableStart);
+		expect(guardSection).toContain("PRE-FLIGHT fail-fast");
 	});
 });
 

--- a/skills/qa/SKILL.test.ts
+++ b/skills/qa/SKILL.test.ts
@@ -446,9 +446,14 @@ describe("new-prose: Scenarios Executed roster (roster axis)", () => {
 		);
 	});
 
-	test("both source tokens are enumerated", () => {
-		expect(skillMd).toContain("self-authored");
-		expect(skillMd).toContain("caller-provided");
+	test("both source tokens are enumerated in the roster section", () => {
+		const rosterStart = skillMd.indexOf("## Scenarios Executed");
+		expect(rosterStart).not.toBe(-1);
+		const rosterEnd = skillMd.indexOf("\n## ", rosterStart + 1);
+		expect(rosterEnd).not.toBe(-1);
+		const rosterSection = skillMd.slice(rosterStart, rosterEnd);
+		expect(rosterSection).toContain("self-authored");
+		expect(rosterSection).toContain("caller-provided");
 	});
 
 	test("stage3-handson.md is referenced from inside the roster section", () => {
@@ -464,6 +469,27 @@ describe("new-prose: Scenarios Executed roster (roster axis)", () => {
 		expect(skillMd).not.toContain(
 			"Self-authored scenarios reported under ADVERSARIAL E2E carry the six-field shape",
 		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// NEW-PROSE: issuance precondition names the inert-refactor carve-out
+// (Finding 1 fix — a zero-row roster from a genuinely inert refactor is a
+// complete cycle and still issues a verdict; must FAIL before the SKILL.md
+// edit — RED)
+// ---------------------------------------------------------------------------
+
+describe("new-prose: issuance precondition names the inert-refactor carve-out", () => {
+	test("the Approval Decision guard prose names the inert-refactor carve-out", () => {
+		const guardStart = skillMd.indexOf("## Approval Decision");
+		expect(guardStart).not.toBe(-1);
+		const tableStart = skillMd.indexOf(
+			"| Condition | Verdict |",
+			guardStart + 1,
+		);
+		expect(tableStart).not.toBe(-1);
+		const guardSection = skillMd.slice(guardStart, tableStart);
+		expect(guardSection).toContain("inert refactor");
 	});
 });
 

--- a/skills/qa/SKILL.test.ts
+++ b/skills/qa/SKILL.test.ts
@@ -511,6 +511,30 @@ describe("new-prose: issuance precondition names both carve-outs", () => {
 });
 
 // ---------------------------------------------------------------------------
+// NEW-PROSE: the Quick Reference ROSTER line carries the PRE-FLIGHT carve-out
+//
+// The Quick Reference is a compression of the body, and an agent that leans on
+// it alone must not read the roster precondition as unconditional: the
+// PRE-FLIGHT fail-fast issues a verdict with no roster. Stated unconditionally,
+// the line pushes an agent to synthesize an empty roster on that path, which
+// collides with the inert-refactor state (roster present, zero rows) and makes
+// "cycle never ran" indistinguishable from "cycle ran, no risk surface".
+// ---------------------------------------------------------------------------
+
+describe("new-prose: Quick Reference ROSTER line names the PRE-FLIGHT carve-out", () => {
+	test("the ROSTER line inside Quick Reference names the PRE-FLIGHT fail-fast exception", () => {
+		const quickRefStart = skillMd.indexOf("## Quick Reference");
+		expect(quickRefStart).not.toBe(-1);
+		const quickRef = skillMd.slice(quickRefStart);
+		const rosterLine = quickRef
+			.split("\n")
+			.find((line) => line.startsWith("ROSTER:"));
+		expect(rosterLine).toBeDefined();
+		expect(rosterLine).toContain("PRE-FLIGHT fail-fast");
+	});
+});
+
+// ---------------------------------------------------------------------------
 // REGRESSION GUARD: frontmatter identity (must PASS before AND after)
 // ---------------------------------------------------------------------------
 

--- a/skills/qa/SKILL.test.ts
+++ b/skills/qa/SKILL.test.ts
@@ -432,6 +432,42 @@ describe("structural-integrity: scenario-authoring.md pointer resolves to a real
 });
 
 // ---------------------------------------------------------------------------
+// NEW-PROSE: Scenarios Executed roster (roster axis) (must FAIL before rewrite — RED)
+// ---------------------------------------------------------------------------
+
+describe("new-prose: Scenarios Executed roster (roster axis)", () => {
+	test('"## Scenarios Executed" heading is present', () => {
+		expect(skillMd).toContain("## Scenarios Executed");
+	});
+
+	test("the nine-column header appears in the pinned order", () => {
+		expect(skillMd).toContain(
+			"| # | source | actor | preconditions | steps | expected | result | why-needed | priority |",
+		);
+	});
+
+	test("both source tokens are enumerated", () => {
+		expect(skillMd).toContain("self-authored");
+		expect(skillMd).toContain("caller-provided");
+	});
+
+	test("stage3-handson.md is referenced from inside the roster section", () => {
+		const rosterStart = skillMd.indexOf("## Scenarios Executed");
+		expect(rosterStart).not.toBe(-1);
+		const rosterEnd = skillMd.indexOf("\n## ", rosterStart + 1);
+		expect(rosterEnd).not.toBe(-1);
+		const rosterSection = skillMd.slice(rosterStart, rosterEnd);
+		expect(rosterSection).toContain("stage3-handson.md");
+	});
+
+	test("the old prose line naming the six-field shape directly is absent", () => {
+		expect(skillMd).not.toContain(
+			"Self-authored scenarios reported under ADVERSARIAL E2E carry the six-field shape",
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
 // REGRESSION GUARD: frontmatter identity (must PASS before AND after)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 📌 Summary

qa가 실행한 시나리오를 9열 로스터(`## Scenarios Executed`)로 기록하게 하고, 그 로스터가 없으면 verdict 발행 자체를 보류시킵니다. 검증 누락이 리포트 바깥에서 침묵하는 대신 산출물 안에서 드러납니다.

---

## 🔧 Changes

### `skills/qa/SKILL.md` — 출력계약

- Output Format에 `## Scenarios Executed` 섹션 신설. 9열 표(번호 · source · actor · preconditions · steps · expected · result · why-needed · priority)와, 표를 닫는 커버리지 델타 1줄(impact-map 도메인 중 무엇을 덮었고 무엇이 남았는지 호명).
- Approval Decision 표 **앞**에 발행 전제조건 1항목 추가. 로스터가 없으면 `## Verdict` 헤딩 자체를 쓰지 않습니다 — 판정 보류가 아니라 *끝나지 않은 사이클*로 읽힙니다.
- 예외 두 개를 명시. **PRE-FLIGHT fail-fast**(계약 위반이라 사이클을 안 돌린 경우 — 로스터 없이 `REQUEST_CHANGES` 발행)와 **inert refactor**(위험 표면을 안 건드린 순수 리팩터 — 로스터는 있고 행만 0개, 완결 사이클로 판정 발행).
- Quick Reference에 `ROSTER:` 1줄.

배경: qa가 프론트엔드 표면을 한 번도 구동하지 않고 `APPROVE`를 낸 일이 두 번 있었습니다. 리포트에 무엇을 검증했는지 목록이 없으니, 무엇을 검증하지 **않았는지**도 보이지 않았습니다. 분모가 없으면 빈약함은 빈약해 보이지 않습니다.

**영향 범위**
- `skills/qa`는 5개 프로젝트에 배포됩니다(`projects/*/sync.yaml`). 실제 반영은 `make sync` 시점.
- 판정값 도메인 `{APPROVE, REQUEST_CHANGES, COMMENT}` 불변. Approval Decision 표의 헤더와 세 행은 바이트 불변입니다.
- `## Verdict`를 기계적으로 파싱하는 소비자는 레포에 없습니다(`goal`의 완료 게이트는 사람에게 qa 실행을 권할 뿐 출력을 읽지 않음). 하위 호환 파손 없음.
- 문서 변경이라 런타임 성능 영향 없음.

### `skills/qa/SKILL.test.ts` — 정적 가드

- 로스터 헤딩·9열 헤더·`source` 토큰 2종(`self-authored`/`caller-provided`)·`stage3-handson.md` 참조를, 파일 전역이 아니라 **로스터 섹션 슬라이스 안에서** 검증.
- 발행 전제조건 문단이 예외 두 개를 모두 호명하는지 검증.
- 흡수된 기존 산문 1줄이 되살아나지 않도록 부재를 회귀로 고정.

**영향 범위**: 테스트 72 → 79. `make validate` exit 0, `make test` 3240 pass.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 발행 전제조건을 Approval Decision 표 **안**이 아니라 **앞**에 둔 이유

**배경 및 문제 상황:**
"로스터가 없으면 verdict를 내지 마라"를 가장 자연스럽게 표현하는 자리는 Approval Decision 표입니다. `| 로스터 부재 | 발행 금지 |` 행 하나면 끝납니다. 그런데 그 순간 `Verdict` 열의 값 도메인이 `{APPROVE, REQUEST_CHANGES, COMMENT}`를 벗어납니다. 사실상 네 번째 판정값이 생기고, "발행 금지"를 소비자가 어떻게 읽어야 하는지가 미정의로 남습니다.

**해결 방안:**
게이트를 표 밖으로 뺐습니다. 로스터 부재는 판정값이 아니라 **사이클의 상태**입니다 — 아직 끝나지 않은 사이클. 그래서 `## Verdict` 헤딩 자체를 쓰지 않습니다. 표는 손대지 않았습니다.

**구현 세부사항:**
표 헤더와 세 행이 바이트 불변임을 회귀로 고정했습니다. 게이트 문장은 `## Approval Decision` 헤딩과 `| Condition | Verdict |` 사이에만 존재하고, 가드도 정확히 그 슬라이스만 봅니다.

**선택과 트레이드오프:**
대가는 "verdict 없는 리포트"라는 새 산출물 모양이 생긴다는 것입니다. 만약 `## Verdict`를 grep하는 소비자가 있었다면 파싱 실패와 "증거 대기"를 구별하지 못했을 겁니다. 확인해 보니 그런 소비자는 없었습니다 — `goal`은 qa 출력을 읽지 않고 사람에게 실행을 권할 뿐입니다. 그래서 이 위험은 현재 실현 경로가 없고, 대신 하류 소비자에게 이 상태를 가르치는 일은 이 PR 범위 밖으로 남깁니다.

### 2. 증거 형식(모달리티) 게이트를 **만들지 않은** 이유

**배경 및 문제 상황:**
원래 축이 둘이었습니다. 로스터 하나, 그리고 "프론트엔드 변경이면 스크린샷 1장 이상을 반드시 증거로 남겨라"는 모달리티 게이트 하나. 사고 두 건 모두 프론트엔드를 안 구동한 경우였으니 후자가 더 직접적인 처방처럼 보였습니다.

**해결 방안:**
편집하기 전에 행동 A/B를 돌렸습니다. `SKILL.md`를 **읽기만 한** 에이전트에게 프론트엔드가 섞인 변경을 던지고, 편집 없는 control 팔이 이미 그 행동을 하는지 봤습니다.

**구현 세부사항:**
control 6회(압박 3 + 무압박 3)가 **전부** 브라우저를 구동하고 스크린샷을 남기고 `REQUEST_CHANGES`를 냈습니다. 즉 `SKILL.md`는 이미 그렇게 지시하고 있었고, 그 지시는 지켜지고 있었습니다. 강제가 결핍된 게 아니었습니다. 반면 로스터는 control 6회 중 **0회** 등장했고 treatment 3회 중 3회 등장했습니다.

**선택과 트레이드오프:**
모달리티 축은 폐기했습니다. 이미 지켜지는 것을 다시 강제하는 문장은 토큰만 먹고, 브라우저 엔진이 없는 러너에서 사이클을 영영 못 끝내게 만들 위험만 남깁니다. 대가는 "스크린샷 없는 프론트엔드 검증"이 여전히 문법적으로 가능하다는 것입니다. 다만 로스터의 커버리지 델타가 그 누락을 호명하게 되어 있어, 은폐가 아니라 명시된 갭이 됩니다.

### 3. 정적 가드를 파일 전역이 아니라 섹션 슬라이스에 묶고, 예외 둘을 대칭으로 지킨 이유

**배경 및 문제 상황:**
첫 가드는 `expect(skillMd).toContain("caller-provided")`였습니다. 그런데 그 토큰은 로스터와 무관한 기존 산문(`SKILL.md:92`)에도 있습니다. 로스터에서 토큰이 통째로 빠져도 테스트는 초록입니다. **통과하는 술어는 그 자체로 아무것도 증명하지 않습니다.**

같은 병이 예외 쪽에도 있었습니다. `33fdc390`이 inert-refactor 예외를 추가하면서 가드도 같이 넣었는데, 같은 문단의 **PRE-FLIGHT fail-fast 예외는 무가드**로 남았습니다.

**해결 방안:**
모든 가드를 해당 섹션 슬라이스에 결속했습니다. 그리고 예외 두 개를 대칭으로 고정했습니다.

**관련 코드:**
```ts
// Before — 파일 전역. 무관한 산문에 매치되어 공허함
expect(skillMd).toContain("caller-provided");

// After — 로스터 섹션만 잘라내어 검증
const rosterStart = skillMd.indexOf("## Scenarios Executed");
const rosterEnd = skillMd.indexOf("\n## ", rosterStart + 1);
const rosterSection = skillMd.slice(rosterStart, rosterEnd);
expect(rosterSection).toContain("caller-provided");
```

**선택과 트레이드오프:**
예외 두 개는 각각 다른 경로를 교착에서 구합니다. inert 예외가 없으면 순수 리팩터가 영영 `APPROVE`를 못 받고, PRE-FLIGHT 예외가 없으면 계약 위반 변경이 영영 `REQUEST_CHANGES`를 못 받습니다. 후자가 더 나쁩니다 — fail-fast의 존재 이유가 무력화되니까요. 그래서 `8cfed6c7`에서 후자에도 가드를 붙였고, RED을 변이 탐침으로 증명했습니다: 예외 문장을 지우면 편집 전엔 78 pass / 0 fail(못 잡음), 편집 후엔 78 pass / **1 fail**(새 테스트만).

대가는 슬라이스 앵커(`## Scenarios Executed`, `| Condition | Verdict |`)에 가드가 결합된다는 점입니다. 헤딩을 바꾸면 가드가 `-1`로 깨집니다. 그건 조용한 통과보다 낫다고 판단했습니다.

---

## ✅ Checklist

### 출력계약
- [x] `## Scenarios Executed` 섹션이 Output Format 템플릿에 존재하고, 9열 헤더가 고정된 순서로 나타난다
  - `skills/qa/SKILL.md`
- [x] 로스터 템플릿에 헤더행·구분행만 있고 채워진 예시행이 없다 (자리표시자 베끼기 방지)
  - `skills/qa/SKILL.md`
- [x] Approval Decision 표의 헤더와 세 행이 변경 전과 바이트 동일하다
  - `skills/qa/SKILL.md`
- [x] 발행 전제조건 문단이 PRE-FLIGHT fail-fast 예외와 inert-refactor 예외를 모두 호명한다
  - `skills/qa/SKILL.md`

### 정적 가드
- [x] 로스터 토큰 검증이 로스터 섹션 슬라이스 안에서만 수행되어, 무관한 산문에 매치되지 않는다
  - `skills/qa/SKILL.test.ts`
- [x] `SKILL.md`에서 PRE-FLIGHT 예외 문장을 삭제하면 정확히 1개 테스트가 실패한다 (편집 전에는 0개)
  - `skills/qa/SKILL.test.ts`
- [x] `bun test skills/qa/SKILL.test.ts` 79 pass / 0 fail
  - `skills/qa/SKILL.test.ts`

### 저장소 게이트
- [x] `make validate` exit 0
- [x] `make test` 전체 통과 (3240 pass / 0 fail)
- [x] `skills/qa/`의 나머지 파일(`scenario-authoring.md`, `stage3-handson.md`, `stage1-commands.md`, `feedback-protocol.md`, `scripts/`)이 바이트 불변이다

### 행동 검증 (정적 가드가 줄 수 없는 증거)
- [x] 편집 없는 control 팔 6회 중 로스터를 낸 횟수가 0이고, treatment 팔 3회 중 3회가 로스터를 낸다
- [x] 사후 적대검증 5회(불활성 리팩터 ×2 · PRE-FLIGHT 위반 · 누락 은폐 · 프롬프트 주입)가 모두 계약을 지키고 교착 없이 verdict를 발행한다