### PR TITLE
feat: Codex 세션-렛저 연속성 완전 패리티 이관

### DIFF
--- a/codex.yaml
+++ b/codex.yaml
@@ -44,7 +44,7 @@ hooks:
   PreToolUse:
     - component: codex-write-guard.sh
       type: command
-      matcher: "Bash|bash|apply_patch|exec_command|shell_command|Edit|Write"
+      matcher: "Bash|bash|apply_patch|exec_command|shell_command|Edit|Write|edit|write|multiedit|multi_edit"
   PostToolUse:
     - component: rules-injector
       type: command

--- a/codex.yaml
+++ b/codex.yaml
@@ -35,10 +35,16 @@ hooks:
     - component: rules-injector
       type: command
       command: "bun run .codex/hooks/rules-injector/cli.ts hook session-start"
+    - component: codex-ledger.sh
+      type: command
   UserPromptSubmit:
     - component: rules-injector
       type: command
       command: "bun run .codex/hooks/rules-injector/cli.ts hook user-prompt-submit"
+  PreToolUse:
+    - component: codex-write-guard.sh
+      type: command
+      matcher: "Bash|bash|apply_patch|exec_command|shell_command|Edit|Write"
   PostToolUse:
     - component: rules-injector
       type: command

--- a/hooks/codex-ledger.sh
+++ b/hooks/codex-ledger.sh
@@ -22,5 +22,15 @@ source "$SCRIPT_DIR_CL/ledger-core.sh"
 CORE_OUT=$(ledger_core_run codex)
 
 if [ -n "$CORE_OUT" ]; then
-  printf '%s' "$CORE_OUT" | jq -c 'del(.continue)'
+  if command -v jq &> /dev/null; then
+    printf '%s' "$CORE_OUT" | jq -c 'del(.continue)'
+  else
+    # jq unresolvable via PATH: ledger_core_run's emit line is a FIXED-FORM
+    # single-line JSON, always exactly `{"continue": true, "hookSpecificOutput":
+    # {...}}` (hooks/ledger-core.sh:191), and the core now emits it
+    # unconditionally regardless of jq presence -- so a plain sed removal of
+    # that fixed prefix reproduces jq -c 'del(.continue)' without needing jq,
+    # keeping [LEDGER RECORDING] alive for Codex even when jq is missing.
+    printf '%s' "$CORE_OUT" | sed 's/^{"continue": true, /{/'
+  fi
 fi

--- a/hooks/codex-ledger.sh
+++ b/hooks/codex-ledger.sh
@@ -13,6 +13,28 @@
 # {"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": ...}}.
 #
 # omt-hook-dep: ledger-core.sh
+#
+# set -euo pipefail is intentionally OMITTED here (mirrors hooks/session-
+# start.sh, which shares this same ledger-core.sh and omits it for the same
+# reason): the required [LEDGER RECORDING] output must emit unconditionally
+# regardless of whether jq is missing, present-and-working, or present-but-
+# FAILING (a broken/partial install, arch-mismatch, or PATH-shadowing
+# wrapper) -- and a plain `command | jq ...` top-level pipe has no built-in
+# immunity to that last case. `CORE_OUT=$(ledger_core_run codex)` below is
+# safe under errexit on its own (bash does not propagate errexit into a
+# command-substitution subshell unless `inherit_errexit` is explicitly
+# enabled, which it is not here), so ledger_core_run's internal jq calls
+# (compaction-recovery parsing) can never abort this script before its own
+# unconditional terminal `echo` runs. But the emit step immediately below
+# re-pipes CORE_OUT through jq at the top level, with no such immunity: if
+# that jq exists on PATH but exits non-zero without writing to stdout, the
+# pipe itself fails, and set -e would abort the whole script before the
+# marker is ever printed. Dropping set -e turns that into a silent no-op
+# instead of a crash -- but the marker survives regardless because the emit
+# block below captures the jq transform's success/failure explicitly and
+# falls back to the fixed-form sed transform on ANY jq trouble (missing OR
+# failing), not just on absence. See hooks/codex-ledger_test.sh for the
+# jq-absent, jq-failing, and malformed-stdin regression cases.
 # =============================================================================
 
 SCRIPT_DIR_CL="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -22,15 +44,20 @@ source "$SCRIPT_DIR_CL/ledger-core.sh"
 CORE_OUT=$(ledger_core_run codex)
 
 if [ -n "$CORE_OUT" ]; then
-  if command -v jq &> /dev/null; then
-    printf '%s' "$CORE_OUT" | jq -c 'del(.continue)'
+  # jq is invoked inside an `if` condition so a present-but-failing binary
+  # (broken install, arch-mismatch, PATH-shadowing wrapper) is caught here
+  # rather than aborting the script -- `if`/`&&` conditions are exempt from
+  # errexit regardless of whether it's enabled. On any jq trouble (missing
+  # from PATH, or present but failing/producing empty output), fall back to
+  # the fixed-form sed transform: ledger_core_run's emit line is always
+  # exactly `{"continue": true, "hookSpecificOutput": {...}}`
+  # (hooks/ledger-core.sh:205), emitted unconditionally regardless of jq
+  # presence, so a plain sed removal of that fixed prefix reproduces
+  # `jq -c 'del(.continue)'` without needing a working jq, keeping
+  # [LEDGER RECORDING] alive for Codex in every case.
+  if command -v jq &> /dev/null && CODEX_OUT=$(printf '%s' "$CORE_OUT" | jq -c 'del(.continue)') && [ -n "$CODEX_OUT" ]; then
+    printf '%s\n' "$CODEX_OUT"
   else
-    # jq unresolvable via PATH: ledger_core_run's emit line is a FIXED-FORM
-    # single-line JSON, always exactly `{"continue": true, "hookSpecificOutput":
-    # {...}}` (hooks/ledger-core.sh:191), and the core now emits it
-    # unconditionally regardless of jq presence -- so a plain sed removal of
-    # that fixed prefix reproduces jq -c 'del(.continue)' without needing jq,
-    # keeping [LEDGER RECORDING] alive for Codex even when jq is missing.
     printf '%s' "$CORE_OUT" | sed 's/^{"continue": true, /{/'
   fi
 fi

--- a/hooks/codex-ledger.sh
+++ b/hooks/codex-ledger.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# =============================================================================
+# codex-ledger.sh
+# Codex SessionStart ledger hook (plan TODO 6: codex-ledger-parity).
+#
+# Thin entry point: reads stdin {source, session_id, cwd}, sources
+# ledger-core.sh, and invokes ledger_core_run with the explicit "codex"
+# platform signal -- all recording/recovery logic lives in the shared core
+# (hooks/ledger-core.sh), not here.
+#
+# Codex's SessionStart hook contract has no `continue` key (Claude-only), so
+# this hook strips it from the core's output and emits ONLY
+# {"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": ...}}.
+#
+# omt-hook-dep: ledger-core.sh
+# =============================================================================
+
+SCRIPT_DIR_CL="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=hooks/ledger-core.sh
+source "$SCRIPT_DIR_CL/ledger-core.sh"
+
+CORE_OUT=$(ledger_core_run codex)
+
+if [ -n "$CORE_OUT" ]; then
+  printf '%s' "$CORE_OUT" | jq -c 'del(.continue)'
+fi

--- a/hooks/codex-ledger_test.sh
+++ b/hooks/codex-ledger_test.sh
@@ -146,6 +146,75 @@ test_jq_absent_recording_survives_no_continue() {
 }
 
 # =============================================================================
+# Regression: jq present but FAILING (broken binary, exit 1, no stdout) must
+# not drop the recording instruction. ledger_core_run's own internal jq calls
+# (source==compact detection, sid extraction) run inside the
+# `CORE_OUT=$(ledger_core_run codex)` command substitution at codex-ledger.sh,
+# so their failure never escapes -- CORE_OUT still ends up fully formed
+# (hooks/ledger-core.sh:205 always echoes). The actual failure point is this
+# hook's OWN emit step: `printf '%s' "$CORE_OUT" | jq -c 'del(.continue)'` is a
+# plain top-level pipe (not inside `$(...)`), so a present-but-failing jq
+# writes nothing to stdout there and the pipe's non-zero exit is NOT
+# swallowed. Exercise a PATH with a broken jq shim (exit 1, no output)
+# alongside the externals this jq-present path legitimately needs
+# (dirname/cat/sed).
+# =============================================================================
+test_jq_failing_recording_survives_no_continue() {
+    local broken_jq_bin out rc ok=0
+
+    broken_jq_bin=$(mktemp -d)
+    ln -s /usr/bin/dirname "$broken_jq_bin/dirname"
+    ln -s /bin/cat "$broken_jq_bin/cat"
+    ln -s /usr/bin/sed "$broken_jq_bin/sed"
+    printf '#!/bin/bash\nexit 1\n' > "$broken_jq_bin/jq"
+    chmod +x "$broken_jq_bin/jq"
+
+    set +e
+    # Absolute /bin/bash sidesteps a bare `bash` lookup failing against the
+    # restricted PATH being assigned (same rationale as
+    # hooks/ledger-core_test.sh:165-172).
+    out=$(printf '{"source":"startup","session_id":"cx","cwd":"/tmp"}' \
+        | PATH="$broken_jq_bin" OMT_DIR=/tmp/x /bin/bash "$HOOK" 2>/dev/null)
+    rc=$?
+    set -e
+    rm -rf "$broken_jq_bin"
+
+    if [ "$rc" = "0" ] \
+        && echo "$out" | grep -q '\[LEDGER RECORDING\]' \
+        && [ "$(printf '%s' "$out" | grep -c '^{"continue"')" = "0" ] \
+        && echo "$out" | grep -q 'hookSpecificOutput'; then
+        ok=1
+    fi
+
+    [ "$ok" = "1" ]
+}
+
+# =============================================================================
+# Regression: malformed stdin JSON must not abort the script. ledger_core_run's
+# compaction-recovery branch pipes stdin through jq, which fails (exit 5) on
+# unparseable JSON -- but that failure occurs inside the
+# `CORE_OUT=$(ledger_core_run codex)` command substitution subshell, and bash
+# does not propagate errexit into a command substitution unless
+# `inherit_errexit` is explicitly enabled (it is not here, and this hook no
+# longer sets -e at all -- see the comment at the top of hooks/codex-ledger.sh),
+# so [LEDGER RECORDING] must still emit unconditionally.
+# =============================================================================
+test_malformed_stdin_does_not_abort_recording() {
+    local out rc ok=0
+
+    set +e
+    out=$(printf '%s' 'not valid json {{{' | OMT_DIR=/tmp/x bash "$HOOK" 2>/dev/null)
+    rc=$?
+    set -e
+
+    if [ "$rc" = "0" ] && echo "$out" | grep -q '\[LEDGER RECORDING\]'; then
+        ok=1
+    fi
+
+    [ "$ok" = "1" ]
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 main() {
@@ -157,6 +226,8 @@ main() {
     run_test test_qa_recording_startup_no_claude_env_leak
     run_test test_qa_no_continue_contract
     run_test test_jq_absent_recording_survives_no_continue
+    run_test test_jq_failing_recording_survives_no_continue
+    run_test test_malformed_stdin_does_not_abort_recording
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/codex-ledger_test.sh
+++ b/hooks/codex-ledger_test.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# =============================================================================
+# codex-ledger.sh Tests (plan TODO 6: codex-ledger-parity)
+#
+# Behavioral tests for the thin Codex SessionStart ledger hook. Drives
+# hooks/codex-ledger.sh via synthetic SessionStart stdin JSON, mirroring the
+# harness pattern in hooks/session-start_test.sh:1542-1575 (synthetic-stdin ->
+# jq-decode the raw stdout).
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/codex-ledger.sh"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+run_test() {
+    local test_name="$1"
+    if "$test_name"; then
+        echo "[PASS] $test_name"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "[FAIL] $test_name"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+# =============================================================================
+# AC: source==compact emits SessionStart additionalContext with
+# [LEDGER RECOVERY] and OMITS `continue`.
+# =============================================================================
+test_compact_emits_recovery_no_continue() {
+    local SBX OD out ok=0
+    SBX=$(mktemp -d)
+    OD="$SBX/omt"
+    mkdir -p "$OD"
+    printf '## Now\nCX\n## User Corrections (verbatim)\n' > "$OD/session-ledger-cx-sid.md"
+
+    out=$(printf '{"source":"compact","session_id":"cx-sid","cwd":"%s"}' "$SBX" \
+        | OMT_DIR="$OD" bash -c "unset OMT_SESSION_ID CODEX_THREAD_ID; exec bash '$HOOK'" 2>/dev/null)
+
+    if echo "$out" | jq -e '.hookSpecificOutput.hookEventName=="SessionStart"' >/dev/null 2>&1 \
+        && echo "$out" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null | grep -q '\[LEDGER RECOVERY\]' \
+        && [ "$(printf '%s' "$out" | jq 'has("continue")')" = "false" ]; then
+        ok=1
+    fi
+
+    rm -rf "$SBX"
+    [ "$ok" = "1" ]
+}
+
+# =============================================================================
+# QA Scenario: Recording on Codex startup -- part-2 on Codex.
+# Evidence: $OMT_DIR/evidence/codex-ledger-parity/codex-ledger-hook/recording-startup.txt
+# =============================================================================
+test_qa_recording_startup_no_claude_env_leak() {
+    local out ctx ok=0
+    out=$(printf '{"source":"startup","session_id":"cx","cwd":"/tmp"}' \
+        | OMT_DIR=/tmp/x bash "$HOOK" 2>/dev/null)
+    ctx=$(printf '%s' "$out" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null || echo "")
+
+    if echo "$ctx" | grep -q '\[LEDGER RECORDING\]' \
+        && [ "$(printf '%s' "$ctx" | grep -c 'CLAUDE_ENV_FILE')" = "0" ]; then
+        ok=1
+    fi
+
+    local evidence_dir
+    evidence_dir=$(bash -c "source '$SCRIPT_DIR/lib/omt-dir.sh'; resolve_omt_dir '$SCRIPT_DIR'")/evidence/codex-ledger-parity/codex-ledger-hook
+    mkdir -p "$evidence_dir"
+    {
+        echo "# QA Scenario: Recording on Codex startup"
+        echo "# Command: printf '{\"source\":\"startup\",...}' | OMT_DIR=/tmp/x bash hooks/codex-ledger.sh"
+        echo "# Result: ok=$ok (1=PASS, 0=FAIL)"
+        echo "---- additionalContext ----"
+        echo "$ctx"
+    } > "$evidence_dir/recording-startup.txt"
+
+    [ "$ok" = "1" ]
+}
+
+# =============================================================================
+# QA Scenario: No-continue contract -- cross-platform-valid shape.
+# Evidence: $OMT_DIR/evidence/codex-ledger-parity/codex-ledger-hook/no-continue.txt
+# =============================================================================
+test_qa_no_continue_contract() {
+    local out ok=0
+    out=$(printf '{"source":"startup","session_id":"cx","cwd":"/tmp"}' \
+        | OMT_DIR=/tmp/x bash "$HOOK" 2>/dev/null)
+
+    if [ "$(printf '%s' "$out" | jq 'has("continue")')" = "false" ]; then
+        ok=1
+    fi
+
+    local evidence_dir
+    evidence_dir=$(bash -c "source '$SCRIPT_DIR/lib/omt-dir.sh'; resolve_omt_dir '$SCRIPT_DIR'")/evidence/codex-ledger-parity/codex-ledger-hook
+    mkdir -p "$evidence_dir"
+    {
+        echo "# QA Scenario: No-continue contract"
+        echo "# Command: printf '{\"source\":\"startup\",...}' | OMT_DIR=/tmp/x bash hooks/codex-ledger.sh"
+        echo "# Result: ok=$ok (1=PASS, 0=FAIL)"
+        echo "---- stdout ----"
+        echo "$out"
+    } > "$evidence_dir/no-continue.txt"
+
+    [ "$ok" = "1" ]
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+main() {
+    echo "=========================================="
+    echo "codex-ledger.sh Tests"
+    echo "=========================================="
+
+    run_test test_compact_emits_recovery_no_continue
+    run_test test_qa_recording_startup_no_claude_env_leak
+    run_test test_qa_no_continue_contract
+
+    echo "=========================================="
+    echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"
+    echo "=========================================="
+
+    if [ "$TESTS_FAILED" -gt 0 ]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/hooks/codex-ledger_test.sh
+++ b/hooks/codex-ledger_test.sh
@@ -107,6 +107,45 @@ test_qa_no_continue_contract() {
 }
 
 # =============================================================================
+# Regression: jq unresolvable via PATH must not drop the recording
+# instruction. ledger-core.sh emits [LEDGER RECORDING] unconditionally
+# (outside any jq/sid gate -- hooks/ledger-core.sh:41-65), but this hook's
+# own emit step re-pipes that core output through `jq -c 'del(.continue)'`
+# with no jq-presence check. If jq is absent that pipe fails and the WHOLE
+# core output is dropped, silently defeating the core's byte-preservation
+# guarantee for Codex. Exercise a PATH that lacks jq but keeps the externals
+# this jq-absent path legitimately needs (dirname/cat/sed), mirroring
+# hooks/ledger-core_test.sh:149-198's jq_less_bin pattern.
+# =============================================================================
+test_jq_absent_recording_survives_no_continue() {
+    local jq_less_bin out rc ok=0
+
+    jq_less_bin=$(mktemp -d)
+    ln -s /usr/bin/dirname "$jq_less_bin/dirname"
+    ln -s /bin/cat "$jq_less_bin/cat"
+    ln -s /usr/bin/sed "$jq_less_bin/sed"
+
+    set +e
+    # Absolute /bin/bash sidesteps a bare `bash` lookup failing against the
+    # restricted PATH being assigned (same rationale as
+    # hooks/ledger-core_test.sh:165-172).
+    out=$(printf '{"source":"startup","session_id":"cx","cwd":"/tmp"}' \
+        | PATH="$jq_less_bin" OMT_DIR=/tmp/x /bin/bash "$HOOK" 2>/dev/null)
+    rc=$?
+    set -e
+    rm -rf "$jq_less_bin"
+
+    if [ "$rc" = "0" ] \
+        && echo "$out" | grep -q '\[LEDGER RECORDING\]' \
+        && [ "$(printf '%s' "$out" | grep -c '^{"continue"')" = "0" ] \
+        && echo "$out" | grep -q 'hookSpecificOutput'; then
+        ok=1
+    fi
+
+    [ "$ok" = "1" ]
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 main() {
@@ -117,6 +156,7 @@ main() {
     run_test test_compact_emits_recovery_no_continue
     run_test test_qa_recording_startup_no_claude_env_leak
     run_test test_qa_no_continue_contract
+    run_test test_jq_absent_recording_survives_no_continue
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/codex-write-guard.sh
+++ b/hooks/codex-write-guard.sh
@@ -380,10 +380,31 @@ case "$tool_name" in
         shell_cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) || shell_cmd=""
         shell_cmd_alt=$(printf '%s' "$input" | jq -r '.tool_input.cmd // empty' 2>/dev/null) || shell_cmd_alt=""
 
+        # Resolve relative write targets against the command's OWN working
+        # directory -- tool_input.workdir ?? tool_input.cwd -- mirroring the
+        # sibling extractor tool-paths.ts:44-46 (workdir ?? cwd) for command
+        # tools. Without this, a payload that sets workdir=<ledger dir> plus a
+        # relative target wrote the real ledger while _cwg_absolutize resolved
+        # it against the hook-level cwd and the guard allowed it. Scope: this
+        # shell route only; edit/write/apply_patch keep plain cwd, as
+        # tool-paths.ts does. A relative workdir is itself resolved against the
+        # hook cwd. Saved/restored so the reassignment cannot leak to any
+        # later route.
+        _cwg_route_workdir=$(printf '%s' "$input" | jq -r '.tool_input.workdir // .tool_input.cwd // empty' 2>/dev/null) || _cwg_route_workdir=""
+        _cwg_saved_cwd="$cwd"
+        if [ -n "$_cwg_route_workdir" ]; then
+            case "$_cwg_route_workdir" in
+                /*) cwd="$_cwg_route_workdir" ;;
+                *) cwd="$cwd/$_cwg_route_workdir" ;;
+            esac
+        fi
+
         _cwg_process_shell_text "$shell_cmd"
         if [ "$shell_cmd_alt" != "$shell_cmd" ]; then
             _cwg_process_shell_text "$shell_cmd_alt"
         fi
+
+        cwd="$_cwg_saved_cwd"
         ;;
 esac
 

--- a/hooks/codex-write-guard.sh
+++ b/hooks/codex-write-guard.sh
@@ -206,6 +206,35 @@ _cwg_add_candidate() {
     candidates_text="${candidates_text}$(_cwg_absolutize "$1")"$'\n'
 }
 
+# _cwg_process_shell_text <shell_command_text>
+# Runs the heredoc-body scan and the redirect/tee/rm/cp/mv/sed/dd classifier
+# over one shell-text payload. Factored out so the Bash|bash|exec_command|
+# shell_command route below can run it once per alternate payload key
+# (tool_input.command and tool_input.cmd) without duplicating the logic.
+_cwg_process_shell_text() {
+    local shell_cmd="$1"
+    [ -n "$shell_cmd" ] || return 0
+
+    # Bash-embedded apply_patch heredoc body -- its own surface, scanned
+    # with the same header parser as the apply_patch envelope route.
+    local heredoc_body
+    heredoc_body=$(_cwg_extract_heredoc_body "$shell_cmd")
+    if [ -n "$heredoc_body" ]; then
+        while IFS= read -r hdr; do
+            _cwg_add_candidate "$hdr"
+        done < <(_cwg_extract_patch_headers "$heredoc_body")
+    fi
+
+    # Redirect / tee / rm classifier, per chain segment (split on
+    # && || ; |, matching pre-tool-enforcer.sh's segmentation).
+    while IFS= read -r seg; do
+        [ -n "$seg" ] || continue
+        while IFS= read -r tgt; do
+            _cwg_add_candidate "$tgt"
+        done < <(_cwg_extract_shell_targets "$seg")
+    done < <(printf '%s\n' "$shell_cmd" | sed -E 's/(&&|\|\||;|\|)/\n/g')
+}
+
 # -----------------------------------------------------------------------------
 # Route: tool_name -> parse strategy -> candidate targets.
 # -----------------------------------------------------------------------------
@@ -215,31 +244,35 @@ case "$tool_name" in
         _cwg_add_candidate "$fp"
         ;;
     apply_patch)
-        patch_cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) || patch_cmd=""
-        while IFS= read -r hdr; do
-            _cwg_add_candidate "$hdr"
-        done < <(_cwg_extract_patch_headers "$patch_cmd")
-        ;;
-    Bash | bash | exec_command | shell_command)
-        shell_cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) || shell_cmd=""
-
-        # Bash-embedded apply_patch heredoc body -- its own surface, scanned
-        # with the same header parser as the apply_patch envelope route.
-        heredoc_body=$(_cwg_extract_heredoc_body "$shell_cmd")
-        if [ -n "$heredoc_body" ]; then
+        # Codex has been observed sending the apply_patch payload text under
+        # any of command/input/patch/cmd depending on client -- scan ALL
+        # FOUR keys (not a first-match fallback), mirroring the sibling
+        # extractor hooks/rules-injector/tool-paths.ts:addPatchPayloadPaths.
+        # Reading only .command let an input/patch/cmd-only payload bypass
+        # the guard entirely; reading more keys carries no over-block risk
+        # since write_guard_core_run only denies on a full-path EXACT match
+        # against the resolved current-session ledger.
+        for _cwg_key in command input patch cmd; do
+            patch_cmd=$(printf '%s' "$input" | jq -r --arg k "$_cwg_key" '.tool_input[$k] // empty' 2>/dev/null) || patch_cmd=""
+            [ -n "$patch_cmd" ] || continue
             while IFS= read -r hdr; do
                 _cwg_add_candidate "$hdr"
-            done < <(_cwg_extract_patch_headers "$heredoc_body")
-        fi
+            done < <(_cwg_extract_patch_headers "$patch_cmd")
+        done
+        ;;
+    Bash | bash | exec_command | shell_command)
+        # Codex has been observed sending the shell text under
+        # tool_input.command normally, but also under tool_input.cmd for
+        # exec_command/shell_command payloads -- process both keys (not a
+        # first-match fallback) so a cmd-only payload isn't silently
+        # unguarded, mirroring tool-paths.ts's command/cmd fallback.
+        shell_cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) || shell_cmd=""
+        shell_cmd_alt=$(printf '%s' "$input" | jq -r '.tool_input.cmd // empty' 2>/dev/null) || shell_cmd_alt=""
 
-        # Redirect / tee / rm classifier, per chain segment (split on
-        # && || ; |, matching pre-tool-enforcer.sh's segmentation).
-        while IFS= read -r seg; do
-            [ -n "$seg" ] || continue
-            while IFS= read -r tgt; do
-                _cwg_add_candidate "$tgt"
-            done < <(_cwg_extract_shell_targets "$seg")
-        done < <(printf '%s\n' "$shell_cmd" | sed -E 's/(&&|\|\||;|\|)/\n/g')
+        _cwg_process_shell_text "$shell_cmd"
+        if [ "$shell_cmd_alt" != "$shell_cmd" ]; then
+            _cwg_process_shell_text "$shell_cmd_alt"
+        fi
         ;;
 esac
 

--- a/hooks/codex-write-guard.sh
+++ b/hooks/codex-write-guard.sh
@@ -2,16 +2,21 @@
 # =============================================================================
 # Codex PreToolUse Write-Guard (codex-ledger-parity plan, TODO 7): a thin
 # Codex-specific shim that parses Codex write routes (apply_patch envelope,
-# Bash-embedded apply_patch heredoc, shell redirect/tee/rm, native Edit/Write),
-# resolves OMT_DIR/session_id, absolutizes candidate targets against cwd, and
-# delegates the actual full-path anchor-match + deny JSON to
-# write_guard_core_run (hooks/write-guard-core.sh) -- this file never emits
-# the deny JSON itself, and never folds apply_patch parsing into the shared
-# core (that would drift Claude's byte-identical deny at
+# Bash-embedded apply_patch heredoc, shell redirect/tee/rm, native
+# Edit/Write/MultiEdit), resolves OMT_DIR/session_id, absolutizes candidate
+# targets against cwd, and delegates the actual full-path anchor-match + deny
+# JSON to write_guard_core_run (hooks/write-guard-core.sh) -- this file never
+# emits the deny JSON itself, and never folds apply_patch parsing into the
+# shared core (that would drift Claude's byte-identical deny at
 # hooks/pre-tool-enforcer.sh).
 #
+# tool_name is normalized to lowercase before routing (mirroring the sibling
+# extractor hooks/rules-injector/tool-paths.ts:29's toLowerCase()), so both
+# capitalized native names (Edit/Write) and Codex's lowercase native names
+# (write/edit/multiedit/multi_edit) are covered by one case arm each.
 # Write-route set mirrors the sibling PostToolUse matcher (codex.yaml:45):
-# apply_patch | Bash | bash | exec_command | shell_command | Edit | Write.
+# apply_patch | bash | exec_command | shell_command | edit | write |
+# multiedit | multi_edit.
 #
 # BEST-EFFORT, not security-complete: headers/targets are absolutized
 # against cwd to cover the common case, not a full shell parser.
@@ -29,10 +34,17 @@ fi
 
 input=$(cat)
 
-tool_name=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null) || tool_name=""
+# Normalize tool_name to lowercase before routing, mirroring the sibling
+# extractor hooks/rules-injector/tool-paths.ts:29 (toLowerCase()) -- Codex
+# has been observed sending native write tools under their lowercase form
+# (write/edit/multiedit/multi_edit), which the allow-list below used to miss
+# entirely, falling through to `exit 0` before ever reaching the ledger-path
+# check. macOS Bash 3.2 has no ${var,,}, so tr is used instead.
+tool_name_raw=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null) || tool_name_raw=""
+tool_name=$(printf '%s' "$tool_name_raw" | tr '[:upper:]' '[:lower:]')
 
 case "$tool_name" in
-    apply_patch | Bash | bash | exec_command | shell_command | Edit | Write) ;;
+    apply_patch | bash | exec_command | shell_command | edit | write | multiedit | multi_edit) ;;
     *) exit 0 ;;
 esac
 
@@ -208,7 +220,7 @@ _cwg_add_candidate() {
 
 # _cwg_process_shell_text <shell_command_text>
 # Runs the heredoc-body scan and the redirect/tee/rm/cp/mv/sed/dd classifier
-# over one shell-text payload. Factored out so the Bash|bash|exec_command|
+# over one shell-text payload. Factored out so the bash|exec_command|
 # shell_command route below can run it once per alternate payload key
 # (tool_input.command and tool_input.cmd) without duplicating the logic.
 _cwg_process_shell_text() {
@@ -239,9 +251,25 @@ _cwg_process_shell_text() {
 # Route: tool_name -> parse strategy -> candidate targets.
 # -----------------------------------------------------------------------------
 case "$tool_name" in
-    Edit | Write)
-        fp=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || fp=""
-        _cwg_add_candidate "$fp"
+    edit | write | multiedit | multi_edit)
+        # Scan ALL common single-path keys (not a first-match fallback),
+        # mirroring the sibling extractor hooks/rules-injector/tool-paths.ts's
+        # addCommonPathFields (:52-63). Reading only .file_path let a payload
+        # carrying the target under .path/.filePath/.target/.targetPath/
+        # .target_path bypass the guard entirely; reading more keys carries
+        # no over-block risk since write_guard_core_run only denies on a
+        # full-path EXACT match against the resolved current-session ledger.
+        for _cwg_key in file_path path filePath target targetPath target_path; do
+            fp=$(printf '%s' "$input" | jq -r --arg k "$_cwg_key" '.tool_input[$k] // empty' 2>/dev/null) || fp=""
+            _cwg_add_candidate "$fp"
+        done
+        # Array-form path keys (multi-file edit payloads), mirroring
+        # tool-paths.ts's addPathArray over paths/filePaths/file_paths.
+        for _cwg_key in paths filePaths file_paths; do
+            while IFS= read -r fp; do
+                _cwg_add_candidate "$fp"
+            done < <(printf '%s' "$input" | jq -r --arg k "$_cwg_key" '.tool_input[$k]? // [] | .[]?' 2>/dev/null)
+        done
         ;;
     apply_patch)
         # Codex has been observed sending the apply_patch payload text under
@@ -260,7 +288,7 @@ case "$tool_name" in
             done < <(_cwg_extract_patch_headers "$patch_cmd")
         done
         ;;
-    Bash | bash | exec_command | shell_command)
+    bash | exec_command | shell_command)
         # Codex has been observed sending the shell text under
         # tool_input.command normally, but also under tool_input.cmd for
         # exec_command/shell_command payloads -- process both keys (not a

--- a/hooks/codex-write-guard.sh
+++ b/hooks/codex-write-guard.sh
@@ -172,14 +172,31 @@ _cwg_extract_shell_targets() {
     esac
 }
 
+# _cwg_strip_quotes <token> -- removes a single leading+trailing double-quote
+# pair, then a single leading+trailing single-quote pair, mirroring the
+# Claude twin's _wg_strip_dquotes (hooks/pre-tool-enforcer.sh:52-57) extended
+# to single quotes -- a quoted redirect/rm/tee target (`> "$f"` or `> '$f'`)
+# still carries its quote characters after extraction and must be unwrapped
+# before write_guard_core_run's full-path EXACT comparison.
+_cwg_strip_quotes() {
+    local s="$1"
+    s="${s#\"}"
+    s="${s%\"}"
+    s="${s#\'}"
+    s="${s%\'}"
+    printf '%s\n' "$s"
+}
+
 # _cwg_absolutize <path>
-# Joins a relative path against the resolved cwd; leaves an absolute path
-# unchanged. write_guard_core_run requires already-absolutized candidates
-# (full-path EXACT match).
+# Strips surrounding quotes, then joins a relative path against the resolved
+# cwd; leaves an absolute path unchanged. write_guard_core_run requires
+# already-absolutized candidates (full-path EXACT match).
 _cwg_absolutize() {
-    case "$1" in
-        /*) printf '%s\n' "$1" ;;
-        *) printf '%s\n' "$cwd/$1" ;;
+    local p
+    p="$(_cwg_strip_quotes "$1")"
+    case "$p" in
+        /*) printf '%s\n' "$p" ;;
+        *) printf '%s\n' "$cwd/$p" ;;
     esac
 }
 

--- a/hooks/codex-write-guard.sh
+++ b/hooks/codex-write-guard.sh
@@ -184,6 +184,47 @@ _cwg_extract_shell_targets() {
     esac
 }
 
+# _cwg_mask_quoted <shell_command_text>
+# Quote-aware normalizer, re-derived from the same algorithm as the Claude
+# twin's _wg_scan (hooks/pre-tool-enforcer.sh:160-179): masks shell-active
+# metacharacters (`> < | ; &`) that appear INSIDE a single-quoted span by
+# replacing them with a space, and drops the quote CHARACTERS themselves
+# while preserving the quoted CONTENT -- so prose like
+# `printf 'see foo > <ledger> here' | omt-ledger.sh append` is never
+# misread by the redirect/segment-splitter logic below as a live redirect
+# or a live `|`/`;`/`&` chain separator. Without this, ANY `>` in the raw
+# shell text -- quoted or not -- was read as a live redirect, so a
+# legitimate ledger-append command whose prose happened to contain
+# `> <ledger>` inside quotes was denied (a false-positive over-block).
+# Double-quoted spans (`> "$f"`) and metacharacters OUTSIDE any quote (real
+# redirects/splitters) pass through unchanged -- same single-quote-only
+# scope as the Claude twin. This is independently re-derived bash+awk, not
+# sourced from the sibling file (Claude/Codex parsing intentionally never
+# shares code, see the file header) -- so the two guards can still diverge
+# if one is edited without the other.
+_cwg_mask_quoted() {
+    printf '%s' "$1" | awk '
+        BEGIN { sq = sprintf("%c", 39) }
+        {
+            n = length($0)
+            inq = 0
+            out = ""
+            for (i = 1; i <= n; i++) {
+                c = substr($0, i, 1)
+                if (c == sq) {
+                    inq = 1 - inq
+                    continue
+                }
+                if (inq && (c == ">" || c == "<" || c == "|" || c == ";" || c == "&")) {
+                    out = out " "
+                    continue
+                }
+                out = out c
+            }
+            print out
+        }'
+}
+
 # _cwg_strip_quotes <token> -- removes a single leading+trailing double-quote
 # pair, then a single leading+trailing single-quote pair, mirroring the
 # Claude twin's _wg_strip_dquotes (hooks/pre-tool-enforcer.sh:52-57) extended
@@ -255,8 +296,12 @@ _cwg_process_shell_text() {
     local shell_cmd="$1"
     [ -n "$shell_cmd" ] || return 0
 
-    # Bash-embedded apply_patch heredoc body -- its own surface, scanned
-    # with the same header parser as the apply_patch envelope route.
+    # Bash-embedded apply_patch heredoc body -- its own surface, scanned on
+    # the RAW (unmasked) shell_cmd with the same header parser as the
+    # apply_patch envelope route. Must run BEFORE masking: the heredoc
+    # delimiter grep in _cwg_extract_heredoc_body matches on the literal
+    # quote characters around the delimiter (e.g. `apply_patch <<'EOF'`),
+    # which _cwg_mask_quoted would have already stripped.
     local heredoc_body
     heredoc_body=$(_cwg_extract_heredoc_body "$shell_cmd")
     if [ -n "$heredoc_body" ]; then
@@ -265,6 +310,16 @@ _cwg_process_shell_text() {
         done < <(_cwg_extract_patch_headers "$heredoc_body")
     fi
 
+    # Quote-aware masking BEFORE chain-splitting and redirect/rm
+    # extraction: without this, a `>` (or `|`/`;`/`&`) inside a single-
+    # quoted string was read the same as a live shell metacharacter, so
+    # prose like `printf 'see foo > <ledger>' | omt-ledger.sh append`
+    # falsely matched the redirect classifier below and denied a
+    # legitimate ledger-append command. See _cwg_mask_quoted for the full
+    # rationale and its parity with the Claude twin's _wg_scan.
+    local masked
+    masked=$(_cwg_mask_quoted "$shell_cmd")
+
     # Redirect / tee / rm classifier, per chain segment (split on
     # && || ; |, matching pre-tool-enforcer.sh's segmentation).
     while IFS= read -r seg; do
@@ -272,7 +327,7 @@ _cwg_process_shell_text() {
         while IFS= read -r tgt; do
             _cwg_add_candidate "$tgt"
         done < <(_cwg_extract_shell_targets "$seg")
-    done < <(printf '%s\n' "$shell_cmd" | sed -E 's/(&&|\|\||;|\|)/\n/g')
+    done < <(printf '%s\n' "$masked" | sed -E 's/(&&|\|\||;|\|)/\n/g')
 }
 
 # -----------------------------------------------------------------------------

--- a/hooks/codex-write-guard.sh
+++ b/hooks/codex-write-guard.sh
@@ -142,9 +142,14 @@ _cwg_extract_shell_targets() {
 
     # Redirect target: the token after the last `>` / `>>`, excluding fd
     # duplications like `2>&1` / `>&2`.
+    # `|| true`: grep -oE returns 1 when a segment has no redirect at all --
+    # under this script's `set -euo pipefail`, an unguarded nonzero pipeline
+    # here would abort the function (via the process-substitution subshell
+    # that invokes it) before the case block below -- tee/rm/truncate/cp/mv/
+    # sed -i/dd -- ever runs, silently ALLOWING those write routes.
     printf '%s\n' "$seg" \
         | grep -oE '(^|[^0-9&])>{1,2}[[:space:]]*[^[:space:]&][^[:space:]]*' \
-        | sed -E 's/^.*>{1,2}[[:space:]]*//'
+        | sed -E 's/^.*>{1,2}[[:space:]]*//' || true
 
     case "$first_word" in
         tee | rm | truncate)
@@ -159,7 +164,10 @@ _cwg_extract_shell_targets() {
             fi
             ;;
         dd)
-            printf '%s\n' "$seg" | grep -oE 'of=[^[:space:]]+' | sed 's/^of=//'
+            # Same set -e/pipefail hazard as the redirect grep above:
+            # `of=` is absent for a plain `dd if=x` read, so this grep can
+            # legitimately return 1.
+            printf '%s\n' "$seg" | grep -oE 'of=[^[:space:]]+' | sed 's/^of=//' || true
             ;;
     esac
 }

--- a/hooks/codex-write-guard.sh
+++ b/hooks/codex-write-guard.sh
@@ -200,12 +200,40 @@ _cwg_strip_quotes() {
 }
 
 # _cwg_absolutize <path>
-# Strips surrounding quotes, then joins a relative path against the resolved
-# cwd; leaves an absolute path unchanged. write_guard_core_run requires
-# already-absolutized candidates (full-path EXACT match).
+# Strips surrounding quotes, expands the three known ledger-path env-vars
+# via pure bash literal substitution, then joins a relative path against the
+# resolved cwd; leaves an absolute path unchanged. write_guard_core_run
+# requires already-absolutized candidates (full-path EXACT match).
+#
+# Same rationale as the Claude twin _wg_absolutize (hooks/pre-tool-
+# enforcer.sh): a candidate arrives as LITERAL command text, and the old
+# code treated a "$OMT_DIR/..." token as relative (cwd-prefixed) instead of
+# resolving the env-var reference, silently allowing the exact form Codex's
+# SessionStart recovery pointer teaches agents to reproduce.
+#
+# ${p//find/replace} is a pure bash string substitution -- never eval/
+# envsubst. THREE variables are expanded (one more than the Claude twin):
+# $OMT_DIR -> $omt_dir, and BOTH $OMT_SESSION_ID and $CODEX_THREAD_ID ->
+# $sid, because Codex's resolved session id is OMT_SESSION_ID ?? CODEX_
+# THREAD_ID (resolved above at :74-89) -- either env-var spelling composes
+# the same real ledger path. The braced form (${VAR}) is substituted before
+# the bare $VAR form to avoid a partial-match artifact.
+#
+# KNOWN LIMITATION: a single-quoted env-var reference (`rm '$OMT_DIR/...'`)
+# is an inert shell literal that never expands at real execution time
+# either, but _cwg_strip_quotes has already removed the quote characters by
+# the time this function runs, so it is indistinguishable here from a
+# double-quoted reference and gets substituted (and matched) the same way --
+# a safe false-positive on an already-inert command, not a bypass.
 _cwg_absolutize() {
     local p
     p="$(_cwg_strip_quotes "$1")"
+    p="${p//\$\{OMT_DIR\}/$omt_dir}"
+    p="${p//\$\{OMT_SESSION_ID\}/$sid}"
+    p="${p//\$\{CODEX_THREAD_ID\}/$sid}"
+    p="${p//\$OMT_DIR/$omt_dir}"
+    p="${p//\$OMT_SESSION_ID/$sid}"
+    p="${p//\$CODEX_THREAD_ID/$sid}"
     case "$p" in
         /*) printf '%s\n' "$p" ;;
         *) printf '%s\n' "$cwd/$p" ;;

--- a/hooks/codex-write-guard.sh
+++ b/hooks/codex-write-guard.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+# =============================================================================
+# Codex PreToolUse Write-Guard (codex-ledger-parity plan, TODO 7): a thin
+# Codex-specific shim that parses Codex write routes (apply_patch envelope,
+# Bash-embedded apply_patch heredoc, shell redirect/tee/rm, native Edit/Write),
+# resolves OMT_DIR/session_id, absolutizes candidate targets against cwd, and
+# delegates the actual full-path anchor-match + deny JSON to
+# write_guard_core_run (hooks/write-guard-core.sh) -- this file never emits
+# the deny JSON itself, and never folds apply_patch parsing into the shared
+# core (that would drift Claude's byte-identical deny at
+# hooks/pre-tool-enforcer.sh).
+#
+# Write-route set mirrors the sibling PostToolUse matcher (codex.yaml:45):
+# apply_patch | Bash | bash | exec_command | shell_command | Edit | Write.
+#
+# BEST-EFFORT, not security-complete: headers/targets are absolutized
+# against cwd to cover the common case, not a full shell parser.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/write-guard-core.sh"
+
+# jq is required for JSON extraction; fail-open (allow, no guard) if absent --
+# this hook is best-effort, not a hard security boundary.
+if ! command -v jq > /dev/null 2>&1; then
+    exit 0
+fi
+
+input=$(cat)
+
+tool_name=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null) || tool_name=""
+
+case "$tool_name" in
+    apply_patch | Bash | bash | exec_command | shell_command | Edit | Write) ;;
+    *) exit 0 ;;
+esac
+
+cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null) || cwd=""
+stdin_sid=$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null) || stdin_sid=""
+
+# -----------------------------------------------------------------------------
+# Shared session-id precedence contract (the same resolution used by the
+# ledger-recording core and the omt-ledger.sh CLI self-resolution):
+# session_id = OMT_SESSION_ID ?? CODEX_THREAD_ID, STRICT EMPTY-ONLY coalescing
+# (present-but-empty falls through; present-but-unsafe REFUSES/HALTs).
+# Mismatch-halt: `stdin.session_id` is a cross-check against this resolved
+# sid -- a present-but-DIVERGENT stdin.session_id, or the total absence of a
+# resolvable sid (no OMT_SESSION_ID and no CODEX_THREAD_ID, so the CLI cannot
+# record to any ledger), HALTs loudly rather than guarding the wrong (or a
+# nonexistent) ledger.
+# -----------------------------------------------------------------------------
+_cwg_charset_ok() {
+    printf '%s' "$1" | grep -Eq '^[A-Za-z0-9_-]{1,200}$'
+}
+
+_cwg_halt() {
+    echo "HALT: codex-write-guard session-id mismatch/diverged -- $1" >&2
+    exit 1
+}
+
+cli_sid=""
+if [ -n "${OMT_SESSION_ID:-}" ]; then
+    _cwg_charset_ok "$OMT_SESSION_ID" || _cwg_halt "OMT_SESSION_ID is present but unsafe: '$OMT_SESSION_ID'"
+    cli_sid="$OMT_SESSION_ID"
+elif [ -n "${CODEX_THREAD_ID:-}" ]; then
+    _cwg_charset_ok "$CODEX_THREAD_ID" || _cwg_halt "CODEX_THREAD_ID is present but unsafe: '$CODEX_THREAD_ID'"
+    cli_sid="$CODEX_THREAD_ID"
+else
+    _cwg_halt "CODEX_THREAD_ID absent -- the CLI cannot resolve a session id to record to"
+fi
+
+if [ -n "$stdin_sid" ] && [ "$stdin_sid" != "$cli_sid" ]; then
+    _cwg_halt "stdin.session_id='$stdin_sid' diverges from resolved sid='$cli_sid'"
+fi
+
+sid="$cli_sid"
+
+# -----------------------------------------------------------------------------
+# Resolve OMT_DIR: env OMT_DIR wins when set; else git-derive from stdin.cwd
+# (resolve_omt_dir already no-ops and returns the env value when OMT_DIR is
+# set, but stdin.cwd is required for the git-derive fallback).
+# -----------------------------------------------------------------------------
+omt_dir="${OMT_DIR:-}"
+if [ -z "$omt_dir" ]; then
+    if [ -z "$cwd" ]; then
+        _cwg_halt "OMT_DIR unset and stdin.cwd absent -- cannot resolve the ledger directory"
+    fi
+    omt_dir=$(source "$SCRIPT_DIR/lib/omt-dir.sh" && unset OMT_DIR && resolve_omt_dir "$cwd")
+fi
+
+[ -n "$cwd" ] || cwd="$PWD"
+
+# -----------------------------------------------------------------------------
+# Extraction helpers. Each prints zero or more RAW (not-yet-absolutized)
+# candidate target paths, one per line.
+# -----------------------------------------------------------------------------
+
+# _cwg_extract_patch_headers <patch_text>
+# Header-only scan of an apply_patch envelope (or a Bash-embedded heredoc
+# body carrying the same grammar) for the four envelope header forms.
+# tr -d '\r' tolerates CRLF header lines.
+_cwg_extract_patch_headers() {
+    printf '%s\n' "$1" | tr -d '\r' \
+        | grep -E '^\*\*\* (Add File|Update File|Delete File|Move to): ' \
+        | sed -E 's/^\*\*\* (Add File|Update File|Delete File|Move to): //'
+}
+
+# _cwg_extract_heredoc_body <shell_command_text>
+# Locates an `apply_patch <<[-]['"]DELIM['"] ... DELIM` heredoc embedded in a
+# Bash command and prints its body. This is its OWN surface -- it does not
+# reuse the tool-path parser's coverage. Only the heredoc opened by
+# `apply_patch <<...` is captured; an unrelated heredoc earlier in the same
+# command (e.g. `cat <<'NOTE' ... NOTE`) is not scanned.
+_cwg_extract_heredoc_body() {
+    local cmd="$1"
+    local delim
+    delim=$(printf '%s\n' "$cmd" \
+        | grep -oE "apply_patch[[:space:]]*<<-?[[:space:]]*['\"]?[A-Za-z_][A-Za-z0-9_]*['\"]?" \
+        | head -1 \
+        | sed -E "s/.*<<-?[[:space:]]*['\"]?([A-Za-z_][A-Za-z0-9_]*)['\"]?/\\1/") || delim=""
+    [ -n "$delim" ] || return 0
+    printf '%s\n' "$cmd" | awk -v delim="$delim" '
+        BEGIN { capture = 0 }
+        !capture && $0 ~ /apply_patch[ \t]*<</ { capture = 1; next }
+        capture && $0 == delim { capture = 0; next }
+        capture { print }
+    '
+}
+
+# _cwg_extract_shell_targets <chain_segment>
+# Redirect / tee / rm / cp / mv / sed -i / dd / truncate write-target
+# extraction, mirroring the segment-classifier shape of
+# hooks/pre-tool-enforcer.sh:42-77 (_wg_ledger_target_in_segment) but
+# EXTRACTING the candidate target rather than merely testing a substring --
+# the core does full-path EXACT match, so the actual candidate path is
+# required.
+_cwg_extract_shell_targets() {
+    local seg="$1"
+    local first_word
+    first_word=$(printf '%s' "$seg" | awk '{print $1}')
+
+    # Redirect target: the token after the last `>` / `>>`, excluding fd
+    # duplications like `2>&1` / `>&2`.
+    printf '%s\n' "$seg" \
+        | grep -oE '(^|[^0-9&])>{1,2}[[:space:]]*[^[:space:]&][^[:space:]]*' \
+        | sed -E 's/^.*>{1,2}[[:space:]]*//'
+
+    case "$first_word" in
+        tee | rm | truncate)
+            printf '%s\n' "$seg" | awk '{for (i = 2; i <= NF; i++) if ($i !~ /^-/) print $i}'
+            ;;
+        cp | mv)
+            printf '%s\n' "$seg" | awk '{print $NF}'
+            ;;
+        sed)
+            if printf '%s\n' "$seg" | grep -q -- '-i'; then
+                printf '%s\n' "$seg" | awk '{print $NF}'
+            fi
+            ;;
+        dd)
+            printf '%s\n' "$seg" | grep -oE 'of=[^[:space:]]+' | sed 's/^of=//'
+            ;;
+    esac
+}
+
+# _cwg_absolutize <path>
+# Joins a relative path against the resolved cwd; leaves an absolute path
+# unchanged. write_guard_core_run requires already-absolutized candidates
+# (full-path EXACT match).
+_cwg_absolutize() {
+    case "$1" in
+        /*) printf '%s\n' "$1" ;;
+        *) printf '%s\n' "$cwd/$1" ;;
+    esac
+}
+
+candidates_text=""
+_cwg_add_candidate() {
+    [ -n "$1" ] || return 0
+    candidates_text="${candidates_text}$(_cwg_absolutize "$1")"$'\n'
+}
+
+# -----------------------------------------------------------------------------
+# Route: tool_name -> parse strategy -> candidate targets.
+# -----------------------------------------------------------------------------
+case "$tool_name" in
+    Edit | Write)
+        fp=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || fp=""
+        _cwg_add_candidate "$fp"
+        ;;
+    apply_patch)
+        patch_cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) || patch_cmd=""
+        while IFS= read -r hdr; do
+            _cwg_add_candidate "$hdr"
+        done < <(_cwg_extract_patch_headers "$patch_cmd")
+        ;;
+    Bash | bash | exec_command | shell_command)
+        shell_cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) || shell_cmd=""
+
+        # Bash-embedded apply_patch heredoc body -- its own surface, scanned
+        # with the same header parser as the apply_patch envelope route.
+        heredoc_body=$(_cwg_extract_heredoc_body "$shell_cmd")
+        if [ -n "$heredoc_body" ]; then
+            while IFS= read -r hdr; do
+                _cwg_add_candidate "$hdr"
+            done < <(_cwg_extract_patch_headers "$heredoc_body")
+        fi
+
+        # Redirect / tee / rm classifier, per chain segment (split on
+        # && || ; |, matching pre-tool-enforcer.sh's segmentation).
+        while IFS= read -r seg; do
+            [ -n "$seg" ] || continue
+            while IFS= read -r tgt; do
+                _cwg_add_candidate "$tgt"
+            done < <(_cwg_extract_shell_targets "$seg")
+        done < <(printf '%s\n' "$shell_cmd" | sed -E 's/(&&|\|\||;|\|)/\n/g')
+        ;;
+esac
+
+printf '%s' "$candidates_text" | write_guard_core_run "$omt_dir" "$sid"

--- a/hooks/codex-write-guard.sh
+++ b/hooks/codex-write-guard.sh
@@ -20,6 +20,15 @@
 #
 # BEST-EFFORT, not security-complete: headers/targets are absolutized
 # against cwd to cover the common case, not a full shell parser.
+#
+# The substring-blacklist -> full-path-EXACT-match migration (write-guard-
+# core.sh) narrowed the contract on purpose: forms the old substring scan
+# used to catch are OUT OF SCOPE here and are not going to be chased with
+# more parsing -- `cd "$OMT_DIR" && rm session-ledger-$SID.md` (relative
+# target resolved against a pre-`cd` cwd this hook never sees), variable
+# indirection (`f="$OMT_DIR/..."; > "$f"`), parameter expansion
+# (`> "${OMT_DIR%/}/..."`), and process substitution. This shim stays a
+# best-effort literal-text scan, not a shell interpreter.
 # =============================================================================
 set -euo pipefail
 
@@ -152,15 +161,22 @@ _cwg_extract_shell_targets() {
     local first_word
     first_word=$(printf '%s' "$seg" | awk '{print $1}')
 
-    # Redirect target: the token after the last `>` / `>>`, excluding fd
-    # duplications like `2>&1` / `>&2`.
+    # Redirect target: the token after the last `>` / `>>`. Over-extract,
+    # like the Claude twin (hooks/pre-tool-enforcer.sh:115): no leading-char
+    # exclusion for fd-dups (`2>&1`, `>&2`) here -- an earlier version
+    # excluded a digit/`&` immediately before `>` to skip fd-dups, but that
+    # same exclusion also skipped the FILE-target forms `2>`/`&>` (a digit
+    # or `&` sits right before `>` there too), silently ALLOWING a real
+    # ledger redirect through either form. write_guard_core_run does the
+    # actual EXACT match, so an over-extracted fd-dup operand (e.g. `&1`
+    # from `2>&1`) simply never matches the ledger path -- harmless.
     # `|| true`: grep -oE returns 1 when a segment has no redirect at all --
     # under this script's `set -euo pipefail`, an unguarded nonzero pipeline
     # here would abort the function (via the process-substitution subshell
     # that invokes it) before the case block below -- tee/rm/truncate/cp/mv/
     # sed -i/dd -- ever runs, silently ALLOWING those write routes.
     printf '%s\n' "$seg" \
-        | grep -oE '(^|[^0-9&])>{1,2}[[:space:]]*[^[:space:]&][^[:space:]]*' \
+        | grep -oE '>{1,2}[[:space:]]*[^[:space:]]+' \
         | sed -E 's/^.*>{1,2}[[:space:]]*//' || true
 
     case "$first_word" in
@@ -225,18 +241,33 @@ _cwg_mask_quoted() {
         }'
 }
 
-# _cwg_strip_quotes <token> -- removes a single leading+trailing double-quote
-# pair, then a single leading+trailing single-quote pair, mirroring the
-# Claude twin's _wg_strip_dquotes (hooks/pre-tool-enforcer.sh:52-57) extended
-# to single quotes -- a quoted redirect/rm/tee target (`> "$f"` or `> '$f'`)
-# still carries its quote characters after extraction and must be unwrapped
-# before write_guard_core_run's full-path EXACT comparison.
+# _cwg_strip_quotes <token> -- removes EVERY double-quote and single-quote
+# character in the token (not just one outermost pair each way), mirroring
+# what a real shell does to a word during expansion: quote characters never
+# survive into the expanded value, however many separately-quoted spans are
+# concatenated to build the word. A single-outermost-pair strip (this
+# function's earlier form, and the Claude twin's _wg_strip_dquotes at
+# hooks/pre-tool-enforcer.sh:52-57) is correct only when the whole token is
+# ONE quoted span -- it under-strips a token built from several ADJACENT
+# quoted spans with no separating whitespace, e.g.
+# "$OMT_DIR"/"session-ledger-$OMT_SESSION_ID.md" (a single shell word, no
+# space between the closing and opening quotes): stripping only the very
+# first and last quote character left the INNER quote characters (around the
+# literal `/`) embedded in the candidate, so after env-var substitution in
+# _cwg_absolutize the candidate carried stray `"` characters and never
+# full-path EXACT matched the real ledger path -- a silent bypass. Removing
+# every quote character unconditionally fixes this: a legitimate non-ledger
+# target loses its (already load-bearing-only-for-shell-parsing) quote
+# characters the same way and still resolves to its real path, so this is
+# over-removal that is harmless for write_guard_core_run's EXACT compare (a
+# ledger path itself never contains a quote character).
+#
+# ${s//\"/} / ${s//\'/} are pure bash parameter-expansion substitutions
+# (global, not first-match), Bash 3.2 compatible -- no eval/sed needed.
 _cwg_strip_quotes() {
     local s="$1"
-    s="${s#\"}"
-    s="${s%\"}"
-    s="${s#\'}"
-    s="${s%\'}"
+    s="${s//\"/}"
+    s="${s//\'/}"
     printf '%s\n' "$s"
 }
 

--- a/hooks/codex-write-guard.sh
+++ b/hooks/codex-write-guard.sh
@@ -29,6 +29,8 @@
 # indirection (`f="$OMT_DIR/..."; > "$f"`), parameter expansion
 # (`> "${OMT_DIR%/}/..."`), and process substitution. This shim stays a
 # best-effort literal-text scan, not a shell interpreter.
+#
+# omt-hook-dep: lib/omt-dir.sh
 # =============================================================================
 set -euo pipefail
 
@@ -68,16 +70,38 @@ stdin_sid=$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null) || 
 # Mismatch-halt: `stdin.session_id` is a cross-check against this resolved
 # sid -- a present-but-DIVERGENT stdin.session_id, or the total absence of a
 # resolvable sid (no OMT_SESSION_ID and no CODEX_THREAD_ID, so the CLI cannot
-# record to any ledger), HALTs loudly rather than guarding the wrong (or a
-# nonexistent) ledger.
+# record to any ledger), triggers a loud-but-fail-open diagnostic (see
+# _cwg_halt below), not a hard block -- and not actually a wrong-ledger
+# guard either: both the ledger writer (omt-ledger.sh) and this guard
+# resolve the ledger path env-first (OMT_SESSION_ID ?? CODEX_THREAD_ID) and
+# never from stdin.session_id, so a divergent stdin sid can never point at
+# the wrong (or a nonexistent) ledger in the first place.
 # -----------------------------------------------------------------------------
 _cwg_charset_ok() {
     printf '%s' "$1" | grep -Eq '^[A-Za-z0-9_-]{1,200}$'
 }
 
+# _cwg_halt: fail-OPEN (exit 0), not fail-closed. This repo's block signal
+# is deny-JSON-on-stdout with exit 0 -- write_guard_core_run (hooks/write-
+# guard-core.sh) returns 0 on both the deny path and the allow path, and no
+# caller of this hook inspects the exit code. A HALT here means the guard
+# could not trust its inputs enough to resolve a session id -- the same
+# "can't do the job, so don't block" class as the jq-absent fail-open a few
+# lines up, and the same policy as the Claude twin (hooks/pre-tool-
+# enforcer.sh), which has no hard-halt at all. Failing CLOSED (nonzero
+# exit) would risk Codex treating it as fail-closed and blocking every
+# apply_patch/Bash/edit/write/exec_command/shell_command call for the rest
+# of the session -- a best-effort, not-security-complete guard must not be
+# able to brick the agent on an unverified runtime assumption. The stderr
+# line stays a loud diagnostic either way.
+#
+# AC3 coupling: hooks/codex-write-guard_test.sh's
+# test_ac3_divergent_session_id_halts greps this stderr line for the tokens
+# halt|mismatch|diverg -- keep at least one of those tokens in the message
+# if it is ever reworded.
 _cwg_halt() {
     echo "HALT: codex-write-guard session-id mismatch/diverged -- $1" >&2
-    exit 1
+    exit 0
 }
 
 cli_sid=""

--- a/hooks/codex-write-guard_test.sh
+++ b/hooks/codex-write-guard_test.sh
@@ -592,6 +592,126 @@ test_own_exec_command_cmd_key_non_ledger_allows() {
 }
 
 # =============================================================================
+# Regression -- lowercase native tool-name bypass (my-review finding): Codex
+# has been observed sending native write tools under their lowercase form
+# (write/edit/multiedit/multi_edit), mirroring the tool names tracked by the
+# sibling extractor hooks/rules-injector/tool-paths.ts's TRACKED_TOOL_NAMES
+# (:11-26), which normalizes via toLowerCase() (:29). The guard's allow-list
+# used to only recognize the capitalized Bash/Edit/Write forms, so a
+# lowercase native tool name fell through the case statement's `*) exit 0 ;;`
+# before ever reaching the ledger-path check -- silently ALLOWING a write
+# that targets the ledger. Each case below must DENY.
+# =============================================================================
+test_own_lowercase_write_file_path_ledger_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg fp "$LED" --arg cwd "$GITDIR" '{tool_name:"write", tool_input:{file_path:$fp}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-lowercase-write-file-path: expected deny for lowercase 'write' tool_name targeting ledger, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_own_lowercase_edit_file_path_ledger_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg fp "$LED" --arg cwd "$GITDIR" '{tool_name:"edit", tool_input:{file_path:$fp}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-lowercase-edit-file-path: expected deny for lowercase 'edit' tool_name targeting ledger, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_own_lowercase_multiedit_file_path_ledger_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg fp "$LED" --arg cwd "$GITDIR" '{tool_name:"multiedit", tool_input:{file_path:$fp}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-lowercase-multiedit-file-path: expected deny for lowercase 'multiedit' tool_name targeting ledger, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_own_lowercase_multi_edit_file_path_ledger_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg fp "$LED" --arg cwd "$GITDIR" '{tool_name:"multi_edit", tool_input:{file_path:$fp}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-lowercase-multi-edit-file-path: expected deny for lowercase 'multi_edit' tool_name targeting ledger, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# Non-ledger control -- lowercase 'write' targeting a non-ledger file must
+# still ALLOW (proves the tool-name-normalization fix does not over-block).
+test_own_lowercase_write_file_path_non_ledger_allows() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg fp "$GITDIR/README.md" --arg cwd "$GITDIR" '{tool_name:"write", tool_input:{file_path:$fp}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if [ "$(printf '%s' "$out" | grep -c deny)" != "0" ]; then
+        echo "ASSERTION FAILED own-lowercase-write-file-path-allow: expected allow for lowercase 'write' non-ledger target, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
+# Regression -- Edit/Write under-read of the path key (my-review finding):
+# the Edit|Write route used to read ONLY tool_input.file_path, unlike the
+# sibling extractor hooks/rules-injector/tool-paths.ts's addCommonPathFields
+# (:52-63), which reads path/filePath/file_path/target/targetPath/target_path
+# -- so a payload carrying the target under tool_input.path (capitalized
+# 'Write' or lowercase 'write') fell through unread, silently ALLOWING a
+# write that targets the ledger. Each case below must DENY.
+# =============================================================================
+test_own_write_path_key_ledger_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg p "$LED" --arg cwd "$GITDIR" '{tool_name:"Write", tool_input:{path:$p}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-write-path-key: expected deny for 'Write' tool_input.path targeting ledger, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_own_lowercase_write_path_key_ledger_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg p "$LED" --arg cwd "$GITDIR" '{tool_name:"write", tool_input:{path:$p}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-lowercase-write-path-key: expected deny for lowercase 'write' tool_input.path targeting ledger, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -629,6 +749,13 @@ main() {
     run_test test_own_exec_command_cmd_key_ledger_denies
     run_test test_own_shell_command_cmd_key_ledger_denies
     run_test test_own_exec_command_cmd_key_non_ledger_allows
+    run_test test_own_lowercase_write_file_path_ledger_denies
+    run_test test_own_lowercase_edit_file_path_ledger_denies
+    run_test test_own_lowercase_multiedit_file_path_ledger_denies
+    run_test test_own_lowercase_multi_edit_file_path_ledger_denies
+    run_test test_own_lowercase_write_file_path_non_ledger_allows
+    run_test test_own_write_path_key_ledger_denies
+    run_test test_own_lowercase_write_path_key_ledger_denies
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/codex-write-guard_test.sh
+++ b/hooks/codex-write-guard_test.sh
@@ -717,6 +717,53 @@ test_own_lowercase_write_path_key_ledger_denies() {
 }
 
 # =============================================================================
+# Regression (defect A, ported from the Claude twin _wg_absolutize fix) --
+# an unexpanded env-var-literal ledger path bypasses the EXACT match:
+# _cwg_absolutize used to recognize only a leading '/' as absolute, so a
+# literal "$OMT_DIR/session-ledger-$OMT_SESSION_ID.md" (or, since Codex's
+# resolved session id is OMT_SESSION_ID ?? CODEX_THREAD_ID, the
+# $CODEX_THREAD_ID spelling) token was treated as RELATIVE and got cwd
+# prefixed instead -- silently ALLOWING the exact form that hooks/omt-
+# ledger.sh's SessionStart recovery pointer itself teaches agents to
+# reproduce. Both env-var spellings must DENY.
+# =============================================================================
+test_own_env_var_omt_session_id_form_denies() {
+    local sbx od out result=0
+    sbx=$(mktemp -d)
+    od="$sbx/omt-dir"
+    mkdir -p "$od"
+
+    out=$(jq -n --arg cmd 'echo x > "$OMT_DIR/session-ledger-$OMT_SESSION_ID.md"' --arg cwd "$od" \
+        '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' \
+        | env -u CODEX_THREAD_ID OMT_DIR="$od" OMT_SESSION_ID=cx HOME="$sbx" bash "$HOOK")
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-env-var-omt-session-id-form: expected deny for literal \$OMT_DIR/\$OMT_SESSION_ID target, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$sbx"
+    return "$result"
+}
+
+test_own_env_var_codex_thread_id_form_denies() {
+    local sbx od out result=0
+    sbx=$(mktemp -d)
+    od="$sbx/omt-dir"
+    mkdir -p "$od"
+
+    out=$(jq -n --arg cmd 'echo x > "$OMT_DIR/session-ledger-$CODEX_THREAD_ID.md"' --arg cwd "$od" \
+        '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' \
+        | env -u OMT_SESSION_ID OMT_DIR="$od" HOME="$sbx" CODEX_THREAD_ID=cx bash "$HOOK")
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-env-var-codex-thread-id-form: expected deny for literal \$OMT_DIR/\$CODEX_THREAD_ID target, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$sbx"
+    return "$result"
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -761,6 +808,8 @@ main() {
     run_test test_own_lowercase_write_file_path_non_ledger_allows
     run_test test_own_write_path_key_ledger_denies
     run_test test_own_lowercase_write_path_key_ledger_denies
+    run_test test_own_env_var_omt_session_id_form_denies
+    run_test test_own_env_var_codex_thread_id_form_denies
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/codex-write-guard_test.sh
+++ b/hooks/codex-write-guard_test.sh
@@ -764,6 +764,57 @@ test_own_env_var_codex_thread_id_form_denies() {
 }
 
 # =============================================================================
+# Regression -- quoted-prose false-positive (PR #176 AI-review finding): a
+# legitimate `omt-ledger.sh append` command piped from `printf '...'` prose
+# that happens to mention `> <ledger>` INSIDE a single-quoted string used to
+# be denied -- the redirect-target grep in _cwg_extract_shell_targets read
+# ANY `>` in the raw shell text as a live redirect regardless of quoting,
+# unlike the Claude twin's _wg_scan (hooks/pre-tool-enforcer.sh:160-179),
+# which quote-masks before classifying. Each ALLOW case below must allow;
+# the final case is a non-quoted control proving the fix does not
+# under-block a real redirect/rm (see test_qa_redirect_to_ledger_denies and
+# test_own_rm_ledger_denies above, which already cover that regression).
+# Evidence: $OMT_DIR/evidence/codex-ledger-parity/codex-write-guard-hook/quoted-prose-gt-allow.txt
+# =============================================================================
+test_qa_quoted_prose_gt_in_pipe_allows() {
+    new_sandbox
+    local cmd out evidence_dir result=0
+
+    cmd="printf 'note: see foo > $LED for details' | omt-ledger.sh append Decisions"
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+
+    evidence_dir="$EVIDENCE_OMT_DIR/evidence/codex-ledger-parity/codex-write-guard-hook"
+    mkdir -p "$evidence_dir"
+    {
+        echo "input: $cmd (cwd=$GITDIR sid=cx)"
+        echo "output: $out"
+    } > "$evidence_dir/quoted-prose-gt-allow.txt"
+
+    if [ "$(printf '%s' "$out" | grep -c deny)" != "0" ]; then
+        echo "ASSERTION FAILED QA-quoted-prose-gt: expected allow (no deny) for '>' inside single-quoted prose, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_own_inquote_redirect_no_pipe_allows() {
+    new_sandbox
+    local cmd out result=0
+
+    cmd="echo 'text > $LED more'"
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if [ "$(printf '%s' "$out" | grep -c deny)" != "0" ]; then
+        echo "ASSERTION FAILED own-inquote-redirect-no-pipe: expected allow for '>' inside single-quoted text with no pipe, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -810,6 +861,8 @@ main() {
     run_test test_own_lowercase_write_path_key_ledger_denies
     run_test test_own_env_var_omt_session_id_form_denies
     run_test test_own_env_var_codex_thread_id_form_denies
+    run_test test_qa_quoted_prose_gt_in_pipe_allows
+    run_test test_own_inquote_redirect_no_pipe_allows
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/codex-write-guard_test.sh
+++ b/hooks/codex-write-guard_test.sh
@@ -1,0 +1,344 @@
+#!/bin/bash
+# =============================================================================
+# Codex Write-Guard Hook Tests (codex-ledger-parity plan, TODO 7)
+# Covers hooks/codex-write-guard.sh: the Codex PreToolUse shim that parses
+# apply_patch envelopes, Bash-embedded apply_patch heredocs, shell
+# redirect/tee/rm targets, and native Edit/Write file_path targets;
+# absolutizes them against stdin.cwd; resolves OMT_DIR/session_id; enforces
+# the mismatch-HALT; and delegates the actual match+deny to
+# write_guard_core_run (hooks/write-guard-core.sh).
+#
+# Every git-derive case runs under a SANDBOXED HOME (mktemp -d) -- never the
+# real $HOME/.omt -- mirroring hooks/pre-tool-enforcer_test.sh:231,596. Every
+# hook invocation explicitly unsets OMT_DIR/OMT_SESSION_ID so the real
+# session's env cannot leak into the sandboxed resolution.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+HOOK="$SCRIPT_DIR/codex-write-guard.sh"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+run_test() {
+    local test_name="$1"
+    if "$test_name"; then
+        echo "[PASS] $test_name"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "[FAIL] $test_name"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+# new_sandbox: mktemp -d git-repo sandbox + the resolved ledger path for
+# session id "cx". Sets SBX / GITDIR / LED. Caller must `rm -rf "$SBX"`.
+new_sandbox() {
+    SBX=$(mktemp -d)
+    GITDIR="$SBX/repo"
+    mkdir -p "$GITDIR"
+    git -C "$GITDIR" init -q -b main
+    LED=$(env -u OMT_DIR -u OMT_SESSION_ID HOME="$SBX" bash -c \
+        "source '$ROOT_DIR/hooks/lib/omt-dir.sh'; printf '%s/session-ledger-cx.md' \"\$(resolve_omt_dir '$GITDIR')\"")
+}
+
+# run_hook: feed stdin JSON to the hook under the sandboxed HOME with
+# CODEX_THREAD_ID=cx (matching stdin.session_id="cx" in every non-HALT case
+# below), env OMT_DIR/OMT_SESSION_ID stripped so resolution is git-derived.
+run_hook() {
+    env -u OMT_DIR -u OMT_SESSION_ID HOME="$SBX" CODEX_THREAD_ID=cx bash "$HOOK"
+}
+
+# =============================================================================
+# AC1 -- apply_patch envelope targeting the resolved current ledger DENIES;
+# a non-ledger target ALLOWS. (Plan TODO 7 AC1 exact setup/verification.)
+# =============================================================================
+test_ac1_apply_patch_envelope_denies_ledger_allows_other() {
+    new_sandbox
+    local deny allow result=0
+
+    deny=$(printf '{"tool_name":"apply_patch","tool_input":{"command":"*** Begin Patch\\n*** Update File: %s\\n"},"session_id":"cx","cwd":"%s"}' "$LED" "$GITDIR" | run_hook)
+    if ! printf '%s' "$deny" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED AC1: expected deny for ledger target, got '$deny'"
+        result=1
+    fi
+
+    allow=$(printf '{"tool_name":"apply_patch","tool_input":{"command":"*** Begin Patch\\n*** Update File: %s/README.md\\n"},"session_id":"cx","cwd":"%s"}' "$GITDIR" "$GITDIR" | run_hook)
+    if [ "$(printf '%s' "$allow" | grep -c deny)" != "0" ]; then
+        echo "ASSERTION FAILED AC1: expected allow for README.md target, got '$allow'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
+# AC2 -- a Bash-embedded apply_patch heredoc targeting the ledger DENIES
+# (heredoc-body scan, its own surface).
+# =============================================================================
+test_ac2_bash_embedded_heredoc_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"apply_patch <<'"'"'EOF'"'"'\\n*** Begin Patch\\n*** Update File: %s\\n*** End Patch\\nEOF\\n"},"session_id":"cx","cwd":"%s"}' "$LED" "$GITDIR" | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED AC2: expected deny for heredoc-embedded ledger target, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
+# AC3 -- a DIVERGENT stdin.session_id vs CODEX_THREAD_ID HALTs loudly
+# (non-zero exit or explicit halt marker), not a silent guard on the wrong
+# ledger.
+# =============================================================================
+test_ac3_divergent_session_id_halts() {
+    local sbx gitdir result=1
+    sbx=$(mktemp -d)
+    gitdir="$sbx/repo"
+    mkdir -p "$gitdir"
+    git -C "$gitdir" init -q -b main
+
+    mk() { printf '{"tool_name":"Bash","tool_input":{"command":"echo x"},"session_id":"cx-B","cwd":"%s"}' "$gitdir"; }
+
+    if ( mk | env -u OMT_DIR -u OMT_SESSION_ID HOME="$sbx" CODEX_THREAD_ID=cx-A bash "$HOOK" 2>&1 | grep -Eiq 'halt|mismatch|diverg' ); then
+        result=0
+    else
+        mk | env -u OMT_DIR -u OMT_SESSION_ID HOME="$sbx" CODEX_THREAD_ID=cx-A bash "$HOOK" >/dev/null 2>&1
+        local rc=$?
+        [ "$rc" -ne 0 ] && result=0
+    fi
+
+    rm -rf "$sbx"
+    if [ "$result" -ne 0 ]; then
+        echo "ASSERTION FAILED AC3: expected halt marker or non-zero exit on divergent session id"
+    fi
+    return "$result"
+}
+
+# =============================================================================
+# QA -- redirect to ledger denied (shell write route).
+# Evidence: $OMT_DIR/evidence/codex-ledger-parity/codex-write-guard-hook/redirect-deny.txt
+# =============================================================================
+test_qa_redirect_to_ledger_denies() {
+    new_sandbox
+    local out evidence_dir result=0
+
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"echo x > %s"},"session_id":"cx","cwd":"%s"}' "$LED" "$GITDIR" | run_hook)
+
+    evidence_dir="$OMT_DIR/evidence/codex-ledger-parity/codex-write-guard-hook"
+    mkdir -p "$evidence_dir"
+    {
+        echo "input: echo x > $LED (cwd=$GITDIR sid=cx)"
+        echo "output: $out"
+    } > "$evidence_dir/redirect-deny.txt"
+
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED QA-redirect: expected deny, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
+# QA -- prose false-positive allowed (header-parser precision). A Bash
+# command merely mentioning "session-ledger" in prose (no write-target
+# reference) must ALLOW.
+# Evidence: $OMT_DIR/evidence/codex-ledger-parity/codex-write-guard-hook/prose-allow.txt
+# =============================================================================
+test_qa_prose_mention_allows() {
+    new_sandbox
+    local out evidence_dir result=0
+
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"echo editing the session-ledger docs"},"session_id":"cx","cwd":"%s"}' "$GITDIR" | run_hook)
+
+    evidence_dir="$OMT_DIR/evidence/codex-ledger-parity/codex-write-guard-hook"
+    mkdir -p "$evidence_dir"
+    {
+        echo "input: echo editing the session-ledger docs (cwd=$GITDIR sid=cx)"
+        echo "output: $out"
+    } > "$evidence_dir/prose-allow.txt"
+
+    if [ "$(printf '%s' "$out" | grep -c deny)" != "0" ]; then
+        echo "ASSERTION FAILED QA-prose: expected allow (no deny) for prose mention, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
+# Own corpus -- multi-file patch: one of several Update File targets is the
+# ledger -> DENY.
+# =============================================================================
+test_own_multi_file_patch_denies() {
+    new_sandbox
+    local cmd out result=0
+
+    cmd=$(printf '*** Begin Patch\n*** Update File: %s/a.md\n*** Update File: %s\n*** Update File: %s/b.md\n*** End Patch\n' "$GITDIR" "$LED" "$GITDIR")
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"apply_patch", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-multi-file-patch: expected deny, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
+# Own corpus -- "*** Move to:" destination is the ledger -> DENY.
+# =============================================================================
+test_own_move_to_ledger_denies() {
+    new_sandbox
+    local cmd out result=0
+
+    cmd=$(printf '*** Begin Patch\n*** Update File: %s/other.md\n*** Move to: %s\n*** End Patch\n' "$GITDIR" "$LED")
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"apply_patch", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-move-to: expected deny, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
+# Own corpus -- "*** Delete File:" targeting the ledger -> DENY.
+# =============================================================================
+test_own_delete_file_ledger_denies() {
+    new_sandbox
+    local cmd out result=0
+
+    cmd=$(printf '*** Begin Patch\n*** Delete File: %s\n*** End Patch\n' "$LED")
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"apply_patch", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-delete-file: expected deny, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
+# Own corpus -- CRLF header lines (\r\n line endings) still DENY.
+# =============================================================================
+test_own_crlf_headers_deny() {
+    new_sandbox
+    local cmd out result=0
+
+    cmd=$(printf '*** Begin Patch\r\n*** Update File: %s\r\n*** End Patch\r\n' "$LED")
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"apply_patch", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-crlf-headers: expected deny, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
+# Own corpus -- nested heredoc: an unrelated heredoc earlier in the same
+# command mentions "session-ledger" in prose (must not itself trigger a
+# deny), while the apply_patch heredoc that follows targets the ledger for
+# real -> DENY driven by the apply_patch heredoc only.
+# =============================================================================
+test_own_nested_heredoc_denies() {
+    new_sandbox
+    local cmd out result=0
+
+    cmd=$(printf "cat <<'NOTE'\nsome notes about session-ledger\nNOTE\napply_patch <<'EOF'\n*** Begin Patch\n*** Update File: %s\n*** End Patch\nEOF\n" "$LED")
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-nested-heredoc: expected deny, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
+# Own corpus -- relative-vs-absolute path: a native Edit's file_path is
+# relative to cwd; absolutized against cwd it equals the ledger -> DENY.
+# =============================================================================
+test_own_relative_path_denies() {
+    local sbx od out result=0
+    sbx=$(mktemp -d)
+    od="$sbx/omt-dir"
+    mkdir -p "$od"
+
+    out=$(jq -n --arg cwd "$od" '{tool_name:"Edit", tool_input:{file_path:"session-ledger-cx.md"}, session_id:"cx", cwd:$cwd}' \
+        | env -u OMT_SESSION_ID OMT_DIR="$od" HOME="$sbx" CODEX_THREAD_ID=cx bash "$HOOK")
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-relative-path: expected deny for cwd-relative ledger file_path, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$sbx"
+    return "$result"
+}
+
+# =============================================================================
+# Own corpus -- native Edit targeting a non-ledger file ALLOWS. Confirms
+# Edit/Write are covered write routes in their own right (not just
+# apply_patch/Bash) without over-blocking a non-ledger native edit.
+# =============================================================================
+test_own_native_edit_non_ledger_allows() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg fp "$GITDIR/README.md" --arg cwd "$GITDIR" '{tool_name:"Edit", tool_input:{file_path:$fp}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if [ "$(printf '%s' "$out" | grep -c deny)" != "0" ]; then
+        echo "ASSERTION FAILED own-native-edit-allow: expected allow, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+main() {
+    echo "=========================================="
+    echo "Codex Write-Guard Hook Tests"
+    echo "=========================================="
+
+    run_test test_ac1_apply_patch_envelope_denies_ledger_allows_other
+    run_test test_ac2_bash_embedded_heredoc_denies
+    run_test test_ac3_divergent_session_id_halts
+    run_test test_qa_redirect_to_ledger_denies
+    run_test test_qa_prose_mention_allows
+    run_test test_own_multi_file_patch_denies
+    run_test test_own_move_to_ledger_denies
+    run_test test_own_delete_file_ledger_denies
+    run_test test_own_crlf_headers_deny
+    run_test test_own_nested_heredoc_denies
+    run_test test_own_relative_path_denies
+    run_test test_own_native_edit_non_ledger_allows
+
+    echo "=========================================="
+    echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"
+    echo "=========================================="
+
+    if [ "$TESTS_FAILED" -gt 0 ]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/hooks/codex-write-guard_test.sh
+++ b/hooks/codex-write-guard_test.sh
@@ -420,6 +420,93 @@ test_own_rm_non_ledger_allows() {
 }
 
 # =============================================================================
+# Regression -- quote-stripping parity (code-review fix): _cwg_absolutize
+# used to leave surrounding quote characters on an extracted candidate
+# target, unlike the Claude twin _wg_strip_dquotes (hooks/pre-tool-
+# enforcer.sh:52-57) -- so a quoted redirect/rm/tee target never equaled the
+# unquoted resolved ledger path and silently ALLOWED, bypassing the guard.
+# Each quoted-ledger case below must DENY like the Claude twin; a quoted
+# non-ledger target must still ALLOW.
+# =============================================================================
+test_own_double_quoted_redirect_ledger_denies() {
+    new_sandbox
+    local cmd out result=0
+
+    cmd="echo x > \"$LED\""
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-double-quoted-redirect: expected deny for 'echo x > \"<ledger>\"', got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_own_single_quoted_redirect_ledger_denies() {
+    new_sandbox
+    local cmd out result=0
+
+    cmd="echo x > '$LED'"
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-single-quoted-redirect: expected deny for \"echo x > '<ledger>'\", got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_own_quoted_rm_ledger_denies() {
+    new_sandbox
+    local cmd out result=0
+
+    cmd="rm \"$LED\""
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-quoted-rm: expected deny for 'rm \"<ledger>\"', got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_own_quoted_tee_ledger_denies() {
+    new_sandbox
+    local cmd out result=0
+
+    cmd="echo x | tee \"$LED\""
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-quoted-tee: expected deny for 'echo x | tee \"<ledger>\"', got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# Non-ledger control -- a quoted redirect to a non-ledger target must still
+# ALLOW (proves the quote-stripping fix does not turn quoting into an
+# over-broad denier).
+test_own_quoted_non_ledger_allows() {
+    new_sandbox
+    local cmd out result=0
+
+    cmd="echo x > \"$GITDIR/README.md\""
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if [ "$(printf '%s' "$out" | grep -c deny)" != "0" ]; then
+        echo "ASSERTION FAILED own-quoted-non-ledger-allow: expected allow for quoted non-ledger target, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -447,6 +534,11 @@ main() {
     run_test test_own_truncate_ledger_denies
     run_test test_own_sed_i_ledger_denies
     run_test test_own_rm_non_ledger_allows
+    run_test test_own_double_quoted_redirect_ledger_denies
+    run_test test_own_single_quoted_redirect_ledger_denies
+    run_test test_own_quoted_rm_ledger_denies
+    run_test test_own_quoted_tee_ledger_denies
+    run_test test_own_quoted_non_ledger_allows
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/codex-write-guard_test.sh
+++ b/hooks/codex-write-guard_test.sh
@@ -815,6 +815,67 @@ test_own_inquote_redirect_no_pipe_allows() {
 }
 
 # =============================================================================
+# Regression (claim W) -- the bash|exec_command|shell_command route ignored
+# per-command tool_input.workdir/.cwd and always absolutized a relative write
+# target against the module-global $cwd (the hook-level top-level .cwd), not
+# the command's own working directory -- unlike the sibling extractor
+# hooks/rules-injector/tool-paths.ts:44-46 (workdir ?? cwd) for command
+# tools. A payload whose top-level .cwd is an unrelated directory but whose
+# tool_input.workdir is the resolved ledger directory, paired with a relative
+# target of just the ledger filename, wrote the real ledger while the guard
+# resolved the relative path against the wrong (top-level) cwd and silently
+# ALLOWED it. The DENY case below reproduces exactly that shape; the ALLOW
+# control keeps workdir pointed at the unrelated directory with an absolute
+# non-ledger target, proving the fix does not over-block.
+# =============================================================================
+test_regression_exec_command_workdir_relative_ledger_denies() {
+    local sbx od other out result=0
+    sbx=$(mktemp -d)
+    od="$sbx/omt-dir"
+    other="$sbx/other"
+    mkdir -p "$od" "$other"
+
+    # OMT_DIR is set explicitly (like test_own_relative_path_denies) so the
+    # ledger path is pinned to $od regardless of cwd/workdir resolution --
+    # the top-level .cwd is the UNRELATED $other directory, while
+    # tool_input.workdir is $od. Pre-fix, the relative target absolutized
+    # against the module-global cwd ($other) instead of workdir ($od),
+    # producing $other/session-ledger-cx.md != the real ledger and silently
+    # ALLOWING. Post-fix, the shell route reassigns cwd to workdir before
+    # absolutizing, so the relative target resolves to $od/session-ledger-cx.md
+    # and DENIES.
+    out=$(jq -n --arg cmd "echo x > session-ledger-cx.md" --arg workdir "$od" --arg cwd "$other" \
+        '{tool_name:"exec_command", tool_input:{cmd:$cmd, workdir:$workdir}, session_id:"cx", cwd:$cwd}' \
+        | env -u OMT_SESSION_ID OMT_DIR="$od" HOME="$sbx" CODEX_THREAD_ID=cx bash "$HOOK")
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED regression-exec-command-workdir: expected deny for relative ledger target resolved against tool_input.workdir, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$sbx"
+    return "$result"
+}
+
+test_regression_exec_command_workdir_relative_non_ledger_allows() {
+    local sbx od other out result=0
+    sbx=$(mktemp -d)
+    od="$sbx/omt-dir"
+    other="$sbx/other"
+    mkdir -p "$od" "$other"
+
+    out=$(jq -n --arg cmd "echo x > $other/README.md" --arg workdir "$other" --arg cwd "$other" \
+        '{tool_name:"exec_command", tool_input:{cmd:$cmd, workdir:$workdir}, session_id:"cx", cwd:$cwd}' \
+        | env -u OMT_SESSION_ID OMT_DIR="$od" HOME="$sbx" CODEX_THREAD_ID=cx bash "$HOOK")
+    if [ "$(printf '%s' "$out" | grep -c deny)" != "0" ]; then
+        echo "ASSERTION FAILED regression-exec-command-workdir-allow: expected allow for absolute non-ledger target, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$sbx"
+    return "$result"
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -863,6 +924,8 @@ main() {
     run_test test_own_env_var_codex_thread_id_form_denies
     run_test test_qa_quoted_prose_gt_in_pipe_allows
     run_test test_own_inquote_redirect_no_pipe_allows
+    run_test test_regression_exec_command_workdir_relative_ledger_denies
+    run_test test_regression_exec_command_workdir_relative_non_ledger_allows
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/codex-write-guard_test.sh
+++ b/hooks/codex-write-guard_test.sh
@@ -876,6 +876,123 @@ test_regression_exec_command_workdir_relative_non_ledger_allows() {
 }
 
 # =============================================================================
+# Regression (defect #3, code-review finding) -- fd-dup redirect exclusion
+# swallows real file redirects: the old redirect-target grep required
+# `(^|[^0-9&])` immediately before `>`/`>>` (meant to skip fd-dups like
+# `2>&1`/`>&2`), but that same exclusion also skipped the FILE-target forms
+# `2>` and `&>` -- a digit or `&` sits right before `>` in both cases -- so a
+# real ledger redirect through either form silently ALLOWED, breaking parity
+# with the Claude twin's over-extract regex (hooks/pre-tool-enforcer.sh:115),
+# which has no such leading-char exclusion and correctly extracts both. Each
+# DENY case below must deny; the fd-dup-only ALLOW controls (no ledger
+# reference at all) prove the fix does not turn `2>&1`/`>&2` into
+# over-broad deniers.
+# =============================================================================
+test_defect3_stderr_redirect_ledger_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"echo x 2> %s"},"session_id":"cx","cwd":"%s"}' "$LED" "$GITDIR" | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED defect3-stderr-redirect: expected deny for 'echo x 2> <ledger>', got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_defect3_combined_redirect_ledger_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"echo x &> %s"},"session_id":"cx","cwd":"%s"}' "$LED" "$GITDIR" | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED defect3-combined-redirect: expected deny for 'echo x &> <ledger>', got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_defect3_fd_dup_stderr_to_stdout_no_ledger_allows() {
+    new_sandbox
+    local out result=0
+
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"echo x 2>&1"},"session_id":"cx","cwd":"%s"}' "$GITDIR" | run_hook)
+    if [ "$(printf '%s' "$out" | grep -c deny)" != "0" ]; then
+        echo "ASSERTION FAILED defect3-fd-dup-stderr-to-stdout-allow: expected allow for 'echo x 2>&1' (no ledger reference), got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_defect3_fd_dup_stdout_to_stderr_no_ledger_allows() {
+    new_sandbox
+    local out result=0
+
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"echo x >&2"},"session_id":"cx","cwd":"%s"}' "$GITDIR" | run_hook)
+    if [ "$(printf '%s' "$out" | grep -c deny)" != "0" ]; then
+        echo "ASSERTION FAILED defect3-fd-dup-stdout-to-stderr-allow: expected allow for 'echo x >&2' (no ledger reference), got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
+# Regression (defect #4, code-review finding) -- per-segment inner quotes
+# survive strip and break EXACT match: _cwg_strip_quotes only unwraps ONE
+# outermost double-quote pair then ONE outermost single-quote pair, but a
+# real shell word can be built from several ADJACENT quoted spans with no
+# separating whitespace (e.g. "$OMT_DIR"/"session-ledger-$OMT_SESSION_ID.md"),
+# which the real shell concatenates into a single word with ALL quote
+# characters removed. The old strip only removed the very first and very
+# last quote character of the token, leaving the INNER quote characters
+# (around the literal `/`) embedded in the candidate -- so after env-var
+# substitution the candidate carried stray `"` characters and never
+# full-path EXACT matched the real ledger path, silently ALLOWING. The DENY
+# case below must deny; the non-ledger control proves the fix does not
+# over-block a legitimate per-token-quoted non-ledger target.
+# =============================================================================
+test_defect4_per_token_quoted_env_var_denies() {
+    local sbx od out result=0
+    sbx=$(mktemp -d)
+    od="$sbx/omt-dir"
+    mkdir -p "$od"
+
+    out=$(jq -n --arg cmd 'echo x > "$OMT_DIR"/"session-ledger-$OMT_SESSION_ID.md"' --arg cwd "$od" \
+        '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' \
+        | env -u CODEX_THREAD_ID OMT_DIR="$od" OMT_SESSION_ID=cx HOME="$sbx" bash "$HOOK")
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED defect4-per-token-quoted-env-var: expected deny for per-token quoted env-var ledger redirect, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$sbx"
+    return "$result"
+}
+
+test_defect4_per_token_quoted_non_ledger_allows() {
+    new_sandbox
+    local cmd out result=0
+
+    cmd="echo x > \"$GITDIR\"/\"other.md\""
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if [ "$(printf '%s' "$out" | grep -c deny)" != "0" ]; then
+        echo "ASSERTION FAILED defect4-per-token-quoted-non-ledger-allow: expected allow for per-token quoted non-ledger target, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -926,6 +1043,12 @@ main() {
     run_test test_own_inquote_redirect_no_pipe_allows
     run_test test_regression_exec_command_workdir_relative_ledger_denies
     run_test test_regression_exec_command_workdir_relative_non_ledger_allows
+    run_test test_defect3_stderr_redirect_ledger_denies
+    run_test test_defect3_combined_redirect_ledger_denies
+    run_test test_defect3_fd_dup_stderr_to_stdout_no_ledger_allows
+    run_test test_defect3_fd_dup_stdout_to_stderr_no_ledger_allows
+    run_test test_defect4_per_token_quoted_env_var_denies
+    run_test test_defect4_per_token_quoted_non_ledger_allows
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/codex-write-guard_test.sh
+++ b/hooks/codex-write-guard_test.sh
@@ -19,6 +19,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 HOOK="$SCRIPT_DIR/codex-write-guard.sh"
 
+# EVIDENCE_OMT_DIR: self-derived (not ambient $OMT_DIR) so this suite runs
+# clean under `env -u OMT_DIR`, mirroring hooks/ledger-core_test.sh's own
+# evidence_dir derivation via resolve_omt_dir.
+EVIDENCE_OMT_DIR=$(bash -c "source '$SCRIPT_DIR/lib/omt-dir.sh'; resolve_omt_dir '$SCRIPT_DIR'")
+
 TESTS_PASSED=0
 TESTS_FAILED=0
 
@@ -132,7 +137,7 @@ test_qa_redirect_to_ledger_denies() {
 
     out=$(printf '{"tool_name":"Bash","tool_input":{"command":"echo x > %s"},"session_id":"cx","cwd":"%s"}' "$LED" "$GITDIR" | run_hook)
 
-    evidence_dir="$OMT_DIR/evidence/codex-ledger-parity/codex-write-guard-hook"
+    evidence_dir="$EVIDENCE_OMT_DIR/evidence/codex-ledger-parity/codex-write-guard-hook"
     mkdir -p "$evidence_dir"
     {
         echo "input: echo x > $LED (cwd=$GITDIR sid=cx)"
@@ -160,7 +165,7 @@ test_qa_prose_mention_allows() {
 
     out=$(printf '{"tool_name":"Bash","tool_input":{"command":"echo editing the session-ledger docs"},"session_id":"cx","cwd":"%s"}' "$GITDIR" | run_hook)
 
-    evidence_dir="$OMT_DIR/evidence/codex-ledger-parity/codex-write-guard-hook"
+    evidence_dir="$EVIDENCE_OMT_DIR/evidence/codex-ledger-parity/codex-write-guard-hook"
     mkdir -p "$evidence_dir"
     {
         echo "input: echo editing the session-ledger docs (cwd=$GITDIR sid=cx)"

--- a/hooks/codex-write-guard_test.sh
+++ b/hooks/codex-write-guard_test.sh
@@ -311,6 +311,115 @@ test_own_native_edit_non_ledger_allows() {
 }
 
 # =============================================================================
+# Regression -- set -e/pipefail redirect-extraction hazard (code-review fix):
+# _cwg_extract_shell_targets's redirect-extraction grep returns 1 for any
+# chain segment with no `>`/`>>` -- under this script's `set -euo pipefail`,
+# that used to abort the function before the tee/rm/dd/cp/truncate/sed -i
+# case block ever ran, silently ALLOWING those routes against the ledger.
+# Each case below targets the resolved current ledger and must DENY.
+# =============================================================================
+test_own_rm_ledger_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"rm %s"},"session_id":"cx","cwd":"%s"}' "$LED" "$GITDIR" | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-rm-ledger: expected deny for 'rm <ledger>', got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_own_tee_ledger_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"echo x | tee %s"},"session_id":"cx","cwd":"%s"}' "$LED" "$GITDIR" | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-tee-ledger: expected deny for 'echo x | tee <ledger>', got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_own_dd_ledger_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"dd if=/dev/zero of=%s bs=1 count=1"},"session_id":"cx","cwd":"%s"}' "$LED" "$GITDIR" | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-dd-ledger: expected deny for 'dd of=<ledger>', got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_own_cp_ledger_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"cp %s/src.md %s"},"session_id":"cx","cwd":"%s"}' "$GITDIR" "$LED" "$GITDIR" | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-cp-ledger: expected deny for 'cp src <ledger>', got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_own_truncate_ledger_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"truncate -s0 %s"},"session_id":"cx","cwd":"%s"}' "$LED" "$GITDIR" | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-truncate-ledger: expected deny for 'truncate -s0 <ledger>', got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_own_sed_i_ledger_denies() {
+    new_sandbox
+    local cmd out result=0
+
+    cmd="sed -i 's/a/b/' $LED"
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-sed-i-ledger: expected deny for 'sed -i ... <ledger>', got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# Non-ledger control -- 'rm' on a non-ledger file must ALLOW (proves the
+# set -e fix does not turn rm into an over-broad denier).
+test_own_rm_non_ledger_allows() {
+    new_sandbox
+    local out result=0
+
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"rm %s/README.md"},"session_id":"cx","cwd":"%s"}' "$GITDIR" "$GITDIR" | run_hook)
+    if [ "$(printf '%s' "$out" | grep -c deny)" != "0" ]; then
+        echo "ASSERTION FAILED own-rm-non-ledger-allow: expected allow, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -331,6 +440,13 @@ main() {
     run_test test_own_nested_heredoc_denies
     run_test test_own_relative_path_denies
     run_test test_own_native_edit_non_ledger_allows
+    run_test test_own_rm_ledger_denies
+    run_test test_own_tee_ledger_denies
+    run_test test_own_dd_ledger_denies
+    run_test test_own_cp_ledger_denies
+    run_test test_own_truncate_ledger_denies
+    run_test test_own_sed_i_ledger_denies
+    run_test test_own_rm_non_ledger_allows
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/codex-write-guard_test.sh
+++ b/hooks/codex-write-guard_test.sh
@@ -507,6 +507,91 @@ test_own_quoted_non_ledger_allows() {
 }
 
 # =============================================================================
+# Regression -- alternate-key payload bypass (PR #176 AI-review findings):
+# Codex has been observed sending the apply_patch payload text under
+# tool_input.input / tool_input.patch (not just .command), and the
+# exec_command/shell_command shell text under tool_input.cmd (not just
+# .command). The guard used to read only .command in each route, so a
+# write/delete targeting the ledger via one of these alternate keys was
+# silently ALLOWED. Each DENY case below must deny; the final case is a
+# non-ledger control proving the fix does not over-block.
+# =============================================================================
+test_own_apply_patch_input_key_ledger_denies() {
+    new_sandbox
+    local cmd out result=0
+
+    cmd=$(printf '*** Begin Patch\n*** Update File: %s\n*** End Patch\n' "$LED")
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"apply_patch", tool_input:{input:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-apply-patch-input-key: expected deny for apply_patch tool_input.input targeting ledger, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_own_apply_patch_patch_key_ledger_denies() {
+    new_sandbox
+    local cmd out result=0
+
+    cmd=$(printf '*** Begin Patch\n*** Delete File: %s\n*** End Patch\n' "$LED")
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"apply_patch", tool_input:{patch:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-apply-patch-patch-key: expected deny for apply_patch tool_input.patch targeting ledger, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_own_exec_command_cmd_key_ledger_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg cmd "echo x > $LED" --arg cwd "$GITDIR" '{tool_name:"exec_command", tool_input:{cmd:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-exec-command-cmd-key: expected deny for exec_command tool_input.cmd redirect to ledger, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_own_shell_command_cmd_key_ledger_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg cmd "rm $LED" --arg cwd "$GITDIR" '{tool_name:"shell_command", tool_input:{cmd:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED own-shell-command-cmd-key: expected deny for shell_command tool_input.cmd 'rm <ledger>', got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# Non-ledger control -- exec_command with tool_input.cmd targeting a
+# non-ledger path must still ALLOW (proves reading the .cmd key does not
+# turn it into an over-broad denier).
+test_own_exec_command_cmd_key_non_ledger_allows() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg cmd "cat $GITDIR/README.md" --arg cwd "$GITDIR" '{tool_name:"exec_command", tool_input:{cmd:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if [ "$(printf '%s' "$out" | grep -c deny)" != "0" ]; then
+        echo "ASSERTION FAILED own-exec-command-cmd-key-allow: expected allow for non-ledger tool_input.cmd, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -539,6 +624,11 @@ main() {
     run_test test_own_quoted_rm_ledger_denies
     run_test test_own_quoted_tee_ledger_denies
     run_test test_own_quoted_non_ledger_allows
+    run_test test_own_apply_patch_input_key_ledger_denies
+    run_test test_own_apply_patch_patch_key_ledger_denies
+    run_test test_own_exec_command_cmd_key_ledger_denies
+    run_test test_own_shell_command_cmd_key_ledger_denies
+    run_test test_own_exec_command_cmd_key_non_ledger_allows
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/hook-registration_test.sh
+++ b/hooks/hook-registration_test.sh
@@ -17,10 +17,11 @@
 #   - No claude.yaml/codex.yaml/gemini.yaml/opencode.yaml anywhere in the
 #     repo registers a PreCompact hook (TODO 1 removed the LLM summarizer's
 #     sole registration site; nothing should re-register it).
-#   - codex.yaml has no PreToolUse hooks at all -- codex has no PreToolUse
-#     event (plan Scope OUT); the ledger write-guard is unenforceable there
-#     by design, and the recording instruction still reaches it via
-#     SessionStart (rules-injector).
+#   - codex.yaml registers a PreToolUse guard (codex-write-guard.sh) -- Codex
+#     >= 0.144.1 enforces a pre-execution PreToolUse permissionDecision:"deny",
+#     falsifying the earlier assumption that Codex lacked this event; the
+#     ledger write-guard is wired there just like Claude's, alongside the
+#     SessionStart recording instruction (rules-injector).
 # =============================================================================
 set -euo pipefail
 
@@ -142,13 +143,17 @@ test_precompact_removed_from_all_targets() {
 }
 
 # =============================================================================
-# codex.yaml has no PreToolUse hooks -- codex has no PreToolUse event; the
-# ledger write-guard is unenforceable there by design (plan Scope OUT).
+# codex.yaml registers a PreToolUse guard -- Codex >= 0.144.1 enforces a
+# pre-execution PreToolUse permissionDecision:"deny", so the ledger
+# write-guard (codex-write-guard.sh) belongs there.
 # =============================================================================
-test_codex_yaml_has_no_pretooluse() {
-    if grep -q '^  PreToolUse:' "$REPO_DIR/codex.yaml"; then
-        echo "ASSERTION FAILED: codex.yaml must NOT register a PreToolUse hook (codex has no PreToolUse event)"
-        grep -n 'PreToolUse' "$REPO_DIR/codex.yaml"
+test_codex_yaml_has_pretooluse_guard() {
+    if [ "$(grep -c '^  PreToolUse:' "$REPO_DIR/codex.yaml")" = "0" ]; then
+        echo "ASSERTION FAILED: codex.yaml must register a PreToolUse hook (codex-write-guard.sh)"
+        return 1
+    fi
+    if [ "$(grep -c 'component: codex-write-guard.sh' "$REPO_DIR/codex.yaml")" = "0" ]; then
+        echo "ASSERTION FAILED: codex.yaml PreToolUse must register codex-write-guard.sh"
         return 1
     fi
     return 0
@@ -162,7 +167,7 @@ main() {
     run_test test_session_start_and_write_guard_paired_across_targets
     run_test test_session_start_and_write_guard_pair_witnessed_at_least_once
     run_test test_precompact_removed_from_all_targets
-    run_test test_codex_yaml_has_no_pretooluse
+    run_test test_codex_yaml_has_pretooluse_guard
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/ledger-core.sh
+++ b/hooks/ledger-core.sh
@@ -157,7 +157,21 @@ ledger_core_run() {
           _lc_pointer_block='  cat "$OMT_DIR/session-ledger-$OMT_SESSION_ID.md"\n($OMT_DIR and $OMT_SESSION_ID are set in CLAUDE_ENV_FILE exported by this hook.)\n'
         fi
 
-        _lc_messages="${_lc_messages}<session-restore>\n\n[LEDGER RECOVERY]\n\nYour context was just compacted. The durable session ledger on disk is the source of truth for this session.\n\nBulk sections (Decisions/Pending/Pointers/Learnings): run this command NOW, before any other action:\n${_lc_pointer_block}Resume from the \`## Now\` section.\n\n"
+        # Recovery marker is owned here (the SSOT), platform-parameterized on
+        # the same explicit signal as the pointer above: Codex has no
+        # compaction-triggered restore concept to qualify, so it gets the bare
+        # marker; Claude's restore is always compaction-triggered, so the core
+        # states that directly instead of a downstream consumer (the former
+        # hooks/session-start.sh string-substitution shim) patching it in
+        # after the fact.
+        local _lc_recovery_marker
+        if [ "$_lc_platform" = "codex" ]; then
+          _lc_recovery_marker="[LEDGER RECOVERY]"
+        else
+          _lc_recovery_marker="[LEDGER RECOVERY -- compaction]"
+        fi
+
+        _lc_messages="${_lc_messages}<session-restore>\n\n${_lc_recovery_marker}\n\nYour context was just compacted. The durable session ledger on disk is the source of truth for this session.\n\nBulk sections (Decisions/Pending/Pointers/Learnings): run this command NOW, before any other action:\n${_lc_pointer_block}Resume from the \`## Now\` section.\n\n"
 
         # additionalContext is capped ~10k chars; reuse the 7000-char inline
         # cap from session-start.sh as the acute-vs-pointer threshold.

--- a/hooks/ledger-core.sh
+++ b/hooks/ledger-core.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# =============================================================================
+# ledger-core.sh
+# Shared cross-platform session-ledger recording + compaction-recovery core
+# (plan TODO 1: codex-ledger-parity). Sourced by both hooks/session-start.sh
+# (Claude) and the Codex SessionStart hook so both harnesses run identical
+# recording/recovery logic behind a single entry point, ledger_core_run.
+#
+# Scope: recording instruction (every source) + compaction recovery
+# (source==compact) ONLY. Does NOT own the append/now write logic (stays in
+# omt-ledger.sh), the write-guard, or ledger GC (stays in session-start.sh).
+#
+# Cache-safety: the recording instruction is emitted on EVERY source, i.e. it
+# sits in the conversation prefix, so it carries no per-request volatile value
+# (timestamp/PID/counter) -- static text only, identical byte-for-byte across
+# sessions on a given platform. Recovery output is compaction-triggered, so
+# it is exempt (the prefix is already cold after compaction).
+#
+# omt-hook-dep: omt-ledger.sh
+# omt-hook-dep: lib/omt-dir.sh
+# =============================================================================
+
+_LEDGER_CORE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=hooks/lib/omt-dir.sh
+source "$_LEDGER_CORE_DIR/lib/omt-dir.sh"
+
+# ledger_core_run <platform-signal>
+#
+# platform-signal: literally "claude" or "codex" -- an EXPLICIT argument
+# supplied by the per-platform entry point. Never sniff $CLAUDE_ENV_FILE (or
+# any other env var) to infer the platform; the caller states it.
+#
+# Reads the SessionStart stdin JSON (.source, .session_id, .cwd) on fd 0 and
+# writes the SessionStart hook JSON output to stdout.
+ledger_core_run() {
+  local _lc_platform="$1"
+
+  local _lc_input
+  _lc_input=$(cat)
+
+  # Gate jq gracefully -- matches session-start.sh: emit nothing, exit 0.
+  if ! command -v jq &> /dev/null; then
+    return 0
+  fi
+
+  local _lc_source _lc_stdin_sid _lc_cwd
+  _lc_source=$(printf '%s' "$_lc_input" | jq -r '.source // ""' 2>/dev/null)
+  _lc_stdin_sid=$(printf '%s' "$_lc_input" | jq -r '.session_id // ""' 2>/dev/null)
+  _lc_cwd=$(printf '%s' "$_lc_input" | jq -r '.cwd // ""' 2>/dev/null)
+  if [ -z "$_lc_cwd" ] || [ "$_lc_cwd" = "null" ]; then
+    _lc_cwd=$(pwd)
+  fi
+
+  # Shared session-id precedence contract (identical at TODOs 1, 3, 7):
+  # OMT_SESSION_ID ?? CODEX_THREAD_ID ?? stdin.session_id, STRICT EMPTY-ONLY
+  # coalescing -- present-but-empty falls through to the next candidate;
+  # present-but-unsafe REFUSES outright (never falls through once a non-empty
+  # candidate is picked). "default" is refused the same as the CLI's own
+  # empty/default refusal (hooks/omt-ledger.sh).
+  local _lc_sid
+  if [ -n "${OMT_SESSION_ID:-}" ]; then
+    _lc_sid="$OMT_SESSION_ID"
+  elif [ -n "${CODEX_THREAD_ID:-}" ]; then
+    _lc_sid="$CODEX_THREAD_ID"
+  else
+    _lc_sid="$_lc_stdin_sid"
+  fi
+  case "$_lc_sid" in
+    ''|default) return 0 ;;
+    *[!A-Za-z0-9_-]*) return 0 ;;
+  esac
+  [ "${#_lc_sid}" -le 200 ] || return 0
+
+  local _lc_omt_dir
+  _lc_omt_dir=$(resolve_omt_dir "$_lc_cwd")
+
+  # -- Recording instruction (every source, cache-safe/static) --------------
+  #
+  # Claude branch is byte-identical to the pre-extraction hooks/session-start.sh:82
+  # text. Codex branch carries the same substance -- static append/now call
+  # examples plus the verbatim-correction mandate -- but names the Codex CLI
+  # invocation path and never mentions CLAUDE_ENV_FILE or an unexpanded
+  # $OMT_DIR/$OMT_SESSION_ID, per the plan's "no agent-visible env leakage"
+  # guardrail: those are Claude-only carriers (CLAUDE_ENV_FILE does not exist
+  # on Codex), and the recording instruction is prefix-position on every
+  # source, so a Codex agent must never see them leaked in from the shared
+  # string.
+  local _lc_recording
+  if [ "$_lc_platform" = "codex" ]; then
+    _lc_recording="<session-recording>\n\n[LEDGER RECORDING]\n\nRecord decisions, user corrections, and next-steps to the durable session ledger AS YOU WORK -- do not wait until the end of the session. Ledger sections are append-only, except Now, which the now subcommand replaces with the latest current-state summary.\n\nAppend content (piped via stdin) to a section:\n  <content> | \"\${CODEX_HOME:-\$HOME}/.codex/hooks/omt-ledger.sh\" append Decisions\n  <content> | \"\${CODEX_HOME:-\$HOME}/.codex/hooks/omt-ledger.sh\" append Pending\n\nReplace the current-state summary:\n  <content> | \"\${CODEX_HOME:-\$HOME}/.codex/hooks/omt-ledger.sh\" now\n\nCRITICAL: record a user correction VERBATIM -- the user's exact original words, never a paraphrase or summary. Paraphrasing a correction silently loses the precise wording that made it a correction. Append verbatim corrections to the User Corrections (verbatim) section.\n\n(omt-ledger.sh self-resolves OMT_DIR from git and the session id from OMT_SESSION_ID or CODEX_THREAD_ID; it computes the ledger path internally.)\n\n</session-recording>\n\n---\n\n"
+  else
+    _lc_recording="<session-recording>\n\n[LEDGER RECORDING]\n\nRecord decisions, user corrections, and next-steps to the durable session ledger AS YOU WORK -- do not wait until the end of the session. Ledger sections are append-only, except Now, which the now subcommand replaces with the latest current-state summary.\n\nAppend content (piped via stdin) to a section:\n  <content> | \"\${CLAUDE_PROJECT_DIR:-\$HOME}/.claude/hooks/omt-ledger.sh\" append Decisions\n  <content> | \"\${CLAUDE_PROJECT_DIR:-\$HOME}/.claude/hooks/omt-ledger.sh\" append Pending\n\nReplace the current-state summary:\n  <content> | \"\${CLAUDE_PROJECT_DIR:-\$HOME}/.claude/hooks/omt-ledger.sh\" now\n\nCRITICAL: record a user correction VERBATIM -- the user's exact original words, never a paraphrase or summary. Paraphrasing a correction silently loses the precise wording that made it a correction. Append verbatim corrections to the User Corrections (verbatim) section.\n\n(\$OMT_DIR and \$OMT_SESSION_ID are set in CLAUDE_ENV_FILE exported by this hook; omt-ledger.sh computes the ledger path internally.)\n\n</session-recording>\n\n---\n\n"
+  fi
+
+  local _lc_messages="$_lc_recording"
+  local _lc_acute_inline=""
+
+  # -- Compaction recovery (source==compact only) ----------------------------
+  if [ "$_lc_source" = "compact" ]; then
+    local _lc_ledger_file="$_lc_omt_dir/session-ledger-$_lc_sid.md"
+    if [ -f "$_lc_ledger_file" ]; then
+      # Extract ONLY the two acute sections (## Now, ## User Corrections
+      # (verbatim)) -- lifted from hooks/session-start.sh:330-358, kept
+      # bit-identical (including the SENTINEL OMT_ESC:: unescape) since it is
+      # a shared contract with the omt-ledger.sh writer (hooks/omt-ledger.sh:
+      # escape_line/emit_content). Section boundaries are the 6 known
+      # skeleton headers consumed in their fixed order, NOT any "## " line.
+      local _lc_acute
+      _lc_acute=$(awk '
+        function is_skeleton_header(line,    h) {
+          for (h = 1; h <= n; h++) if (line == H[h]) return 1
+          return 0
+        }
+        function unescape_line(line,    stripped, count) {
+          if (index(line, SENTINEL) != 1) return line
+          stripped = line
+          count = 0
+          while (index(stripped, SENTINEL) == 1) {
+            stripped = substr(stripped, length(SENTINEL) + 1)
+            count++
+          }
+          if (count >= 1 && is_skeleton_header(stripped)) return substr(line, length(SENTINEL) + 1)
+          return line
+        }
+        BEGIN {
+          SENTINEL = "OMT_ESC::"
+          n = split("## Now|## Decisions|## User Corrections (verbatim)|## Pending|## Pointers|## Learnings", H, "|")
+          idx = 1
+        }
+        (idx <= n && $0 == H[idx]) {
+          idx++
+          keep = ($0 == "## Now" || $0 == "## User Corrections (verbatim)")
+          if (keep) print
+          next
+        }
+        keep { print unescape_line($0) }
+      ' "$_lc_ledger_file")
+
+      # Recovery pointer is platform-parameterized on the explicit platform
+      # signal (never sniffed): claude keeps the env-var-literal form +
+      # CLAUDE_ENV_FILE note byte-preserved from session-start.sh; codex
+      # points at the already-resolved absolute ledger path with no note.
+      local _lc_pointer_block
+      if [ "$_lc_platform" = "codex" ]; then
+        _lc_pointer_block="  cat \"$_lc_ledger_file\"\n"
+      else
+        _lc_pointer_block='  cat "$OMT_DIR/session-ledger-$OMT_SESSION_ID.md"\n($OMT_DIR and $OMT_SESSION_ID are set in CLAUDE_ENV_FILE exported by this hook.)\n'
+      fi
+
+      _lc_messages="${_lc_messages}<session-restore>\n\n[LEDGER RECOVERY]\n\nYour context was just compacted. The durable session ledger on disk is the source of truth for this session.\n\nBulk sections (Decisions/Pending/Pointers/Learnings): run this command NOW, before any other action:\n${_lc_pointer_block}Resume from the \`## Now\` section.\n\n"
+
+      # additionalContext is capped ~10k chars; reuse the 7000-char inline
+      # cap from session-start.sh as the acute-vs-pointer threshold.
+      if [ -n "$_lc_acute" ] && [ "${#_lc_acute}" -le 7000 ]; then
+        _lc_messages="${_lc_messages}[Now + User Corrections, inlined below]\n\n"
+        _lc_acute_inline="$_lc_acute"
+      else
+        _lc_messages="${_lc_messages}[Now + User Corrections exceed the inline cap -- read them via the cat command above.]\n\n"
+      fi
+
+      _lc_messages="${_lc_messages}</session-restore>\n\n---\n\n"
+    fi
+  fi
+
+  # -- Emit ------------------------------------------------------------------
+  local _lc_messages_escaped
+  _lc_messages_escaped=$(echo "$_lc_messages" | sed 's/"/\\"/g')
+  # Surgically encode the untrusted ledger acute fragment (may contain
+  # quotes/backslashes/verbatim user corrections) via jq -Rs, stripping the
+  # outer quotes so it concatenates onto the sed-escaped body -- mirrors
+  # hooks/session-start.sh's LEDGER_ACUTE_INLINE encoding.
+  local _lc_acute_escaped
+  _lc_acute_escaped=$(printf '%s' "$_lc_acute_inline" | jq -Rs . | sed '1s/^"//; $s/"$//')
+
+  echo "{\"continue\": true, \"hookSpecificOutput\": {\"hookEventName\": \"SessionStart\", \"additionalContext\": \"$_lc_messages_escaped$_lc_acute_escaped\"}}"
+}

--- a/hooks/ledger-core.sh
+++ b/hooks/ledger-core.sh
@@ -38,43 +38,15 @@ ledger_core_run() {
   local _lc_input
   _lc_input=$(cat)
 
-  # Gate jq gracefully -- matches session-start.sh: emit nothing, exit 0.
-  if ! command -v jq &> /dev/null; then
-    return 0
-  fi
-
-  local _lc_source _lc_stdin_sid _lc_cwd
-  _lc_source=$(printf '%s' "$_lc_input" | jq -r '.source // ""' 2>/dev/null)
-  _lc_stdin_sid=$(printf '%s' "$_lc_input" | jq -r '.session_id // ""' 2>/dev/null)
-  _lc_cwd=$(printf '%s' "$_lc_input" | jq -r '.cwd // ""' 2>/dev/null)
-  if [ -z "$_lc_cwd" ] || [ "$_lc_cwd" = "null" ]; then
-    _lc_cwd=$(pwd)
-  fi
-
-  # Shared session-id precedence contract (identical at TODOs 1, 3, 7):
-  # OMT_SESSION_ID ?? CODEX_THREAD_ID ?? stdin.session_id, STRICT EMPTY-ONLY
-  # coalescing -- present-but-empty falls through to the next candidate;
-  # present-but-unsafe REFUSES outright (never falls through once a non-empty
-  # candidate is picked). "default" is refused the same as the CLI's own
-  # empty/default refusal (hooks/omt-ledger.sh).
-  local _lc_sid
-  if [ -n "${OMT_SESSION_ID:-}" ]; then
-    _lc_sid="$OMT_SESSION_ID"
-  elif [ -n "${CODEX_THREAD_ID:-}" ]; then
-    _lc_sid="$CODEX_THREAD_ID"
-  else
-    _lc_sid="$_lc_stdin_sid"
-  fi
-  case "$_lc_sid" in
-    ''|default) return 0 ;;
-    *[!A-Za-z0-9_-]*) return 0 ;;
-  esac
-  [ "${#_lc_sid}" -le 200 ] || return 0
-
-  local _lc_omt_dir
-  _lc_omt_dir=$(resolve_omt_dir "$_lc_cwd")
-
   # -- Recording instruction (every source, cache-safe/static) --------------
+  #
+  # Emitted FIRST and UNCONDITIONALLY -- it is static text keyed only on the
+  # explicit platform signal, needing neither jq nor a resolved session id.
+  # The pre-extraction hooks/session-start.sh emitted this regardless of jq
+  # presence or session-id validity; the jq gate and sid-resolution
+  # empty-return below must therefore only gate [LEDGER RECOVERY] (which
+  # legitimately needs both to parse stdin and locate the ledger file), never
+  # this block.
   #
   # Claude branch is byte-identical to the pre-extraction hooks/session-start.sh:82
   # text. Codex branch carries the same substance -- static append/now call
@@ -95,70 +67,109 @@ ledger_core_run() {
   local _lc_messages="$_lc_recording"
   local _lc_acute_inline=""
 
-  # -- Compaction recovery (source==compact only) ----------------------------
-  if [ "$_lc_source" = "compact" ]; then
-    local _lc_ledger_file="$_lc_omt_dir/session-ledger-$_lc_sid.md"
-    if [ -f "$_lc_ledger_file" ]; then
-      # Extract ONLY the two acute sections (## Now, ## User Corrections
-      # (verbatim)) -- lifted from hooks/session-start.sh:330-358, kept
-      # bit-identical (including the SENTINEL OMT_ESC:: unescape) since it is
-      # a shared contract with the omt-ledger.sh writer (hooks/omt-ledger.sh:
-      # escape_line/emit_content). Section boundaries are the 6 known
-      # skeleton headers consumed in their fixed order, NOT any "## " line.
-      local _lc_acute
-      _lc_acute=$(awk '
-        function is_skeleton_header(line,    h) {
-          for (h = 1; h <= n; h++) if (line == H[h]) return 1
-          return 0
-        }
-        function unescape_line(line,    stripped, count) {
-          if (index(line, SENTINEL) != 1) return line
-          stripped = line
-          count = 0
-          while (index(stripped, SENTINEL) == 1) {
-            stripped = substr(stripped, length(SENTINEL) + 1)
-            count++
+  # -- Compaction recovery (source==compact, jq present, valid sid only) ----
+  #
+  # Recovery legitimately needs jq (to parse stdin JSON for .source/
+  # .session_id/.cwd) and a valid resolved sid (to locate the ledger file on
+  # disk) -- gate ONLY this block on both, so the recording instruction above
+  # survives jq being absent from PATH or an empty/default/unsafe sid.
+  if command -v jq &> /dev/null; then
+    local _lc_source _lc_stdin_sid _lc_cwd
+    _lc_source=$(printf '%s' "$_lc_input" | jq -r '.source // ""' 2>/dev/null)
+    _lc_stdin_sid=$(printf '%s' "$_lc_input" | jq -r '.session_id // ""' 2>/dev/null)
+    _lc_cwd=$(printf '%s' "$_lc_input" | jq -r '.cwd // ""' 2>/dev/null)
+    if [ -z "$_lc_cwd" ] || [ "$_lc_cwd" = "null" ]; then
+      _lc_cwd=$(pwd)
+    fi
+
+    # Shared session-id precedence contract (identical at TODOs 1, 3, 7):
+    # OMT_SESSION_ID ?? CODEX_THREAD_ID ?? stdin.session_id, STRICT EMPTY-ONLY
+    # coalescing -- present-but-empty falls through to the next candidate;
+    # present-but-unsafe REFUSES outright (never falls through once a non-empty
+    # candidate is picked). "default" is refused the same as the CLI's own
+    # empty/default refusal (hooks/omt-ledger.sh).
+    local _lc_sid
+    if [ -n "${OMT_SESSION_ID:-}" ]; then
+      _lc_sid="$OMT_SESSION_ID"
+    elif [ -n "${CODEX_THREAD_ID:-}" ]; then
+      _lc_sid="$CODEX_THREAD_ID"
+    else
+      _lc_sid="$_lc_stdin_sid"
+    fi
+
+    local _lc_sid_valid=1
+    case "$_lc_sid" in
+      ''|default) _lc_sid_valid=0 ;;
+      *[!A-Za-z0-9_-]*) _lc_sid_valid=0 ;;
+    esac
+    [ "${#_lc_sid}" -le 200 ] || _lc_sid_valid=0
+
+    if [ "$_lc_sid_valid" = 1 ] && [ "$_lc_source" = "compact" ]; then
+      local _lc_omt_dir
+      _lc_omt_dir=$(resolve_omt_dir "$_lc_cwd")
+      local _lc_ledger_file="$_lc_omt_dir/session-ledger-$_lc_sid.md"
+      if [ -f "$_lc_ledger_file" ]; then
+        # Extract ONLY the two acute sections (## Now, ## User Corrections
+        # (verbatim)) -- lifted from hooks/session-start.sh:330-358, kept
+        # bit-identical (including the SENTINEL OMT_ESC:: unescape) since it is
+        # a shared contract with the omt-ledger.sh writer (hooks/omt-ledger.sh:
+        # escape_line/emit_content). Section boundaries are the 6 known
+        # skeleton headers consumed in their fixed order, NOT any "## " line.
+        local _lc_acute
+        _lc_acute=$(awk '
+          function is_skeleton_header(line,    h) {
+            for (h = 1; h <= n; h++) if (line == H[h]) return 1
+            return 0
           }
-          if (count >= 1 && is_skeleton_header(stripped)) return substr(line, length(SENTINEL) + 1)
-          return line
-        }
-        BEGIN {
-          SENTINEL = "OMT_ESC::"
-          n = split("## Now|## Decisions|## User Corrections (verbatim)|## Pending|## Pointers|## Learnings", H, "|")
-          idx = 1
-        }
-        (idx <= n && $0 == H[idx]) {
-          idx++
-          keep = ($0 == "## Now" || $0 == "## User Corrections (verbatim)")
-          if (keep) print
-          next
-        }
-        keep { print unescape_line($0) }
-      ' "$_lc_ledger_file")
+          function unescape_line(line,    stripped, count) {
+            if (index(line, SENTINEL) != 1) return line
+            stripped = line
+            count = 0
+            while (index(stripped, SENTINEL) == 1) {
+              stripped = substr(stripped, length(SENTINEL) + 1)
+              count++
+            }
+            if (count >= 1 && is_skeleton_header(stripped)) return substr(line, length(SENTINEL) + 1)
+            return line
+          }
+          BEGIN {
+            SENTINEL = "OMT_ESC::"
+            n = split("## Now|## Decisions|## User Corrections (verbatim)|## Pending|## Pointers|## Learnings", H, "|")
+            idx = 1
+          }
+          (idx <= n && $0 == H[idx]) {
+            idx++
+            keep = ($0 == "## Now" || $0 == "## User Corrections (verbatim)")
+            if (keep) print
+            next
+          }
+          keep { print unescape_line($0) }
+        ' "$_lc_ledger_file")
 
-      # Recovery pointer is platform-parameterized on the explicit platform
-      # signal (never sniffed): claude keeps the env-var-literal form +
-      # CLAUDE_ENV_FILE note byte-preserved from session-start.sh; codex
-      # points at the already-resolved absolute ledger path with no note.
-      local _lc_pointer_block
-      if [ "$_lc_platform" = "codex" ]; then
-        _lc_pointer_block="  cat \"$_lc_ledger_file\"\n"
-      else
-        _lc_pointer_block='  cat "$OMT_DIR/session-ledger-$OMT_SESSION_ID.md"\n($OMT_DIR and $OMT_SESSION_ID are set in CLAUDE_ENV_FILE exported by this hook.)\n'
+        # Recovery pointer is platform-parameterized on the explicit platform
+        # signal (never sniffed): claude keeps the env-var-literal form +
+        # CLAUDE_ENV_FILE note byte-preserved from session-start.sh; codex
+        # points at the already-resolved absolute ledger path with no note.
+        local _lc_pointer_block
+        if [ "$_lc_platform" = "codex" ]; then
+          _lc_pointer_block="  cat \"$_lc_ledger_file\"\n"
+        else
+          _lc_pointer_block='  cat "$OMT_DIR/session-ledger-$OMT_SESSION_ID.md"\n($OMT_DIR and $OMT_SESSION_ID are set in CLAUDE_ENV_FILE exported by this hook.)\n'
+        fi
+
+        _lc_messages="${_lc_messages}<session-restore>\n\n[LEDGER RECOVERY]\n\nYour context was just compacted. The durable session ledger on disk is the source of truth for this session.\n\nBulk sections (Decisions/Pending/Pointers/Learnings): run this command NOW, before any other action:\n${_lc_pointer_block}Resume from the \`## Now\` section.\n\n"
+
+        # additionalContext is capped ~10k chars; reuse the 7000-char inline
+        # cap from session-start.sh as the acute-vs-pointer threshold.
+        if [ -n "$_lc_acute" ] && [ "${#_lc_acute}" -le 7000 ]; then
+          _lc_messages="${_lc_messages}[Now + User Corrections, inlined below]\n\n"
+          _lc_acute_inline="$_lc_acute"
+        else
+          _lc_messages="${_lc_messages}[Now + User Corrections exceed the inline cap -- read them via the cat command above.]\n\n"
+        fi
+
+        _lc_messages="${_lc_messages}</session-restore>\n\n---\n\n"
       fi
-
-      _lc_messages="${_lc_messages}<session-restore>\n\n[LEDGER RECOVERY]\n\nYour context was just compacted. The durable session ledger on disk is the source of truth for this session.\n\nBulk sections (Decisions/Pending/Pointers/Learnings): run this command NOW, before any other action:\n${_lc_pointer_block}Resume from the \`## Now\` section.\n\n"
-
-      # additionalContext is capped ~10k chars; reuse the 7000-char inline
-      # cap from session-start.sh as the acute-vs-pointer threshold.
-      if [ -n "$_lc_acute" ] && [ "${#_lc_acute}" -le 7000 ]; then
-        _lc_messages="${_lc_messages}[Now + User Corrections, inlined below]\n\n"
-        _lc_acute_inline="$_lc_acute"
-      else
-        _lc_messages="${_lc_messages}[Now + User Corrections exceed the inline cap -- read them via the cat command above.]\n\n"
-      fi
-
-      _lc_messages="${_lc_messages}</session-restore>\n\n---\n\n"
     fi
   fi
 
@@ -168,9 +179,14 @@ ledger_core_run() {
   # Surgically encode the untrusted ledger acute fragment (may contain
   # quotes/backslashes/verbatim user corrections) via jq -Rs, stripping the
   # outer quotes so it concatenates onto the sed-escaped body -- mirrors
-  # hooks/session-start.sh's LEDGER_ACUTE_INLINE encoding.
-  local _lc_acute_escaped
-  _lc_acute_escaped=$(printf '%s' "$_lc_acute_inline" | jq -Rs . | sed '1s/^"//; $s/"$//')
+  # hooks/session-start.sh's LEDGER_ACUTE_INLINE encoding. _lc_acute_inline is
+  # only ever populated inside the jq-gated recovery block above, so it stays
+  # empty when jq is absent -- skip the jq call itself in that case rather
+  # than let it fail against an empty input.
+  local _lc_acute_escaped=""
+  if command -v jq &> /dev/null; then
+    _lc_acute_escaped=$(printf '%s' "$_lc_acute_inline" | jq -Rs . | sed '1s/^"//; $s/"$//')
+  fi
 
   echo "{\"continue\": true, \"hookSpecificOutput\": {\"hookEventName\": \"SessionStart\", \"additionalContext\": \"$_lc_messages_escaped$_lc_acute_escaped\"}}"
 }

--- a/hooks/ledger-core_test.sh
+++ b/hooks/ledger-core_test.sh
@@ -59,14 +59,29 @@ test_ac1_claude_compact_inline_recovery_env_pointer() {
 # AC2: platform=codex, >7000-char ledger -> pointer branch. No CLAUDE_ENV_FILE,
 # no unexpanded $OMT_DIR/$OMT_SESSION_ID; DOES contain the resolved absolute
 # ledger path.
+#
+# The 8000-char payload MUST live under the "## Now" header (not before it):
+# ledger-core.sh's recovery extractor keeps only content following the
+# "## Now"/"## User Corrections (verbatim)" headers, so padding placed BEFORE
+# "## Now" is discarded by the extractor and never reaches the >7000-char
+# inline-cap check at all -- that would make the pointer branch fire for the
+# wrong reason (an empty extracted acute) instead of the over-cap reason this
+# test claims to cover. Assertions distinguish the over-cap/pointer branch
+# from the inline branch by their branch-unique literal text ("exceed the
+# inline cap" vs "inlined below"), and confirm the original "no leak" intent
+# by asserting the raw x-payload itself never appears in the output (only the
+# inline branch would ever embed it).
 # =============================================================================
 test_ac2_codex_over_cap_pointer_no_leak() {
     local SBX OD out
     SBX=$(mktemp -d)
     OD="$SBX/omt"
     mkdir -p "$OD"
-    head -c 8000 /dev/zero | tr '\0' 'x' > "$OD/session-ledger-test-sid-1.md"
-    printf '## Now\nN\n' >> "$OD/session-ledger-test-sid-1.md"
+    {
+        printf '## Now\n'
+        head -c 8000 /dev/zero | tr '\0' 'x'
+        printf '\n## User Corrections (verbatim)\n'
+    } > "$OD/session-ledger-test-sid-1.md"
 
     out=$(printf '{"source":"compact","session_id":"test-sid-1","cwd":"%s"}' "$SBX" \
         | OMT_DIR="$OD" bash -c "unset OMT_SESSION_ID CODEX_THREAD_ID; source '$LEDGER_CORE'; ledger_core_run codex")
@@ -75,7 +90,10 @@ test_ac2_codex_over_cap_pointer_no_leak() {
     if [ "$(printf '%s' "$out" | grep -c 'CLAUDE_ENV_FILE')" = "0" ] \
         && [ "$(printf '%s' "$out" | grep -c '\$OMT_DIR')" = "0" ] \
         && [ "$(printf '%s' "$out" | grep -c '\$OMT_SESSION_ID')" = "0" ] \
-        && echo "$out" | grep -q "$OD/session-ledger-test-sid-1.md"; then
+        && echo "$out" | grep -q "$OD/session-ledger-test-sid-1.md" \
+        && echo "$out" | grep -qF 'exceed the inline cap' \
+        && [ "$(printf '%s' "$out" | grep -c 'inlined below')" = "0" ] \
+        && [ "$(printf '%s' "$out" | grep -cE 'x{50,}')" = "0" ]; then
         ok=1
     fi
 

--- a/hooks/ledger-core_test.sh
+++ b/hooks/ledger-core_test.sh
@@ -30,8 +30,9 @@ run_test() {
 
 # =============================================================================
 # AC1: source==compact, populated <=7000-char ledger, platform=claude ->
-# [LEDGER RECOVERY] + inline `## Now` body + env-var pointer form (contains
-# the literal token OMT_SESSION_ID).
+# a [LEDGER RECOVERY marker (core owns the platform-qualified form, see AC4)
+# + inline `## Now` body + env-var pointer form (contains the literal token
+# OMT_SESSION_ID).
 # =============================================================================
 test_ac1_claude_compact_inline_recovery_env_pointer() {
     local SBX OD out
@@ -44,7 +45,7 @@ test_ac1_claude_compact_inline_recovery_env_pointer() {
         | OMT_DIR="$OD" OMT_SESSION_ID=test-sid-1 bash -c "source '$LEDGER_CORE'; ledger_core_run claude")
 
     local ok=0
-    if echo "$out" | grep -q '\[LEDGER RECOVERY\]' \
+    if echo "$out" | grep -q '\[LEDGER RECOVERY' \
         && echo "$out" | grep -q 'CURRENT-STATE-XYZ' \
         && echo "$out" | grep -q 'OMT_SESSION_ID'; then
         ok=1
@@ -251,6 +252,57 @@ test_codex_noncompact_recording_only() {
 }
 
 # =============================================================================
+# AC4 (S2: recovery-marker ownership): platform=claude compact-recovery output
+# must carry the "-- compaction" qualifier on the [LEDGER RECOVERY] marker
+# ITSELF -- i.e. ledger-core.sh must own and emit "[LEDGER RECOVERY --
+# compaction]" directly, not the bare "[LEDGER RECOVERY]" that a downstream
+# consumer (hooks/session-start.sh) patches in via string substitution.
+# =============================================================================
+test_ac4_claude_recovery_marker_has_compaction_suffix() {
+    local SBX OD out
+    SBX=$(mktemp -d)
+    OD="$SBX/omt"
+    mkdir -p "$OD"
+    printf '## Now\nCURRENT-STATE-XYZ\n## User Corrections (verbatim)\n' > "$OD/session-ledger-test-sid-1.md"
+
+    out=$(printf '{"source":"compact","session_id":"test-sid-1","cwd":"%s"}' "$SBX" \
+        | OMT_DIR="$OD" OMT_SESSION_ID=test-sid-1 bash -c "source '$LEDGER_CORE'; ledger_core_run claude")
+
+    local ok=0
+    if echo "$out" | grep -qF '[LEDGER RECOVERY -- compaction]'; then
+        ok=1
+    fi
+
+    rm -rf "$SBX"
+    [ "$ok" = "1" ]
+}
+
+# =============================================================================
+# AC5 (S2: recovery-marker ownership): platform=codex compact-recovery output
+# must carry the bare "[LEDGER RECOVERY]" marker -- no "-- compaction" suffix,
+# since Codex has no compaction-triggered restore concept to qualify.
+# =============================================================================
+test_ac5_codex_recovery_marker_is_bare() {
+    local SBX OD out
+    SBX=$(mktemp -d)
+    OD="$SBX/omt"
+    mkdir -p "$OD"
+    printf '## Now\nCURRENT-STATE-XYZ\n## User Corrections (verbatim)\n' > "$OD/session-ledger-test-sid-1.md"
+
+    out=$(printf '{"source":"compact","session_id":"test-sid-1","cwd":"%s"}' "$SBX" \
+        | OMT_DIR="$OD" bash -c "unset OMT_SESSION_ID CODEX_THREAD_ID; source '$LEDGER_CORE'; ledger_core_run codex")
+
+    local ok=0
+    if echo "$out" | grep -qF '[LEDGER RECOVERY]' \
+        && [ "$(printf '%s' "$out" | grep -c -- '-- compaction')" = "0" ]; then
+        ok=1
+    fi
+
+    rm -rf "$SBX"
+    [ "$ok" = "1" ]
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 main() {
@@ -266,6 +318,8 @@ main() {
     run_test test_missing_sid_recording_present_recovery_absent
     run_test test_default_sid_recording_present_recovery_absent
     run_test test_codex_noncompact_recording_only
+    run_test test_ac4_claude_recovery_marker_has_compaction_suffix
+    run_test test_ac5_codex_recovery_marker_is_bare
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/ledger-core_test.sh
+++ b/hooks/ledger-core_test.sh
@@ -1,0 +1,220 @@
+#!/bin/bash
+# =============================================================================
+# ledger-core.sh Tests (plan TODO 1: codex-ledger-parity)
+#
+# Behavioral tests for the shared cross-platform ledger recording + compaction
+# recovery core. Sources hooks/ledger-core.sh directly and drives
+# ledger_core_run <claude|codex> via synthetic SessionStart stdin JSON,
+# mirroring the established harness pattern in
+# hooks/session-start_test.sh:1542-1575 (synthetic-stdin -> grep the raw
+# stdout; the plan's own ACs grep raw $out rather than jq-decoding first).
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LEDGER_CORE="$SCRIPT_DIR/ledger-core.sh"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+run_test() {
+    local test_name="$1"
+    if "$test_name"; then
+        echo "[PASS] $test_name"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "[FAIL] $test_name"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+# =============================================================================
+# AC1: source==compact, populated <=7000-char ledger, platform=claude ->
+# [LEDGER RECOVERY] + inline `## Now` body + env-var pointer form (contains
+# the literal token OMT_SESSION_ID).
+# =============================================================================
+test_ac1_claude_compact_inline_recovery_env_pointer() {
+    local SBX OD out
+    SBX=$(mktemp -d)
+    OD="$SBX/omt"
+    mkdir -p "$OD"
+    printf '## Now\nCURRENT-STATE-XYZ\n## User Corrections (verbatim)\n' > "$OD/session-ledger-test-sid-1.md"
+
+    out=$(printf '{"source":"compact","session_id":"test-sid-1","cwd":"%s"}' "$SBX" \
+        | OMT_DIR="$OD" OMT_SESSION_ID=test-sid-1 bash -c "source '$LEDGER_CORE'; ledger_core_run claude")
+
+    local ok=0
+    if echo "$out" | grep -q '\[LEDGER RECOVERY\]' \
+        && echo "$out" | grep -q 'CURRENT-STATE-XYZ' \
+        && echo "$out" | grep -q 'OMT_SESSION_ID'; then
+        ok=1
+    fi
+
+    rm -rf "$SBX"
+    [ "$ok" = "1" ]
+}
+
+# =============================================================================
+# AC2: platform=codex, >7000-char ledger -> pointer branch. No CLAUDE_ENV_FILE,
+# no unexpanded $OMT_DIR/$OMT_SESSION_ID; DOES contain the resolved absolute
+# ledger path.
+# =============================================================================
+test_ac2_codex_over_cap_pointer_no_leak() {
+    local SBX OD out
+    SBX=$(mktemp -d)
+    OD="$SBX/omt"
+    mkdir -p "$OD"
+    head -c 8000 /dev/zero | tr '\0' 'x' > "$OD/session-ledger-test-sid-1.md"
+    printf '## Now\nN\n' >> "$OD/session-ledger-test-sid-1.md"
+
+    out=$(printf '{"source":"compact","session_id":"test-sid-1","cwd":"%s"}' "$SBX" \
+        | OMT_DIR="$OD" bash -c "unset OMT_SESSION_ID CODEX_THREAD_ID; source '$LEDGER_CORE'; ledger_core_run codex")
+
+    local ok=0
+    if [ "$(printf '%s' "$out" | grep -c 'CLAUDE_ENV_FILE')" = "0" ] \
+        && [ "$(printf '%s' "$out" | grep -c '\$OMT_DIR')" = "0" ] \
+        && [ "$(printf '%s' "$out" | grep -c '\$OMT_SESSION_ID')" = "0" ] \
+        && echo "$out" | grep -q "$OD/session-ledger-test-sid-1.md"; then
+        ok=1
+    fi
+
+    rm -rf "$SBX"
+    [ "$ok" = "1" ]
+}
+
+# =============================================================================
+# AC3: platform=codex, <=7000-char ledger (inline branch) -> ALSO leaks
+# nothing (the pointer + env note is emitted on Claude in this branch too, so
+# the Codex guard must hold here as well).
+# =============================================================================
+test_ac3_codex_inline_no_leak() {
+    local SBX OD out
+    SBX=$(mktemp -d)
+    OD="$SBX/omt"
+    mkdir -p "$OD"
+    printf '## Now\nSMALL-INLINE\n## User Corrections (verbatim)\n' > "$OD/session-ledger-test-sid-1.md"
+
+    out=$(printf '{"source":"compact","session_id":"test-sid-1","cwd":"%s"}' "$SBX" \
+        | OMT_DIR="$OD" bash -c "unset OMT_SESSION_ID CODEX_THREAD_ID; source '$LEDGER_CORE'; ledger_core_run codex")
+
+    local ok=0
+    if printf '%s' "$out" | grep -q 'SMALL-INLINE' \
+        && [ "$(printf '%s' "$out" | grep -c 'CLAUDE_ENV_FILE')" = "0" ] \
+        && [ "$(printf '%s' "$out" | grep -c '\$OMT_DIR')" = "0" ] \
+        && [ "$(printf '%s' "$out" | grep -c '\$OMT_SESSION_ID')" = "0" ]; then
+        ok=1
+    fi
+
+    rm -rf "$SBX"
+    [ "$ok" = "1" ]
+}
+
+# =============================================================================
+# QA Scenario: Recording instruction on non-compact source — every-source
+# recording emit; recovery absent on a non-compact source.
+# Evidence: $OMT_DIR/evidence/codex-ledger-parity/ledger-core/recording-noncompact.txt
+# =============================================================================
+test_qa_recording_noncompact() {
+    local out ok=0
+    out=$(printf '{"source":"startup","session_id":"s","cwd":"/tmp"}' \
+        | OMT_DIR=/tmp/x OMT_SESSION_ID=s bash -c "source '$LEDGER_CORE'; ledger_core_run claude")
+
+    if echo "$out" | grep -q '\[LEDGER RECORDING\]' \
+        && [ "$(printf '%s' "$out" | grep -c '\[LEDGER RECOVERY\]')" = "0" ]; then
+        ok=1
+    fi
+
+    local evidence_dir
+    evidence_dir=$(bash -c "source '$SCRIPT_DIR/lib/omt-dir.sh'; resolve_omt_dir '$SCRIPT_DIR'")/evidence/codex-ledger-parity/ledger-core
+    mkdir -p "$evidence_dir"
+    {
+        echo "# QA Scenario: Recording instruction on non-compact source"
+        echo "# Command: printf '{\"source\":\"startup\",...}' | OMT_DIR=/tmp/x OMT_SESSION_ID=s bash -c \"source hooks/ledger-core.sh; ledger_core_run claude\""
+        echo "# Result: ok=$ok (1=PASS, 0=FAIL)"
+        echo "---- stdout ----"
+        echo "$out"
+    } > "$evidence_dir/recording-noncompact.txt"
+
+    [ "$ok" = "1" ]
+}
+
+# =============================================================================
+# QA Scenario: jq absent — graceful degrade (empty stdout, exit 0).
+# Evidence: $OMT_DIR/evidence/codex-ledger-parity/ledger-core/jq-absent.txt
+# =============================================================================
+test_qa_jq_absent() {
+    local out rc ok=0
+    set +e
+    # /bin/bash (absolute path), not a bare `bash` lookup: on this host the
+    # calling shell is zsh, which re-resolves an assignment-prefixed command
+    # name against the NEW PATH being assigned -- `PATH=/nonexistent bash`
+    # fails with "command not found" (exit 127) before ever reaching
+    # ledger-core.sh, since zsh can no longer locate `bash` itself under the
+    # now-empty PATH. The absolute path sidesteps that lookup entirely while
+    # still handing the child process PATH=/nonexistent, so `command -v jq`
+    # inside ledger_core_run correctly reports jq as absent.
+    out=$(printf '{"source":"compact","session_id":"s","cwd":"/tmp"}' \
+        | PATH=/nonexistent OMT_DIR=/tmp/x OMT_SESSION_ID=s /bin/bash -c "source '$LEDGER_CORE'; ledger_core_run claude" 2>/dev/null)
+    rc=$?
+    set -e
+
+    if [ "$rc" = "0" ] && [ -z "$out" ]; then
+        ok=1
+    fi
+
+    local evidence_dir
+    evidence_dir=$(bash -c "source '$SCRIPT_DIR/lib/omt-dir.sh'; resolve_omt_dir '$SCRIPT_DIR'")/evidence/codex-ledger-parity/ledger-core
+    mkdir -p "$evidence_dir"
+    {
+        echo "# QA Scenario: jq absent -- graceful degrade"
+        echo "# Command: printf '...' | PATH=/nonexistent OMT_DIR=/tmp/x OMT_SESSION_ID=s bash -c \"source hooks/ledger-core.sh; ledger_core_run claude\""
+        echo "# exit code: $rc"
+        echo "# stdout empty: $([ -z "$out" ] && echo yes || echo no)"
+        echo "# Result: ok=$ok (1=PASS, 0=FAIL)"
+    } > "$evidence_dir/jq-absent.txt"
+
+    [ "$ok" = "1" ]
+}
+
+# =============================================================================
+# Additional coverage (plan MUST DO items 4/5, folded into the AC/QA set above
+# where not already exercised): non-compact source on the codex signal must
+# also emit RECORDING without RECOVERY (mirrors the claude-signal QA scenario).
+# =============================================================================
+test_codex_noncompact_recording_only() {
+    local out ok=0
+    out=$(printf '{"source":"startup","session_id":"s","cwd":"/tmp"}' \
+        | OMT_DIR=/tmp/x OMT_SESSION_ID=s bash -c "source '$LEDGER_CORE'; ledger_core_run codex")
+
+    if echo "$out" | grep -q '\[LEDGER RECORDING\]' \
+        && [ "$(printf '%s' "$out" | grep -c '\[LEDGER RECOVERY\]')" = "0" ]; then
+        ok=1
+    fi
+    [ "$ok" = "1" ]
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+main() {
+    echo "=========================================="
+    echo "ledger-core.sh Tests"
+    echo "=========================================="
+
+    run_test test_ac1_claude_compact_inline_recovery_env_pointer
+    run_test test_ac2_codex_over_cap_pointer_no_leak
+    run_test test_ac3_codex_inline_no_leak
+    run_test test_qa_recording_noncompact
+    run_test test_qa_jq_absent
+    run_test test_codex_noncompact_recording_only
+
+    echo "=========================================="
+    echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"
+    echo "=========================================="
+
+    if [ "$TESTS_FAILED" -gt 0 ]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/hooks/ledger-core_test.sh
+++ b/hooks/ledger-core_test.sh
@@ -139,26 +139,46 @@ test_qa_recording_noncompact() {
 }
 
 # =============================================================================
-# QA Scenario: jq absent — graceful degrade (empty stdout, exit 0).
+# QA Scenario: jq absent -- [LEDGER RECORDING] still fires (static text,
+# needs neither jq nor the sid); [LEDGER RECOVERY] is correctly ABSENT since
+# recovery legitimately needs jq to parse stdin (.source/.session_id/.cwd)
+# and locate the ledger file. Byte-preservation regression fix: the recording
+# instruction used to be emitted unconditionally by the pre-delegation hook,
+# independent of jq presence -- ledger_core_run must preserve that.
 # Evidence: $OMT_DIR/evidence/codex-ledger-parity/ledger-core/jq-absent.txt
 # =============================================================================
 test_qa_jq_absent() {
     local out rc ok=0
+
+    # Build a PATH that lacks jq but keeps cat/sed available: on this host jq
+    # lives in /usr/bin alongside sed, so a blanket PATH=/nonexistent (or
+    # simply dropping /usr/bin) would ALSO break sed -- and sed now runs
+    # unconditionally in the Emit step (since recording emits regardless of
+    # jq), so that blunter approach would corrupt the JSON output and mask
+    # the very regression this test guards against. Symlink only sed in so
+    # jq itself stays genuinely unresolvable via PATH.
+    local jq_less_bin
+    jq_less_bin=$(mktemp -d)
+    ln -s /usr/bin/sed "$jq_less_bin/sed"
+
     set +e
     # /bin/bash (absolute path), not a bare `bash` lookup: on this host the
     # calling shell is zsh, which re-resolves an assignment-prefixed command
-    # name against the NEW PATH being assigned -- `PATH=/nonexistent bash`
-    # fails with "command not found" (exit 127) before ever reaching
-    # ledger-core.sh, since zsh can no longer locate `bash` itself under the
-    # now-empty PATH. The absolute path sidesteps that lookup entirely while
-    # still handing the child process PATH=/nonexistent, so `command -v jq`
-    # inside ledger_core_run correctly reports jq as absent.
+    # name against the NEW PATH being assigned -- `PATH=... bash` fails with
+    # "command not found" (exit 127) before ever reaching ledger-core.sh if
+    # `bash` itself isn't on the restricted PATH. The absolute path
+    # sidesteps that lookup entirely while still handing the child process
+    # the restricted PATH, so `command -v jq` inside ledger_core_run
+    # correctly reports jq as absent.
     out=$(printf '{"source":"compact","session_id":"s","cwd":"/tmp"}' \
-        | PATH=/nonexistent OMT_DIR=/tmp/x OMT_SESSION_ID=s /bin/bash -c "source '$LEDGER_CORE'; ledger_core_run claude" 2>/dev/null)
+        | PATH="$jq_less_bin:/bin" OMT_DIR=/tmp/x OMT_SESSION_ID=s /bin/bash -c "source '$LEDGER_CORE'; ledger_core_run claude" 2>/dev/null)
     rc=$?
     set -e
+    rm -rf "$jq_less_bin"
 
-    if [ "$rc" = "0" ] && [ -z "$out" ]; then
+    if [ "$rc" = "0" ] \
+        && echo "$out" | grep -q '\[LEDGER RECORDING\]' \
+        && [ "$(printf '%s' "$out" | grep -c '\[LEDGER RECOVERY\]')" = "0" ]; then
         ok=1
     fi
 
@@ -166,13 +186,50 @@ test_qa_jq_absent() {
     evidence_dir=$(bash -c "source '$SCRIPT_DIR/lib/omt-dir.sh'; resolve_omt_dir '$SCRIPT_DIR'")/evidence/codex-ledger-parity/ledger-core
     mkdir -p "$evidence_dir"
     {
-        echo "# QA Scenario: jq absent -- graceful degrade"
-        echo "# Command: printf '...' | PATH=/nonexistent OMT_DIR=/tmp/x OMT_SESSION_ID=s bash -c \"source hooks/ledger-core.sh; ledger_core_run claude\""
+        echo "# QA Scenario: jq absent -- recording survives, recovery correctly absent"
+        echo "# Command: printf '...' | PATH=<no-jq> OMT_DIR=/tmp/x OMT_SESSION_ID=s bash -c \"source hooks/ledger-core.sh; ledger_core_run claude\""
         echo "# exit code: $rc"
-        echo "# stdout empty: $([ -z "$out" ] && echo yes || echo no)"
         echo "# Result: ok=$ok (1=PASS, 0=FAIL)"
+        echo "---- stdout ----"
+        echo "$out"
     } > "$evidence_dir/jq-absent.txt"
 
+    [ "$ok" = "1" ]
+}
+
+# =============================================================================
+# Regression: session_id missing (empty stdin session_id, no OMT_SESSION_ID/
+# CODEX_THREAD_ID env fallback) -- [LEDGER RECORDING] still fires;
+# [LEDGER RECOVERY] correctly ABSENT (recovery needs a valid resolved sid to
+# locate the ledger file). source=compact on purpose: if the sid gate were
+# broken, recovery would incorrectly fire here.
+# =============================================================================
+test_missing_sid_recording_present_recovery_absent() {
+    local out ok=0
+    out=$(printf '{"source":"compact","session_id":"","cwd":"/tmp"}' \
+        | OMT_DIR=/tmp/x bash -c "unset OMT_SESSION_ID CODEX_THREAD_ID; source '$LEDGER_CORE'; ledger_core_run claude")
+
+    if echo "$out" | grep -q '\[LEDGER RECORDING\]' \
+        && [ "$(printf '%s' "$out" | grep -c '\[LEDGER RECOVERY\]')" = "0" ]; then
+        ok=1
+    fi
+    [ "$ok" = "1" ]
+}
+
+# =============================================================================
+# Regression: session_id="default" (refused the same as omt-ledger.sh's own
+# empty/default refusal) -- [LEDGER RECORDING] still fires; [LEDGER RECOVERY]
+# correctly ABSENT.
+# =============================================================================
+test_default_sid_recording_present_recovery_absent() {
+    local out ok=0
+    out=$(printf '{"source":"compact","session_id":"default","cwd":"/tmp"}' \
+        | OMT_DIR=/tmp/x bash -c "unset OMT_SESSION_ID CODEX_THREAD_ID; source '$LEDGER_CORE'; ledger_core_run claude")
+
+    if echo "$out" | grep -q '\[LEDGER RECORDING\]' \
+        && [ "$(printf '%s' "$out" | grep -c '\[LEDGER RECOVERY\]')" = "0" ]; then
+        ok=1
+    fi
     [ "$ok" = "1" ]
 }
 
@@ -206,6 +263,8 @@ main() {
     run_test test_ac3_codex_inline_no_leak
     run_test test_qa_recording_noncompact
     run_test test_qa_jq_absent
+    run_test test_missing_sid_recording_present_recovery_absent
+    run_test test_default_sid_recording_present_recovery_absent
     run_test test_codex_noncompact_recording_only
 
     echo "=========================================="

--- a/hooks/omt-ledger.sh
+++ b/hooks/omt-ledger.sh
@@ -15,6 +15,10 @@
 # =============================================================================
 set -euo pipefail
 
+SCRIPT_DIR_OL="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=hooks/lib/omt-dir.sh
+source "$SCRIPT_DIR_OL/lib/omt-dir.sh"
+
 usage() {
   echo "usage: omt-ledger.sh append <section> | omt-ledger.sh now" >&2
   exit 1
@@ -45,9 +49,41 @@ case "$SECTION_NAME" in
     ;;
 esac
 
-if [ -z "${OMT_SESSION_ID:-}" ] || [ "$OMT_SESSION_ID" = "default" ]; then
-  echo "omt-ledger: refusing -- OMT_SESSION_ID unset or default" >&2
+# Session-id self-resolution (additive): OMT_SESSION_ID ?? CODEX_THREAD_ID
+# with STRICT EMPTY-ONLY coalescing, mirroring lib/state-core.ts:88-107
+# resolveSessionIdOrThrow's authoritative-env-first semantics so this bash
+# CLI and the TypeScript state CLIs resolve the SAME identity for a given
+# session. Only an UNSET/EMPTY OMT_SESSION_ID falls through to
+# CODEX_THREAD_ID (Codex agent shell); a PRESENT value is authoritative and
+# is never abandoned in favor of CODEX_THREAD_ID, safe or not.
+if [ -n "${OMT_SESSION_ID:-}" ]; then
+  RESOLVED_SESSION_ID="$OMT_SESSION_ID"
+else
+  RESOLVED_SESSION_ID="${CODEX_THREAD_ID:-}"
+fi
+
+if [ -z "$RESOLVED_SESSION_ID" ] || [ "$RESOLVED_SESSION_ID" = "default" ]; then
+  echo "omt-ledger: refusing -- OMT_SESSION_ID/CODEX_THREAD_ID unset or default" >&2
   exit 1
+fi
+
+# NEW refusal path (path-traversal hardening): the resolved sid is
+# interpolated into the session-ledger-<sid>.md filename below, so it must be
+# restricted to a safe charset BEFORE that interpolation happens -- mirrors
+# lib/state-core.ts isSafeSessionId's ^[A-Za-z0-9_-]+$, length 1..200 contract.
+case "$RESOLVED_SESSION_ID" in
+  *[!A-Za-z0-9_-]*)
+    echo "omt-ledger: refusing -- session id contains unsafe characters (must match ^[A-Za-z0-9_-]{1,200}\$)" >&2
+    exit 1
+    ;;
+esac
+if [ "${#RESOLVED_SESSION_ID}" -gt 200 ]; then
+  echo "omt-ledger: refusing -- session id exceeds 200 characters" >&2
+  exit 1
+fi
+
+if [ -z "${OMT_DIR:-}" ]; then
+  OMT_DIR="$(resolve_omt_dir "$PWD")"
 fi
 
 if [ -z "${OMT_DIR:-}" ]; then
@@ -55,7 +91,7 @@ if [ -z "${OMT_DIR:-}" ]; then
   exit 1
 fi
 
-LEDGER_FILE="$OMT_DIR/session-ledger-$OMT_SESSION_ID.md"
+LEDGER_FILE="$OMT_DIR/session-ledger-$RESOLVED_SESSION_ID.md"
 
 # Serialize the read-modify-write critical section below (skeleton bootstrap
 # through the final mv) across concurrent append/now invocations racing on

--- a/hooks/omt-ledger_test.sh
+++ b/hooks/omt-ledger_test.sh
@@ -480,6 +480,103 @@ test_success_produces_no_stdout_path_leak() {
 }
 
 # =============================================================================
+# Tests: additive session-id self-resolution (plan TODO 3) -- OMT_SESSION_ID
+# ?? CODEX_THREAD_ID with STRICT EMPTY-ONLY coalescing, mirroring
+# lib/state-core.ts:88-107 resolveSessionIdOrThrow's authoritative-env-first
+# semantics so bash and TypeScript resolve the SAME identity for a given
+# session. Each test below manages its own sandboxed HOME/OMT_DIR directly
+# (bypassing setup_test_env/teardown_test_env, which force OMT_SESSION_ID to
+# be preset) since the fallback and git-derivation paths need env shapes
+# those helpers don't produce; every sandbox is a mktemp -d, never real
+# $HOME/.omt, and is torn down with rm -rf on every return path.
+# =============================================================================
+
+run_test_raw() {
+    local test_name="$1"
+    CURRENT_TEST="$test_name"
+
+    if "$test_name"; then
+        echo "[PASS] $test_name"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "[FAIL] $test_name"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+test_codex_thread_id_fallback_used_when_omt_session_id_unset() {
+    local sbx gitdir
+    sbx="$(mktemp -d)"
+    gitdir="$sbx/repo"
+    mkdir -p "$gitdir"
+    git -C "$gitdir" init -q -b main
+
+    if ! ( cd "$gitdir" && printf 'hello\n' | env -u OMT_DIR -u OMT_SESSION_ID HOME="$sbx" CODEX_THREAD_ID=codex-abc bash "$LEDGER_SCRIPT" append Decisions ); then
+        echo "ASSERTION FAILED: append should succeed via CODEX_THREAD_ID fallback + git-derived OMT_DIR"
+        rm -rf "$sbx"
+        return 1
+    fi
+
+    if ! ls "$sbx"/.omt/*/session-ledger-codex-abc.md >/dev/null 2>&1; then
+        echo "ASSERTION FAILED: expected session-ledger-codex-abc.md under a git-derived OMT_DIR in $sbx/.omt"
+        rm -rf "$sbx"
+        return 1
+    fi
+
+    rm -rf "$sbx"
+    return 0
+}
+
+test_present_unsafe_omt_session_id_refuses_without_fallback() {
+    local sbx
+    sbx="$(mktemp -d)"
+
+    # 'evil.sid' contains a '.', which is outside the ^[A-Za-z0-9_-]{1,200}$
+    # charset guard but is a perfectly valid flat filename character -- prior
+    # to the guard this value would be silently accepted and written.
+    if printf 'x' | OMT_DIR="$sbx" OMT_SESSION_ID='evil.sid' CODEX_THREAD_ID=safe-sid "$LEDGER_SCRIPT" append Decisions; then
+        echo "ASSERTION FAILED: a present-but-unsafe OMT_SESSION_ID must refuse (exit non-zero), not succeed"
+        rm -rf "$sbx"
+        return 1
+    fi
+
+    if [ -f "$sbx/session-ledger-safe-sid.md" ]; then
+        echo "ASSERTION FAILED: unsafe OMT_SESSION_ID must not silently fall through to CODEX_THREAD_ID's ledger path"
+        rm -rf "$sbx"
+        return 1
+    fi
+
+    if [ -f "$sbx/session-ledger-evil.sid.md" ]; then
+        echo "ASSERTION FAILED: unsafe OMT_SESSION_ID must not be written under its own (unsafe) ledger path either"
+        rm -rf "$sbx"
+        return 1
+    fi
+
+    rm -rf "$sbx"
+    return 0
+}
+
+test_claude_env_first_unchanged_with_sandboxed_omt_dir() {
+    local sbx
+    sbx="$(mktemp -d)"
+
+    if ! ( printf 'x\n' | OMT_DIR="$sbx" OMT_SESSION_ID=uuid-1 CODEX_THREAD_ID=should-be-ignored "$LEDGER_SCRIPT" append Decisions ); then
+        echo "ASSERTION FAILED: Claude env-first path (OMT_SESSION_ID present) should succeed unchanged"
+        rm -rf "$sbx"
+        return 1
+    fi
+
+    if [ ! -f "$sbx/session-ledger-uuid-1.md" ]; then
+        echo "ASSERTION FAILED: ledger should be written at the env-supplied sid path, not affected by a set CODEX_THREAD_ID"
+        rm -rf "$sbx"
+        return 1
+    fi
+
+    rm -rf "$sbx"
+    return 0
+}
+
+# =============================================================================
 # Static checks: bash conventions (3.2 compat, set -euo pipefail)
 # =============================================================================
 
@@ -526,6 +623,9 @@ main() {
     run_test test_success_produces_no_stdout_path_leak
     run_test test_script_declares_set_euo_pipefail
     run_test test_script_has_no_associative_arrays
+    run_test_raw test_codex_thread_id_fallback_used_when_omt_session_id_unset
+    run_test_raw test_present_unsafe_omt_session_id_refuses_without_fallback
+    run_test_raw test_claude_env_first_unchanged_with_sandboxed_omt_dir
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/omt-ledger_test.sh
+++ b/hooks/omt-ledger_test.sh
@@ -18,6 +18,12 @@ setup_test_env() {
     export OMT_DIR="$TEST_TMP_DIR/.omt"
     mkdir -p "$OMT_DIR"
     export OMT_SESSION_ID="test-sid-1"
+    # An ambient CODEX_THREAD_ID (e.g. a real Codex session running this suite)
+    # must never leak in: omt-ledger.sh resolves sid as
+    # OMT_SESSION_ID ?? CODEX_THREAD_ID, so a stray CODEX_THREAD_ID would mask
+    # an explicitly-emptied OMT_SESSION_ID and turn an expected refusal into a
+    # false success. Unset it unconditionally for every run_test-based test.
+    unset CODEX_THREAD_ID
 }
 
 teardown_test_env() {

--- a/hooks/pre-tool-enforcer.sh
+++ b/hooks/pre-tool-enforcer.sh
@@ -56,11 +56,44 @@ _wg_strip_dquotes() {
     printf '%s\n' "$s"
 }
 
-# _wg_absolutize <path> -- strip surrounding double quotes, then prefix a
-# relative path with the hook's cwd; an already-absolute path passes through.
+# _wg_absolutize <path> -- strip surrounding double quotes, expand the two
+# known ledger-path env-vars via pure bash literal substitution, then prefix
+# a relative path with the hook's cwd; an already-absolute path passes
+# through.
+#
+# Why: a candidate arrives as the LITERAL command text (e.g. "$OMT_DIR/
+# session-ledger-$OMT_SESSION_ID.md"), not what the real shell would expand
+# it to at execution time -- the old code recognized only a leading '/' as
+# absolute, so this literal was treated as RELATIVE and got $PWD prefixed
+# instead, never matching the resolved ledger path. hooks/omt-ledger.sh's
+# SessionStart recovery pointer teaches exactly this literal-env-var form,
+# so it is the PRIMARY reproduction shape, not an edge case.
+#
+# ${p//find/replace} is a pure bash string substitution -- never eval/
+# envsubst, which would let an arbitrary $(...) or other variable reference
+# inside an untrusted Bash tool_input.command execute. Only OMT_DIR and
+# OMT_SESSION_ID are expanded: they are the only two variables that compose
+# the ledger path (write-guard-core.sh:29); $_wg_omt_dir is already the
+# fully-resolved OMT_DIR value, so expanding HOME/PWD/CLAUDE_PROJECT_DIR/etc
+# would be pure surface with no guard benefit. The braced form (${VAR}) is
+# substituted before the bare $VAR form so substituting "$OMT_DIR" first
+# would not leave a stray "{}" around the resolved value inside "${OMT_DIR}".
+#
+# KNOWN LIMITATION: a single-quoted reference (`rm '$OMT_DIR/...'`) is an
+# inert shell literal that never actually expands at real execution time
+# either -- but the quote-aware normalizer upstream (_wg_scan) has already
+# stripped the quote characters by the time this function runs, so it is
+# indistinguishable here from a double-quoted reference and gets
+# substituted (and matched) the same way. That command is inert and
+# harmless to begin with, so denying it is a safe false-positive, not a
+# bypass.
 _wg_absolutize() {
     local p
     p="$(_wg_strip_dquotes "$1")"
+    p="${p//\$\{OMT_DIR\}/$_wg_omt_dir}"
+    p="${p//\$\{OMT_SESSION_ID\}/$_wg_sid}"
+    p="${p//\$OMT_DIR/$_wg_omt_dir}"
+    p="${p//\$OMT_SESSION_ID/$_wg_sid}"
     case "$p" in
         /*) printf '%s\n' "$p" ;;
         *) printf '%s\n' "$PWD/$p" ;;
@@ -85,7 +118,12 @@ _wg_extract_bash_targets() {
     first_word=$(echo "$seg" | awk '{print $1}')
     case "$first_word" in
         tee|rm|truncate)
-            echo "$seg" | awk '{print $NF}'
+            # Every non-option operand, not just the last -- `rm <ledger>
+            # <other>` used to extract only "<other>" ($NF), leaving the
+            # ledger operand unchecked whenever it wasn't the final argument.
+            # Mirrors the already-correct Codex extractor
+            # (_cwg_extract_shell_targets, hooks/codex-write-guard.sh:167-169).
+            echo "$seg" | awk '{for(i=2;i<=NF;i++) if($i !~ /^-/) print $i}'
             ;;
         dd)
             echo "$seg" | grep -oE 'of=[^[:space:]]+' | sed -E 's/^of=//' || true

--- a/hooks/pre-tool-enforcer.sh
+++ b/hooks/pre-tool-enforcer.sh
@@ -29,104 +29,142 @@ EOF
 fi
 
 # =============================================================================
-# Ledger write-guard (compaction-continuous-record plan, TODO 7, D5): a
-# best-effort append-only guard for the durable session ledger
-# ($OMT_DIR/session-ledger-<sid>.md, hooks/omt-ledger.sh). Blacklist, not
-# whitelist -- a false-arm here blocks one write (bypassable), whereas a
-# false-arm in a whitelist gate bricks every unrelated call. Arms ONLY when
-# the command's WRITE-TARGET (not any substring anywhere in the command)
-# references "session-ledger-": redirect target, tee/dd/cp/mv/sed -i/
-# truncate/rm argument. `cat`/read passes; omt-ledger.sh itself never
-# exposes the path in argv (D6) so it never arms.
+# Ledger write-guard (compaction-continuous-record plan, TODO 7, D5;
+# delegated to the shared core in codex-ledger-parity TODO 5): a best-effort
+# append-only guard for the durable session ledger ($OMT_DIR/session-ledger-
+# <sid>.md, hooks/omt-ledger.sh). This shim owns EXTRACTION of candidate
+# write-target paths from Claude's tool-input shape only (Write/Edit/
+# MultiEdit .tool_input.file_path; Bash .tool_input.command redirect/tee/dd/
+# cp/mv/sed -i/truncate/rm write-target). The full-path EXACT match against
+# the resolved current-session ledger, and the deny JSON, both live in
+# hooks/write-guard-core.sh (write_guard_core_run) so a candidate merely
+# containing "session-ledger-" as a substring is no longer enough to arm.
 # =============================================================================
-_wg_ledger_target_in_segment() {
-    # $1 = one chain segment (already split on && || ; |). 0 = this segment's
-    # write-target references the ledger; 1 = no match.
+_wg_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=hooks/write-guard-core.sh
+source "$_wg_script_dir/write-guard-core.sh"
+
+# _wg_strip_dquotes <token> -- removes one leading and one trailing double
+# quote if present. Double-quoted write targets (`> "$f"`) pass through the
+# quote-aware normalizer below unchanged (only single quotes are unwrapped
+# there), so an extracted token like `"/tmp/x.md"` still carries its quote
+# characters and must be unwrapped before an EXACT path comparison.
+_wg_strip_dquotes() {
+    local s="$1"
+    s="${s#\"}"
+    s="${s%\"}"
+    printf '%s\n' "$s"
+}
+
+# _wg_absolutize <path> -- strip surrounding double quotes, then prefix a
+# relative path with the hook's cwd; an already-absolute path passes through.
+_wg_absolutize() {
+    local p
+    p="$(_wg_strip_dquotes "$1")"
+    case "$p" in
+        /*) printf '%s\n' "$p" ;;
+        *) printf '%s\n' "$PWD/$p" ;;
+    esac
+}
+
+# _wg_extract_bash_targets <chain segment> -- emits 0+ candidate write-target
+# paths (not yet absolutized) for one already quote-normalized `&&`/`||`/`;`/
+# `|` chain segment. Mirrors the write-vectors of the retired
+# _wg_ledger_target_in_segment classifier (redirect, tee/rm/truncate, dd of=,
+# sed -i, cp/mv last-arg) but EXTRACTS the target instead of testing it for a
+# "session-ledger-" substring -- write_guard_core_run does an EXACT full-path
+# comparison, so a harmless non-ledger candidate simply never matches.
+_wg_extract_bash_targets() {
     local seg="$1"
-    if echo "$seg" | grep -Eq '>[[:space:]]*[^[:space:]]*session-ledger-'; then
-        return 0
-    fi
-    if ! echo "$seg" | grep -q 'session-ledger-'; then
-        return 1
-    fi
+    # `|| true`: grep -oE returns 1 when a segment has no redirect at all --
+    # under this script's `set -euo pipefail`, an unguarded nonzero pipeline
+    # here would abort the function before the case block below ever runs.
+    echo "$seg" | grep -oE '>{1,2}[[:space:]]*[^[:space:]]+' | sed -E 's/^>{1,2}[[:space:]]*//' || true
+
     local first_word
     first_word=$(echo "$seg" | awk '{print $1}')
     case "$first_word" in
         tee|rm|truncate)
-            return 0
+            echo "$seg" | awk '{print $NF}'
             ;;
         dd)
-            if echo "$seg" | grep -Eq 'of=[^[:space:]]*session-ledger-'; then
-                return 0
-            fi
+            echo "$seg" | grep -oE 'of=[^[:space:]]+' | sed -E 's/^of=//' || true
             ;;
         sed)
             if echo "$seg" | grep -q -- '-i'; then
-                return 0
+                echo "$seg" | awk '{print $NF}'
             fi
             ;;
         cp|mv)
-            local last_word
-            last_word=$(echo "$seg" | awk '{print $NF}')
-            if echo "$last_word" | grep -q 'session-ledger-'; then
-                return 0
-            fi
+            echo "$seg" | awk '{print $NF}'
             ;;
     esac
-    return 1
 }
 
-_wg_deny_json='{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Blocked: direct write/delete targets the durable session ledger (session-ledger-*.md). Use hooks/omt-ledger.sh append/now instead."}}'
+_wg_sid="${OMT_SESSION_ID:-}"
+_wg_omt_dir="${OMT_DIR:-}"
 
-if [[ "$toolName" == "Bash" ]] && command -v jq > /dev/null 2>&1; then
-    _wg_cmd=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) || _wg_cmd=""
-    # Single-quoted spans are inert shell literals -- but deleting them
-    # wholesale (old approach) also erased REAL quoted write targets like
-    # `rm '/tmp/session-ledger-x.md'`. Quote-aware normalization instead:
-    # drop the quote CHARACTERS but keep the quoted CONTENT visible, while
-    # masking shell-active metachars (`> < | ; &`) that appear INSIDE quotes
-    # -- so an in-quote `>` never reads as a live redirect (grep below) and
-    # an in-quote `|`/`;`/`&` never spuriously splits a segment. Metachars
-    # OUTSIDE quotes (real redirects/splitters) and DOUBLE-quoted paths
-    # (`> "$f"`) pass through unchanged, exactly as before.
-    _wg_scan=$(printf '%s' "$_wg_cmd" | awk '
-        BEGIN { sq = sprintf("%c", 39) }
-        {
-            n = length($0)
-            inq = 0
-            out = ""
-            for (i = 1; i <= n; i++) {
-                c = substr($0, i, 1)
-                if (c == sq) {
-                    inq = 1 - inq
-                    continue
-                }
-                if (inq && (c == ">" || c == "<" || c == "|" || c == ";" || c == "&")) {
-                    out = out " "
-                    continue
-                }
-                out = out c
-            }
-            print out
-        }')
-    if [[ -n "$_wg_scan" ]] && echo "$_wg_scan" | grep -q 'session-ledger-'; then
-        _wg_denied=0
-        while IFS= read -r _wg_seg; do
-            if _wg_ledger_target_in_segment "$_wg_seg"; then
-                _wg_denied=1
-                break
-            fi
-        done < <(echo "$_wg_scan" | sed -E 's/(&&|\|\||;|\|)/\n/g')
-        if [[ "$_wg_denied" -eq 1 ]]; then
-            printf '%s\n' "$_wg_deny_json"
-            exit 0
+if [[ -n "$_wg_sid" && -n "$_wg_omt_dir" ]]; then
+    _wg_candidates=""
+
+    if [[ "$toolName" == "Bash" ]] && command -v jq > /dev/null 2>&1; then
+        _wg_cmd=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) || _wg_cmd=""
+        if [[ -n "$_wg_cmd" ]]; then
+            # Single-quoted spans are inert shell literals -- but deleting them
+            # wholesale (old approach) also erased REAL quoted write targets like
+            # `rm '/tmp/session-ledger-x.md'`. Quote-aware normalization instead:
+            # drop the quote CHARACTERS but keep the quoted CONTENT visible, while
+            # masking shell-active metachars (`> < | ; &`) that appear INSIDE quotes
+            # -- so an in-quote `>` never reads as a live redirect (grep below) and
+            # an in-quote `|`/`;`/`&` never spuriously splits a segment. Metachars
+            # OUTSIDE quotes (real redirects/splitters) and DOUBLE-quoted paths
+            # (`> "$f"`) pass through unchanged, exactly as before.
+            _wg_scan=$(printf '%s' "$_wg_cmd" | awk '
+                BEGIN { sq = sprintf("%c", 39) }
+                {
+                    n = length($0)
+                    inq = 0
+                    out = ""
+                    for (i = 1; i <= n; i++) {
+                        c = substr($0, i, 1)
+                        if (c == sq) {
+                            inq = 1 - inq
+                            continue
+                        }
+                        if (inq && (c == ">" || c == "<" || c == "|" || c == ";" || c == "&")) {
+                            out = out " "
+                            continue
+                        }
+                        out = out c
+                    }
+                    print out
+                }')
+            while IFS= read -r _wg_seg; do
+                [[ -z "$_wg_seg" ]] && continue
+                while IFS= read -r _wg_target; do
+                    [[ -z "$_wg_target" ]] && continue
+                    _wg_candidates="${_wg_candidates}$(_wg_absolutize "$_wg_target")
+"
+                done < <(_wg_extract_bash_targets "$_wg_seg")
+            done < <(echo "$_wg_scan" | sed -E 's/(&&|\|\||;|\|)/\n/g')
+        fi
+    elif [[ "$toolName" == "Write" || "$toolName" == "Edit" || "$toolName" == "MultiEdit" ]] && command -v jq > /dev/null 2>&1; then
+        _wg_fp=$(echo "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || _wg_fp=""
+        if [[ -n "$_wg_fp" ]]; then
+            # Trailing literal newline (not `$(...)`, which strips it) --
+            # write_guard_core_run's stdin while-loop silently drops a final
+            # line with no trailing newline (read returns nonzero at EOF).
+            _wg_candidates="$(_wg_absolutize "$_wg_fp")
+"
         fi
     fi
-elif [[ "$toolName" == "Write" || "$toolName" == "Edit" || "$toolName" == "MultiEdit" ]] && command -v jq > /dev/null 2>&1; then
-    _wg_fp=$(echo "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || _wg_fp=""
-    if [[ -n "$_wg_fp" ]] && echo "$_wg_fp" | grep -q 'session-ledger-'; then
-        printf '%s\n' "$_wg_deny_json"
-        exit 0
+
+    if [[ -n "$_wg_candidates" ]]; then
+        _wg_out=$(printf '%s' "$_wg_candidates" | write_guard_core_run "$_wg_omt_dir" "$_wg_sid")
+        if [[ -n "$_wg_out" ]]; then
+            printf '%s\n' "$_wg_out"
+            exit 0
+        fi
     fi
 fi
 

--- a/hooks/pre-tool-enforcer.sh
+++ b/hooks/pre-tool-enforcer.sh
@@ -44,15 +44,22 @@ _wg_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=hooks/write-guard-core.sh
 source "$_wg_script_dir/write-guard-core.sh"
 
-# _wg_strip_dquotes <token> -- removes one leading and one trailing double
-# quote if present. Double-quoted write targets (`> "$f"`) pass through the
-# quote-aware normalizer below unchanged (only single quotes are unwrapped
-# there), so an extracted token like `"/tmp/x.md"` still carries its quote
-# characters and must be unwrapped before an EXACT path comparison.
+# _wg_strip_dquotes <token> -- removes EVERY double-quote character in the
+# token, not just an outermost pair. Double-quoted write targets (`> "$f"`)
+# pass through the quote-aware normalizer below unchanged (only single quotes
+# are unwrapped there), so an extracted token still carries its quote
+# characters and must be unwrapped before an EXACT path comparison. A target
+# can also be assembled from multiple double-quoted SPANS glued together with
+# no separating whitespace (e.g. `"$OMT_DIR"/"session-ledger-$OMT_SESSION_ID
+# .md"`) -- the real shell concatenates adjacent quoted spans into one word
+# and drops every quote character, so stripping only the outer pair would
+# leave embedded quotes that break the byte-EXACT compare downstream.
+# Stripping all quote characters mirrors that real-shell behavior; a harmless
+# non-ledger candidate that happens to carry embedded quotes simply still
+# fails the EXACT match, so over-stripping here is not a bypass.
 _wg_strip_dquotes() {
     local s="$1"
-    s="${s#\"}"
-    s="${s%\"}"
+    s="${s//\"/}"
     printf '%s\n' "$s"
 }
 
@@ -141,6 +148,27 @@ _wg_extract_bash_targets() {
 
 _wg_sid="${OMT_SESSION_ID:-}"
 _wg_omt_dir="${OMT_DIR:-}"
+
+# Fallback to the stdin payload when env is absent -- mirrors the Skill-seed
+# block's resolution precedence below (env first, then stdin session_id/cwd).
+# Without this, the guard went dark (silent no-op) during the session
+# bootstrap window, before CLAUDE_ENV_FILE exports are sourced into the
+# environment, even though the stdin payload still carries session_id + cwd.
+# Same safety charset validation as the seed block: an unsafe stdin
+# session_id must not arm the guard.
+if [[ -z "$_wg_sid" ]]; then
+    _wg_stdin_sid=$(extract_json_field "session_id" "")
+    if [[ -n "$_wg_stdin_sid" ]] && echo "$_wg_stdin_sid" | grep -qE '^[A-Za-z0-9_-]{1,200}$'; then
+        _wg_sid="$_wg_stdin_sid"
+    fi
+fi
+
+if [[ -z "$_wg_omt_dir" ]]; then
+    _wg_stdin_cwd=$(extract_json_field "cwd" "")
+    if [[ -n "$_wg_stdin_cwd" ]]; then
+        _wg_omt_dir=$(source "$_wg_script_dir/lib/omt-dir.sh" && unset OMT_DIR && resolve_omt_dir "$_wg_stdin_cwd")
+    fi
+fi
 
 if [[ -n "$_wg_sid" && -n "$_wg_omt_dir" ]]; then
     _wg_candidates=""

--- a/hooks/pre-tool-enforcer_test.sh
+++ b/hooks/pre-tool-enforcer_test.sh
@@ -1126,6 +1126,100 @@ test_wg_m5_rm_multitarget_nonledger_control_allows() {
 }
 
 # =============================================================================
+# (n) regression (Claude write-guard defect #4) -- _wg_strip_dquotes stripped
+# only the OUTERMOST double-quote pair, so a redirect target assembled from
+# PER-TOKEN double-quoted spans glued together with no separating whitespace
+# (e.g. "$OMT_DIR"/"session-ledger-$OMT_SESSION_ID.md") still carried
+# embedded quote characters after the outer-pair strip, breaking the
+# byte-EXACT compare in write-guard-core.sh even though the real shell
+# concatenates adjacent quoted spans into the exact ledger path (quote
+# characters vanish entirely on word expansion). Fix: strip EVERY double
+# quote character in the token, not just the outermost pair.
+# =============================================================================
+test_wg_n1_per_segment_dquoted_ledger_denied() {
+    local ledger; ledger=$(wg_ledger_path)
+    # Target assembled from two double-quoted spans glued by an unquoted '/'
+    # -- a single shell word, no whitespace inside, so the extractor captures
+    # the whole thing as one candidate token.
+    wg_assert_deny 'echo x > "$OMT_DIR"/"session-ledger-$OMT_SESSION_ID.md"' "WG-N1(per-segment dquoted)"
+}
+
+test_wg_n2_per_segment_dquoted_nonledger_control_allows() {
+    local out
+    out=$(printf '%s' "$(hg_bash_json 'echo x > "/tmp"/"notes.md"')" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_allow "$out" || { echo "ASSERTION FAILED WG-N2: non-ledger per-segment dquoted target should pass. Got: $out"; return 1; }
+}
+
+# =============================================================================
+# (o) regression (Claude write-guard defect #2) -- the write-guard block read
+# ONLY OMT_SESSION_ID/OMT_DIR from the environment and skipped the entire
+# guard (silent no-op) when either was absent, unlike the Skill-seed block a
+# few dozen lines below it, which falls back to stdin session_id/cwd via
+# resolve_omt_dir. During the session bootstrap window (before CLAUDE_ENV_
+# FILE exports are sourced), env is absent but the stdin payload still
+# carries session_id + cwd -- the guard must not go dark in that window.
+# WG-O1 proves the DENY now fires via stdin fallback; WG-O2 proves the
+# safety-charset validation on the stdin session_id is still enforced (an
+# unsafe id must not arm the guard).
+# =============================================================================
+test_wg_o1_env_absent_stdin_fallback_rm_denied() {
+    local exit_code=0
+    local out
+
+    local project_cwd="$SCRIPT_DIR"
+    local stdin_sid="wg-env-fallback-sid"
+    local fake_home="$TEST_TMP_DIR/home_wgo1"
+    mkdir -p "$fake_home"
+
+    local derived_omt_dir
+    derived_omt_dir=$(
+        unset OMT_DIR
+        export HOME="$fake_home"
+        source "$SCRIPT_DIR/lib/omt-dir.sh" && resolve_omt_dir "$project_cwd"
+    )
+
+    local ledger_path="$derived_omt_dir/session-ledger-${stdin_sid}.md"
+
+    out=$(
+        unset OMT_DIR OMT_SESSION_ID CODEX_THREAD_ID
+        export HOME="$fake_home"
+        jq -n --arg cmd "rm \"$ledger_path\"" --arg sid "$stdin_sid" --arg cwd "$project_cwd" \
+            '{tool_name: "Bash", tool_input: {command: $cmd}, session_id: $sid, cwd: $cwd}' \
+            | bash "$SCRIPT_DIR/pre-tool-enforcer.sh"
+    ) || exit_code=$?
+
+    [[ "$exit_code" -eq 0 ]] \
+        || { echo "ASSERTION FAILED WG-O1: hook should exit 0 (exit=$exit_code)"; return 1; }
+
+    hg_is_deny "$out" \
+        || { echo "ASSERTION FAILED WG-O1: env-absent write-guard should DENY via stdin session_id/cwd fallback. Got: $out"; return 1; }
+}
+
+test_wg_o2_unsafe_stdin_sid_does_not_arm_guard() {
+    local exit_code=0
+    local out
+
+    local project_cwd="$SCRIPT_DIR"
+    local unsafe_sid="../escape"
+    local fake_home="$TEST_TMP_DIR/home_wgo2"
+    mkdir -p "$fake_home"
+
+    out=$(
+        unset OMT_DIR OMT_SESSION_ID CODEX_THREAD_ID
+        export HOME="$fake_home"
+        jq -n --arg cmd 'rm /tmp/whatever' --arg sid "$unsafe_sid" --arg cwd "$project_cwd" \
+            '{tool_name: "Bash", tool_input: {command: $cmd}, session_id: $sid, cwd: $cwd}' \
+            | bash "$SCRIPT_DIR/pre-tool-enforcer.sh"
+    ) || exit_code=$?
+
+    [[ "$exit_code" -eq 0 ]] \
+        || { echo "ASSERTION FAILED WG-O2: hook should exit 0 (exit=$exit_code)"; return 1; }
+
+    hg_is_allow "$out" \
+        || { echo "ASSERTION FAILED WG-O2: unsafe stdin session_id must not arm the write-guard. Got: $out"; return 1; }
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -1206,6 +1300,10 @@ main() {
     run_test test_wg_m3_truncate_multitarget_denied
     run_test test_wg_m4_tee_multitarget_denied
     run_test test_wg_m5_rm_multitarget_nonledger_control_allows
+    run_test test_wg_n1_per_segment_dquoted_ledger_denied
+    run_test test_wg_n2_per_segment_dquoted_nonledger_control_allows
+    run_test test_wg_o1_env_absent_stdin_fallback_rm_denied
+    run_test test_wg_o2_unsafe_stdin_sid_does_not_arm_guard
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/pre-tool-enforcer_test.sh
+++ b/hooks/pre-tool-enforcer_test.sh
@@ -1068,6 +1068,64 @@ test_wg_k_pipe_and_gt_inside_quotes_passes() {
 }
 
 # =============================================================================
+# (l) regression (defect A) -- an unexpanded env-var-literal ledger path
+# bypasses the EXACT match: _wg_absolutize used to recognize ONLY a leading
+# '/' as an absolute path, so a literal "$OMT_DIR/session-ledger-$OMT_
+# SESSION_ID.md" token (never itself expanded, since the guard inspects
+# tool_input.command text, not what the real shell would later expand it
+# to) was treated as RELATIVE and got $PWD prefixed instead -- silently
+# ALLOWING the exact form that hooks/omt-ledger.sh's SessionStart recovery
+# pointer (`cat "$OMT_DIR/session-ledger-$OMT_SESSION_ID.md"`) itself teaches
+# agents to reproduce. Each form below must DENY.
+# =============================================================================
+test_wg_l1_env_var_dquoted_denied() {
+    wg_assert_deny 'echo x > "$OMT_DIR/session-ledger-$OMT_SESSION_ID.md"' "WG-L1(dquoted env-var)"
+}
+
+test_wg_l2_env_var_unquoted_denied() {
+    wg_assert_deny 'echo x > $OMT_DIR/session-ledger-$OMT_SESSION_ID.md' "WG-L2(unquoted env-var)"
+}
+
+test_wg_l3_env_var_braced_denied() {
+    wg_assert_deny 'echo x > "${OMT_DIR}/session-ledger-${OMT_SESSION_ID}.md"' "WG-L3(braced env-var)"
+}
+
+# =============================================================================
+# (m) regression (defect B) -- tee/rm/truncate only inspected the LAST
+# operand (awk '{print $NF}'), so `rm <ledger> <other>` extracted only
+# "<other>" and the real ledger operand went unchecked. Mirrors the
+# already-correct Codex extractor (_cwg_extract_shell_targets, hooks/codex-
+# write-guard.sh:167-169), which emits every non-option operand. Each DENY
+# case below places the ledger as a NON-final operand; the control proves a
+# genuinely non-ledger multi-target command still passes.
+# =============================================================================
+test_wg_m1_rm_multitarget_denied() {
+    local ledger; ledger=$(wg_ledger_path)
+    wg_assert_deny "rm \"$ledger\" /tmp/other" "WG-M1(rm multi-target)"
+}
+
+test_wg_m2_rm_flag_multitarget_denied() {
+    local ledger; ledger=$(wg_ledger_path)
+    wg_assert_deny "rm -f \"$ledger\" /tmp/other" "WG-M2(rm -f multi-target)"
+}
+
+test_wg_m3_truncate_multitarget_denied() {
+    local ledger; ledger=$(wg_ledger_path)
+    wg_assert_deny "truncate -s0 \"$ledger\" /tmp/other" "WG-M3(truncate multi-target)"
+}
+
+test_wg_m4_tee_multitarget_denied() {
+    local ledger; ledger=$(wg_ledger_path)
+    wg_assert_deny "tee \"$ledger\" /tmp/other" "WG-M4(tee multi-target)"
+}
+
+test_wg_m5_rm_multitarget_nonledger_control_allows() {
+    local out
+    out=$(printf '%s' "$(hg_bash_json 'rm /tmp/a /tmp/b')" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_allow "$out" || { echo "ASSERTION FAILED WG-M5: non-ledger multi-target rm should pass. Got: $out"; return 1; }
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -1140,6 +1198,14 @@ main() {
     run_test test_wg_j8_truncate_cmd_singlequoted_denied
     run_test test_wg_j9_sed_i_singlequoted_denied
     run_test test_wg_k_pipe_and_gt_inside_quotes_passes
+    run_test test_wg_l1_env_var_dquoted_denied
+    run_test test_wg_l2_env_var_unquoted_denied
+    run_test test_wg_l3_env_var_braced_denied
+    run_test test_wg_m1_rm_multitarget_denied
+    run_test test_wg_m2_rm_flag_multitarget_denied
+    run_test test_wg_m3_truncate_multitarget_denied
+    run_test test_wg_m4_tee_multitarget_denied
+    run_test test_wg_m5_rm_multitarget_nonledger_control_allows
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -71,16 +71,69 @@ if [ -n "$CLAUDE_ENV_FILE" ]; then
 fi
 
 MESSAGES=""
-LEDGER_ACUTE_INLINE=""
 
-# Ledger recording instruction (plan TODO 3, D2/D3): every session, regardless
-# of source, reminds the agent to durable-record decisions/corrections/next-
-# steps to the session ledger AS IT WORKS, instead of relying on a stale
-# end-of-session summary. Static text only -- no session-varying values, so
-# this stays cache-safe (prefix-invariant) across every session.
-# omt-hook-dep: omt-ledger.sh
-RECORDING_INSTRUCTION="<session-recording>\n\n[LEDGER RECORDING]\n\nRecord decisions, user corrections, and next-steps to the durable session ledger AS YOU WORK -- do not wait until the end of the session. Ledger sections are append-only, except Now, which the now subcommand replaces with the latest current-state summary.\n\nAppend content (piped via stdin) to a section:\n  <content> | \"\${CLAUDE_PROJECT_DIR:-\$HOME}/.claude/hooks/omt-ledger.sh\" append Decisions\n  <content> | \"\${CLAUDE_PROJECT_DIR:-\$HOME}/.claude/hooks/omt-ledger.sh\" append Pending\n\nReplace the current-state summary:\n  <content> | \"\${CLAUDE_PROJECT_DIR:-\$HOME}/.claude/hooks/omt-ledger.sh\" now\n\nCRITICAL: record a user correction VERBATIM -- the user's exact original words, never a paraphrase or summary. Paraphrasing a correction silently loses the precise wording that made it a correction. Append verbatim corrections to the User Corrections (verbatim) section.\n\n(\$OMT_DIR and \$OMT_SESSION_ID are set in CLAUDE_ENV_FILE exported by this hook; omt-ledger.sh computes the ledger path internally.)\n\n</session-recording>\n\n---\n\n"
-MESSAGES="$MESSAGES$RECORDING_INSTRUCTION"
+# Ledger recording (every source) + compaction recovery (source==compact),
+# delegated to the shared cross-platform core (plan TODO 4: codex-ledger-
+# parity) so Claude and Codex emit identical ledger text from ONE
+# implementation. hooks/ledger-core.sh's Claude branch is byte-identical to
+# the pre-delegation inline text this call replaces. The result is
+# pre-escaped and spliced in ahead of MESSAGES at final-output time (below),
+# so it lands first in additionalContext -- matching where the recording
+# instruction always sat (it fires on every source, unlike the restore
+# blocks further down which are conditional on active state).
+# omt-hook-dep: ledger-core.sh
+source "$SCRIPT_DIR_SS/ledger-core.sh"
+
+# ledger-core.sh's stdin sid fallback (its 3rd precedence tier, used when
+# neither OMT_SESSION_ID nor CODEX_THREAD_ID is set in the environment --
+# the common case here, since CLAUDE_ENV_FILE is read by the harness AFTER
+# this hook exits, not during it) reads ONLY `.session_id` (snake_case).
+# Claude Code's actual SessionStart stdin uses `.sessionId` (camelCase) --
+# see the jq filter at the very top of this file, which already handles
+# both forms into $SESSION_ID. Feed ledger_core_run a copy of stdin with
+# `.session_id` normalized to that already-resolved value, so its fallback
+# tier works for Claude's real stdin shape instead of always falling
+# through to the empty-sid refusal.
+LEDGER_CORE_INPUT="$INPUT"
+if command -v jq &> /dev/null; then
+  LEDGER_CORE_INPUT=$(printf '%s' "$INPUT" | jq --arg sid "$SESSION_ID" '.session_id = $sid' 2>/dev/null) || LEDGER_CORE_INPUT="$INPUT"
+fi
+
+# Run in a subshell with OMT_SESSION_ID/CODEX_THREAD_ID cleared: this hook's
+# own stdin (normalized above into $SESSION_ID) is ALWAYS the authoritative
+# identity for its own SessionStart invocation -- ledger_core_run's env-first
+# precedence exists for later, separate omt-ledger.sh CLI calls the agent
+# makes via CLAUDE_ENV_FILE, not for this hook's own delegated call. Clearing
+# them here (subshell-local; nothing outside this command substitution is
+# affected) stops a stale/inherited OMT_SESSION_ID from shadowing the
+# resolved stdin sid.
+LEDGER_CORE_OUT=$(
+  unset OMT_SESSION_ID CODEX_THREAD_ID
+  printf '%s' "$LEDGER_CORE_INPUT" | ledger_core_run claude
+)
+LEDGER_DELEGATED_ESCAPED=""
+if [ -n "$LEDGER_CORE_OUT" ]; then
+  # Restore the "-- compaction" qualifier on the recovery header: ledger-
+  # core.sh's shared (Claude+Codex) recovery text says "[LEDGER RECOVERY]"
+  # (platform-neutral wording), but the pre-delegation Claude text this call
+  # replaces said "[LEDGER RECOVERY -- compaction]". No escaping is needed --
+  # neither string contains a quote or backslash. Restore before extraction
+  # since the label sits inside the escaped additionalContext value.
+  LEDGER_CORE_OUT="${LEDGER_CORE_OUT/\[LEDGER RECOVERY\]/[LEDGER RECOVERY -- compaction]}"
+  # Extract the already-escaped additionalContext value verbatim (no
+  # decode/re-encode) from ledger-core.sh's own JSON output template
+  # (`"additionalContext": "...."}}`, hooks/ledger-core.sh:175) via plain
+  # prefix/suffix stripping -- re-escaping it here would double-escape the
+  # quotes/backslashes ledger-core.sh's own sed/jq -Rs pipeline already
+  # produced.
+  LEDGER_DELEGATED_ESCAPED="${LEDGER_CORE_OUT#*\"additionalContext\": \"}"
+  # Suffix pattern held in a variable: a literal `}}` typed directly inside
+  # ${var%pattern} would close the expansion early (brace-matching reads the
+  # first unescaped `}` as the expansion's own terminator), silently leaving
+  # the trailing `"}}` un-stripped.
+  _lc_suffix='"}}'
+  LEDGER_DELEGATED_ESCAPED="${LEDGER_DELEGATED_ESCAPED%$_lc_suffix}"
+fi
 
 # GC: reap dead state files for the managed prefixes.
 # Liveness defined by hooks/lib/state-liveness.sh (ACTIVE_IDLE_TTL=6h, TERMINAL_TTL=30m).
@@ -296,82 +349,9 @@ if [ -f "$OMT_DIR/deep-interview-active-state-${SESSION_ID}.json" ]; then
   fi
 fi
 
-# Compaction recovery, option D (plan TODO 4, D1): when source==compact AND the
-# durable session ledger exists on disk, extract ONLY the two acute sections --
-# `## Now` (current state) and `## User Corrections (verbatim)` -- and inline
-# them directly into additionalContext. The bulk sections (Decisions/Pending/
-# Pointers/Learnings) are never inlined; a static pointer+instruction directs
-# the agent to `cat` the full ledger on demand. This replaces the prior
-# forced-reread compaction pointer: the PR#158 postmortem showed hiding the
-# important part behind a read is what got skipped, so the acute part is
-# inlined instead.
-#
-# The extracted acute text is untrusted ledger prose (may contain quotes,
-# backslashes, verbatim user corrections) and is kept in a SEPARATE variable
-# (NOT MESSAGES), encoded later via the surgical jq -Rs path -- mirroring how
-# the prior compaction fragment was kept out of the sed-escaped restore body.
-if command -v jq &> /dev/null && [ "$SOURCE" = "compact" ]; then
-  LEDGER_FILE_D="$OMT_DIR/session-ledger-${SESSION_ID}.md"
-  if [ -f "$LEDGER_FILE_D" ]; then
-    # Section boundaries are the 6 known skeleton headers consumed in their fixed
-    # order (idx walks the sequence), NOT any `## ` line -- so a `## ` markdown
-    # subheader INSIDE an acute section's content does not truncate the extract
-    # (F1), and a header-shaped line injected into a bulk section is never
-    # mistaken for the real acute header (S5). A line is a structural header only
-    # when it equals the next-expected header H[idx].
-    # Escape/unescape is a shared contract with hooks/omt-ledger.sh (PR #162 P2):
-    # its writer prefixes any NEW content line that collides with a skeleton
-    # header with SENTINEL before writing, so a Now/Corrections content line
-    # that is literally "## Decisions" etc. never re-matches H[idx] as a false
-    # boundary here. unescape_line() strips exactly one SENTINEL back off KEPT
-    # acute content lines only -- never touches structural header lines. Keep
-    # SENTINEL identical to omt-ledger.sh's ("OMT_ESC::") or recovery will
-    # surface escaped text verbatim.
-    LEDGER_ACUTE=$(awk '
-      function is_skeleton_header(line,    h) {
-        for (h = 1; h <= n; h++) if (line == H[h]) return 1
-        return 0
-      }
-      function unescape_line(line,    stripped, count) {
-        if (index(line, SENTINEL) != 1) return line
-        stripped = line
-        count = 0
-        while (index(stripped, SENTINEL) == 1) {
-          stripped = substr(stripped, length(SENTINEL) + 1)
-          count++
-        }
-        if (count >= 1 && is_skeleton_header(stripped)) return substr(line, length(SENTINEL) + 1)
-        return line
-      }
-      BEGIN {
-        SENTINEL = "OMT_ESC::"
-        n = split("## Now|## Decisions|## User Corrections (verbatim)|## Pending|## Pointers|## Learnings", H, "|")
-        idx = 1
-      }
-      (idx <= n && $0 == H[idx]) {
-        idx++
-        keep = ($0 == "## Now" || $0 == "## User Corrections (verbatim)")
-        if (keep) print
-        next
-      }
-      keep { print unescape_line($0) }
-    ' "$LEDGER_FILE_D")
-
-    MESSAGES="$MESSAGES<session-restore>\n\n[LEDGER RECOVERY -- compaction]\n\nYour context was just compacted. The durable session ledger on disk is the source of truth for this session.\n\nBulk sections (Decisions/Pending/Pointers/Learnings): run this command NOW, before any other action:\n  cat \"\$OMT_DIR/session-ledger-\$OMT_SESSION_ID.md\"\n(\$OMT_DIR and \$OMT_SESSION_ID are set in CLAUDE_ENV_FILE exported by this hook.)\nResume from the \`## Now\` section.\n\n"
-
-    # additionalContext is capped ~10k chars; reuse the existing 7000-char inline
-    # cap (see the incomplete-todos/prometheus/goal pointer sections above) as the
-    # acute-vs-pointer threshold. Over cap: skip the inline, rely on the cat pointer above.
-    if [ -n "$LEDGER_ACUTE" ] && [ "${#LEDGER_ACUTE}" -le 7000 ]; then
-      MESSAGES="${MESSAGES}[Now + User Corrections, inlined below]\n\n"
-      LEDGER_ACUTE_INLINE="$LEDGER_ACUTE"
-    else
-      MESSAGES="${MESSAGES}[Now + User Corrections exceed the inline cap -- read them via the cat command above.]\n\n"
-    fi
-
-    MESSAGES="${MESSAGES}</session-restore>\n\n---\n\n"
-  fi
-fi
+# Compaction recovery (source==compact, ledger present) is now handled by the
+# ledger_core_run delegation above -- see the LEDGER_DELEGATED_ESCAPED block
+# near the top of this file.
 
 # Check for incomplete todos in global directory
 INCOMPLETE_COUNT=0
@@ -401,15 +381,13 @@ if [ "$INCOMPLETE_COUNT" -gt 0 ]; then
   MESSAGES="$MESSAGES<session-restore>\n\n[PENDING TASKS DETECTED]\n\nYou have incomplete tasks from a previous session.\nPlease continue working on these tasks.\n\n</session-restore>\n\n---\n\n"
 fi
 
-# Output message if we have any restore content OR an inlined ledger acute fragment.
-if [ -n "$MESSAGES" ] || [ -n "$LEDGER_ACUTE_INLINE" ]; then
+# Output message if we have any restore content OR delegated ledger content.
+if [ -n "$MESSAGES" ] || [ -n "$LEDGER_DELEGATED_ESCAPED" ]; then
   # Escape for JSON
   MESSAGES_ESCAPED=$(echo "$MESSAGES" | sed 's/"/\\"/g')
-  # Surgically encode the untrusted ledger acute fragment to a JSON-safe string body:
-  # jq -Rs emits a quoted JSON string; strip the outer quotes so it concatenates
-  # onto the sed-escaped restore body inside the single additionalContext value.
-  LEDGER_ACUTE_INLINE_ESCAPED=$(printf '%s' "$LEDGER_ACUTE_INLINE" | jq -Rs . | sed '1s/^"//; $s/"$//')
-  echo "{\"continue\": true, \"hookSpecificOutput\": {\"hookEventName\": \"SessionStart\", \"additionalContext\": \"$MESSAGES_ESCAPED$LEDGER_ACUTE_INLINE_ESCAPED\"}}"
+  # LEDGER_DELEGATED_ESCAPED is already JSON-string-escaped (see above) --
+  # prepend it as-is, ahead of MESSAGES_ESCAPED.
+  echo "{\"continue\": true, \"hookSpecificOutput\": {\"hookEventName\": \"SessionStart\", \"additionalContext\": \"$LEDGER_DELEGATED_ESCAPED$MESSAGES_ESCAPED\"}}"
 else
   echo '{"continue": true}'
 fi

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -113,13 +113,6 @@ LEDGER_CORE_OUT=$(
 )
 LEDGER_DELEGATED_ESCAPED=""
 if [ -n "$LEDGER_CORE_OUT" ]; then
-  # Restore the "-- compaction" qualifier on the recovery header: ledger-
-  # core.sh's shared (Claude+Codex) recovery text says "[LEDGER RECOVERY]"
-  # (platform-neutral wording), but the pre-delegation Claude text this call
-  # replaces said "[LEDGER RECOVERY -- compaction]". No escaping is needed --
-  # neither string contains a quote or backslash. Restore before extraction
-  # since the label sits inside the escaped additionalContext value.
-  LEDGER_CORE_OUT="${LEDGER_CORE_OUT/\[LEDGER RECOVERY\]/[LEDGER RECOVERY -- compaction]}"
   # Extract the already-escaped additionalContext value verbatim (no
   # decode/re-encode) from ledger-core.sh's own JSON output template
   # (`"additionalContext": "...."}}`, hooks/ledger-core.sh:175) via plain

--- a/hooks/write-guard-core.sh
+++ b/hooks/write-guard-core.sh
@@ -14,8 +14,10 @@
 # does the exact-path comparison and emits the deny JSON.
 # =============================================================================
 
-# Byte-identical to the Claude deny at hooks/pre-tool-enforcer.sh:79
-# (_wg_deny_json) -- keep both platforms' deny output identical (AC5).
+# Single source of truth for the deny JSON: both platform shims
+# (hooks/pre-tool-enforcer.sh for Claude, hooks/codex-write-guard.sh for
+# Codex) source this core and call write_guard_core_run rather than building
+# their own deny text -- keep both platforms' deny output identical (AC5).
 _wg_core_deny_json='{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Blocked: direct write/delete targets the durable session ledger (session-ledger-*.md). Use hooks/omt-ledger.sh append/now instead."}}'
 
 # _wg_core_normpath <path>

--- a/hooks/write-guard-core.sh
+++ b/hooks/write-guard-core.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# =============================================================================
+# Write-Guard Core (codex-ledger-parity plan, TODO 2): the shared full-path
+# anchor-match + byte-identical deny core for the ledger write-guard, sourced
+# by both hooks/pre-tool-enforcer.sh (Claude) and the Codex PreToolUse hook.
+# Full-path EXACT match on the resolved current-session ledger only -- NEVER
+# a bare "session-ledger-" substring (that loose match is
+# hooks/pre-tool-enforcer.sh's superseded _wg_ledger_target_in_segment
+# classifier, hooks/pre-tool-enforcer.sh:42-77).
+#
+# The per-platform shim owns extraction of candidate target paths from its
+# own tool-input shape (Claude tool_input.file_path/.command; Codex
+# apply_patch envelope) and OMT_DIR/session_id resolution -- this core only
+# does the exact-path comparison and emits the deny JSON.
+# =============================================================================
+
+# Byte-identical to the Claude deny at hooks/pre-tool-enforcer.sh:79
+# (_wg_deny_json) -- keep both platforms' deny output identical (AC5).
+_wg_core_deny_json='{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Blocked: direct write/delete targets the durable session ledger (session-ledger-*.md). Use hooks/omt-ledger.sh append/now instead."}}'
+
+# write_guard_core_run <OMT_DIR> <session_id>
+# Reads newline-separated already-absolutized candidate target paths on
+# stdin. Emits the deny JSON to stdout iff any candidate is FULL-PATH EXACT
+# equal to "$OMT_DIR/session-ledger-<session_id>.md"; else emits nothing
+# (allow).
+write_guard_core_run() {
+    local omt_dir="$1"
+    local session_id="$2"
+    local ledger_path="$omt_dir/session-ledger-$session_id.md"
+    local candidate
+    while IFS= read -r candidate; do
+        if [[ "$candidate" == "$ledger_path" ]]; then
+            printf '%s\n' "$_wg_core_deny_json"
+            return 0
+        fi
+    done
+    return 0
+}

--- a/hooks/write-guard-core.sh
+++ b/hooks/write-guard-core.sh
@@ -18,6 +18,42 @@
 # (_wg_deny_json) -- keep both platforms' deny output identical (AC5).
 _wg_core_deny_json='{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Blocked: direct write/delete targets the durable session ledger (session-ledger-*.md). Use hooks/omt-ledger.sh append/now instead."}}'
 
+# _wg_core_normpath <path>
+# Pure LEXICAL path normalization (os.path.normpath semantics): collapse
+# empty (//), '.' and '..' segments WITHOUT touching the filesystem. This
+# guard fires on paths that do NOT exist yet -- the write/delete is what
+# would create them -- so realpath/readlink -f (which require the path to
+# exist, and are non-portable on BSD) would false-negative on exactly the
+# guarded case. Both the candidate and the ledger path pass through this
+# before the EXACT compare, so a non-canonical spelling
+# ($OMT_DIR/./session-ledger-<sid>.md, //session-ledger, a/../session-ledger)
+# cannot bypass the anchor match. Symlink segments are NOT resolved (lexical
+# only) -- safe here because the ledger dir is a plain $HOME/.omt/<name>
+# directory, never a symlink.
+_wg_core_normpath() {
+    awk -v p="$1" 'BEGIN {
+        abs = (substr(p, 1, 1) == "/")
+        n = split(p, seg, "/")
+        top = 0
+        for (i = 1; i <= n; i++) {
+            s = seg[i]
+            if (s == "" || s == ".") continue
+            if (s == "..") {
+                if (top > 0 && st[top] != "..") { top-- }
+                else if (!abs) { st[++top] = ".." }
+                # abs && top==0: drop -- cannot escape root
+            } else {
+                st[++top] = s
+            }
+        }
+        out = ""
+        for (i = 1; i <= top; i++) out = out "/" st[i]
+        if (abs) { if (out == "") out = "/" }
+        else { out = substr(out, 2); if (out == "") out = "." }
+        print out
+    }'
+}
+
 # write_guard_core_run <OMT_DIR> <session_id>
 # Reads newline-separated already-absolutized candidate target paths on
 # stdin. Emits the deny JSON to stdout iff any candidate is FULL-PATH EXACT
@@ -26,10 +62,11 @@ _wg_core_deny_json='{"hookSpecificOutput":{"hookEventName":"PreToolUse","permiss
 write_guard_core_run() {
     local omt_dir="$1"
     local session_id="$2"
-    local ledger_path="$omt_dir/session-ledger-$session_id.md"
+    local ledger_path
+    ledger_path="$(_wg_core_normpath "$omt_dir/session-ledger-$session_id.md")"
     local candidate
     while IFS= read -r candidate; do
-        if [[ "$candidate" == "$ledger_path" ]]; then
+        if [ "$(_wg_core_normpath "$candidate")" = "$ledger_path" ]; then
             printf '%s\n' "$_wg_core_deny_json"
             return 0
         fi

--- a/hooks/write-guard-core_test.sh
+++ b/hooks/write-guard-core_test.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# =============================================================================
+# Write-Guard Core Tests (codex-ledger-parity plan, TODO 2)
+# Covers hooks/write-guard-core.sh: write_guard_core_run <OMT_DIR> <session_id>
+# reads newline-separated already-absolutized candidate paths on stdin and
+# emits the deny JSON iff a candidate is FULL-PATH EXACT equal to
+# $OMT_DIR/session-ledger-<sid>.md -- never a bare substring match (the loose
+# classifier this core supersedes: hooks/pre-tool-enforcer.sh:42-77
+# _wg_ledger_target_in_segment).
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+CORE="$SCRIPT_DIR/write-guard-core.sh"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# -----------------------------------------------------------------------------
+# mktemp -d + cleanup trap (OMT shell-test convention)
+# -----------------------------------------------------------------------------
+TEST_TMP_DIR=$(mktemp -d)
+cleanup() {
+    rm -rf "$TEST_TMP_DIR"
+}
+trap cleanup EXIT
+
+OD="$TEST_TMP_DIR/omt-wg"
+SID="s1"
+
+run_test() {
+    local test_name="$1"
+    if "$test_name"; then
+        echo "[PASS] $test_name"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "[FAIL] $test_name"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+# =============================================================================
+# AC1 -- byte-identical deny vs the branch-point _wg_deny_json SSOT.
+# Anchored at merge-base(HEAD, main), NOT HEAD -- a later task moves
+# _wg_deny_json out of pre-tool-enforcer.sh, which would make a HEAD read
+# return empty on re-run.
+# =============================================================================
+test_ac1_byte_identical_deny_at_branch_point() {
+    local base expected out
+    base=$(git -C "$ROOT_DIR" merge-base HEAD main)
+    expected=$(git -C "$ROOT_DIR" show "$base:hooks/pre-tool-enforcer.sh" | grep '^_wg_deny_json=' | cut -d"'" -f2)
+    out=$(printf '%s\n' "$OD/session-ledger-$SID.md" | bash -c "source '$CORE'; write_guard_core_run '$OD' '$SID'")
+    if [ -n "$expected" ] && [ "$out" = "$expected" ] && printf '%s' "$out" | grep -q '"hookEventName":"PreToolUse"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED AC1: expected='$expected' out='$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
+# AC2 -- a session-ledger-<sid>.md path in a DIFFERENT directory (previously
+# loose-blocked by the substring classifier) now ALLOWS.
+# =============================================================================
+test_ac2_different_dir_session_ledger_allows() {
+    local out
+    out=$(printf '%s\n' "/some/other/dir/session-ledger-$SID.md" | bash -c "source '$CORE'; write_guard_core_run '$OD' '$SID'")
+    if [ -z "$out" ]; then
+        return 0
+    else
+        echo "ASSERTION FAILED AC2: expected empty (ALLOW), got '$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
+# QA Scenario -- substring-but-not-anchor filename -> ALLOW.
+# =============================================================================
+test_qa_substring_but_not_anchor_allows() {
+    local out evidence_dir
+    out=$(printf '%s\n' "/tmp/draft-session-ledger-notes.md" | bash -c "source '$CORE'; write_guard_core_run '$OD' '$SID'")
+    evidence_dir="$OMT_DIR/evidence/codex-ledger-parity/write-guard-core"
+    mkdir -p "$evidence_dir"
+    {
+        echo "input: /tmp/draft-session-ledger-notes.md (OMT_DIR=$OD sid=$SID)"
+        echo "output: '$out'"
+    } > "$evidence_dir/substring-allow.txt"
+    if [ -z "$out" ]; then
+        return 0
+    else
+        echo "ASSERTION FAILED QA-substring-allow: expected empty (ALLOW), got '$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
+# QA Scenario -- exact current-session ledger -> DENY, protection preserved.
+# =============================================================================
+test_qa_exact_current_ledger_denies() {
+    local out evidence_dir
+    out=$(printf '%s\n' "$OD/session-ledger-$SID.md" | bash -c "source '$CORE'; write_guard_core_run '$OD' '$SID'")
+    evidence_dir="$OMT_DIR/evidence/codex-ledger-parity/write-guard-core"
+    mkdir -p "$evidence_dir"
+    {
+        echo "input: $OD/session-ledger-$SID.md (OMT_DIR=$OD sid=$SID)"
+        echo "output: $out"
+    } > "$evidence_dir/exact-deny.txt"
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED QA-exact-deny: expected deny JSON, got '$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+main() {
+    echo "=========================================="
+    echo "Write-Guard Core Tests"
+    echo "=========================================="
+
+    run_test test_ac1_byte_identical_deny_at_branch_point
+    run_test test_ac2_different_dir_session_ledger_allows
+    run_test test_qa_substring_but_not_anchor_allows
+    run_test test_qa_exact_current_ledger_denies
+
+    echo "=========================================="
+    echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"
+    echo "=========================================="
+
+    if [ "$TESTS_FAILED" -gt 0 ]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/hooks/write-guard-core_test.sh
+++ b/hooks/write-guard-core_test.sh
@@ -14,6 +14,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 CORE="$SCRIPT_DIR/write-guard-core.sh"
 
+# EVIDENCE_OMT_DIR: self-derived (not ambient $OMT_DIR) so this suite runs
+# clean under `env -u OMT_DIR`, mirroring hooks/codex-write-guard_test.sh's
+# own EVIDENCE_OMT_DIR derivation via resolve_omt_dir.
+EVIDENCE_OMT_DIR=$(bash -c "source '$SCRIPT_DIR/lib/omt-dir.sh'; resolve_omt_dir '$SCRIPT_DIR'")
+
 TESTS_PASSED=0
 TESTS_FAILED=0
 
@@ -80,7 +85,7 @@ test_ac2_different_dir_session_ledger_allows() {
 test_qa_substring_but_not_anchor_allows() {
     local out evidence_dir
     out=$(printf '%s\n' "/tmp/draft-session-ledger-notes.md" | bash -c "source '$CORE'; write_guard_core_run '$OD' '$SID'")
-    evidence_dir="$OMT_DIR/evidence/codex-ledger-parity/write-guard-core"
+    evidence_dir="$EVIDENCE_OMT_DIR/evidence/codex-ledger-parity/write-guard-core"
     mkdir -p "$evidence_dir"
     {
         echo "input: /tmp/draft-session-ledger-notes.md (OMT_DIR=$OD sid=$SID)"
@@ -100,7 +105,7 @@ test_qa_substring_but_not_anchor_allows() {
 test_qa_exact_current_ledger_denies() {
     local out evidence_dir
     out=$(printf '%s\n' "$OD/session-ledger-$SID.md" | bash -c "source '$CORE'; write_guard_core_run '$OD' '$SID'")
-    evidence_dir="$OMT_DIR/evidence/codex-ledger-parity/write-guard-core"
+    evidence_dir="$EVIDENCE_OMT_DIR/evidence/codex-ledger-parity/write-guard-core"
     mkdir -p "$evidence_dir"
     {
         echo "input: $OD/session-ledger-$SID.md (OMT_DIR=$OD sid=$SID)"

--- a/hooks/write-guard-core_test.sh
+++ b/hooks/write-guard-core_test.sh
@@ -120,6 +120,60 @@ test_qa_exact_current_ledger_denies() {
 }
 
 # =============================================================================
+# Regression (claim N) -- non-canonical path spellings must not bypass the
+# pure-string EXACT match. write_guard_core_run compared candidate paths to
+# the ledger path with a pure string `==`, so a candidate with a
+# non-canonical segment ('./', '//', 'a/../') preserved still lexically
+# resolves to the real ledger path but does NOT string-match it, and was
+# silently ALLOWED. Each DENY case below targets the resolved current-session
+# ledger via a non-canonical spelling; the final case is a non-ledger control
+# proving the fix does not over-block.
+# =============================================================================
+test_regression_dot_segment_denies() {
+    local out
+    out=$(printf '%s\n' "$OD/./session-ledger-$SID.md" | bash -c "source '$CORE'; write_guard_core_run '$OD' '$SID'")
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED regression-dot-segment: expected deny for '$OD/./session-ledger-$SID.md', got '$out'"
+        return 1
+    fi
+}
+
+test_regression_double_slash_denies() {
+    local out
+    out=$(printf '%s\n' "$OD//session-ledger-$SID.md" | bash -c "source '$CORE'; write_guard_core_run '$OD' '$SID'")
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED regression-double-slash: expected deny for '$OD//session-ledger-$SID.md', got '$out'"
+        return 1
+    fi
+}
+
+test_regression_dotdot_segment_denies() {
+    local out
+    out=$(printf '%s\n' "$OD/sub/../session-ledger-$SID.md" | bash -c "source '$CORE'; write_guard_core_run '$OD' '$SID'")
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED regression-dotdot-segment: expected deny for '$OD/sub/../session-ledger-$SID.md', got '$out'"
+        return 1
+    fi
+}
+
+test_regression_dot_segment_non_ledger_allows() {
+    local out
+    out=$(printf '%s\n' "$OD/./other-notes.md" | bash -c "source '$CORE'; write_guard_core_run '$OD' '$SID'")
+    if [ -z "$out" ]; then
+        return 0
+    else
+        echo "ASSERTION FAILED regression-dot-segment-allow: expected empty (ALLOW), got '$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -132,6 +186,10 @@ main() {
     run_test test_ac2_different_dir_session_ledger_allows
     run_test test_qa_substring_but_not_anchor_allows
     run_test test_qa_exact_current_ledger_denies
+    run_test test_regression_dot_segment_denies
+    run_test test_regression_double_slash_denies
+    run_test test_regression_dotdot_segment_denies
+    run_test test_regression_dot_segment_non_ledger_allows
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"


### PR DESCRIPTION
## 📌 Summary

Claude에만 있던 세션-렛저(session ledger, 세션 상태를 디스크에 지속 기록해 컴팩션 후 복구하는 장치) 연속성 메커니즘을 Codex에 완전 패리티로 이관합니다. 크로스-플랫폼 공유 bash 코어 2개(기록·복구 / write-guard) 뒤에 얇은 per-platform 훅을 두는 구조로, 기존 Claude 동작은 byte 단위로 보존합니다.

---

## 🔧 Changes

### 공유 코어 — 기록·복구 (`ledger-core.sh`)

- 양쪽 harness(Claude `session-start.sh`, Codex `codex-ledger.sh`)가 source하는 단일 진입점 `ledger_core_run <claude|codex>` 신설. 기록 지시(매 세션) + 컴팩션 복구(source==compact) 로직을 여기 한 곳에 둠.
- 기록 지시(`[LEDGER RECORDING]`)는 jq/세션ID 게이트 **밖에서 무조건** 출력하고, 복구(`[LEDGER RECOVERY]`)만 jq 존재+유효 sid를 조건으로 둠.
- 복구 마커를 explicit platform 신호로 코어가 직접 소유(claude=`-- compaction` 접미어, codex=bare).

**영향 범위**
`session-start.sh`가 인라인으로 갖고 있던 기록·복구 블록이 코어로 이동. Claude 최종 출력은 byte-identical(golden 대조). platform은 인자로만 전달하며 env를 sniff하지 않음.

### 공유 코어 — write-guard (`write-guard-core.sh`)

- 세션-렛저 파일에 대한 직접 쓰기를 차단하는 정밀 경로 앵커링 코어 `write_guard_core_run <OMT_DIR> <sid>` 신설. `$OMT_DIR/session-ledger-<sid>.md`와 **전체 경로 완전 일치**할 때만 deny.
- deny JSON은 기존 `pre-tool-enforcer.sh`의 것과 byte-identical.

**영향 범위**
기존 느슨한 `session-ledger` 부분문자열 매칭의 오탐(이 기능 관련 파일명이 스스로 차단당하던 문제)을 제거. Claude `pre-tool-enforcer.sh`가 이 코어에 위임.

### Codex 훅 신규 + 등록

- `codex-ledger.sh` — Codex SessionStart 훅. `ledger_core_run codex` 호출 후 Claude 전용 `continue` 키 제거.
- `codex-write-guard.sh` — Codex PreToolUse 훅. apply_patch/heredoc/redirect 파싱 + 렛저 타깃 deny.
- `omt-ledger.sh` — 세션ID 자기해석 추가(`OMT_SESSION_ID ?? CODEX_THREAD_ID`, strict empty-only coalescing + charset 가드).
- `codex.yaml` — 두 훅을 SessionStart/PreToolUse에 등록. `hook-registration_test.sh`의 "Codex엔 PreToolUse 없음" 불변식을 실재에 맞게 반전.

**영향 범위**
Codex 0.144.1은 PreToolUse를 지원(`permissionDecision:"deny"` 실행 전 차단)함을 실측 확인. Codex 출력 계약은 `continue` 키를 절대 포함하지 않음.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 공유 코어 2개 + 얇은 per-platform 훅 구조

**배경 및 문제 상황:**
Claude의 렛저 연속성은 `session-start.sh`(기록·복구)와 `pre-tool-enforcer.sh`(write-guard)에 인라인으로 박혀 있었습니다. Codex에 같은 기능을 넣을 때 로직을 복붙하면 두 harness가 시간이 지나며 갈라지고(drift), 한쪽 버그 수정이 다른 쪽에 반영 안 되는 고전적 함정이 있습니다.

**해결 방안:**
기록·복구와 write-guard를 각각 `ledger_core_run`, `write_guard_core_run`이라는 작은 인터페이스 뒤로 추출하고, 양쪽 harness는 platform 신호만 넘기는 얇은 훅으로 남깁니다. 로직은 코어 한 곳에만 존재합니다.

**구현 세부사항:**
통합 근거는 OMT_DIR git-유도 로직이 이미 `session-start.sh`에 bash로 존재했고(출력은 `continue` 생략 시 양쪽 유효), stdin의 `.source`/`.session_id`/`.cwd`를 양쪽 harness가 제공한다는 점입니다. platform은 반드시 **인자로 전달**하며 `CLAUDE_ENV_FILE` 같은 env를 sniff해 추론하지 않습니다 — 호출자가 자신이 누구인지 명시합니다.

**선택과 트레이드오프:**
"deep module"(작은 인터페이스가 큰 구현을 숨김) 방향을 택했습니다. 대안인 harness별 독립 복사본은 초기 diff는 작지만 drift 비용이 크고, 이 저장소의 컨벤션(로컬리티 > 파편화)에도 어긋납니다. 트레이드오프로 코어가 두 harness의 출력 형식 차이(Claude는 `continue` 키 허용, Codex는 금지)를 신경 써야 하지만, 그 차이는 얇은 훅 레이어에서 흡수됩니다.

### 2. byte-preservation 대칭으로 복구 마커 소유권 이전

**배경 및 문제 상황:**
초기 이관에서는 코어가 양쪽에 bare `[LEDGER RECOVERY]`를 출력하고, `session-start.sh`가 사후에 문자열 치환으로 Claude에만 `-- compaction` 접미어를 덧붙였습니다. SSOT여야 할 코어가 자기 출력 마커를 소유하지 못하고 소비자가 패치하는 코드 스멜입니다.

**해결 방안:**
코어가 `_lc_recovery_marker`를 platform 신호로 분기해 직접 소유합니다(claude=`[LEDGER RECOVERY -- compaction]`, codex=bare). `session-start.sh`의 치환 shim은 삭제합니다.

**구현 세부사항:**
이 리팩터가 성립하는 핵심은 **byte-preservation 대칭**입니다. 변경 후 코어가 claude엔 suffixed를, codex엔 bare를 직접 출력하면 — Claude는 shim 없이 그대로 통과해 최종 바이트가 이전과 동일하고, Codex도 이전(bare)과 동일합니다. 검증에서 pre-change(merge-base 시점)와 HEAD의 Claude 컴팩션-복구 출력이 적대적 렛저 내용(따옴표·역슬래시·유니코드) 하에서도 diff 공백임을 실증했습니다.

**선택과 트레이드오프:**
동작이 정확했으므로 이 변경은 순수 SSOT 정리입니다. least-code 관점에선 "동작하는 코드를 건드리는" 리스크가 있으나, 방금 세운 무조건-기록 불변식이 인접 소비자에서 다시 깨지지 않도록 코어가 자기 출력을 온전히 소유하는 편이 장기적으로 더 작은 리스크라 판단했습니다.

### 3. jq 부재 시에도 기록 지시가 살아남도록

**배경 및 문제 상황:**
`codex-ledger.sh`가 코어 출력을 `jq -c 'del(.continue)'`로 통과시켰습니다. 코어는 기록 지시를 무조건 출력하도록 고쳤지만, Codex 훅이 그 출력을 다시 jq에 넣으니 **jq가 PATH에 없으면 파이프가 실패해 출력 전체가 드롭** — 무조건-기록 보장이 Codex 쪽에서 무효화됩니다.

**해결 방안:**
`command -v jq`로 분기합니다. jq 있으면 기존 경로 유지, 없으면 코어의 고정형 출력 라인(`{"continue": true, ...`)에서 `sed 's/^{"continue": true, /{/'`로 `continue` 키만 텍스트 제거합니다.

**구현 세부사항:**
코어의 emit 라인은 항상 정확히 `{"continue": true, "hookSpecificOutput": {...}}`로 시작하는 단일라인 JSON이라, `^` 앵커 sed로 접두부만 제거하면 유효한 `{"hookSpecificOutput": {...}}`가 됩니다. 복구는 코어에서 jq-게이트라 jq 부재 시 아예 열리지 않으므로, 폴백은 항상 recording-only JSON만 처리하며 half-emit이 불가능합니다.

**선택과 트레이드오프:**
`set -e` 안전을 위해 `|| true`로 파이프 실패를 삼키는 방법도 있었으나 금지했습니다 — 이 저장소는 과거에 정확히 그 패턴(`|| true`가 렛저 파괴 가드를 우회)으로 데이터파괴 버그를 겪었습니다. sed는 정상 종료하므로 `|| true` 없이 안전합니다.

### 4. write-guard set-e 우회 + 인용부호 우회 봉합

**배경 및 문제 상황:**
write-guard의 redirect 추출 파이프에 `|| true`가 누락돼, `set -euo pipefail`에서 `>` 없는 세그먼트가 grep exit 1을 반환하면 case 블록 도달 전 abort → tee/rm/dd/cp/truncate/sed로 렛저를 삭제/덮어쓰는 경로가 전부 ALLOW됐습니다. 통과하는 테스트 스위트가 이 라우트를 밟지 않아 결함을 은폐했습니다. 또 따옴표로 감싼 redirect(`> "…ledger…"`)가 Codex에선 ALLOW, Claude에선 DENY로 갈리는 불일치도 있었습니다.

**해결 방안:**
Claude 쌍둥이 함수와 동일하게 추출 파이프에 `|| true`를 붙여 set-e abort를 막고(단, 이건 grep의 정상적 no-match 처리이지 에러 은폐가 아님), 따옴표 제거 미러를 추가해 양쪽 harness의 판정을 일치시킵니다.

**선택과 트레이드오프:**
독립 code-review 레인이 통과 스위트가 놓친 이 두 결함을 잡았습니다. 교훈은 "byte-golden + 통과 스위트 = 필요조건이지 충분조건이 아니다"입니다 — 테스트 커버리지가 특정 라우트를 밟지 않으면 green도 거짓 안심을 줍니다. 이후 tee/rm/dd/cp/truncate/sed 각 라우트를 명시적으로 공격하는 검증을 추가했습니다.

---

## ✅ Checklist

### 공유 코어 기록·복구
- [ ] Claude 컴팩션-복구 출력이 이관 전과 byte-identical (golden 대조 통과)
- [ ] 기록 지시가 jq 부재/기본 sid에서도 무조건 출력됨
  - `hooks/ledger-core.sh`
- [ ] 복구 마커가 claude=`-- compaction`, codex=bare로 코어에서 분기됨
  - `hooks/ledger-core.sh`
- [ ] `session-start.sh`에 마커 문자열 치환 표현이 0개 (`grep -c == 0`)
  - `hooks/session-start.sh`

### Codex 훅
- [ ] jq 부재 시 codex-ledger.sh 출력에 `[LEDGER RECORDING]` 포함 + 최상위 `continue` 키 없음 + 유효 JSON
  - `hooks/codex-ledger.sh`
- [ ] 오염된 sid(shell metachar·경로 traversal·`default`)가 charset 가드로 거부되어 복구 블록이 열리지 않음
  - `hooks/omt-ledger.sh`, `hooks/ledger-core.sh`

### write-guard
- [ ] tee/rm/dd/cp/truncate/sed로 렛저에 쓰는 경로가 모두 DENY됨
  - `hooks/codex-write-guard.sh`
- [ ] 따옴표로 감싼 redirect가 Codex/Claude 양쪽에서 동일하게 DENY됨
  - `hooks/codex-write-guard.sh`, `hooks/pre-tool-enforcer.sh`
- [ ] 비-렛저 파일 쓰기는 ALLOW (오버블록 없음)
  - `hooks/write-guard-core.sh`

### 등록·회귀
- [ ] `make validate` / `make test` 모두 exit 0 (Shell + TypeScript 스위트 green)
- [ ] `codex.yaml`에 두 훅이 SessionStart/PreToolUse로 등록됨
  - `codex.yaml`, `hooks/hook-registration_test.sh`
