### PR TITLE
feat: 변경 범위 검증 강제 (게이트 deny + 플랜 유도)

### DIFF
--- a/scripts/verify-caps-gate/index.ts
+++ b/scripts/verify-caps-gate/index.ts
@@ -150,7 +150,22 @@ function scopedScriptWithoutSelector(
 	const match = re.exec(s);
 	if (match === null) return false;
 
-	return !hasTestSelector(s.slice(match[0].length));
+	return !hasTestSelector(stripScopeFlagOperands(s.slice(match[0].length), scopeFlags));
+}
+
+// A scope flag written AFTER the script in space-separated form (`test --filter
+// web`, `test -F web`) leaves its VALUE (`web`) as a bareword in the post-script
+// text — where hasTestSelector would misread it as a test selector and wrongly
+// let the whole-package run through (the `--filter=web` equals form is already
+// skipped as a `-`-prefixed flag; only the space-separated value leaks). Strip
+// each scope flag and its value before the selector check, mirroring the
+// leading-forms value-consumption above (flag with `=value` or ` value`).
+function stripScopeFlagOperands(rest: string, scopeFlags: string[]): string {
+	let s = rest;
+	for (const flag of scopeFlags) {
+		s = s.replace(new RegExp(`(^|\\s)${escapeRegExp(flag)}(?:=\\S+|\\s+\\S+)`, "g"), " ");
+	}
+	return s;
 }
 
 // Does the text after the script token carry a test selector? Cut everything

--- a/scripts/verify-caps-gate/index.ts
+++ b/scripts/verify-caps-gate/index.ts
@@ -1,5 +1,6 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 /**
@@ -29,6 +30,10 @@ import { fileURLToPath } from "node:url";
 export type RunnerDenyConfig = {
 	scripts: string[];
 	scope_flags: string[];
+	// Second deny axis: scripts that, even WITH a scope flag, are denied when run
+	// without a test selector (a scoped-but-whole-package run). Absent → axis off.
+	selector_required_scripts?: string[];
+	selector_required_reason?: string;
 };
 
 export type RunnerRule = {
@@ -95,8 +100,91 @@ function findDenyReason(command: string, config: VerifyCapsConfig): string | nul
 		) {
 			return buildDenyReason(runnerName, rule.deny.scope_flags);
 		}
+
+		// Second axis: a scoped-but-whole-package run. Past the unfiltered check
+		// above, so if this fires the segment DID carry a scope flag — a
+		// `pnpm --filter <pkg> test` with no test selector runs the whole package
+		// suite. Deny and steer to verify:quick (message from policy).
+		if (
+			rule.deny.selector_required_scripts !== undefined &&
+			scopedScriptWithoutSelector(
+				segment,
+				runnerName,
+				rule.deny.selector_required_scripts,
+				rule.deny.scope_flags,
+			)
+		) {
+			return rule.deny.selector_required_reason ?? buildSelectorRequiredReason(runnerName);
+		}
 	}
 	return null;
+}
+
+// True when `segment` is `<runner> [run/-r/--filter <pkg>/…] <script>` for a
+// script in `scripts` (matched EXACTLY — `test:changed` does not match `test`),
+// a scope flag is present, AND no test selector follows the script. "Selector"
+// = a positional operand (`test payment.router`) or a `-t`/`--testNamePattern`
+// flag; redirections and pipes after the script (`test 2>&1`, `test > out`) are
+// NOT selectors, so a bare-with-redirection run still matches (whole-package).
+function scopedScriptWithoutSelector(
+	segment: string,
+	runnerName: string,
+	scripts: string[],
+	scopeFlags: string[],
+): boolean {
+	const s = stripLeadingEnvAssignments(segment);
+	// Must be scoped — an unscoped bare `test` is the first axis's job, not this one.
+	if (!hasAnyScopeFlag(stripAfterEndOfOptions(s), scopeFlags)) return false;
+
+	const leadingForms = ["run", "-r", "--recursive"];
+	for (const flag of scopeFlags) {
+		// value-taking scope flag consumed with its value as one leading token
+		leadingForms.push(`${escapeRegExp(flag)}(?:=\\S+|\\s+\\S+)`);
+	}
+	leadingForms.push("-\\S+"); // any other boolean flag before the script
+	const leading = leadingForms.join("|");
+	const scriptAlt = scripts.map(escapeRegExp).join("|");
+	// `(?:${scriptAlt})(?:\\s+|$)` — exact script terminated by whitespace/end, so
+	// `test:changed` (colon after `test`) does not match the `test` alternative.
+	const re = new RegExp(`^${escapeRegExp(runnerName)}(?:\\s+(?:${leading}))*\\s+(?:${scriptAlt})(?:\\s+|$)`);
+	const match = re.exec(s);
+	if (match === null) return false;
+
+	return !hasTestSelector(s.slice(match[0].length));
+}
+
+// Does the text after the script token carry a test selector? Cut everything
+// from the first redirection/pipe onward (a redirect target like `out.txt` in
+// `test > out.txt` is not a selector), then a remaining positional operand or a
+// `-t`/`--testNamePattern` flag counts as a selector.
+function hasTestSelector(afterScript: string): boolean {
+	const args = argsBeforeRedirect(afterScript).trim();
+	if (args.length === 0) return false;
+	for (const tok of args.split(/\s+/)) {
+		if (tok.length === 0) continue;
+		if (tok.startsWith("-")) {
+			if (
+				tok === "-t" ||
+				tok === "--testNamePattern" ||
+				tok.startsWith("-t=") ||
+				tok.startsWith("--testNamePattern=")
+			) {
+				return true;
+			}
+			continue; // a non-selector flag (--coverage, --reporter, …)
+		}
+		return true; // a positional operand — a test file/name selector
+	}
+	return false;
+}
+
+// The command text before the first redirection or pipe operator. A redirect
+// operator is an optional fd digit / `&` followed by `<`/`>` (`>`, `>>`, `2>`,
+// `2>&1`, `&>`), or a bare `|`. Cutting here keeps redirect targets from being
+// misread as test selectors.
+function argsBeforeRedirect(text: string): string {
+	const marker = /(?:^|\s)(?:(?:&|\d)?>>?|\d*<|\|)/.exec(text);
+	return marker === null ? text : text.slice(0, marker.index);
 }
 
 // Quote-aware: a delimiter (&& || | & ; newline) inside a single- or
@@ -216,6 +304,11 @@ function stripAfterEndOfOptions(segment: string): string {
 
 function buildDenyReason(runnerName: string, scopeFlags: string[]): string {
 	return `무필터 \`${runnerName}\` test/lint 실행은 모노레포 전체를 실행해 리소스 폭증을 유발합니다. ${scopeFlags.join(" 또는 ")} 중 하나를 사용하세요.`;
+}
+
+// Fallback for the selector-required deny when the policy omits its own reason.
+function buildSelectorRequiredReason(runnerName: string): string {
+	return `\`${runnerName} --filter <pkg> test\`는 패키지 전체 스위트를 실행합니다. 변경 영향 범위만 검증하거나(예: \`${runnerName} verify:quick\`) 테스트명/경로를 지정하세요.`;
 }
 
 // -----------------------------------------------------------------------------
@@ -395,6 +488,15 @@ function toRunnerRule(raw: Record<string, unknown>): RunnerRule {
 			scripts: toStringArray(raw.deny.scripts),
 			scope_flags: toStringArray(raw.deny.scope_flags),
 		};
+		// Only set the selector-required axis when the yaml declares the script list:
+		// absent stays undefined (axis off), never coerces to [] and silently changes
+		// behavior. The reason string is optional (a default is used when omitted).
+		if (Array.isArray(raw.deny.selector_required_scripts)) {
+			rule.deny.selector_required_scripts = toStringArray(raw.deny.selector_required_scripts);
+		}
+		if (typeof raw.deny.selector_required_reason === "string") {
+			rule.deny.selector_required_reason = raw.deny.selector_required_reason;
+		}
 	}
 	return rule;
 }
@@ -423,6 +525,41 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 // -----------------------------------------------------------------------------
+// Decision log — a JSONL audit trail of what the gate DID, so an unexpected
+// outcome (e.g. a test suite still spawning 16 workers) is diagnosable after
+// the fact: did the gate fire and inject a cap, or never fire at all? Only deny
+// and allow (the gate's actual actions) are logged — passthrough is skipped, so
+// the log stays scoped to gate decisions rather than every Bash command. The
+// injected/rewritten command is recorded so "allow with cap injected" is
+// distinguishable from "harness ran the original uncapped". Fail-open: any log
+// I/O error (bad path, permission, full disk) is swallowed — logging must never
+// throw or block the tool call. NOT injected context, so a timestamp here is
+// fine (the cache-safety rule governs prefix-injected context, not side files).
+// -----------------------------------------------------------------------------
+function defaultLogPath(): string {
+	const override = process.env.VERIFY_CAPS_LOG;
+	if (typeof override === "string" && override.length > 0) return override;
+	return join(homedir(), ".claude", "logs", "verify-caps-gate.jsonl");
+}
+
+type LogEntry = {
+	ts: string;
+	decision: "deny" | "allow";
+	command: string;
+	// deny → the reason shown to the caller; allow → the rewritten (cap-injected) command.
+	result: string;
+};
+
+function logDecision(entry: LogEntry, logPath: string): void {
+	try {
+		mkdirSync(dirname(logPath), { recursive: true });
+		appendFileSync(logPath, JSON.stringify(entry) + "\n");
+	} catch {
+		// fail-open: a logging failure must never block or throw.
+	}
+}
+
+// -----------------------------------------------------------------------------
 // PreToolUse IO contract — parses the hook's stdin JSON, calls decide(), and
 // formats the hook output envelope. Kept separate from main() (which only
 // handles the stdin/stdout plumbing) so it's directly testable with JSON
@@ -437,6 +574,7 @@ type PreToolUseInput = {
 export function processHookInput(
 	raw: string,
 	configDir: string = fileURLToPath(new URL(".", import.meta.url)),
+	logPath: string = defaultLogPath(),
 ): string {
 	try {
 		const input: PreToolUseInput = JSON.parse(raw);
@@ -449,6 +587,7 @@ export function processHookInput(
 		const result = decide(command, config);
 
 		if (result.action === "deny") {
+			logDecision({ ts: new Date().toISOString(), decision: "deny", command, result: result.reason }, logPath);
 			return JSON.stringify({
 				hookSpecificOutput: {
 					hookEventName: "PreToolUse",
@@ -458,6 +597,7 @@ export function processHookInput(
 			});
 		}
 		if (result.action === "allow") {
+			logDecision({ ts: new Date().toISOString(), decision: "allow", command, result: result.command }, logPath);
 			return JSON.stringify({
 				hookSpecificOutput: {
 					hookEventName: "PreToolUse",

--- a/scripts/verify-caps-gate/verify-caps-gate.test.ts
+++ b/scripts/verify-caps-gate/verify-caps-gate.test.ts
@@ -169,6 +169,8 @@ describe("decide — deny (scoped-but-whole-package: `--filter <pkg> test` with 
 		["pnpm --filter web test > /tmp/out.txt"], // redirect target is not a selector
 		["pnpm --filter web test 2>&1 | tail -20"], // seg1 is whole-package; pipe target isn't a selector
 		["pnpm --filter web test --coverage"], // a non-selector flag doesn't rescue it
+		["pnpm test --filter web"], // space-separated filter AFTER script: `web` is the filter value, not a selector
+		["pnpm test -F web"], // same, short scope-flag form
 	])("%s denies (whole package suite)", (command) => {
 		const result = decide(command, FIXTURE);
 		expect(result.action).toBe("deny");
@@ -187,6 +189,7 @@ describe("decide — deny (scoped-but-whole-package: `--filter <pkg> test` with 
 		['pnpm --filter @algocare/backend test -t "some name"'], // -t selector flag
 		["pnpm --filter @algocare/backend test --testNamePattern=login"], // long-form selector
 		["pnpm --filter @algocare/backend test:changed"], // sub-scripted, not exact `test`
+		["pnpm test --filter web payment.router"], // space-separated filter + a real selector after it
 	])("%s is not denied (a narrowed run carries a selector)", (command) => {
 		const result = decide(command, FIXTURE);
 		expect(result.action).not.toBe("deny");

--- a/scripts/verify-caps-gate/verify-caps-gate.test.ts
+++ b/scripts/verify-caps-gate/verify-caps-gate.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { fileURLToPath } from "node:url";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -32,7 +32,13 @@ const FIXTURE: VerifyCapsConfig = {
 		pnpm: {
 			env: { VITEST_MAX_FORKS: "2", VITEST_MAX_THREADS: "2" },
 			inject_scripts: ["test", "lint", "verify"],
-			deny: { scripts: ["test", "lint"], scope_flags: ["--filter", "-F", "--affected"] },
+			deny: {
+				scripts: ["test", "lint"],
+				scope_flags: ["--filter", "-F", "--affected"],
+				selector_required_scripts: ["test"],
+				selector_required_reason:
+					"`pnpm --filter <pkg> test`는 패키지 전체 스위트를 실행합니다. `pnpm verify:quick`을 쓰거나 테스트명/경로를 지정하세요.",
+			},
 		},
 	},
 };
@@ -73,8 +79,10 @@ describe("decide — deny (unfiltered root test/lint)", () => {
 		expect(result.action).toBe("deny");
 	});
 
-	test("defect7: `pnpm dev & pnpm test --filter=web` is not denied (seg2 has a scope flag)", () => {
-		const result = decide("pnpm dev & pnpm test --filter=web", FIXTURE);
+	test("defect7: `pnpm dev & pnpm test:changed --filter=web` is not denied (seg2 has a scope flag; test:changed carries its own selector)", () => {
+		// test:changed (not exact `test`) is not subject to the selector-required
+		// axis, so this still exercises only the bare-`&` split + scope-flag rescue.
+		const result = decide("pnpm dev & pnpm test:changed --filter=web", FIXTURE);
 		expect(result.action).not.toBe("deny");
 	});
 
@@ -107,8 +115,10 @@ describe("decide — deny (unfiltered root test/lint)", () => {
 		expect(result.action).not.toBe("deny");
 	});
 
-	test("denyBypass regression: `pnpm test --filter=web` (no `--`) is still not denied", () => {
-		const result = decide("pnpm test --filter=web", FIXTURE);
+	test("denyBypass regression: `pnpm test:changed --filter=web` (no `--`) is still not denied", () => {
+		// Uses test:changed (selector-required axis doesn't apply) so this stays a
+		// pure regression of the end-of-options bypass, not a selector-axis deny.
+		const result = decide("pnpm test:changed --filter=web", FIXTURE);
 		expect(result.action).not.toBe("deny");
 	});
 
@@ -127,21 +137,73 @@ describe("decide — deny (unfiltered root test/lint)", () => {
 		expect(result.action).toBe("deny");
 	});
 
-	test("recursive regression: `pnpm -r test --filter=web` is not denied (a real scope flag still rescues even alongside -r)", () => {
-		const result = decide("pnpm -r test --filter=web", FIXTURE);
+	test("recursive regression: `pnpm -r test:changed --filter=web` is not denied (a real scope flag still rescues even alongside -r)", () => {
+		// test:changed keeps this a pure recursive-axis regression; bare `-r test
+		// --filter` now (correctly) hits the selector-required whole-package deny.
+		const result = decide("pnpm -r test:changed --filter=web", FIXTURE);
 		expect(result.action).not.toBe("deny");
 	});
 });
 
 describe("decide — allow (not a deny match)", () => {
 	test.each([
-		["pnpm test --filter=@algocare/backend"],
+		["pnpm --filter=@algocare/backend test:changed"],
+		["pnpm --filter=@algocare/backend test payment.router"],
 		["turbo run test --affected"],
 		["pnpm verify:quick"],
 		["pnpm test:changed"],
 		["pnpm build"],
 	])("%s is not denied", (command) => {
 		const result = decide(command, FIXTURE);
+		expect(result.action).not.toBe("deny");
+	});
+});
+
+describe("decide — deny (scoped-but-whole-package: `--filter <pkg> test` with no selector)", () => {
+	test.each([
+		["pnpm --filter @algocare/backend test"],
+		["pnpm --filter=web test"],
+		["pnpm test --filter=web"],
+		["pnpm -F web test"],
+		["pnpm --filter web test 2>&1"], // redirection after test is not a selector
+		["pnpm --filter web test > /tmp/out.txt"], // redirect target is not a selector
+		["pnpm --filter web test 2>&1 | tail -20"], // seg1 is whole-package; pipe target isn't a selector
+		["pnpm --filter web test --coverage"], // a non-selector flag doesn't rescue it
+	])("%s denies (whole package suite)", (command) => {
+		const result = decide(command, FIXTURE);
+		expect(result.action).toBe("deny");
+	});
+
+	test("the selector-required deny reason steers to verify:quick", () => {
+		const result = decide("pnpm --filter @algocare/backend test", FIXTURE);
+		expect(result.action).toBe("deny");
+		if (result.action === "deny") {
+			expect(result.reason).toContain("verify:quick");
+		}
+	});
+
+	test.each([
+		["pnpm --filter @algocare/backend test payment.router"], // positional selector
+		['pnpm --filter @algocare/backend test -t "some name"'], // -t selector flag
+		["pnpm --filter @algocare/backend test --testNamePattern=login"], // long-form selector
+		["pnpm --filter @algocare/backend test:changed"], // sub-scripted, not exact `test`
+	])("%s is not denied (a narrowed run carries a selector)", (command) => {
+		const result = decide(command, FIXTURE);
+		expect(result.action).not.toBe("deny");
+	});
+
+	test("a selector-carrying scoped test still injects caps (not denied → reaches injection)", () => {
+		const result = decide("pnpm --filter @algocare/backend test payment.router", FIXTURE);
+		expect(result.action).toBe("allow");
+		if (result.action === "allow") {
+			expect(result.command).toContain("VITEST_MAX_FORKS=2");
+		}
+	});
+
+	test("turbo has no selector-required axis: `turbo run test --filter=web` is not denied by it", () => {
+		// Only pnpm declares selector_required_scripts in FIXTURE; turbo's scoped
+		// test stays allow+cap (its whole-monorepo run is the --affected/-less deny).
+		const result = decide("turbo run test --filter=web", FIXTURE);
 		expect(result.action).not.toBe("deny");
 	});
 });
@@ -276,8 +338,11 @@ describe("decide — `--` and compound guards (`--` keeps env; compound skips in
 		expect(result.action).toBe("passthrough");
 	});
 
-	test("`pnpm test --filter=web && pnpm publish` is passthrough (a scope-flagged verification segment still can't smuggle an auto-approval)", () => {
-		const result = decide("pnpm test --filter=web && pnpm publish", FIXTURE);
+	test("`pnpm test:changed --filter=web && pnpm publish` is passthrough (a scope-flagged verification segment still can't smuggle an auto-approval)", () => {
+		// test:changed keeps seg1 allow-eligible (bare `test --filter` would now hit
+		// the selector-required deny, changing what this test exercises); the point
+		// is that the compound still falls through to passthrough, not auto-approve.
+		const result = decide("pnpm test:changed --filter=web && pnpm publish", FIXTURE);
 		expect(result.action).toBe("passthrough");
 	});
 
@@ -322,8 +387,10 @@ describe("decide — general-purpose runners inject only on verification scripts
 	// Verification invocations still inject — including the flags-before-script
 	// form (`pnpm --filter x test:changed`), where the `--filter x` value is
 	// skipped as a leading token so the script after it stays recognized.
-	test("`pnpm test --filter=web` still injects env (verification preserved)", () => {
-		const result = decide("pnpm test --filter=web", FIXTURE);
+	test("`pnpm test payment.router --filter=web` still injects env (selector-carrying scoped test)", () => {
+		// A scoped test WITH a selector (positional `payment.router`) is a narrowed
+		// run — not caught by the selector-required deny — so it still injects caps.
+		const result = decide("pnpm test payment.router --filter=web", FIXTURE);
 		expect(result.action).toBe("allow");
 		if (result.action === "allow") {
 			expect(result.command).toContain("VITEST_MAX_FORKS=2");
@@ -423,8 +490,16 @@ describe("decide — real verify-caps.yaml drift pin", () => {
 		expect(result.action).toBe("deny");
 	});
 
-	test("`pnpm test --filter=x` is not denied against the shipped yaml", () => {
-		const result = decide("pnpm test --filter=x", realConfig);
+	test("`pnpm --filter=x test` denies against the shipped yaml (selector-required whole-package run)", () => {
+		const result = decide("pnpm --filter=x test", realConfig);
+		expect(result.action).toBe("deny");
+		if (result.action === "deny") {
+			expect(result.reason).toContain("verify:quick");
+		}
+	});
+
+	test("`pnpm --filter=x test:changed` is not denied against the shipped yaml (sub-scripted, not exact `test`)", () => {
+		const result = decide("pnpm --filter=x test:changed", realConfig);
 		expect(result.action).not.toBe("deny");
 	});
 
@@ -449,8 +524,8 @@ describe("decide — real verify-caps.yaml drift pin", () => {
 		expect(result.action).toBe("passthrough");
 	});
 
-	test("`pnpm test --filter=x` still injects env against the shipped yaml", () => {
-		const result = decide("pnpm test --filter=x", realConfig);
+	test("`pnpm --filter=x test:changed` still injects env against the shipped yaml", () => {
+		const result = decide("pnpm --filter=x test:changed", realConfig);
 		expect(result.action).toBe("allow");
 		if (result.action === "allow") {
 			expect(result.command).toContain("VITEST_MAX_FORKS=2");
@@ -615,5 +690,108 @@ describe("processHookInput", () => {
 			moduleDir,
 		);
 		expect(output).toBe("");
+	});
+});
+
+// -----------------------------------------------------------------------------
+// Decision logging — a fail-open JSONL audit trail of deny/allow decisions
+// (passthrough is not logged). This is the diagnostic instrument for "the gate
+// fired but the cap didn't stick vs the gate never fired": an allow entry with
+// the injected command in `result` proves the gate rewrote the command.
+// -----------------------------------------------------------------------------
+describe("processHookInput — decision logging", () => {
+	const moduleDir = fileURLToPath(new URL(".", import.meta.url));
+	const logDirs: string[] = [];
+
+	afterEach(() => {
+		while (logDirs.length > 0) {
+			const dir = logDirs.pop();
+			if (dir !== undefined) rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	function makeLogPath(): string {
+		const dir = mkdtempSync(join(tmpdir(), "verify-caps-log-"));
+		logDirs.push(dir);
+		// a nested path so the mkdir-recursive branch is exercised too
+		return join(dir, "nested", "verify-caps-gate.jsonl");
+	}
+
+	function readLines(logPath: string): Record<string, unknown>[] {
+		if (!existsSync(logPath)) return [];
+		return readFileSync(logPath, "utf8")
+			.split("\n")
+			.filter((line) => line.length > 0)
+			.map((line) => JSON.parse(line) as Record<string, unknown>);
+	}
+
+	test("a deny logs one JSONL entry with the command and reason", () => {
+		const logPath = makeLogPath();
+		processHookInput(
+			JSON.stringify({ tool_name: "Bash", tool_input: { command: "pnpm test" } }),
+			moduleDir,
+			logPath,
+		);
+		const lines = readLines(logPath);
+		expect(lines.length).toBe(1);
+		expect(lines[0].decision).toBe("deny");
+		expect(lines[0].command).toBe("pnpm test");
+		expect(typeof lines[0].result).toBe("string");
+		expect(typeof lines[0].ts).toBe("string");
+	});
+
+	test("an allow logs the REWRITTEN command in `result` (proves cap injection)", () => {
+		const logPath = makeLogPath();
+		processHookInput(
+			JSON.stringify({ tool_name: "Bash", tool_input: { command: "vitest run" } }),
+			moduleDir,
+			logPath,
+		);
+		const lines = readLines(logPath);
+		expect(lines.length).toBe(1);
+		expect(lines[0].decision).toBe("allow");
+		expect(lines[0].command).toBe("vitest run");
+		expect(lines[0].result).toContain("VITEST_MAX_FORKS=2");
+	});
+
+	test("a passthrough logs nothing (log scoped to gate actions only)", () => {
+		const logPath = makeLogPath();
+		processHookInput(
+			JSON.stringify({ tool_name: "Bash", tool_input: { command: "ls -la" } }),
+			moduleDir,
+			logPath,
+		);
+		expect(readLines(logPath)).toEqual([]);
+	});
+
+	test("consecutive decisions append (JSONL grows, not overwrites)", () => {
+		const logPath = makeLogPath();
+		const raw = (command: string) =>
+			JSON.stringify({ tool_name: "Bash", tool_input: { command } });
+		processHookInput(raw("pnpm test"), moduleDir, logPath);
+		processHookInput(raw("vitest run"), moduleDir, logPath);
+		const lines = readLines(logPath);
+		expect(lines.length).toBe(2);
+		expect(lines[0].decision).toBe("deny");
+		expect(lines[1].decision).toBe("allow");
+	});
+
+	test("fail-open: an unwritable log path does not throw and the envelope is still returned", () => {
+		// A path whose parent is a FILE (not a dir) makes mkdir/append fail; the
+		// gate must swallow it and still emit the decision envelope.
+		const dir = mkdtempSync(join(tmpdir(), "verify-caps-log-"));
+		logDirs.push(dir);
+		const fileAsParent = join(dir, "afile");
+		writeFileSync(fileAsParent, "x");
+		const badLogPath = join(fileAsParent, "cannot", "log.jsonl");
+		let output = "";
+		expect(() => {
+			output = processHookInput(
+				JSON.stringify({ tool_name: "Bash", tool_input: { command: "pnpm test" } }),
+				moduleDir,
+				badLogPath,
+			);
+		}).not.toThrow();
+		expect(JSON.parse(output).hookSpecificOutput.permissionDecision).toBe("deny");
 	});
 });

--- a/scripts/verify-caps-gate/verify-caps.yaml
+++ b/scripts/verify-caps-gate/verify-caps.yaml
@@ -61,3 +61,16 @@ runners:
     deny:
       scripts: ["test", "lint"]
       scope_flags: ["--filter", "-F", "--affected"]
+      # selector_required_scripts — a SECOND deny axis for a scoped-but-whole-package
+      # run. `pnpm --filter <pkg> test` (with a scope flag but NO test selector) runs
+      # that package's ENTIRE suite — the exact whole-suite habit verification-discipline
+      # exists to prevent (witnessed: 16 vitest forks from one such command). Deny it
+      # and steer to verify:quick (change-affected scope) or a named selector. A run
+      # that DOES carry a selector — a positional (`test payment.router`), a `-t`/
+      # `--testNamePattern` flag, or a sub-scripted name (`test:changed`, not exact
+      # `test`) — is intentionally narrowed and still allowed+capped. Redirections/pipes
+      # after the script (`test 2>&1 | tail`, `test > out.txt`) are NOT selectors, so a
+      # bare-with-redirection run still denies. This axis is updatedInput-independent:
+      # deny works whether or not the harness honors the cap-injection rewrite.
+      selector_required_scripts: ["test"]
+      selector_required_reason: "`pnpm --filter <pkg> test`는 해당 패키지 전체 테스트 스위트를 실행합니다(리소스 폭증). 변경 영향 범위만 검증하려면 `pnpm verify:quick`을, 특정 테스트만 실행하려면 테스트명/경로를 지정하세요(예: `pnpm --filter <pkg> test <파일명 또는 -t \"패턴\">`)."

--- a/skills/prometheus/SKILL.md
+++ b/skills/prometheus/SKILL.md
@@ -785,7 +785,7 @@ This contract applies to EVERY plan. The contract lives here — not in a refere
 | **Work Objectives** | Core objective, Definition of Done, Must Have, Must NOT Have / Guardrails |
 | **TODOs** | Numbered checkboxed tasks per TODO 7-field format below |
 | **Execution Strategy** | Wave visualization, Dependency Matrix, Critical Path. Target 5-8 tasks/wave. Circular dependencies forbidden. **Final Verification Wave mandatory for Scoped+ intent.** |
-| **Verification Strategy** | Test decision (TDD/tests-after/none), framework, verification commands. Zero Human Intervention — agent-executed with evidence to `$OMT_DIR/evidence/{plan-name}/` |
+| **Verification Strategy** | Test decision (TDD/tests-after/none), framework, verification commands **scoped to the change (not a whole-suite run)**. Zero Human Intervention — agent-executed with evidence to `$OMT_DIR/evidence/{plan-name}/` |
 | **Success Criteria** | Binary pass/fail end state. Verification commands + final checklist |
 | **ADR** | Co-authored decision log of titled `D-N` items — contested tier full 7-field MADR, solo tier lightweight fields + ownership/edges (see `### ADR`). Scoped+ default; Trivial exempt. |
 

--- a/skills/prometheus/plan-template.md
+++ b/skills/prometheus/plan-template.md
@@ -164,14 +164,11 @@ Edges: (controller→UserService.getUser, passes enrich flag; UserService.getUse
 ### Verification Commands
 
 \`\`\`bash
-# Build
-{build-command}  # Expected: exit 0
-
-# Tests
-{test-command}  # Expected: all pass
-
-# Lint
-{lint-command}  # Expected: no errors
+# Verify the CHANGE, not the whole project — scope each command to what changed
+# (the project's change-affected / changed-files command), not a whole-suite run.
+{test-command}  # the project's change-scoped test command
+{lint-command}  # scoped to the changed files where the tooling supports it
+{build-command}  # only when the change can break the build
 \`\`\`
 
 ### Final Checklist
@@ -180,5 +177,5 @@ Edges: (controller→UserService.getUser, passes enrich flag; UserService.getUse
 - [ ] All QA scenarios pass
 - [ ] Evidence artifacts saved to `$OMT_DIR/evidence/{plan-name}/`
 - [ ] No scope creep detected
-- [ ] Build + lint + tests green
+- [ ] Change-scoped build + lint + tests green
 ```


### PR DESCRIPTION
## 📌 Summary

"검증은 변경사항 범위만"이라는 원칙을 두 지점에서 관철한다: verify-caps 게이트가 무인자 `pnpm --filter <pkg> test`(패키지 전체 스위트)를 **차단**하고, prometheus 플랜 템플릿이 whole-suite 검증을 **더 이상 seed하지 않도록** 교정한다. 게이트 결정 로깅도 추가해 캡 주입 여부를 사후 감사한다.

---

## 🔧 Changes

### verify-caps-gate

- 무인자 `pnpm --filter <pkg> test` deny + 변경-범위 검증 유도 (`selector_required_scripts` 축 신설). 셀렉터(positional·`-t`)나 `test:changed`가 있으면 통과+캡, 리다이렉션/파이프는 셀렉터로 치지 않음
- 결정 로깅: deny/allow만 fail-open JSONL append. allow 로그에 재작성된(캡 주입된) 최종 명령을 기록

기존 게이트는 "무필터=deny, 필터=allow+캡"이었으나, 필터가 있어도 셀렉터 없는 패키지 전체 스위트가 리소스를 폭증시켰다(vitest 워커 16개 관측). deny는 `updatedInput` 재작성에 의존하지 않아 캡 경로의 검증 여부와 무관하게 안전하다.

**영향 범위**
게이트는 algocare-home에만 등록됨(글로벌 스크립트, 프로젝트별 raw command 등록). 소스만 반영 → **실동작엔 `make sync` 배포 필요.** `test:changed`·셀렉터 있는 형태·turbo는 영향 없음.

### prometheus

- `plan-template.md` Verification Commands: whole-suite(`build`/`lint`/`test` 전체) 예시 → 프로젝트의 change-affected/changed-files 명령으로 유도
- `SKILL.md` Verification Strategy 행: "scoped to the change (not a whole-suite run)" 명시

**영향 범위**
모든 프로젝트의 플랜 생성에 적용. 프로젝트별 구체 명령은 강요하지 않고 원칙만 제시(프로젝트마다 검증 사이클이 다름).

---

## 💬 Review Points

### 1. cap보다 deny를 우선한 이유

**배경 및 문제 상황:** 게이트의 캡 주입은 PreToolUse `updatedInput`으로 명령을 재작성해 `VITEST_MAX_FORKS=2`를 붙이는 방식이다. 그런데 이 재작성이 실제 실행되는지가 **미검증**이고(트랜스크립트는 원본 명령만 기록, 게이트는 로깅 부재였음), 실측상 캡이 안 먹은 정황(워커 16개)이 있었다.

**해결 방안:** 캡(주입 의존)에 얹지 않고, `updatedInput`과 무관하게 동작하는 **deny**로 패키지 전체 스위트를 차단했다. deny는 재작성 경로가 동작하든 말든 확실히 작동한다.

**선택과 트레이드오프:** deny는 "실행 후 캡"보다 강하지만, 정당한 전체-패키지 검증(드묾)을 막을 수 있다. 그러나 완료-게이트 명령(`verify:full` = `turbo --affected`)은 이 형태를 쓰지 않아 실질적으로 차단되는 정당 경로가 없다. 캡 자체는 유지(셀렉터 있는 실행엔 여전히 주입)하되, 결정 로깅으로 다음 실행에서 `updatedInput` 실행 여부를 판정하기로 했다.

### 2. 셀렉터 판정 — 리다이렉션을 셀렉터로 오인하지 않기

**배경 및 문제 상황:** 에이전트는 보통 `pnpm --filter x test 2>&1 | tail`처럼 리다이렉션/파이프를 붙인다. `test` 뒤 토큰이 있다고 무조건 "셀렉터 있음"으로 보면 `2>&1`·`> out.txt`의 리다이렉트 타깃을 테스트명으로 오인해 전체 스위트를 통과시킨다.

**구현 세부사항:** `test` 뒤 텍스트를 첫 리다이렉션/파이프 이전까지 잘라낸 뒤, 남은 positional 또는 `-t`/`--testNamePattern`만 셀렉터로 인정한다. 값 취하는 비-셀렉터 플래그가 positional을 삼키는 드문 경우는 false-allow로 안전측 처리(과-deny보다 과-allow 선호).

### 3. 로깅 스코프를 deny/allow로 한정

**배경 및 문제 상황:** passthrough까지 로깅하면 모든 Bash 명령이 기록돼 소음이 크다. 목적은 "게이트가 무엇을 했나" 감사다.

**선택과 트레이드오프:** deny/allow만 기록해 게이트 행동으로 스코프를 좁혔다. 대신 "훅이 아예 안 불렸다(세션 미로드)"와 "불렸으나 passthrough"는 로그상 구분되지 않는다 — 현 진단 목표(캡 주입 여부)엔 deny/allow만으로 충분.

---

## ✅ Checklist

### verify-caps-gate
- [ ] 무인자 `pnpm --filter <pkg> test`가 deny되고 사유가 변경-범위 검증을 안내한다
- [ ] `test payment.router` / `test -t "x"` / `test:changed`는 deny되지 않고 캡이 주입된다
- [ ] `test 2>&1 | tail` 등 리다이렉션만 붙은 무인자 실행도 deny된다
- [ ] deny/allow 결정이 JSONL 로그에 남고, allow는 재작성된 명령을 기록한다
- [ ] 로그 경로가 쓰기 불가여도 게이트는 예외 없이 결정을 반환한다
  - \`scripts/verify-caps-gate/index.ts\`

### prometheus
- [ ] 플랜 템플릿의 Verification Commands가 whole-suite 실행을 예시로 seed하지 않는다
  - \`skills/prometheus/plan-template.md\`

## 📎 References
없음