### PR TITLE
chore: codex 모델 gpt-5.6-sol 교체 및 loop-pack docs 편입

### DIFF
--- a/projects/loop-pack-fe-l2-vol1/docs/react/component-boundary.md
+++ b/projects/loop-pack-fe-l2-vol1/docs/react/component-boundary.md
@@ -1,0 +1,175 @@
+# 컴포넌트 경계 — 어디서 자를까
+
+> `.claude/rules/component-design.md`가 가리키는 근거 문서. **"이 컴포넌트를 쪼갤까"**를 판단할 때 읽는다. 각 판단의 "왜"를 Before/After로 보여준다.
+>
+> 전제: 컴포넌트는 **"재사용 가능하게" 만들기 전에 "읽기 쉽게"** 만드는 것이 먼저다.
+>
+> Props·합성 계약(무엇을 어떻게 넘길까)은 [`props-contract.md`](./props-contract.md), Context 전환 판단은 [`context-and-state.md`](./context-and-state.md)에 있다.
+
+
+Props를 어떻게 설계할지(계약)는 그다음 문제다. 먼저 **무엇을 한 컴포넌트로 볼지**를 정한다. 나누는 기준은 "크기"가 아니라 **"무엇이 함께 바뀌는가"**다.
+
+### 변경 이유로 경계 긋기
+
+좋은 경계는 **변경의 경계**다. 한 컴포넌트가 서로 다른 이유로 바뀐다면, 그 이유의 수만큼 잘릴 후보다. 단일 책임을 "기능 1개"가 아니라 "**변경 이유(reason to change) 1개**"로 읽는다.
+
+```tsx
+// ❌ 세 변경 이유(가격 정책 / 추천 / 채팅)가 한 파일에 엉켜 있다
+function ProductPage({ product }: { product: Product }) {
+  const priceLabel = product.isAuction
+    ? `최고가 ${format(product.bidPrice)}` // (A) 가격 표기 정책이 바뀌면 여기
+    : format(product.price);
+  const related = product.tags
+    .flatMap((tag) => findByTag(tag)) // (B) 추천 알고리즘이 바뀌면 여기
+    .filter((p) => p.id !== product.id)
+    .slice(0, 6);
+  return (
+    <div>
+      <h1>{product.title}</h1>
+      <strong>{priceLabel}</strong>
+      <RelatedGrid items={related} />
+      <button onClick={() => openChat(product.sellerId)}>채팅하기</button> {/* (C) 채팅 정책 */}
+    </div>
+  );
+}
+
+// ✅ 경계 = 변경의 경계. 가격이 바뀌면 ProductHeader만, 추천이 바뀌면 RelatedProducts만 연다
+function ProductPage({ product }: { product: Product }) {
+  return (
+    <div>
+      <ProductHeader product={product} />
+      <RelatedProducts product={product} />
+      <ChatCta sellerId={product.sellerId} />
+    </div>
+  );
+}
+```
+
+분리의 효과는 "재사용"이 아니라 **"수정할 때 열어야 할 파일 수"**로 잰다 — "이 컴포넌트는 누구 때문에, 며칠에 한 번 바뀌나?"를 물으면 자를 축이 보인다.
+
+### 구현 vs 조합을 섞지 말기
+
+한 컴포넌트는 **직접 구현하는 것**이거나 **여러 컴포넌트를 조합하는 것**이어야 한다. 둘을 한 파일에 섞으면 읽는 사람이 추상화 고도를 계속 오르내려야 한다. 조합 컴포넌트는 화면의 "목차", 구현 컴포넌트는 "본문"이다 — 목차에 본문 문장이 끼면 안 된다.
+
+```tsx
+// ❌ 조합을 하다가 갑자기 카드 '내부 구현'이 통째로 인라인 — 고도가 섞인다
+function FeedList({ posts }: { posts: Post[] }) {
+  return (
+    <ul>
+      <FeedHeader />
+      {posts.map((post) => (
+        <li key={post.id}>
+          <article className="card">
+            <img src={post.thumbnail} alt="" />
+            <h3>{post.title}</h3>
+            <p>
+              {post.region} · {timeAgo(post.createdAt)}
+            </p>
+          </article>
+        </li>
+      ))}
+      <FeedFooter />
+    </ul>
+  );
+}
+
+// ✅ 구현은 아래로 위임 — FeedList는 화면의 '목차'로만 읽힌다
+function FeedList({ posts }: { posts: Post[] }) {
+  return (
+    <ul>
+      <FeedHeader />
+      {posts.map((post) => (
+        <li key={post.id}>
+          <FeedCard post={post} />
+        </li>
+      ))}
+      <FeedFooter />
+    </ul>
+  );
+}
+```
+
+### 무관한 상태는 추출 신호
+
+거대 컴포넌트(God Component)의 첫째 신호: **한 컴포넌트가 서로 무관한 상태를 함께 들고 있다**(예: 목록 정렬 상태 + 모달 열림 상태).
+
+```tsx
+// ❌ ProductSection이 섹션과 무관한 '모달 열림' 상태를 들고 있다
+function ProductSection({ products }: { products: Product[] }) {
+  const [showShortcutModal, setShowShortcutModal] = useState(false); // ← 이질적
+  const [sortBy, setSortBy] = useState<SortKey>("recent");
+  // ...수백 줄
+}
+
+// ✅ 무관한 상태는 그 상태를 쓰는 UI와 함께 떼어낸다
+function ProductSection({ products }: { products: Product[] }) {
+  const [sortBy, setSortBy] = useState<SortKey>("recent");
+  return (
+    <>
+      <SortableProductGrid products={products} sortBy={sortBy} onSort={setSortBy} />
+      <ShortcutModalButton /> {/* showShortcutModal는 여기로 이사 */}
+    </>
+  );
+}
+```
+
+상태를 보면 경계가 보인다. 상태를 **어디에 둘지**의 판단은 [`react.md`](../../.claude/rules/react.md)에 있다.
+
+### 중복 > 잘못된 추상화
+
+자르는 것보다 **아직 자르지 않는 것**이 더 어렵다. 비슷해 보인다고 성급히 합치면, 추상화가 곧 `if`문 더미가 된다.
+
+```tsx
+// ❌ 상품 카드와 모임 카드가 '비슷해 보여서' 하나로 합침 → 타입마다 if가 늘어난다
+function Card({ type, title, price, host, memberCount, thumbnail, isAuction, region }: CardProps) {
+  return (
+    <div>
+      <img src={thumbnail} alt="" />
+      <h3>{title}</h3>
+      {type === "product" && <strong>{isAuction ? "경매" : price}</strong>}
+      {type === "group" && (
+        <span>
+          {host} · {memberCount}명
+        </span>
+      )}
+      {type === "product" && <small>{region}</small>}
+      {/* 새 타입이 생길 때마다 if가 늘어남 → "앱 전체가 if문 안에" */}
+    </div>
+  );
+}
+
+// ✅ 공통은 '진짜 같은 것'(껍데기)만, 도메인 차이는 각자 구현 — 중복을 허용한다
+function CardShell({ thumbnail, title, children }: CardShellProps) {
+  return (
+    <div className="card">
+      <img src={thumbnail} alt="" />
+      <h3>{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function ProductCard({ product }: { product: Product }) {
+  return (
+    <CardShell thumbnail={product.thumbnail} title={product.title}>
+      <strong>{product.isAuction ? "경매" : format(product.price)}</strong>
+      <small>{product.region}</small>
+    </CardShell>
+  );
+}
+
+function GroupCard({ group }: { group: Group }) {
+  return (
+    <CardShell thumbnail={group.thumbnail} title={group.title}>
+      <span>
+        {group.host} · {group.memberCount}명
+      </span>
+    </CardShell>
+  );
+}
+```
+
+> "prefer duplication over the wrong abstraction." — 잘못된 추상화는 중복보다 비싸다.
+
+추상화는 규칙이 아니라 "feels right"일 때 한다. **세 번째 중복**에서 공통점이 또렷해지면 그때 뽑는다(rule of three). "언제 공통화할지"의 구체 기준은 아래 [공통 컴포넌트 설계 → 도입 시점](./props-contract.md#도입-시점--yagni) 표에 있다.
+

--- a/projects/loop-pack-fe-l2-vol1/docs/react/context-and-state.md
+++ b/projects/loop-pack-fe-l2-vol1/docs/react/context-and-state.md
@@ -1,0 +1,74 @@
+# Context 전환 — Drilling을 언제 끊나
+
+> `.claude/rules/component-design.md`가 가리키는 근거 문서. **Props Drilling을 유지할지 Context로 넘길지** 판단할 때 읽는다.
+>
+> 전제: Props Drilling은 흐름을 추적할 수 있는 **가장 단순한 방법**이다 — 무조건 나쁘지 않다.
+>
+> 컴포넌트 경계는 [`component-boundary.md`](./component-boundary.md), Props·합성 계약은 [`props-contract.md`](./props-contract.md)에 있다. 상태를 **어디에 둘지**(서버/UI/URL/전역)의 분류는 [`react.md`](../../.claude/rules/react.md).
+
+## Props Drilling vs Context
+
+Props Drilling은 데이터 흐름을 추적할 수 있는 **가장 단순한 방법** — 무조건 나쁘지 않다. 핵심은 언제 Context로 전환하는가다.
+
+| 상황                                 | 판단       | 이유                                   |
+| ------------------------------------ | ---------- | -------------------------------------- |
+| 2단계 전달(부모→자식→손자)           | ✅ 유지    | 흐름이 명확하고 추적 가능              |
+| 3단계 이상 + 중간이 그 Props를 안 씀 | ⚠️ 검토    | 중간 컴포넌트가 불필요한 의존성을 가짐 |
+| 여러 트리에서 동일 상태 공유         | ❌ Context | 트리 구조상 전달이 불가능하거나 비효율 |
+
+```tsx
+// ❌ 4단계 전달 — 중간 Layout·ProductSection은 category를 쓰지 않고 넘기기만 한다
+function App() {
+  const [category, setCategory] = useState("all");
+  return <Layout category={category} onCategoryChange={setCategory} />;
+}
+function Layout({ category, onCategoryChange }) {
+  return <ProductSection category={category} onCategoryChange={onCategoryChange} />; // 전달만
+}
+// ProductSection도 동일하게 전달만 — category 타입이 바뀌면 쓰지도 않는 중간 컴포넌트 전체 수정 필요
+
+// ✅ Context — 중간 컴포넌트는 category를 모른다
+const CategoryContext = createContext<{
+  category: string;
+  setCategory: (c: string) => void;
+} | null>(null);
+
+function App() {
+  const [category, setCategory] = useState("all");
+  return (
+    <CategoryContext.Provider value={{ category, setCategory }}>
+      <Layout />
+    </CategoryContext.Provider>
+  );
+}
+function Layout() {
+  return <ProductSection />;
+} // 전달 안 함
+function FilterBar() {
+  const { category, setCategory } = useCategoryContext();
+  return (
+    <select value={category} onChange={(e) => setCategory(e.target.value)}>
+      ...
+    </select>
+  );
+}
+```
+
+Context는 앱 전역 스토어 대용이 아니라 **서브트리 단위 상태 공유** 도구다. 다음 셋에서 고려한다.
+
+1. **Props Drilling 해소** — 중간 컴포넌트들이 데이터를 쓰지 않고 전달만 할 때
+2. **서브트리 상태 공유** — 특정 계층 아래 여러 컴포넌트가 같은 상태를 공유할 때(Tabs, Form)
+3. **테마/언어 설정** — 거의 변하지 않는 전역 값
+
+자주 바뀌는 값과 드물게 바뀌는 값을 한 Context에 넣지 않는다 — Context 값이 바뀌면 구독 하위 전체가 리렌더된다.
+
+```tsx
+// ❌ 드물게 바뀌는 theme과 타이핑마다 바뀌는 inputValue가 한 Context에
+const AppContext = createContext({ theme: "light", inputValue: "" });
+// inputValue가 바뀔 때마다 theme만 쓰는 컴포넌트까지 전부 리렌더된다.
+
+// ✅ 변경 빈도로 Context를 쪼갠다
+const ThemeContext = createContext({ theme: "light" });
+const SearchContext = createContext({ inputValue: "" });
+```
+

--- a/projects/loop-pack-fe-l2-vol1/docs/react/feature-boundary.md
+++ b/projects/loop-pack-fe-l2-vol1/docs/react/feature-boundary.md
@@ -1,0 +1,42 @@
+# 피처 경계·cross-feature 공유
+
+피처끼리 직접 import하지 않는다(depcruise 강제). 여러 피처가 뭔가를 함께 써야 할 때 세 갈래로 판단한다.
+
+## 공유 3분기
+
+**① 타입·순수 유틸(도메인 로직) → `shared`로 내린다**
+가격 포맷·재고 판정·공용 도메인 타입처럼 특정 피처 소유가 아닌 것. 한 피처에 두고 옆 피처가 꺼내 쓰면(cross-feature) 소유가 불명확해지고 테스트 격리가 깨진다. 공용 조각을 `shared`로 내려 둘 다 거기 의존하게 한다.
+
+- 공유 O: 타입, 순수 함수(계산·포맷·검증)
+- 공유 X: 피처의 상태·컴포넌트·훅 (그건 ② 또는 ③)
+
+**② 여러 피처의 UI를 함께 배치 → 상위(`app`)에서 조립**
+피처는 서로를 모른 채, 상위가 데이터·콜백을 넘겨 배선한다.
+
+```tsx
+// ✗ featureA 안에서 import { Cart } from '../cart'  (cross-feature)
+// ✓ app이 조립, 각 피처는 props로만 소통
+function Page() {
+  const [selected, setSelected] = useState<Product | null>(null);
+  return (
+    <>
+      <ProductList onSelect={setSelected} />
+      <Cart product={selected} />
+    </>
+  );
+}
+```
+
+넘기는 수단: props · named slot · DI(context/props 주입).
+
+**③ 두 피처가 늘 함께 바뀜 → 하나로 병합**
+매번 같이 수정되면 경계가 틀린 것. 분리를 고집하지 말고 합친다.
+
+## 이벤트버스
+
+조립·DI로 풀기 어려운 경우(다대다 비동기 알림 등)에만 쓴다. 남용하면 누가 뭘 듣는지 추적이 어려워져 숨긴 결합을 런타임으로 옮길 뿐이다.
+
+## 근거
+
+- Feature-Sliced Design (public API·상위 조립): https://feature-sliced.design/docs/reference/public-api
+- bulletproof-react ("compose features at the application level"): https://github.com/alan2207/bulletproof-react/blob/master/docs/project-structure.md

--- a/projects/loop-pack-fe-l2-vol1/docs/react/hook-design.md
+++ b/projects/loop-pack-fe-l2-vol1/docs/react/hook-design.md
@@ -1,0 +1,213 @@
+# Hook · Effect · 레이어 설계
+
+> `.claude/rules/hook-design.md`가 가리키는 근거 문서. Custom Hook·Effect·레이어 경계를 설계할 때 읽고, 상황에 맞게 적용한다. 각 판단의 "왜"를 Before/After로 보여준다.
+>
+> 전제: 500줄 컴포넌트를 열었을 때 "어디부터 읽지"가 아니라 **"UI는 여기, 로직은 여기, 데이터는 여기"**로 바로 짚이는 구조를 만든다.
+
+## 목차
+
+1. 레이어 — UI / Hook / API / Utils
+2. 상태 3분할 — 서버 / 클라이언트 / 파생값
+3. Custom Hook 추출 — 횟수가 아니라 목적
+4. 명명 — use 접두사와 역할
+5. Hook 책임 — 한 문장으로 설명되는가
+6. Hook state는 공유되지 않는다
+7. useEffect를 줄이는 설계
+8. 직접 fetch할 때 — race와 의존성
+9. DIP — 구현체에 직접 묶이지 않기
+
+---
+
+## 1. 레이어 — UI / Hook / API / Utils
+
+코드를 "어떻게 보이는가 / 어떻게 동작하는가 / 어디서 데이터를 가져오는가"로 나눈다. 각 레이어는 **독립적으로 이해 가능**해야 한다 — UI만 봐도 화면이 그려지고, Hook만 봐도 기능 흐름이 읽히고, API 경계만 봐도 서버 통신이 파악된다.
+
+| 레이어            | 관점              | 담당                                           |
+| ----------------- | ----------------- | ---------------------------------------------- |
+| **UI (컴포넌트)** | 어떻게 보이는가   | JSX 렌더·이벤트 바인딩·스타일·작은 파생값      |
+| **Hook**          | 어떻게 동작하는가 | 상태 관리·필터/정렬/검색·서버 상태 조합·유효성 |
+| **API 경계**      | 어디서 오는가     | 호출 함수·요청/응답 변환·에러 변환             |
+| **Utils**         | 순수 계산         | 상태·side effect 없는 입력→출력                |
+
+> ⚠️ "컴포넌트는 UI만"을 너무 엄격히 읽으면 오버 추상화가 된다. 작은 이벤트 핸들러·작은 파생값(`const isSelected = selectedId === id`)은 컴포넌트 안에 있어도 된다. 밖으로 빼는 기준은 "로직이 있는가"가 아니라 **"별도의 변경 이유를 갖는가"**다.
+
+## 2. 상태 3분할 — 서버 / 클라이언트 / 파생값
+
+"Custom Hook이 뭐고 상태관리가 뭐냐"는 혼란은 대개 세 종류의 상태를 안 나눠서 생긴다.
+
+| 분류                | 도구                                                   | 예시                             |
+| ------------------- | ------------------------------------------------------ | -------------------------------- |
+| **서버 상태**       | 서버 상태 도구, 또는 `useEffect`+Custom Hook 직접 구성 | 주문 내역·게시글·리뷰            |
+| **클라이언트 상태** | `useState`·`useReducer`·전역 스토어                    | 모달 열림·선택 탭·입력값         |
+| **파생값**          | 일반 함수·렌더 중 계산                                 | 필터된 목록·정렬·pagination 계산 |
+
+서버 상태는 클라이언트 상태와 성격이 다르다 — 원격에 저장되고, 비동기로 오고, 다른 사용자/서버가 바꾸고, 캐싱·재요청·stale 관리가 필요하다. 그래서 `useEffect`+`useState`로 직접 들고 있기보다 별도 취급한다.
+
+## 3. Custom Hook 추출 — 횟수가 아니라 목적
+
+**언제 뽑는가** — JSX와 무관한 로직이 컴포넌트를 크게 차지하거나, 테스트하려는 로직이 컴포넌트에 묶였거나, "하나의 흐름"(검색·페이지네이션·validation)으로 설명되는 동작일 때.
+
+**임계값은 "횟수"가 아니라 "목적"이다.** "2곳에서 반복되면 무조건 추출"은 함정이다 — 목적이 같은지 먼저 본다. 애매하면 중복을 유지한다. _잘못된 추상화가 중복보다 비싸다_(Sandi Metz).
+
+```tsx
+// ❌ 오버 추상화 — useState 하나를 감싼 의미 없는 Hook
+function useLoading() {
+  const [isLoading, setIsLoading] = useState(false);
+  return { isLoading, setIsLoading };
+}
+
+// ✅ 관련 상태 + 로직 + 파생값이 응집
+function useOrderStatusFilter() {
+  const [status, setStatus] = useState<OrderStatus | "all">("all");
+  const resetFilter = () => setStatus("all");
+  const isFiltered = status !== "all";
+  return { status, setStatus, resetFilter, isFiltered };
+}
+```
+
+## 4. 명명 — use 접두사와 역할
+
+Hook을 실제로 호출하지 않는 순수 함수엔 `use`를 붙이지 않는다.
+
+```tsx
+// ❌ Hook을 안 쓰는데 use 접두 — 훅 규칙 오해를 부른다
+function useFormatOrderStatus(status: OrderStatus) {
+  return status === "paid" ? "결제완료" : status; // 순수 계산뿐
+}
+
+// ✅ 일반 함수로 충분
+function formatOrderStatus(status: OrderStatus) {
+  return status === "paid" ? "결제완료" : status;
+}
+```
+
+이름은 도메인을 드러낸다(`useOrderStatusFilter`) — `useData`·`useFetch`처럼 메커니즘만 보이면 추상화가 얕다. (React 19의 `use(...)`는 Promise/Context를 읽는 빌트인이고, 우리가 만드는 건 그 위의 `useXxx`다.)
+
+## 5. Hook 책임 — 한 문장으로 설명되는가
+
+좋은 Hook은 **한 문장으로 설명된다**. 안 되면 쪼갠다.
+
+| Hook                   | 좋은 설명                       | 위험 신호                |
+| ---------------------- | ------------------------------- | ------------------------ |
+| `useOrderStatusFilter` | 주문 상태 필터와 변경 규칙 관리 | API 호출·라우팅까지 처리 |
+| `useOrders`            | 주문 목록 서버 상태 조회        | 필터 UI 상태까지 관리    |
+| `usePagination`        | 현재 페이지와 변경 규칙 관리    | 주문 API 응답 구조를 앎  |
+
+> Hook이 너무 커지면 "컴포넌트 500줄"이 "Hook 500줄"로 **이사**한 것뿐이다. 역할별 Hook으로 나누고 페이지에서 조합한다.
+
+```tsx
+// ✅ 페이지는 여러 Hook을 조합만
+function OrderHistoryPage() {
+  const statusFilter = useOrderStatusFilter();
+  const pagination = usePagination();
+  const ordersQuery = useOrders({ status: statusFilter.status, page: pagination.page });
+  return (
+    <OrderHistoryView
+      statusFilter={statusFilter}
+      pagination={pagination}
+      ordersQuery={ordersQuery}
+    />
+  );
+}
+```
+
+## 6. Hook state는 공유되지 않는다
+
+같은 Custom Hook을 여러 곳에서 호출하면 **각자 독립된 state 인스턴스**를 갖는다. Custom Hook은 *로직 재사용*이지 *상태 공유*가 아니다.
+
+```tsx
+function OrderHistoryPage() {
+  const { status, setStatus } = useOrderStatusFilter(); // 인스턴스 A
+  return <OrderFilterModal />;
+}
+
+function OrderFilterModal() {
+  const { status } = useOrderStatusFilter(); // 인스턴스 B — A와 동기화 안 됨
+}
+```
+
+공유가 목적이면 → 한 곳에서 호출해 props로 내리거나, 외부 store(Context/전역/서버 상태 도구)에 둔다.
+
+## 7. useEffect를 줄이는 설계
+
+`useEffect`는 "상태가 바뀌면 뭔가 실행"이 아니라 **React 바깥 외부 시스템과 동기화하는 도구**다.
+
+| ✅ 필요                                                | ❌ 불필요                                                 |
+| ------------------------------------------------------ | --------------------------------------------------------- |
+| 서버 요청·구독·WebSocket·타이머·외부 라이브러리 동기화 | props/state로 계산 가능한 값·필터/정렬 결과·포맷팅·파생값 |
+
+```tsx
+// ❌ 파생값을 state+Effect로 — 동기화 부담
+const [filtered, setFiltered] = useState<Order[]>([]);
+useEffect(() => {
+  setFiltered(orders.filter((o) => o.status === status));
+}, [orders, status]);
+
+// ✅ 렌더 중 계산 — state·Effect 없음, 자동 일관성
+const filtered = orders.filter((o) => o.status === status);
+```
+
+> 계산이 정말 무겁다고 **측정으로 확인되면** `useMemo`로 감싼다 — `useEffect`+state로 되돌리지 않는다. (react.dev "You Might Not Need an Effect")
+
+## 8. 직접 fetch할 때 — race와 의존성
+
+서버 상태 도구 없이 `useEffect`로 직접 요청하면, 도구가 대신하던 걸 손으로 챙긴다.
+
+```tsx
+useEffect(() => {
+  let ignore = false;
+
+  (async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await orderApi.getOrders({ status, page });
+      if (!ignore) setOrders(res.orders);
+    } catch (e) {
+      if (!ignore) setError(e as Error);
+    } finally {
+      if (!ignore) setLoading(false);
+    }
+  })();
+
+  return () => {
+    ignore = true; // 이전 요청 결과 무시
+  };
+}, [status, page]); // ← 객체 아닌 원시 필드
+```
+
+- **race condition**: `ignore` 플래그나 `AbortController`로 이전 요청이 최신 결과를 덮어쓰지 않게.
+- **의존성은 원시 필드로**: `[params]`처럼 객체를 그대로 두면 매 렌더 새 참조 → 무한 요청. `[params.status, params.page]`로 푼다.
+- **반환 형태 일관**: `data`/`isPending`/`error`를 Hook 안에서 묶어 노출하면 나중에 도구 도입 시 호출부 수정이 준다.
+
+## 9. DIP — 구현체에 직접 묶이지 않기
+
+Hook이 구현체(`axios`)에 직접 묶이면 서버가 바뀌거나 테스트할 때 다 무너진다. **API 함수 경계**에 의존한다.
+
+```tsx
+// ❌ Hook이 axios에 직접 의존 — 교체 시 모든 Hook 수정
+function useOrderList() {
+  const [orders, setOrders] = useState<Order[]>([]);
+  useEffect(() => {
+    axios.get("/api/v1/orders").then((r) => setOrders(r.data.orders));
+  }, []);
+  return orders;
+}
+
+// ✅ API 함수에 의존 — 수정 지점이 orderApi로 좁혀짐
+function useOrders(params: OrderListParams) {
+  const [orders, setOrders] = useState<Order[]>([]);
+  useEffect(() => {
+    let ignore = false;
+    orderApi.getOrders(params).then((r) => {
+      if (!ignore) setOrders(r.orders);
+    });
+    return () => {
+      ignore = true;
+    };
+  }, [params.status, params.page]);
+  return orders;
+}
+```
+
+도메인 규칙(취소 가능 여부·상태 라벨)은 UI 사이에 숨기지 말고 순수 함수로 뽑는다 — 별도의 변경 이유를 갖기 때문이다.

--- a/projects/loop-pack-fe-l2-vol1/docs/react/props-contract.md
+++ b/projects/loop-pack-fe-l2-vol1/docs/react/props-contract.md
@@ -261,7 +261,7 @@ interface ButtonProps extends React.ComponentPropsWithoutRef<"button"> {
 
 function Button({ variant = "primary", loading, children, ...rest }: ButtonProps) {
   return (
-    <button disabled={loading || rest.disabled} {...rest}>
+    <button {...rest} disabled={loading || rest.disabled}>
       {loading ? <Spinner /> : children}
     </button>
   );

--- a/projects/loop-pack-fe-l2-vol1/docs/react/props-contract.md
+++ b/projects/loop-pack-fe-l2-vol1/docs/react/props-contract.md
@@ -1,0 +1,277 @@
+# Props·합성 계약 — 무엇을 어떻게 넘길까
+
+> `.claude/rules/component-design.md`가 가리키는 근거 문서. **공통 컴포넌트의 인터페이스를 설계할 때**(Props 모양·값의 주인·합성 방식) 읽는다. 각 판단의 "왜"를 Before/After로 보여준다.
+>
+> 전제: 좋은 공통 컴포넌트는 기능을 많이 넣는 게 아니라 **결정을 사용처에 넘긴다**(Inversion of Control).
+>
+> 컴포넌트를 어디서 자를지는 [`component-boundary.md`](./component-boundary.md), Context 전환 판단은 [`context-and-state.md`](./context-and-state.md)에 있다.
+
+## Props는 적을수록 좋다
+
+Props가 많아지면 사용하는 쪽에서 "어떤 조합이 유효한지" 읽어낼 수 없다. Props를 늘리는 대신 `children`으로 합성한다. 구체적인 Before/After는 아래 [children 합성의 감각](#children-합성의-감각) 예시를 참고한다.
+
+| Props 수 | 판단      | 대응                                |
+| -------- | --------- | ----------------------------------- |
+| 1~3개    | ✅ 깔끔   | 유지                                |
+| 4~5개    | ⚠️ 주의   | 관련 Props를 객체로 그룹화 검토     |
+| 6개 이상 | ❌ 재설계 | Composition 패턴 또는 컴포넌트 분리 |
+
+절대 기준은 아니다. HTML 속성을 그대로 넘기는 래퍼(`ComponentPropsWithoutRef` 확장)처럼, 개수가 많아도 의미가 한 묶음이면 괜찮다. 기준이 잡으려는 건 "**서로 무관한 제어 손잡이가 흩어져 조합 규칙이 사라지는**" 상태다.
+
+## Props 네이밍
+
+| 접두사    | 의미                    | 예시                          |
+| --------- | ----------------------- | ----------------------------- |
+| `onX`     | 외부에서 주입받는 콜백  | `onSearch`, `onClear`         |
+| `handleX` | 이 컴포넌트가 직접 처리 | `handleSubmit`, `handleClick` |
+
+### boolean Props는 긍정형 + `is` 접두
+
+```tsx
+<Button notDisabled={false} />  // ❌ 이중 부정 — "비활성화가 아닌 게 거짓"?
+<Button disabled={true} />      // ✅ 긍정형
+
+<Modal show={true} />           // ❌ show? visible? 컨벤션이 흔들린다
+<Modal isOpen={true} />         // ✅ is + 형용사로 통일
+```
+
+## Controlled vs Uncontrolled
+
+값의 주인이 **부모**인지 **컴포넌트 자신**인지를 먼저 정한다. 이 선택이 Props 모양(`value` vs `defaultValue`)을 결정한다.
+
+|             | Controlled                             | Uncontrolled                             |
+| ----------- | -------------------------------------- | ---------------------------------------- |
+| 상태 위치   | 부모가 `value`·`onChange`로 제어       | 컴포넌트 내부에서 자체 관리              |
+| 초기값      | `value` prop                           | `defaultValue` prop                      |
+| 값 접근     | 부모 state에서 직접                    | `ref`로 접근                             |
+| 적합한 경우 | 폼 검증, 실시간 미리보기, 입력 간 연동 | 단순 입력, 파일 업로드, 성능이 중요할 때 |
+
+```tsx
+// Controlled — 타이핑마다 값이 필요할 때(실시간 미리보기·연동)
+function SearchWithPreview() {
+  const [query, setQuery] = useState("");
+  return (
+    <div>
+      <Input value={query} onChange={(e) => setQuery(e.target.value)} />
+      <p>검색 중: "{query}"</p>
+      <SearchResults query={query} />
+    </div>
+  );
+}
+
+// Uncontrolled — 제출할 때만 값이 필요할 때
+function SimpleLoginForm() {
+  const emailRef = useRef<HTMLInputElement>(null);
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (emailRef.current) login(emailRef.current.value);
+  };
+  return (
+    <form onSubmit={handleSubmit}>
+      <input ref={emailRef} defaultValue="" placeholder="이메일" />
+      <button type="submit">로그인</button>
+    </form>
+  );
+}
+```
+
+```tsx
+// value가 있으면 Controlled, 없으면 Uncontrolled로 분기한다
+interface InputProps {
+  value?: string; // Controlled
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  defaultValue?: string; // Uncontrolled
+}
+
+function Input({ value, onChange, defaultValue, ...rest }: InputProps) {
+  return value !== undefined ? (
+    <input value={value} onChange={onChange} {...rest} />
+  ) : (
+    <input defaultValue={defaultValue} {...rest} />
+  );
+}
+```
+
+## 공통 컴포넌트 설계
+
+### 도입 시점 — YAGNI
+
+"나중에 쓸 것 같아서" 미리 만들지 않는다. 예측은 대부분 틀린다.
+
+| 상황                            | 판단      | 이유                        |
+| ------------------------------- | --------- | --------------------------- |
+| 같은 UI가 3곳 이상에서 반복     | ✅ 공통화 | 중복 제거 효과가 명확       |
+| 2곳이지만 확장이 확실           | ✅ 공통화 | 지금 만들면 확장 비용 절감  |
+| 1곳뿐인데 "나중에 쓸 것 같아서" | ❌ 안 함  | 예측은 대부분 틀린다(YAGNI) |
+
+### 3가지 원칙
+
+**1. 비즈니스 로직을 포함하지 않는다.** 비즈니스 판단은 사용하는 쪽에서 한다.
+
+```tsx
+// ❌ 공통 컴포넌트에 도메인 판단(stock·status)이 섞임
+function ProductButton({ product }: { product: Product }) {
+  const isAvailable = product.stock > 0 && product.status === 'active'
+  return <button disabled={!isAvailable}>{product.name} 구매</button>
+}
+
+// ✅ 공통 컴포넌트는 UI만. 판단은 사용처에서
+function Button({ disabled, children, ...props }: ButtonProps) {
+  return <button disabled={disabled} {...props}>{children}</button>
+}
+const isAvailable = product.stock > 0 && product.status === 'active'
+<Button disabled={!isAvailable}>{product.name} 구매</Button>
+```
+
+**2. 도메인 용어를 이름에 쓰지 않는다.** 이름에 도메인이 박히면 그 맥락에서만 쓸 수 있다.
+
+```
+ProductButton    ❌  // "상품 구매" 맥락 전용
+OrderSubmitForm  ❌  // "주문" 맥락 전용
+Button / Form    ✅  // 어디서든 쓸 수 있다
+```
+
+**3. `variant`/`size`로 외양을 제어한다.** Props에 JSDoc(`/** */`)을 달면 IDE 자동완성에 설명이 떠 별도 문서 없이도 용도를 안다.
+
+```tsx
+interface ButtonProps {
+  /** 버튼 스타일 변형 */
+  variant?: "primary" | "secondary" | "ghost" | "danger";
+  /** 버튼 크기 */
+  size?: "sm" | "md" | "lg";
+  /** 로딩 상태 — true일 때 스피너 표시, 클릭 비활성화 */
+  loading?: boolean;
+  children: React.ReactNode;
+}
+```
+
+### 스타일 확장은 prop 말고 className 위임
+
+스타일 미세조정마다 prop을 새로 파면 공통 컴포넌트가 끝없이 부푼다 — 외양 확장은 **`className`을 받아 사용처에 위임**한다.
+
+```tsx
+// ❌ 디자인 요청 하나 = prop 하나 → Button이 끝없이 부푼다
+<Button fullWidth rounded shadow uppercase marginTop />;
+
+// ✅ className을 받아 자체 클래스와 병합 — 사용처에서만 조정
+interface ButtonProps extends React.ComponentPropsWithoutRef<"button"> {
+  variant?: "primary" | "secondary" | "ghost";
+}
+function Button({ variant = "primary", className, ...rest }: ButtonProps) {
+  // lazy: 문자열 병합으로 충분 — 클래스 충돌·우선순위가 잦아지면 clsx + tailwind-merge 도입
+  return <button className={`btn btn--${variant} ${className ?? ""}`} {...rest} />;
+}
+
+<Button variant="primary" className="checkout-cta" />; // 이 한 곳만, Button은 그대로
+```
+
+원칙은 "**더 많은 prop**" 대신 "**더 열린 확장 지점**" — 확장을 사용처에 위임하면 공통 컴포넌트가 부풀지 않는다.
+
+### children 합성의 감각
+
+Props가 늘어날 때의 대안은 `children`에 JSX를 넘겨받는 합성이다. 변형이 늘어도 컴포넌트를 수정하지 않고 사용처에서 조립한다.
+
+```tsx
+// ❌ Props로 전부 제어 — 변형이 늘 때마다 Props도 는다
+<Card title="원목 스탠드 조명" price={45000} badge="신상품"
+  showLikeButton likeCount={128} showReviewCount reviewCount={42} imageHeight={200} />
+// showShareButton도 추가? → Props +2개...
+
+// ✅ Composition — 사용처에서 필요한 것만 조립
+<Card>
+  <Card.Image src="/lamp.jpg" alt="원목 스탠드 조명" height={200} />
+  <Card.Body>
+    <Card.Badge>신상품</Card.Badge>
+    <Card.Title>원목 스탠드 조명</Card.Title>
+    <Card.Price value={45000} />
+  </Card.Body>
+  <Card.Footer>
+    <LikeButton count={128} />
+    <ReviewCount count={42} />
+  </Card.Footer>
+</Card>
+// ShareButton이 필요하면 Card.Footer에 추가한다 — Card는 손대지 않는다.
+```
+
+기존 컴포넌트를 수정하지 않고 확장하는 것이 핵심 — Context 기반 Compound Component(`<Tabs><Tabs.Trigger/></Tabs>`)는 이 감각의 확장이다.
+
+### children vs slot
+
+`children`은 구멍이 하나일 때다. **이름 붙은 자리가 여럿이고 순서 고정**이면 각 자리를 element prop으로 받는 **slot**이 더 안전하다(React는 네이티브 slot이 없어 prop으로 구현).
+
+```tsx
+// children 하나로 충분 — 자유롭게 채운다
+<Dialog>
+  <p>정말 삭제할까요?</p>
+</Dialog>;
+
+// 자리가 여럿이고 순서가 고정 → slot(이름 있는 element props)
+<Dialog
+  title={<h2>판매 종료</h2>}
+  footer={
+    <>
+      <Button variant="ghost">취소</Button>
+      <Button variant="danger">종료</Button>
+    </>
+  }
+>
+  이 글을 끌올할 수 없게 됩니다.
+</Dialog>;
+```
+
+`children`은 자유, slot은 구조다 — "footer가 header 위로 가면 안 되는" UI엔 slot으로 자리를 고정하고, 상태까지 암시적으로 공유해야 하면 Context 기반 Compound Component로 넘어간다.
+
+## TypeScript Props — 고급 패턴
+
+### 조건부 Props는 Discriminated Union으로
+
+"`variant`가 `'icon'`일 때만 `icon`이 필수" 같은 조건은 타입으로 강제한다 — 전부 optional은 잘못된 조합을 막지 못한다.
+
+```tsx
+// ❌ 전부 optional — 잘못된 조합을 컴파일 타임에 못 막는다
+interface ButtonProps {
+  variant: 'text' | 'icon'
+  label?: string   // text일 땐 필수인데 optional
+  icon?: ReactNode // icon일 땐 필수인데 optional
+}
+
+// ✅ Discriminated Union — 잘못된 조합이 컴파일 에러가 된다
+type ButtonProps =
+  | { variant: 'text'; label: string; icon?: never }
+  | { variant: 'icon'; icon: ReactNode; label?: never }
+
+<Button variant="text" label="확인" />   // ✅
+<Button variant="icon" icon={<X />} />   // ✅
+<Button variant="text" icon={<X />} />   // ❌ 컴파일 에러
+<Button variant="icon" />                // ❌ icon 누락 에러
+```
+
+> discriminated union의 기본기(optional 자루 대신 태그 유니온, `switch`의 `never` 처리)는 [`typescript.md`](../../.claude/rules/typescript.md)에 있다. 위는 그것을 Props에 적용한 형태다.
+
+### HTML 속성 확장은 `ComponentPropsWithoutRef`
+
+`<button>`의 모든 HTML 속성(`type`, `aria-label` 등)을 그대로 받으려면 손으로 나열하지 말고 확장한다.
+
+```tsx
+interface ButtonProps extends React.ComponentPropsWithoutRef<"button"> {
+  variant?: "primary" | "secondary" | "ghost";
+  size?: "sm" | "md" | "lg";
+  loading?: boolean;
+}
+
+function Button({ variant = "primary", loading, children, ...rest }: ButtonProps) {
+  return (
+    <button disabled={loading || rest.disabled} {...rest}>
+      {loading ? <Spinner /> : children}
+    </button>
+  );
+}
+
+<Button type="submit" aria-label="주문하기" variant="primary">
+  주문
+</Button>;
+```
+
+## 참고: Atomic Design
+
+> 설계 어휘로 알아두되 레이어 강제는 맹신하지 않는다. 분류 기준이 모호해 "Atom인가 Molecule인가" 논쟁으로 시간을 쓰기 쉽고, 레이어가 많아 복잡해질 수 있다(Atoms→Molecules→Organisms→Templates/Pages).

--- a/projects/loop-pack-fe-l2-vol1/docs/testing/conventions.md
+++ b/projects/loop-pack-fe-l2-vol1/docs/testing/conventions.md
@@ -1,0 +1,48 @@
+# 테스트 컨벤션 (Vitest + React Testing Library)
+
+> 이 레포는 아직 테스트 스택 미설치다. 테스트 도입 시 Vitest + React Testing Library + (네트워크) MSW 기준으로 이 문서를 적용한다.
+
+## 원칙
+
+테스트는 소프트웨어가 **쓰이는 방식을 닮을수록** 신뢰가 높다. 사용자가 보고 조작하는 동작을 검증하고, 구현 세부(state 변수명·내부 메서드·CSS 클래스)는 검증하지 않는다.
+
+## 무엇을 테스트 / 안 하나
+
+- 한다: 렌더 결과, 인터랙션 후 UI 변화, 에러·빈 상태 메시지
+- 안 한다: 내부 state 변수명, props 전달 여부, 훅 반환값 직접 assert, React 자체 동작(렌더 사이클·Context 내부)
+
+## 쿼리 우선순위
+
+`getByRole`(`name` 옵션) → `getByLabelText`(폼) → `getByPlaceholderText` → `getByText`(비인터랙티브) → `getByAltText`.
+
+- `getByTestId`는 최후수단: 사용자에게 안 보이는 속성이라 접근성과 무관하고 리팩터에 취약하다.
+- `container.querySelector('.class')` 금지: CSS 클래스는 구현 세부다.
+- 단언은 jest-dom matcher로: `expect(...).toBeDisabled()` (`button.disabled` 직접 비교 X).
+
+## 상호작용 · 비동기
+
+- `userEvent.setup()` + `await user.click(...)`. `fireEvent`는 예외적 단일 이벤트에만.
+- 즉시 존재: `getBy*` / 부재 단언: `queryBy*` / 비동기 등장: `await findBy*` / 복잡 조건: `waitFor`.
+- `waitFor` 콜백엔 assertion 하나만. side-effect(이벤트 발생) 금지 — 콜백이 재실행된다.
+
+## 모킹
+
+- 네트워크는 MSW 핸들러(`src/mocks/handlers.ts`)로. axios/fetch 무관하게 환경 레벨에서 인터셉트되고 재사용된다.
+- **외부 경계만** 모킹한다. 내 코드의 내부 모듈을 `vi.mock`하면 실제 통합을 숨겨 false green을 만든다.
+- `afterEach(() => vi.clearAllMocks())`로 테스트 간 오염을 차단한다.
+
+## 네이밍 · 구조
+
+- 이름은 사용자 행동 + 결과로: `it('로그인 실패 시 에러 메시지를 보여준다')` (`it('renders LoginForm')` X).
+- `describe` = 컨텍스트/상태, `it` = 동작. 본문은 given-when-then(Arrange → Act → Assert). 한 `it` = 한 행동.
+
+## AI 단골 안티패턴
+
+| 안티패턴                            | 대신                          |
+| ----------------------------------- | ----------------------------- |
+| `container.querySelector('.class')` | `getByRole(...)`              |
+| 내부 state·메서드 assert            | state 변화가 만든 UI를 검증   |
+| 전체 컴포넌트 snapshot 남용         | 작고 안정적인 조각에만        |
+| `waitFor` 빈/다중 콜백              | 콜백 안 assertion 하나        |
+| 내부 모듈 `vi.mock`                 | 외부 경계만, 내부는 실제 코드 |
+| `getByTestId` 기본 사용             | `getByRole`/`getByLabelText`  |

--- a/projects/loop-pack-fe-l2-vol1/rules/component-design.md
+++ b/projects/loop-pack-fe-l2-vol1/rules/component-design.md
@@ -4,11 +4,17 @@ paths: ["**/*.tsx", "**/*.jsx"]
 
 # 컴포넌트 설계 판단 규칙
 
-> 컴포넌트·Props를 설계하기 전에 **`docs/react/component-design.md`를 읽고** 상황에 맞게 적용하라(판단 기준 표·Before/After 카탈로그).
+> 설계 전에 **상황에 해당하는 근거 문서 하나만 읽고** 적용하라(판단 기준 표·Before/After 카탈로그). 셋을 다 읽지 않는다.
+>
+> | 지금 하려는 판단 | 읽을 문서 |
+> | --- | --- |
+> | 이 컴포넌트를 쪼갤까 (경계·God Component·성급한 추상화) | `docs/react/component-boundary.md` |
+> | 공통 컴포넌트 인터페이스를 어떻게 (Props·값의 주인·합성) | `docs/react/props-contract.md` |
+> | Drilling을 유지할까 Context로 넘길까 | `docs/react/context-and-state.md` |
 
 핵심:
 
-- **경계 = 변경 이유**: 변경 이유가 다르면 자른다. 성급한 공통화보단 중복이 낫다(rule of three) — 판단 기준·Before/After는 docs "경계 — 어디서 자를까".
+- **경계 = 변경 이유**: 변경 이유가 다르면 자른다. 성급한 공통화보단 중복이 낫다(rule of three) — 판단 기준·Before/After는 `component-boundary.md`.
 - **구현 vs 조합 분리**: 한 컴포넌트는 구현이거나 조합이거나 — 같은 추상화 고도. 조합하다 내부를 인라인 구현하지 마라(조합=목차, 구현=본문).
 - **무관한 상태 = 추출 신호**: 서로 무관한 state가 한 컴포넌트에 쌓이면 그 state를 쓰는 UI와 함께 떼어낸다. 상태를 '어디 둘지'의 판단은 react.md.
 - **Props 수**: 6개 이상이면 재설계 신호 — 표시 토글·boolean을 늘리지 말고 `children` 합성이나 컴포넌트 분리로. 4~5개는 관련 Props를 객체로 묶을지 검토. 진짜 문제는 개수 자체가 아니라 "서로 무관한 제어 손잡이가 흩어져 유효 조합을 못 읽는" 상태다.
@@ -16,8 +22,8 @@ paths: ["**/*.tsx", "**/*.jsx"]
 - **값의 주인 먼저**: 부모가 쥐면 Controlled(`value`+`onChange`), 자신이 쥐면 Uncontrolled(`defaultValue`+`ref`). 이 선택이 Props 모양을 결정한다. 공통 컴포넌트는 `value !== undefined`로 분기해 둘 다 지원.
 - **Drilling vs Context**: 2단계 전달은 유지(흐름 추적 가능). 3단계+인데 중간이 그 Props를 안 쓰거나, 여러 트리가 같은 상태를 공유하면 Context. Context는 서브트리 단위 한정 — 전역 스토어 대용이 아니다.
 - **Context 분리**: 자주 바뀌는 값과 드물게 바뀌는 값을 한 Context에 넣지 않는다(구독 하위 전체가 리렌더). 변경 빈도로 쪼갠다.
-- **공통 컴포넌트**: ①비즈니스 로직 미포함(판단은 사용처에서) ②도메인 용어 미사용(`Button`✅ `ProductButton`❌) ③`variant`/`size`로 외양 제어 + JSDoc 주석. 도입은 같은 UI가 3곳 이상 반복될 때 — "나중에 쓸 듯"은 만들 이유가 아니다(YAGNI). 스타일 미세조정 요청이 반복되면 prop 늘리지 말고 `className` 위임 — docs "스타일 확장은 prop 말고 className 위임".
-- **children vs slot**: 채울 구멍이 하나면 `children`, 이름 붙은 자리가 여럿+순서 고정이면 slot(`title`/`footer` element props) — docs "children vs slot".
+- **공통 컴포넌트**: ①비즈니스 로직 미포함(판단은 사용처에서) ②도메인 용어 미사용(`Button`✅ `ProductButton`❌) ③`variant`/`size`로 외양 제어 + JSDoc 주석. 도입은 같은 UI가 3곳 이상 반복될 때 — "나중에 쓸 듯"은 만들 이유가 아니다(YAGNI). 스타일 미세조정 요청이 반복되면 prop 늘리지 말고 `className` 위임 — `props-contract.md` "스타일 확장은 prop 말고 className 위임".
+- **children vs slot**: 채울 구멍이 하나면 `children`, 이름 붙은 자리가 여럿+순서 고정이면 slot(`title`/`footer` element props) — `props-contract.md` "children vs slot".
 - **조건부 Props**: 조합에 규칙이 있으면 전부 optional 대신 discriminated union(`{ variant: 'text'; label } | { variant: 'icon'; icon }`). HTML 속성을 그대로 넘길 땐 손으로 나열 말고 `ComponentPropsWithoutRef<'button'>` 확장.
 
 네이밍(`onX`/`handleX`)·props→state 미러링 금지·추출 기준은 `react.md`, discriminated union 기본기는 `typescript.md`에 있다 — 여기서 중복하지 않는다.

--- a/projects/loop-pack-fe-l2-vol1/sync.yaml
+++ b/projects/loop-pack-fe-l2-vol1/sync.yaml
@@ -9,3 +9,10 @@ rules:
     - typescript
     - hook-design
     - feature-boundary
+
+# rule들이 "docs/react/…를 읽어라"로 가리키는 근거 문서. 디렉토리 형태 →
+# docs/react/ 전체가 docs/react/로, testing/ 전체가 docs/testing/로 착지한다.
+docs:
+  items:
+    - react
+    - testing

--- a/skills/agent-council/council.config.yaml
+++ b/skills/agent-council/council.config.yaml
@@ -26,7 +26,7 @@ council:
       command: codex exec
       emoji: "🤖"
       color: "BLUE"
-      model: "gpt-5.5"
+      model: "gpt-5.6-sol"
       effort_level: "xhigh"
       output_format: json
 

--- a/skills/orchestrate-review/orchestrate-review.config.yaml
+++ b/skills/orchestrate-review/orchestrate-review.config.yaml
@@ -8,54 +8,54 @@ chunk-review:
     # CONFIRMED/PLAUSIBLE/REFUTED) and ranks the survivors.
     #
     # Per-angle model: each member carries its own command/model, so any angle
-    # can run on a different CLI/model. Today every angle runs on codex at gpt-5.5,
+    # can run on a different CLI/model. Today every angle runs on codex at gpt-5.6-sol,
     # xhigh reasoning effort. `model` + `effort_level` + `output_format` resolve
     # (via buildAugmentedCommand) to:
-    #   codex exec -m gpt-5.5 -c model_reasoning_effort=xhigh --json --skip-git-repo-check
+    #   codex exec -m gpt-5.6-sol -c model_reasoning_effort=xhigh --json --skip-git-repo-check
     # Note: codex uses bare model ids (no `openai/` prefix). Git history attests
     # codex with gpt-5.4 / gpt-5.3-codex (gpt-5.5 itself only ran via opencode);
-    # if codex rejects `gpt-5.5`, fall back to `gpt-5.4`.
+    # if codex rejects `gpt-5.6-sol`, fall back to `gpt-5.5`.
     # Change one member's `model`/`command` to run that angle on a different model/CLI.
     #
     # Angle set: 3 correctness lenses + 1 cleanup lens + 1 security lens + 1 coverage lens.
     - name: line-scan
       command: codex exec
-      model: gpt-5.5
+      model: gpt-5.6-sol
       emoji: "\U0001F50D"
       color: "BLUE"
       effort_level: xhigh
       output_format: json
     - name: regression
       command: codex exec
-      model: gpt-5.5
+      model: gpt-5.6-sol
       emoji: "\U0001F5D1"
       color: "MAGENTA"
       effort_level: xhigh
       output_format: json
     - name: cross-file
       command: codex exec
-      model: gpt-5.5
+      model: gpt-5.6-sol
       emoji: "\U0001F517"
       color: "CYAN"
       effort_level: xhigh
       output_format: json
     - name: cleanup
       command: codex exec
-      model: gpt-5.5
+      model: gpt-5.6-sol
       emoji: "\U0001F9F9"
       color: "YELLOW"
       effort_level: xhigh
       output_format: json
     - name: security
       command: codex exec
-      model: gpt-5.5
+      model: gpt-5.6-sol
       emoji: "\U0001F512"
       color: "RED"
       effort_level: xhigh
       output_format: json
     - name: coverage
       command: codex exec
-      model: gpt-5.5
+      model: gpt-5.6-sol
       emoji: "\U0001F4CB"
       color: "GREEN"
       effort_level: xhigh


### PR DESCRIPTION
## 📌 Summary

두 가지를 담습니다. (1) orchestrate-review 리뷰 앵글 6종과 agent-council gpt 멤버가 쓰는 codex 모델을 `gpt-5.5`에서 2026-07-09 GA된 GPT-5.6 플래그십 티어 `gpt-5.6-sol`로 교체합니다. (2) `loop-pack-fe-l2-vol1` 프로젝트의 rule이 가리키던 근거 문서(docs)를 OMT 소스로 편입하고, 509줄로 비대해진 컴포넌트 설계 문서를 트리거별 3개로 분할합니다.

---

## 🔧 Changes

### orchestrate-review

- 6개 리뷰 앵글(line-scan, regression, cross-file, cleanup, security, coverage)의 `model: gpt-5.5` → `model: gpt-5.6-sol`
- stale해진 설정 주석 갱신: 예시 커맨드의 `-m` 값, 모델 거부 시 fallback 안내(`gpt-5.6-sol` 거부 시 `gpt-5.5`로 폴백)

`effort_level: xhigh`는 GPT-5.6에서도 유효한 값이라 유지했습니다.

**영향 범위**
소스(`skills/`)만 수정. `.codex/`·`.gemini/` 배포 사본은 머지 후 `make sync`가 재생성하므로 이 PR에 포함하지 않음. 앵글 동작·프롬프트·출력 포맷 변경 없음.

### agent-council

- `gpt` 멤버의 `model: "gpt-5.5"` → `model: "gpt-5.6-sol"` (claude/glm 멤버 불변)

**영향 범위**
council 구성원 수·타임아웃·체어맨 설정 변경 없음.

### loop-pack-fe-l2-vol1 — docs 편입

- 근거 문서 4종을 프로젝트 소스로 편입: `docs/react/{component-design, hook-design, feature-boundary}.md`, `docs/testing/conventions.md`
- `sync.yaml`에 `docs:` 섹션 신설 — `react`·`testing`을 디렉토리 형태 컴포넌트로 배선

rule 6종은 이미 OMT에 있었지만, 각 rule이 "설계 전에 `docs/react/…`를 읽어라"로 가리키는 근거 문서는 대상 repo에만 있었습니다. 포인터가 뜬 상태였고, 과제 브랜치가 리셋되면 복구 경로가 없었습니다.

**영향 범위**
- OMT의 `docs:` 컴포넌트 타입 첫 사용. 디렉토리 형태(`tryResolveInDir`가 `<name>.md` → 없으면 `<name>/`로 폴백)라 트리 전체가 배포되며, 이후 문서 추가·삭제는 `sync.yaml` 수정 없이 반영됩니다.
- docs는 팬아웃 없이 단일 위치 merge-patch(선언 안 한 사람 파일은 보존, 선언한 파일만 backup 후 덮어씀).
- 배포 타깃(`~/repos/loop-pack-fe-l2-vol1/main`)이 현재 Next 전환 중 CLAUDE.md를 잃어 `make sync` 선결조건에서 멈춥니다. 이 PR의 변경과 무관한 선행 상태이며, 타깃 정리 후 배포됩니다.
- rule 6종 중 `component-design.md` 1개만 수정(포인터 갱신). 나머지 5종 바이트 불변.

### loop-pack-fe-l2-vol1 — 컴포넌트 설계 문서 3분할

- `component-design.md`(509줄) → 트리거별 3파일로 분할
  - `component-boundary.md`(175줄) — 이 컴포넌트를 쪼갤까
  - `props-contract.md`(277줄) — 공통 컴포넌트 인터페이스를 어떻게
  - `context-and-state.md`(74줄) — Drilling을 유지할까 Context로 넘길까
- `rules/component-design.md`의 단일 doc 포인터를 상황별 3-way 라우팅 표로 교체. 본문 항목 3곳의 `docs "섹션명"` 인용도 파일명까지 명시.

**영향 범위**
- 본문 무손실. 코드펜스 34개·표 행 25개가 원본과 일치하며, 문단·예제는 한 글자도 수정하지 않았습니다. 헤더와 크로스링크만 새로 작성했습니다.
- 파일을 건너가게 된 앵커 `#도입-시점--yagni` 1건을 크로스파일 링크로 교정. 같은 파일에 남은 `#children-합성의-감각`은 그대로 유효합니다.
- rule→doc 경로 6개, doc↔doc 크로스링크 7개, 앵커 전수 검사 — 끊긴 참조 0건.
- rule 본문의 판단 항목(핵심 체크리스트)은 변경하지 않았습니다. 바뀐 것은 "어디를 펼쳐 볼지"의 라우팅뿐입니다.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. bare alias `gpt-5.6` 대신 명시적 티어 id `gpt-5.6-sol` 채택

**배경 및 문제 상황:**
GPT-5.6은 Sol(플래그십)/Terra(밸런스)/Luna(경량) 3티어로 출시됐고, bare id `gpt-5.6`은 현재 Sol로 라우팅되는 alias입니다. 리뷰 job은 재현 가능한 판정 품질이 중요한데, OpenAI는 각 티어를 "독립적인 주기로 진화하는 durable capability tier"로 정의해 alias의 라우팅 대상이 바뀔 수 있습니다.

**해결 방안:**
설정에 명시적 `gpt-5.6-sol`을 기록해 alias 재지정으로 인한 무단 모델 변경을 차단했습니다.

**선택과 트레이드오프:**
alias를 쓰면 향후 상위 티어 자동 승격을 공짜로 얻지만, 리뷰 파이프라인의 판정 일관성이 예고 없이 흔들리는 비용이 더 큽니다. 모델 세대 업그레이드는 이번처럼 명시적 diff로 남기는 쪽을 택했습니다. 같은 이유로 reasoning effort도 신설된 `max` 티어로 올리지 않고 기존 `xhigh`를 유지했습니다(비용·지연 증가 대비 리뷰 품질 이득이 검증 안 됨 — 필요 시 별도 실험으로).

### 2. 509줄 단일 문서를 트리거별 3분할 — doc 크기는 rule의 신뢰도 문제다

**배경 및 문제 상황:**
`rules/component-design.md`는 "컴포넌트·Props를 설계하기 전에 `docs/react/component-design.md`를 읽고 적용하라"고 지시합니다. 그런데 그 문서는 509줄이고, 트리거가 서로 다른 세 판단이 한 파일에 눌려 있었습니다 — 경계(언제 자르나) 165줄, Props·합성 계약(무엇을 어떻게 넘기나) 175줄, Context 전환 65줄.

Dialog 하나 만들 때 필요한 건 Controlled/Uncontrolled와 children 합성 약 120줄인데, "중복 > 잘못된 추상화"(57줄)와 Props Drilling(65줄), 참고: Atomic Design까지 전부 딸려옵니다. 문서가 커질수록 "읽어라"는 rule 지시는 거짓말이 됩니다 — 실제로는 아무도 다 읽지 않거나, 읽고 컨텍스트를 태웁니다.

**해결 방안:**
분할 축을 "주제"가 아니라 **"언제 펼쳐 보는가"**로 잡았습니다. 그리고 rule 헤더를 단일 포인터에서 트리거 → 문서 매핑 표로 바꿨습니다.

**구현 세부사항:**
- Context 섹션(65줄)을 계약 파일에 남기지 않은 이유: Dialog는 Context를 *쓰지만* Drilling 유지 여부는 판단하지 않습니다. 남기면 Dialog를 만들 때마다 딸려옵니다.
- 반대로 `children vs slot`은 Compound 패턴 진입로라 계약 파일에 남겼습니다.
- rule 본문(판단 체크리스트)은 손대지 않았습니다. 이미 잘 압축돼 있고, 이 rule의 가치는 편집 시 자동 로드되는 짧은 트리거이기 때문입니다. 바꿀 것은 라우팅뿐이었습니다.

**관련 코드:**
```markdown
<!-- Before: 단일 포인터. 무엇을 하든 509줄을 읽으라고 지시 -->
> 컴포넌트·Props를 설계하기 전에 **`docs/react/component-design.md`를 읽고** 상황에 맞게 적용하라.

<!-- After: 트리거 → 문서 라우팅. 상황에 맞는 한 파일만 -->
> 설계 전에 **상황에 해당하는 근거 문서 하나만 읽고** 적용하라. 셋을 다 읽지 않는다.
>
> | 지금 하려는 판단 | 읽을 문서 |
> | --- | --- |
> | 이 컴포넌트를 쪼갤까 (경계·God Component·성급한 추상화) | `docs/react/component-boundary.md` |
> | 공통 컴포넌트 인터페이스를 어떻게 (Props·값의 주인·합성) | `docs/react/props-contract.md` |
> | Drilling을 유지할까 Context로 넘길까 | `docs/react/context-and-state.md` |
```

**선택과 트레이드오프:**
앵커 참조(`docs "섹션명"`)만 정밀화하는 안도 있었습니다. 파일 이동이 없어 개입이 최소지만, 앵커는 사람에게만 유효하고 문서를 통째로 당겨 읽는 에이전트에겐 절감이 0입니다. 실제 절감을 얻으려면 파일을 갈라야 했습니다.

대가는 파일 수 증가(1 → 3)와 크로스파일 앵커 1건입니다. 그 대신 Dialog 설계 시 509 → 277줄(46% 절감)이고, 무엇보다 이 프로젝트가 곧 다룰 Compound·Headless 패턴을 얹을 자리가 생겼습니다. 기존 509줄에 그대로 얹으면 600줄을 넘습니다.

`props-contract.md`가 277줄로 셋 중 여전히 가장 큽니다. 다만 "인터페이스 설계"라는 단일 트리거로 응집돼 있어 지금 더 자를 근거는 없다고 판단했습니다. 패턴 콘텐츠를 얹은 뒤 재검토할 지점입니다.

### 3. `assignments/`·`images/`는 편입하지 않음 — 소유권이 반대인 자산

**배경 및 문제 상황:**
대상 repo의 `docs/`에는 편입한 4종 말고도 `assignments/week-01~04.md`와 `images/*.png`가 있습니다. "docs를 전부 가져오라"는 요구를 문자 그대로 따르면 이것들도 포함해야 합니다.

**해결 방안:**
커밋 저자와 upstream 트리를 실측해 소유권을 갈랐습니다. `assignments/`·`images/`는 과정 운영진이 커밋했고 `upstream/main`(loopers-labs)에 존재합니다. 반면 `docs/react/`·`docs/testing/`은 본인이 커밋했고 upstream에는 아예 없습니다.

**선택과 트레이드오프:**
OMT의 docs 배포는 선언한 파일을 backup 후 덮어씁니다. upstream 소유 파일을 OMT가 소유하면, upstream이 새 과제를 배포하고 `git pull`로 받은 뒤 `make sync`가 낡은 사본으로 되돌립니다 — pull과 sync가 서로를 지우는 루프가 됩니다. 편입하지 않는 것이 요구를 덜 만족시키는 게 아니라, 요구가 성립하는 범위를 지키는 선택입니다.

부작용으로 대상 repo의 `week-01.md` 로컬 개선분(호출자 관점 네이밍 예시)이 과제 브랜치에 없는 상태가 남습니다. 이건 upstream 파일에 대한 로컬 패치라 OMT docs로 옮길 수 없고, 브랜치 간 재적용이 맞습니다. 이 PR 범위 밖입니다.

---

## ✅ Checklist

### orchestrate-review
- [ ] 6개 앵글 전부 `model: gpt-5.6-sol`이고 `model:` 값으로서의 `gpt-5.5` 잔존 0건
  - `skills/orchestrate-review/orchestrate-review.config.yaml`

### agent-council
- [ ] `gpt` 멤버만 `gpt-5.6-sol`로 변경되고 claude/glm 멤버는 불변
  - `skills/agent-council/council.config.yaml`

### loop-pack docs 편입
- [ ] `docs:` 컴포넌트 `react`·`testing`이 각각 소스 디렉토리로 해석되고, 타깃이 `docs/react`·`docs/testing`으로 계산된다
  - `projects/loop-pack-fe-l2-vol1/sync.yaml`
- [ ] rules가 인용하는 docs 경로 6개가 전부 실재하는 파일이다 (dangling pointer 0건)
  - `projects/loop-pack-fe-l2-vol1/rules/`

### 컴포넌트 설계 문서 3분할
- [ ] 3파일의 코드펜스 총 34개·표 행 총 25개로, 원본 `component-design.md`와 일치한다 (본문 무손실)
  - `projects/loop-pack-fe-l2-vol1/docs/react/component-boundary.md`
  - `projects/loop-pack-fe-l2-vol1/docs/react/props-contract.md`
  - `projects/loop-pack-fe-l2-vol1/docs/react/context-and-state.md`
- [ ] doc 내부 앵커가 전부 같은 파일의 헤더를 가리키고, 파일을 건너가는 앵커는 크로스파일 링크로 표기됐다
  - `projects/loop-pack-fe-l2-vol1/docs/react/`
- [ ] rule의 라우팅 표 3행이 각각 실재하는 doc 파일을 가리킨다
  - `projects/loop-pack-fe-l2-vol1/rules/component-design.md`

### 공통
- [ ] `make validate` 통과
- [ ] codex CLI(≥0.144.0)에서 `codex exec -m gpt-5.6-sol` 실호출이 정상 응답 (로컬 스모크 테스트 완료)

---

## 📎 References
- [GPT-5.6 Sol 모델 스펙 (OpenAI API docs)](https://developers.openai.com/api/docs/models/gpt-5.6-sol)
- [GPT-5.6 Sol/Terra/Luna GA 공지 (OpenAI Help Center)](https://help.openai.com/en/articles/20001325-a-preview-of-gpt-56-sol-terra-and-luna)
- [codex CLI rust-v0.144.0 릴리즈](https://github.com/openai/codex/releases/tag/rust-v0.144.0)
