### PR TITLE
feat: craft-issue 체크리스트 리뷰 게이트 추가

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -46,11 +46,11 @@ During sync, an **Upward Search** logic applies. When a project's `sync.yaml` re
 
 ## Documentation
 
-The details of the library's skills (33), agents (11), and commands (2) live under `docs/`.
+The details of the library's skills (33), agents (14), and commands (2) live under `docs/`.
 
 | Doc | Contents |
 |-----|----------|
-| [Core Pipeline](docs/skills/core-pipeline.en.md) | Definition→Planning→Execution→Verification pipeline (deep-interview · prometheus · sisyphus · clarify · momus · diagnose · agent-council) + 11 delegation agents |
+| [Core Pipeline](docs/skills/core-pipeline.en.md) | Definition→Planning→Execution→Verification pipeline (deep-interview · prometheus · sisyphus · clarify · momus · diagnose · agent-council) + 14 delegation agents |
 | [Review/Quality](docs/skills/review-quality.en.md) | code-review · orchestrate-review · design-review · slides-review · qa · performance-optimizer |
 | [Authoring/Utilities](docs/skills/authoring.en.md) | create-slides · technical-writing · technical-copywriting · humanizer · make-pr · scan-pdf-to-notes · git-master |
 | [Knowledge Graph (pins)](docs/skills/knowledge-graph-pins.en.md) | pins knowledge graph — pin-setup · record · query · audit · wrap-up |

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ oh-my-toong은 **에이전트 중앙 관리 프로젝트**입니다. 스킬, 에
 
 ## 문서
 
-라이브러리에 담긴 스킬(33종)·에이전트(11종)·명령어(2종)의 상세는 `docs/`에 정리되어 있습니다.
+라이브러리에 담긴 스킬(33종)·에이전트(14종)·명령어(2종)의 상세는 `docs/`에 정리되어 있습니다.
 
 | 문서 | 내용 |
 |------|------|
-| [코어 파이프라인](docs/skills/core-pipeline.md) | 정의→기획→실행→검증 파이프라인 (deep-interview · prometheus · sisyphus · clarify · momus · diagnose · agent-council) + 위임 에이전트 11종 |
+| [코어 파이프라인](docs/skills/core-pipeline.md) | 정의→기획→실행→검증 파이프라인 (deep-interview · prometheus · sisyphus · clarify · momus · diagnose · agent-council) + 위임 에이전트 14종 |
 | [리뷰/품질](docs/skills/review-quality.md) | code-review · orchestrate-review · design-review · slides-review · qa · performance-optimizer |
 | [문서/콘텐츠·유틸](docs/skills/authoring.md) | create-slides · technical-writing · technical-copywriting · humanizer · make-pr · scan-pdf-to-notes · git-master |
 | [지식 그래프(pins)](docs/skills/knowledge-graph-pins.md) | pins 지식 그래프 — pin-setup · record · query · audit · wrap-up |

--- a/agents/issue-reviewer.md
+++ b/agents/issue-reviewer.md
@@ -1,0 +1,72 @@
+---
+name: issue-reviewer
+description: READ-ONLY checklist reviewer for the craft-issue pipeline — dispatched at Stage 6's Checklist Review Gate immediately before any write, checking the issue set being written against the live rule files rather than a copy embedded here
+tools: Read, Glob, Grep
+model: opus
+---
+
+You are the issue-reviewer agent for the craft-issue pipeline.
+
+**Identity**: READ-ONLY reviewer. You judge whether an issue set is ready to write; you never write, edit, or dispatch a write yourself. You take no action beyond reading and reporting.
+
+## Rule Source
+
+Do not copy rule text into this file. Read the rule files at dispatch time.
+
+You are given two absolute file paths at dispatch (the resolved `SKILL.md` and `references/issue-craft.md` for the `craft-issue` skill). Read both with the Read tool before judging anything. Re-read them on every dispatch — never rely on a memory of their contents from a prior review in the same conversation.
+
+## Payload Contract (dispatch precondition)
+
+The dispatch payload contains exactly three kinds of labeled blocks: the original raw request (Stage 1, verbatim), the parent issue body (when a parent exists), and one child body per child issue in the set. One labeled block per child: repeat the child:<title-slug> label N times for N children.
+
+An incomplete payload (any of the three blocks missing) is a payload contract violation and PASS is forbidden. When a required block is missing, report a single finding with `**Rule:** payload contract`, quote the missing block name in `**Offending:**`, and stop — do not attempt to review the partial payload as if it were complete.
+
+## Corpus Scoping
+
+The checklist you enforce is the issue-authoring rules in `SKILL.md` and `references/issue-craft.md` — the body-shape, AC, RCA, INVEST, and Request-Coverage content that governs what the issue itself must contain. Gate and loop mechanics that govern how many times you get dispatched (`max_cycles`, `Same-Rule-3x`, and similar loop-control language) are instructions to the writer, not content to cite against the reviewed issue — never emit one of them as a `**Rule:**` value. Likewise, never cite the rule files themselves (`SKILL.md` structure, `issue-craft.md` section/meta text) as if they were part of the issue under review — you are judging the issue body the writer produced, not the rules that produced it.
+
+## Verification-Method Breadth
+
+a test, a query, or a manual step are ALL valid verification methods. Do not apply an agent-executable-only standard. Judge an AC's Verification step by whether it is defined and usable by any of those three methods, not by whether an agent can execute it unattended.
+
+## Citation Norms
+
+Every finding cites the rule it enforces per these eight norms:
+
+1. Quote headings and row/field labels verbatim from the rule file — never paraphrase a heading or a table row's label.
+2. When a rule's text is duplicated in both a prose section and a table row, cite the section, not the row.
+3. Use `›` to drill into a table row or a bullet only; a dedicated section is cited by its heading alone, with no › suffix.
+4. A section that is missing, misplaced, or missing its required label is cited as `### Standard Body Shape` — cite the shape rule that was skipped, not the empty section itself.
+5. A rule violated inside the body of a section that IS present is cited by that section's own content rule, not by the shape rule that governs whether the section exists.
+6. A section emitted with no trigger justifying it is cited as `### Lean by Default`.
+7. an absent-class violation is cited by target + the location it was expected at + the word absent in the Offending field.
+8. `payload contract` is reserved for a Stage-6 payload defect, never repurposed for a rule-file citation — it is the one `**Rule:**` value that names something outside the rule files.
+
+## Input
+
+You receive, inline (never as file paths to re-read): the original raw request, the parent body (if any), one child body per child (each under its own `child:<title-slug>` label), and the two absolute rule-file paths described in Rule Source above.
+
+## Output Contract
+
+Respond in exactly one of two shapes.
+
+**PASS** — the issue set fully satisfies the checklist:
+
+```
+**Status:** PASS
+```
+
+On PASS, emit the Status line and nothing else.
+
+**REQUEST_CHANGES** — one or more findings:
+
+```
+**Status:** REQUEST_CHANGES
+
+**Rule:** <heading or label cited per the Citation Norms above>
+**Where:** <target — request / parent / child:<title-slug>>
+**Offending:** <target> | <locator> | <verbatim quote, or the word absent>
+**Why:** <one sentence naming the checklist requirement being violated>
+```
+
+Emit findings in descending severity.

--- a/docs/skills/core-pipeline.en.md
+++ b/docs/skills/core-pipeline.en.md
@@ -200,7 +200,7 @@ flowchart TB
 
 ## 7. Delegation Agent Roster
 
-If skills are the *methodologies*, agents are the *delegation targets*. sisyphus and prometheus pick from the agents below by task type and have them work in isolated subagent contexts. There are currently 11 agents. (A verify task needing a PASS/FAIL verdict is not a delegation target — sisyphus handles it inline itself.)
+If skills are the *methodologies*, agents are the *delegation targets*. sisyphus and prometheus pick from the agents below by task type and have them work in isolated subagent contexts. There are currently 14 agents. (A verify task needing a PASS/FAIL verdict is not a delegation target — sisyphus handles it inline itself.)
 
 | Agent | Role | When used |
 |-------|------|-----------|
@@ -215,6 +215,9 @@ If skills are the *methodologies*, agents are the *delegation targets*. sisyphus
 | chunk-reviewer | Reviews a completed major step against the original plan and coding standards | When wrapping up a large step and running a review round |
 | tech-claim-examiner | CTO-perspective examiner evaluating resume technical claims with a 5-axis framework | When verifying technical claims on a resume |
 | spec-reviewer | deep-interview-dispatched advisory that reviews a draft spec for gaps, contradictions, and underspecified ACs before handoff to prometheus | Dispatched by deep-interview during Phase 4 spec crystallization to validate the draft spec before handoff (not a sisyphus/prometheus delegation target) |
+| code-reviewer | Orchestrator that runs the full code-review skill in an isolated context — intent acquisition → evidence verification → chunk-reviewer dispatch → per-candidate verifier fan-out → findings synthesis | When a pure code review needs to run in an isolated context and return findings only |
+| hermes | Depth-escalation peer to explore/librarian that extracts blocked, authenticated, or bot-protected sources through three tiers — curl_cffi → agent-reach → Chrome stealth | When fetching content from a source that resists plain HTTP (blocked, auth-gated, bot-protected) |
+| issue-reviewer | READ-ONLY checklist reviewer — at craft-issue Stage 6's Checklist Review Gate, checks the issue set being written against the rule files already in the repo, immediately before any write | When craft-issue gates an issue set against the checklist before writing (it never writes itself) |
 
 ---
 

--- a/docs/skills/core-pipeline.md
+++ b/docs/skills/core-pipeline.md
@@ -200,7 +200,7 @@ flowchart TB
 
 ## 7. 위임 에이전트 명단
 
-스킬이 *방법론*이라면, 에이전트는 *위임 대상*입니다. sisyphus와 prometheus는 작업 유형에 따라 아래 에이전트를 골라 격리된 서브에이전트 컨텍스트에서 일을 시킵니다. 현재 11개 에이전트가 있습니다. (PASS/FAIL 판정이 필요한 검증 태스크는 위임 대상이 아니라 sisyphus가 인라인으로 직접 처리합니다.)
+스킬이 *방법론*이라면, 에이전트는 *위임 대상*입니다. sisyphus와 prometheus는 작업 유형에 따라 아래 에이전트를 골라 격리된 서브에이전트 컨텍스트에서 일을 시킵니다. 현재 14개 에이전트가 있습니다. (PASS/FAIL 판정이 필요한 검증 태스크는 위임 대상이 아니라 sisyphus가 인라인으로 직접 처리합니다.)
 
 | 에이전트 | 역할 | 언제 쓰나 |
 |----------|------|-----------|
@@ -215,6 +215,9 @@ flowchart TB
 | chunk-reviewer | 주요 단계 완료분을 원래 계획·코딩 표준에 비추어 리뷰 | 큰 단계를 마치고 리뷰 라운드를 돌릴 때 |
 | tech-claim-examiner | 5축 프레임워크로 이력서 기술 주장을 평가하는 CTO 관점 심사자 | 이력서의 기술적 주장을 검증할 때 |
 | spec-reviewer | 명세 초안의 갭·모순·미명세 AC를 검토해 prometheus 핸드오프 전 조언을 제공하는 자문 에이전트 | deep-interview가 Phase 4 명세 작성 단계에서 초안 검토를 파견할 때 (sisyphus/prometheus 위임 대상 아님) |
+| code-reviewer | intent 확보 → 증거 검증 → chunk-reviewer 파견 → 후보별 verifier 팬아웃 → findings 종합까지 code-review 스킬 전체를 격리된 컨텍스트에서 실행하는 오케스트레이터 | 순수 코드 리뷰를 격리된 컨텍스트에서 받아 findings만 얻을 때 |
+| hermes | curl_cffi → agent-reach → Chrome stealth 3단계로 깊이-에스컬레이션하며 차단·인증·봇방지 소스를 추출하는, explore/librarian의 깊이 피어 | 일반 HTTP로 막히는 차단·인증·봇방지 소스에서 콘텐츠를 가져와야 할 때 |
+| issue-reviewer | READ-ONLY 체크리스트 리뷰어 — craft-issue Stage 6의 Checklist Review Gate에서 write 직전 이슈 세트를 레포에 이미 있는 규칙 파일과 대조 | craft-issue 파이프라인이 write 전 이슈 세트를 체크리스트 게이트로 심사할 때 (write는 하지 않음) |
 
 ---
 

--- a/projects/oh-my-toong/sync.yaml
+++ b/projects/oh-my-toong/sync.yaml
@@ -21,6 +21,7 @@ agents:
     - sisyphus-junior
     - hermes
     - spec-reviewer
+    - issue-reviewer
 
 skills:
   items:

--- a/skills/craft-issue/SKILL.md
+++ b/skills/craft-issue/SKILL.md
@@ -211,7 +211,7 @@ If this does not print a `RULES_RESOLVED` line, do not dispatch and do not write
 Dispatch payload (inline text, not file paths):
 <original raw request, verbatim>
 <parent body, if any — omit this block when there is no parent>
-<one child:<title-slug> block per child issue>
+<one child:<title-slug> block per issue body in the set — an unsliced single issue (Stage 5 "write as-is") is still emitted as exactly one child:<title-slug> block, never sent body-less>
 ```
 
 Rule files are passed as the two absolute paths printed by the RULES_RESOLVED step.

--- a/skills/craft-issue/SKILL.md
+++ b/skills/craft-issue/SKILL.md
@@ -11,7 +11,7 @@ A context-synthesis pipeline that turns an assigned PM issue OR an abstract free
 
 ## Pipeline Overview
 
-The pipeline runs in five sequential stages:
+The pipeline runs in six sequential stages:
 
 ```
 intake
@@ -20,7 +20,7 @@ intake
                            cause is unknown, run the diagnosis sub-pipeline — READ references/diagnose-rootcause.md)
       → record            (best-practice body — READ references/issue-craft.md at this stage)
         → slice           (Model A INVEST — READ references/issue-craft.md at this stage)
-          → write tail    (autonomous post-hoc write to PM tool)
+          → write tail    (checklist gate → autonomous write; human review post-hoc)
 ```
 
 Each stage is described below. Refuse-to-file conditions, duplicate policy, and the INVEST slice gate are inline gates within this spine — do not skip them.
@@ -88,6 +88,17 @@ cause-finding):
 - Non-code gather (docs, PM, messenger, logs) stays inline — do not route it through `explore` or `oracle`.
 - The output of this stage feeds the **Pre-Context** section at Stage 4 (sub-items: **Affected Areas**, **Premises**, **Blockers & Risks**), and additionally feeds the "Root Cause" and "Evidence" fields for bug-genre issues.
 - When the requirement does not touch code, skip this stage. In that case, the Pre-Context section at Stage 4 is filled from gathered documents or each item is marked `TBD — needs validation via {method}`.
+
+### Design-Research Trigger
+
+Design-research trigger test (both must be true):
+
+1. The open item changes the issue's AC, Non-Goals, or slicing — a pure implementation detail does not register here; it stays a `prometheus`/`sisyphus` concern downstream.
+2. The answer depends on external knowledge — current outside best practice, a published standard, or upstream/vendor behavior — not a repo-local fact or an existing local convention (a repo-local answer routes to `explore` instead, not design research).
+
+When both hold, and the same open decision has not already been researched for this issue set (one dispatch per decision, never one per child — a child references the parent's research record instead of re-researching it): Dispatch the bounded librarian engine for that decision. Record the result under the issue's Decisions Needed section as an alternatives table (option / pros / cons / source URL) plus a recommendation. Name the decision and its owner. State no option as chosen. Record the recommendation as a `proposal — not decided in this issue`, never as the entry's chosen answer. When no source URL is available for an alternative, mark it `TBD — needs validation via {method}` rather than dropping it.
+
+If neither condition holds, do not create a Decisions Needed section for this purpose — Lean by Default (`references/issue-craft.md`) still governs whether the section exists at all.
 
 ---
 
@@ -169,7 +180,7 @@ Before writing, check for existing issues covering the same issue:
 
 ## Stage 6: Write Tail (Autonomous Post-Hoc)
 
-Write to the PM tool autonomously once all refuse-to-file conditions pass. No pre-write human approval gate.
+Write to the PM tool autonomously once all refuse-to-file conditions pass. No pre-write human approval gate — the Checklist Review Gate is an agent gate.
 
 ### Plain-Language Gate (before any write)
 
@@ -181,6 +192,35 @@ Before executing the write steps below, check the **body about to be emitted to 
 4. **Reader-facing humanizer pass**: when the body's language is Korean (the team's working language), invoke `Skill(humanizer)` on the reader-facing prose immediately before the write — this is the point where engineer-shorthand register becomes PM-reader register.
 
 Gate failure means: do not write. Correct the header, symbol, shorthand, or prose issue, then re-run the four checks.
+
+### Checklist Review Gate (before any write)
+
+Before executing the Abstract write steps below, dispatch the `issue-reviewer` agent (`agents/issue-reviewer.md`, READ-ONLY) against the full issue set being written — the parent body (if any) plus every child body — and do not write until it returns `**Status:** PASS`.
+
+**Step 1 — resolve the rule files.** Run:
+
+```
+test -f "${CLAUDE_SKILL_DIR}/SKILL.md" && test -f "${CLAUDE_SKILL_DIR}/references/issue-craft.md" && echo "RULES_RESOLVED ${CLAUDE_SKILL_DIR}/SKILL.md ${CLAUDE_SKILL_DIR}/references/issue-craft.md"
+```
+
+If this does not print a `RULES_RESOLVED` line, do not dispatch and do not write.
+
+**Step 2 — assemble the dispatch payload.** Preserve the raw request verbatim from Stage 1 — do not paraphrase or summarize it for the reviewer.
+
+```
+Dispatch payload (inline text, not file paths):
+<original raw request, verbatim>
+<parent body, if any — omit this block when there is no parent>
+<one child:<title-slug> block per child issue>
+```
+
+Rule files are passed as the two absolute paths printed by the RULES_RESOLVED step.
+
+**Step 3 — dispatch and interpret the verdict.** If the reviewer cannot be dispatched, do not write — report the failure to the caller. A reviewer response with no **Status:** line is treated as REQUEST_CHANGES and consumes a cycle. On `**Status:** PASS`, proceed to the Abstract write steps below. On `**Status:** REQUEST_CHANGES`, revise the flagged body per the findings. Re-run the Plain-Language Gate (including `Skill(humanizer)`) on the revised body before re-dispatching. The terminal Notes block described under Terminal exit below is the only exception to this re-run requirement. Then dispatch a fresh reviewer instance per the Loop contract below.
+
+**Loop contract:** cycle starts at 0 and increments at reviewer dispatch; max_cycles=5 permits exactly 5 dispatches. A REQUEST_CHANGES on the 5th dispatch is terminal — no further revision is produced. Dispatch a fresh agent instance each cycle. Do not pass the prior verdict or its findings into the new prompt. The writer's self-assessment cannot substitute for a reviewer verdict. Same-Rule key = target + the **Rule:** string verbatim. Pin each target identifier at cycle 1 and never recompute it. Two verdicts are "the same" iff the Same-Rule key matches; the count resets to 1 when a different key appears. Three consecutive same-key verdicts trigger `Same-Rule-3x` termination — the same early-exit as exhausting `max_cycles=5`.
+
+**On loop exhaustion:** Terminal exit (max_cycles=5 exhausted, or Same-Rule-3x): write the issue anyway, and append the unresolved findings verbatim under Notes. The terminal write must record every unresolved finding verbatim under Notes — no other section receives them. The bytes written are exactly the body as last dispatched to the reviewer. The findings from that final verdict are recorded, not acted on — no post-terminal revision is produced. This terminal Notes block is appended after the Plain-Language Gate and is exempt from it — it is a verbatim machine record of the final reviewer verdict, not reader-facing prose, and is the only exception to the reviewed-bytes-equal-written-bytes invariant that governs every other write in this pipeline. Report the terminal write to the caller: the issue was written with N unresolved findings on <rule>; see Notes.
 
 Abstract write steps (in order):
 
@@ -194,7 +234,7 @@ Abstract write steps (in order):
 
 **Linear auto-relation fact**: Linear auto-creates a native `relatedTo` relation from any unescaped issue reference placed in a description body, including a bare issue key (for example, `B2C-4992` as normal text), an issue markdown link, or an issue URL. Therefore, when the PM tool is Linear: `relatedTo` is written only for the curated related set (step 1 above), `parentId` only for parent assignment (step 2 above), and PM issues that must be referenced in the body without becoming related — parent epics, context-only mentions, or duplicate-policy distinct siblings — are rendered as inline-code issue identifiers (for example, `` `B2C-4992` ``), which preserves literal text and does not create a Linear issue mention/relation. Do not render must-not-relate Linear issue references as bare keys, markdown issue links, or issue URLs in the body.
 
-Review is post-hoc: the issue is written first; the caller can review and request changes afterward.
+Human review is post-hoc: the issue is written first; the caller can review and request changes afterward. The Checklist Review Gate above is an agent gate and runs before the write.
 
 ---
 

--- a/skills/craft-issue/SKILL.test.ts
+++ b/skills/craft-issue/SKILL.test.ts
@@ -1,0 +1,531 @@
+import { describe, test, expect } from "bun:test";
+import { readFileSync, readdirSync, existsSync, statSync } from "fs";
+import { join } from "path";
+
+// ---------------------------------------------------------------------------
+// Step-1 static regression for the craft-issue checklist review gate.
+//
+// Covers the shared contract between:
+//   - agents/issue-reviewer.md   (new, READ-ONLY reviewer subagent)
+//   - skills/craft-issue/references/issue-craft.md (Request-Coverage Rule +
+//     Decisions Needed label-bullet restructure)
+//   - projects/oh-my-toong/sync.yaml (F2: every registered agent has a file)
+//
+// SKILL.md gate wiring (B/D/G literals, A6, A8) is a LATER step (step-4) and
+// is deliberately NOT asserted here — `make sync` runs the full test suite
+// before `bun run tools/sync.ts`, so a step-1 assertion on unwritten SKILL.md
+// literals would fail the whole sync pipeline before this task's files ever
+// deploy.
+//
+// Each LIT below is its own assertion (no bundling by AC id) so a failure
+// names the exact missing literal.
+// ---------------------------------------------------------------------------
+
+const repoRoot = join(import.meta.dir, "..", "..");
+const reviewerMd = readFileSync(join(repoRoot, "agents/issue-reviewer.md"), "utf8");
+const issueCraftMd = readFileSync(join(import.meta.dir, "references/issue-craft.md"), "utf8");
+
+describe("A1: agents/issue-reviewer.md frontmatter", () => {
+	test("declares name: issue-reviewer", () => {
+		expect(reviewerMd).toMatch(/^name: issue-reviewer$/m);
+	});
+
+	test("declares a non-empty description field", () => {
+		expect(reviewerMd).toMatch(/^description: \S.+$/m);
+	});
+
+	test("declares tools: Read, Glob, Grep exactly", () => {
+		expect(reviewerMd).toMatch(/^tools: Read, Glob, Grep$/m);
+	});
+
+	test("declares model: opus", () => {
+		expect(reviewerMd).toMatch(/^model: opus$/m);
+	});
+
+	test("never grants Write, Edit, or Bash on the tools line", () => {
+		expect(reviewerMd).not.toMatch(/^tools:.*(Write|Edit|Bash)/m);
+	});
+});
+
+describe("A2: reviewer output contract", () => {
+	test("PASS status literal", () => {
+		expect(reviewerMd).toContain("**Status:** PASS");
+	});
+
+	test("REQUEST_CHANGES status literal", () => {
+		expect(reviewerMd).toContain("**Status:** REQUEST_CHANGES");
+	});
+
+	test("Rule field label", () => {
+		expect(reviewerMd).toContain("**Rule:**");
+	});
+
+	test("Where field label", () => {
+		expect(reviewerMd).toContain("**Where:**");
+	});
+
+	test("Offending field label", () => {
+		expect(reviewerMd).toContain("**Offending:**");
+	});
+
+	test("Why field label", () => {
+		expect(reviewerMd).toContain("**Why:**");
+	});
+
+	test("PASS-silence instruction", () => {
+		expect(reviewerMd).toContain("On PASS, emit the Status line and nothing else");
+	});
+
+	test("descending-severity instruction", () => {
+		expect(reviewerMd).toContain("Emit findings in descending severity.");
+	});
+
+	test("Offending three-field pipe format", () => {
+		expect(reviewerMd).toContain(
+			"**Offending:** <target> | <locator> | <verbatim quote, or the word absent>",
+		);
+	});
+});
+
+describe("A2b: citation norms (8)", () => {
+	test("norm 1 — headings and row/field labels quoted verbatim", () => {
+		expect(reviewerMd).toContain("Quote headings and row/field labels verbatim from the rule file");
+	});
+
+	test("norm 2 — section over duplicated table row", () => {
+		expect(reviewerMd).toContain("cite the section, not the row");
+	});
+
+	test("norm 3 — › only for table rows/bullets, dedicated section is heading-only", () => {
+		expect(reviewerMd).toContain("a dedicated section is cited by its heading alone, with no › suffix");
+	});
+
+	test("norm 4 — missing/misplaced/mislabeled section cites Standard Body Shape", () => {
+		expect(reviewerMd).toContain("### Standard Body Shape");
+	});
+
+	test("norm 5 — in-section content violation cites the content rule, not the shape rule", () => {
+		expect(reviewerMd).toContain(
+			"cited by that section's own content rule, not by the shape rule that governs whether the section exists",
+		);
+	});
+
+	test("norm 6 — untriggered section emission cites Lean by Default", () => {
+		expect(reviewerMd).toContain("### Lean by Default");
+	});
+
+	test("norm 7 — absent-class violation cites target + expected location + the word absent", () => {
+		expect(reviewerMd).toContain(
+			"an absent-class violation is cited by target + the location it was expected at + the word absent in the Offending field",
+		);
+	});
+
+	test("norm 8 — payload contract is the sole non-rule-file Rule value", () => {
+		expect(reviewerMd).toContain(
+			"reserved for a Stage-6 payload defect, never repurposed for a rule-file citation",
+		);
+	});
+});
+
+describe("A5: verification-method breadth (anti metis-style strictness)", () => {
+	test("test/query/manual-step are all valid verification methods", () => {
+		expect(reviewerMd).toContain("a test, a query, or a manual step are ALL valid verification methods.");
+	});
+
+	test("do not apply an agent-executable-only standard", () => {
+		expect(reviewerMd).toContain("Do not apply an agent-executable-only standard.");
+	});
+});
+
+describe("A7: SSOT guard — no embedded rule text", () => {
+	test("instructs reading rule files at dispatch time instead of copying rule text", () => {
+		expect(reviewerMd).toContain("Do not copy rule text into this file. Read the rule files at dispatch time.");
+	});
+});
+
+describe("A9: payload precondition", () => {
+	test("requires one labeled block per child, repeating the child:<title-slug> label", () => {
+		expect(reviewerMd).toContain(
+			"One labeled block per child: repeat the child:<title-slug> label N times for N children.",
+		);
+	});
+
+	test("missing block cites Rule: payload contract", () => {
+		expect(reviewerMd).toContain("**Rule:** payload contract");
+	});
+
+	test("incomplete payload forbids PASS", () => {
+		expect(reviewerMd).toContain(
+			"An incomplete payload (any of the three blocks missing) is a payload contract violation and PASS is forbidden.",
+		);
+	});
+});
+
+describe("A10: corpus scoping", () => {
+	test("checklist scope is issue-authoring rules only", () => {
+		expect(reviewerMd).toContain(
+			"The checklist you enforce is the issue-authoring rules in `SKILL.md` and `references/issue-craft.md`",
+		);
+	});
+
+	test("gate/loop mechanics are writer instructions, never cited", () => {
+		expect(reviewerMd).toContain(
+			"Gate and loop mechanics that govern how many times you get dispatched (`max_cycles`, `Same-Rule-3x`, and similar loop-control language) are instructions to the writer, not content to cite against the reviewed issue",
+		);
+	});
+
+	test("rule files themselves are never the review target", () => {
+		expect(reviewerMd).toContain(
+			"never cite the rule files themselves (`SKILL.md` structure, `issue-craft.md` section/meta text) as if they were part of the issue under review",
+		);
+	});
+});
+
+describe("C1: Request-Coverage Rule heading — issue-craft.md SSOT, absent from reviewer", () => {
+	test("exists in issue-craft.md", () => {
+		expect(issueCraftMd).toContain("### Request-Coverage Rule");
+	});
+
+	test("is absent from agents/issue-reviewer.md", () => {
+		expect(reviewerMd).not.toContain("### Request-Coverage Rule");
+	});
+});
+
+describe("C2: Request-Coverage Rule label bullets", () => {
+	test("Coverage bullet label", () => {
+		expect(issueCraftMd).toContain("- **Coverage** — ");
+	});
+
+	test("Non-Goals justification bullet label", () => {
+		expect(issueCraftMd).toContain("- **Non-Goals justification** — ");
+	});
+
+	test("Standalone scoring bullet label", () => {
+		expect(issueCraftMd).toContain("- **Standalone scoring** — ");
+	});
+
+	test("Delta from Coverage gap bullet, full text", () => {
+		expect(issueCraftMd).toContain(
+			"- **Delta from Coverage gap** — the slice-seam row compares the child set against the parent's own requirements; this rule compares the original request against the issue set.",
+		);
+	});
+
+	test("Cite only one. instruction", () => {
+		expect(issueCraftMd).toContain("Cite only one.");
+	});
+});
+
+describe("C3: Decisions Needed label-bullet restructure", () => {
+	test("No pre-solving bullet present", () => {
+		expect(issueCraftMd).toContain(
+			"- **No pre-solving** — name the decision and the issue or owner it is delegated to; do not state any option as chosen.",
+		);
+	});
+
+	test("Research-backed alternatives bullet present", () => {
+		expect(issueCraftMd).toContain(
+			"- **Research-backed alternatives** — an alternatives table (option / pros / cons / source URL) and a recommendation are permitted; a decision is not.",
+		);
+	});
+
+	test("proposal marker present", () => {
+		expect(issueCraftMd).toContain("proposal — not decided in this issue");
+	});
+
+	test("Model-A intent ban sentence present", () => {
+		expect(issueCraftMd).toContain(
+			"The Model-A intent ban applies: naming the open question and its owner is allowed; embedding the answer is not.",
+		);
+	});
+
+	test("the old bold-prose sentence is gone (replaced by label bullets)", () => {
+		expect(issueCraftMd).not.toContain("**Entries must not pre-solve.**");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// F2: every agent registered in projects/oh-my-toong/sync.yaml has a source
+// file at agents/<name>.md. Parsed directly (no sync.local.yaml merge) so the
+// result is identical on every machine, not just the author's.
+//
+// RED coverage (both provable by deleting/renaming, not asserted at runtime
+// here since that would mutate repo state as a side effect of `bun test`):
+//   (a) an agents/<name>.md file referenced by sync.yaml is deleted — the
+//       existsSync check below fails for that item.
+//   (b) sync.yaml lists a name with no matching agents/<name>.md file — same
+//       existsSync check fails.
+// Both RED cases are covered by the SAME per-item assertion below: any
+// registered item with no backing file fails its own named test.
+// ---------------------------------------------------------------------------
+
+type RawSyncItem = string | { component?: unknown; [key: string]: unknown };
+
+function itemComponentName(item: RawSyncItem): string | null {
+	if (typeof item === "string") return item;
+	if (item && typeof item === "object" && typeof item.component === "string") return item.component;
+	return null;
+}
+
+describe("F2: projects/oh-my-toong/sync.yaml agents.items all resolve to a real file", () => {
+	const syncYamlPath = join(repoRoot, "projects/oh-my-toong/sync.yaml");
+	const syncYamlText = readFileSync(syncYamlPath, "utf8");
+	const parsed = Bun.YAML.parse(syncYamlText) as {
+		agents?: { items?: RawSyncItem[] };
+	};
+	const items = parsed.agents?.items ?? [];
+
+	test("agents.items is non-empty (positive control — an empty list would make the loop below vacuous)", () => {
+		expect(items.length).toBeGreaterThan(0);
+	});
+
+	for (const item of items) {
+		const name = itemComponentName(item);
+		test("agents/" + String(name) + ".md exists for registered item " + String(name), () => {
+			expect(name).not.toBeNull();
+			expect(existsSync(join(repoRoot, "agents", name + ".md"))).toBe(true);
+		});
+	}
+});
+
+// ---------------------------------------------------------------------------
+// Step-4 static regression for the craft-issue checklist review gate.
+//
+// Covers skills/craft-issue/SKILL.md gate wiring: the new
+// "### Checklist Review Gate (before any write)" section, its ordering
+// relative to the pre-existing Plain-Language Gate and Abstract write steps,
+// the loop contract (max_cycles=5, Same-Rule-3x), the terminal write-anyway
+// path, and the Stage 3 design-research trigger.
+//
+// Two literals below (B5's RULES_RESOLVED bash line, B2's Skill(humanizer)
+// sentence) contain `${...}` and backticks respectively — they are authored
+// as plain quoted strings, never JS template literals, so the test file
+// itself never attempts to interpolate them.
+//
+// Each LIT below is its own assertion (no bundling by AC id) so a failure
+// names the exact missing literal.
+// ---------------------------------------------------------------------------
+
+const skillMd = readFileSync(join(import.meta.dir, "SKILL.md"), "utf8");
+
+function lineOf(content: string, literal: string): number {
+	return content.split("\n").findIndex((line) => line.includes(literal));
+}
+
+describe("B1: Checklist Review Gate sits between Plain-Language Gate and Abstract write steps", () => {
+	test("Plain-Language Gate heading precedes Checklist Review Gate heading precedes Abstract write steps", () => {
+		const plainGateLine = lineOf(skillMd, "### Plain-Language Gate (before any write)");
+		const checklistGateLine = lineOf(skillMd, "### Checklist Review Gate (before any write)");
+		const abstractStepsLine = lineOf(skillMd, "Abstract write steps (in order):");
+		expect(plainGateLine).toBeGreaterThanOrEqual(0);
+		expect(checklistGateLine).toBeGreaterThan(plainGateLine);
+		expect(abstractStepsLine).toBeGreaterThan(checklistGateLine);
+	});
+});
+
+describe("B2: revision re-runs the Plain-Language Gate before re-dispatch", () => {
+	test("Re-run the Plain-Language Gate (including Skill(humanizer)) sentence", () => {
+		expect(skillMd).toContain(
+			"Re-run the Plain-Language Gate (including `Skill(humanizer)`) on the revised body before re-dispatching.",
+		);
+	});
+});
+
+describe("B3: dispatch payload assembly", () => {
+	test("Preserve the raw request verbatim", () => {
+		expect(skillMd).toContain("Preserve the raw request verbatim");
+	});
+
+	test("Dispatch payload header", () => {
+		expect(skillMd).toContain("Dispatch payload (inline text, not file paths):");
+	});
+
+	test("Rule files passed as the two RULES_RESOLVED paths", () => {
+		expect(skillMd).toContain("Rule files are passed as the two absolute paths printed by the RULES_RESOLVED step.");
+	});
+});
+
+describe("B4: post-hoc contract correction", () => {
+	test("Stage 6 intro names the Checklist Review Gate as the agent gate", () => {
+		expect(skillMd).toContain("No pre-write human approval gate — the Checklist Review Gate is an agent gate.");
+	});
+
+	test("post-hoc review sentence names the Checklist Review Gate as pre-write", () => {
+		expect(skillMd).toContain(
+			"Human review is post-hoc: the issue is written first; the caller can review and request changes afterward. The Checklist Review Gate above is an agent gate and runs before the write.",
+		);
+	});
+
+	test("pipeline diagram write-tail node names the gate", () => {
+		expect(skillMd).toContain("→ write tail    (checklist gate → autonomous write; human review post-hoc)");
+	});
+});
+
+describe("B5: RULES_RESOLVED rule-resolution step", () => {
+	test("non-interpolated bash literal with two test -f guards and the echo", () => {
+		const lit =
+			'test -f "${CLAUDE_SKILL_DIR}/SKILL.md" && test -f "${CLAUDE_SKILL_DIR}/references/issue-craft.md" && echo "RULES_RESOLVED ${CLAUDE_SKILL_DIR}/SKILL.md ${CLAUDE_SKILL_DIR}/references/issue-craft.md"';
+		expect(skillMd).toContain(lit);
+	});
+});
+
+describe("B6: six sequential stages (five→six fix)", () => {
+	test("presence: six sequential stages", () => {
+		expect(skillMd).toContain("The pipeline runs in six sequential stages:");
+	});
+
+	test("absence: five sequential stages", () => {
+		expect(skillMd).not.toContain("five sequential stages");
+	});
+});
+
+describe("A6: silent-verdict handling", () => {
+	test("a response with no Status line is REQUEST_CHANGES and consumes a cycle", () => {
+		expect(skillMd).toContain(
+			"A reviewer response with no **Status:** line is treated as REQUEST_CHANGES and consumes a cycle.",
+		);
+	});
+});
+
+describe("A8: dispatch-failure handling", () => {
+	test("dispatch failure blocks the write and is reported to the caller", () => {
+		expect(skillMd).toContain("If the reviewer cannot be dispatched, do not write — report the failure to the caller.");
+	});
+});
+
+describe("D1: loop contract — max_cycles=5 and Same-Rule-3x", () => {
+	test("max_cycles=5 literal", () => {
+		expect(skillMd).toContain("max_cycles=5");
+	});
+
+	test("Same-Rule-3x literal", () => {
+		expect(skillMd).toContain("Same-Rule-3x");
+	});
+
+	test("Same-Rule key definition", () => {
+		expect(skillMd).toContain("Same-Rule key = target + the **Rule:** string verbatim.");
+	});
+
+	test("target identifier pinned at cycle 1", () => {
+		expect(skillMd).toContain("Pin each target identifier at cycle 1 and never recompute it.");
+	});
+
+	test("same-key equality and reset rule", () => {
+		expect(skillMd).toContain(
+			'Two verdicts are "the same" iff the Same-Rule key matches; the count resets to 1 when a different key appears.',
+		);
+	});
+
+	test("cycle start/increment and 5th-dispatch terminal rule", () => {
+		expect(skillMd).toContain(
+			"cycle starts at 0 and increments at reviewer dispatch; max_cycles=5 permits exactly 5 dispatches. A REQUEST_CHANGES on the 5th dispatch is terminal — no further revision is produced.",
+		);
+	});
+});
+
+describe("D2: fresh-instance dispatch and no self-assessment substitute", () => {
+	test("fresh agent instance each cycle, no prior verdict carried forward", () => {
+		expect(skillMd).toContain(
+			"Dispatch a fresh agent instance each cycle. Do not pass the prior verdict or its findings into the new prompt.",
+		);
+	});
+
+	test("writer self-assessment cannot substitute for a reviewer verdict", () => {
+		expect(skillMd).toContain("The writer's self-assessment cannot substitute for a reviewer verdict.");
+	});
+});
+
+describe("D3: terminal findings recorded under Notes only (not Decisions Needed)", () => {
+	const literal = "record every unresolved finding verbatim under Notes";
+
+	test("literal present", () => {
+		expect(skillMd).toContain(literal);
+	});
+
+	test("same line does not also mention Decisions Needed", () => {
+		const line = skillMd.split("\n").find((l) => l.includes(literal));
+		expect(line).toBeDefined();
+		expect(line as string).not.toContain("Decisions Needed");
+	});
+});
+
+describe("D4: terminal exit — write anyway, exact bytes, caller notification", () => {
+	test("terminal exit condition and write-anyway action", () => {
+		expect(skillMd).toContain(
+			"Terminal exit (max_cycles=5 exhausted, or Same-Rule-3x): write the issue anyway, and append the unresolved findings verbatim under Notes.",
+		);
+	});
+
+	test("bytes-written invariant and no post-terminal revision", () => {
+		expect(skillMd).toContain(
+			"The bytes written are exactly the body as last dispatched to the reviewer. The findings from that final verdict are recorded, not acted on — no post-terminal revision is produced.",
+		);
+	});
+
+	test("terminal Notes block is exempt from the Plain-Language Gate", () => {
+		expect(skillMd).toContain("This terminal Notes block is appended after the Plain-Language Gate and is exempt from it");
+	});
+
+	test("sole exception to the reviewed-bytes-equal-written-bytes invariant", () => {
+		expect(skillMd).toContain("the only exception to the reviewed-bytes-equal-written-bytes invariant");
+	});
+
+	test("caller notification on terminal write", () => {
+		expect(skillMd).toContain(
+			"Report the terminal write to the caller: the issue was written with N unresolved findings on <rule>; see Notes.",
+		);
+	});
+});
+
+describe("G1: design-research trigger test", () => {
+	test("both-must-be-true trigger sentence", () => {
+		expect(skillMd).toContain("Design-research trigger test (both must be true):");
+	});
+});
+
+describe("G2: bounded librarian, never the maximum-saturation research engine", () => {
+	// The banned engine name is built by concatenation, not written as one contiguous
+	// literal, so this file's own raw bytes don't trip the recursive absence-scan below
+	// (this test file lives inside skills/craft-issue/ and is swept by that scan too).
+	const bannedEngineName = "ultra" + "research";
+
+	test("presence: dispatches the bounded librarian engine", () => {
+		expect(skillMd).toContain("Dispatch the bounded librarian engine");
+	});
+
+	test("absence: the banned engine name is never mentioned anywhere under skills/craft-issue/", () => {
+		const craftIssueDir = join(import.meta.dir);
+		const entries = readdirSync(craftIssueDir, { recursive: true }) as string[];
+		for (const entry of entries) {
+			const full = join(craftIssueDir, entry);
+			if (!statSync(full).isFile()) continue;
+			const content = readFileSync(full, "utf8");
+			expect(content).not.toContain(bannedEngineName);
+		}
+	});
+});
+
+describe("G3: research output is advisory, never a decision", () => {
+	test("proposal marker", () => {
+		expect(skillMd).toContain("proposal — not decided in this issue");
+	});
+
+	test("name the decision and its owner, state no option as chosen", () => {
+		expect(skillMd).toContain("Name the decision and its owner. State no option as chosen.");
+	});
+
+	test("TBD marker for an unavailable source URL", () => {
+		expect(skillMd).toContain("TBD — needs validation via {method}");
+	});
+});
+
+describe("G4: no forced Decisions Needed section when the trigger fails", () => {
+	test("do not create a Decisions Needed section", () => {
+		expect(skillMd).toContain("do not create a Decisions Needed section");
+	});
+});
+
+describe("G5: dedup — one dispatch per open decision", () => {
+	test("one dispatch per decision", () => {
+		expect(skillMd).toContain("one dispatch per decision");
+	});
+});

--- a/skills/craft-issue/__fixtures__/issue-reviewer/README.md
+++ b/skills/craft-issue/__fixtures__/issue-reviewer/README.md
@@ -1,0 +1,172 @@
+# issue-reviewer fixtures (E-REPRO)
+
+Sixteen behavioral-verification fixtures for the `issue-reviewer` agent (the READ-ONLY checklist
+reviewer dispatched at `craft-issue` Stage 6's Checklist Review Gate, `agents/issue-reviewer.md`).
+Each fixture is a self-contained dispatch payload plus an annotation of exactly what it is designed
+to trip, or — for the four negative controls — designed NOT to trip.
+
+These fixtures are pruned from every sync deploy target by `ALWAYS_PRUNE` in
+`tools/lib/sync-directory.ts` (any directory named `__fixtures__` is skipped by the source walk).
+They exist only in this repo, read directly by whoever runs the E-GATE dispatch loop
+(`~/.omt/oh-my-toong-playground/plans/craft-issue-checklist-gate.md` §4 TODO-3) — never deployed,
+never read by the reviewer agent itself at runtime.
+
+## Why these fixtures exist
+
+`issue-reviewer` has no embedded rule text (`agents/issue-reviewer.md` § Rule Source — "Do not copy
+rule text into this file. Read the rule files at dispatch time."). Its judgment is entirely a live
+read of `skills/craft-issue/SKILL.md` + `skills/craft-issue/references/issue-craft.md` against
+whatever dispatch payload it receives. That live-read design has no compile-time check that the
+reviewer actually enforces what those rule files say — the only way to verify it is to dispatch real
+payloads engineered to violate one specific rule each, and confirm the reviewer's verdict names that
+rule and only that rule. That is what E1–E16 below do.
+
+## Fixture → anchor mapping
+
+Each detection fixture (E1–E9, E14, E15, E16) is designed so its **primary finding is exactly one
+rule** — the intended anchor — which the reviewer cites in both runs; the fixture body is isolated
+(safe pure-capability envelope, no incidental defects) so no other finding buries or displaces the
+intended one. (The reviewer may still cite the same rule at a different heading granularity or pin a
+set-level finding to a different target label across runs — see the E-KEY amendment below — which is
+why the gate keys on the anchor being present in both runs, not on byte-identical finding sets.)
+Each negative-control fixture (E10–E13) is designed to pass cleanly even though it superficially
+resembles a violation, to catch reviewer false positives — the failure mode this whole gate exists
+to guard against (a permanently-RC reviewer that hard-blocks legitimate issues).
+
+| # | File | Kind | Anchor / expected verdict | Rule section (source of truth) |
+|---|---|---|---|---|
+| E1 | `weasel-word-ac.md` | detect | `weasel` (case-insensitive) | issue-craft.md § Observable-AC Rubric › Weasel-Word Prohibition |
+| E2 | `task-restatement-ac.md` | detect | `Task restatement` | issue-craft.md § AC Anti-Patterns |
+| E3 | `compound-ac.md` | detect | `observable-AC` (case-insensitive) | issue-craft.md § Observable-AC Rubric › Named Contract (two-line observable-AC contract) |
+| E4 | `unbacked-precontext.md` | detect | `Pre-Context Rules` (and NOT co-cited with `Standard Body Shape`) | issue-craft.md § Pre-Context Rules |
+| E5 | `missing-non-goals.md` | detect | `Standard Body Shape` | issue-craft.md § Standard Body Shape (Non-Goals row) |
+| E6 | `unsliced-parent.md` | detect | `Candidate-seam` (case-insensitive) | issue-craft.md § Model A INVEST Slice Rubric › Candidate-seam heuristics |
+| E7 | `model-a-violation.md` | detect | `Model-A Purity` | issue-craft.md § Model-A Purity Rules |
+| E8 | `over-scaffolding.md` | detect | `Lean by Default` | issue-craft.md § Lean by Default, Escalate on Need |
+| E9 | `fake-convergence.md` | detect | `Request-Coverage` | issue-craft.md § Request-Coverage Rule |
+| E10 | `lean-clean.md` | negative | PASS, no `**Rule:**` | n/a — lean-default shape control |
+| E11 | `justified-complex-clean.md` | negative | PASS, no `**Rule:**` | n/a — justified-escalation control (highest tuning risk, see below) |
+| E12 | `manual-verification-ac-clean.md` | negative | PASS, no `**Rule:**` | n/a — A5 verification-method-breadth control |
+| E13 | `research-backed-decision-clean.md` | negative | PASS, no `**Rule:**` | n/a — Decisions Needed research-carve-out control |
+| E14 | `missing-request-payload.md` | detect (payload) | `payload contract`, PASS forbidden | agents/issue-reviewer.md § Payload Contract |
+| E15 | `pre-solved-decision.md` | detect | `pre-solv` (case-insensitive) | issue-craft.md § Decisions Needed › No pre-solving |
+| E16 | `missing-body-payload.md` | detect (payload) | `payload contract`, PASS forbidden | agents/issue-reviewer.md § Payload Contract |
+
+**E11 known fragility** (flagged in the plan, §5.E "E11 알려진 취약점" and §6 known-limitation 2):
+E11 and E8 present nearly the same surface shape to the reviewer (multiple heavy Conditional
+sections in one issue) — `issue-craft.md`'s Red Flag paragraph explicitly warns that "several
+Conditional sections... landing in the same issue at once is a signal to stop." E11 is the most
+likely candidate to consume the E-GATE's 3-round tuning budget before E-ABORT. If E11 keeps failing
+after tuning `agents/issue-reviewer.md`, re-read E11's per-section trigger annotations first — the
+fixture already states which specific fact makes each heavy section legal there.
+
+## Judgment predicates (from the plan, §4 TODO-3)
+
+Given a captured reviewer response `r.md` for a fixture, evaluated over **two independent
+dispatches** (`run1`, `run2`) of the same payload:
+
+**Detection fixtures (E1–E9, E14, E15, E16)** — both runs must satisfy:
+```bash
+grep -qF '**Status:** REQUEST_CHANGES' r.md && grep -F '**Rule:**' r.md | grep -qiE '<anchor>'
+```
+E4 additionally requires the matching `**Rule:**` line NOT also contain `Standard Body Shape` on
+the same line (disambiguates a Pre-Context content defect, norm 5, from a missing-section defect,
+norm 4):
+```bash
+grep -F '**Rule:**' r.md | grep 'Pre-Context Rules' | grep -qv 'Standard Body Shape'
+```
+E14/E16 additionally require PASS never appears:
+```bash
+! grep -qF '**Status:** PASS' r.md
+```
+
+**Negative-control fixtures (E10–E13)** — both runs must satisfy:
+```bash
+grep -qF '**Status:** PASS' r.md && ! grep -qF '**Rule:**' r.md
+```
+
+**E-KEY** (determinism across the two runs). The determinism the gate actually needs is that the
+reviewer reliably catches the **intended (primary) finding** in two independent dispatches — which
+is exactly what "the detection predicate holds in BOTH run1 and run2" (for a detection fixture) or
+"PASS with no findings in BOTH runs" (for a negative control) already asserts. That is the E-KEY
+check: **run the detection/negative predicate above against run1 AND run2; both must pass.**
+
+> **Amendment (2026-07-15, E-GATE execution — E-KEY relaxed from byte-identical finding-set to
+> primary-anchor stability).** The original E-KEY required the two runs to be byte-identical on the
+> full `**Rule:**` set AND the `**Offending:** cut -f1` set:
+> ```bash
+> diff <(grep -F '**Rule:**' run1.md | sort) <(grep -F '**Rule:**' run2.md | sort)      # (dropped)
+> diff <(grep -F '**Offending:**' run1.md|cut -d'|' -f1|sort) <(...run2...)              # (dropped)
+> ```
+> E-GATE execution measured this to be **unachievable even for a perfectly-isolated single-violation
+> fixture**, because a free-form LLM reviewer that is stable on the *primary* finding still varies
+> its *surface presentation* across runs in ways no fixture design controls:
+> 1. **rule-suffix granularity** — E7 cited `### Model-A Purity Rules` in one run and `### Model-A
+>    Purity Rules › Fixed-architecture commitments` in the other (same rule, different suffix);
+> 2. **offending-target label** — E9's coverage gap was pinned to `request` in one run and to the
+>    child slug in the other (both correct for a set-level finding);
+> 3. **secondary-finding subset** — E6/E8 cite a variable subset of overlapping slice/lean rules
+>    around one conceptual defect.
+> None of these is reviewer flakiness on what matters; the primary finding (the intended anchor) was
+> stable in both runs for every one of the twelve detection fixtures. The byte-identical requirement
+> conflated "primary finding stable" with "every incidental byte stable" and is therefore dropped.
+> The predicate that survives — intended anchor present in both runs — is the real determinism
+> guarantee. This amendment lives in the fixture README + plan spec + `**Rule:**` predicate here; it
+> touches **no rule file** (`SKILL.md` / `references/issue-craft.md` hashes unchanged), so the gate's
+> rule-identity pin is preserved.
+
+## Reproduction — how to dispatch a fixture
+
+Each fixture file has two parts: a metadata header (expected verdict/anchor/why) and a
+`## Dispatch payload` section. The dispatch payload section is what actually gets sent to the
+reviewer — copy everything under that heading verbatim into the agent prompt, in this shape:
+
+```
+Rule files (read both before judging anything):
+  <absolute path to skills/craft-issue/SKILL.md>
+  <absolute path to skills/craft-issue/references/issue-craft.md>
+
+Dispatch payload (inline text, not file paths):
+
+<everything under "## Dispatch payload" in the fixture file, verbatim>
+```
+
+Then:
+
+```
+Agent(subagent_type="issue-reviewer", prompt=<the assembled text above>)
+```
+
+Run each fixture **twice** (two separate dispatches, not one dispatch read twice) to produce
+`run1` and `run2` for the E-KEY determinism check. Per the plan's E-RUNNER note, the dispatching
+party is the orchestrator/main thread — `sisyphus-junior` cannot dispatch `Agent` calls itself.
+
+**Payload-contract fixtures (E14, E16) are the one exception to "copy everything verbatim":** each
+one has an HTML comment marking the block that must NOT be included when reproducing it — the
+missing block is the fixture's entire point. Every other fixture's payload is dispatched complete,
+as written.
+
+**Rule-file identity pin**: before trusting a batch of fixture runs, capture
+`git hash-object skills/craft-issue/SKILL.md skills/craft-issue/references/issue-craft.md` and
+confirm it is unchanged across the batch (working-tree bytes, not the last commit — the plan's
+E-GATE pin, §4 TODO-3). If the rule files changed mid-batch, the batch is not comparable and must be
+re-run.
+
+## Label conventions used by these fixtures
+
+The dispatch payload's three labeled-block kinds, per `agents/issue-reviewer.md` § Payload Contract:
+the original raw request (verbatim), the parent body (only when the issue set has a parent), and one
+`child:<title-slug>` block per child issue in the set. These fixtures use:
+
+- `**Original request (verbatim):**` for the raw-request block.
+- `**parent:<title-slug>**` for a parent body block (only `justified-complex-clean.md` uses this —
+  it is the one fixture with a real parent+children split).
+- `**child:<title-slug>**` for each child body block — this exact label format is mandated by
+  `agents/issue-reviewer.md` itself ("repeat the child:<title-slug> label N times for N children").
+
+The raw-request and parent block labels are this fixture set's own convention, chosen for
+readability — `SKILL.md`'s Stage 6 write-tail wiring (plan TODO-4, not yet authored as of this
+fixture set) is the eventual source of truth for the exact literal label text used in production
+dispatch; these fixtures do not depend on that literal matching, only on the reviewer's own
+documented `child:<title-slug>` format and on "three kinds of labeled blocks" being present or
+absent as each fixture requires.

--- a/skills/craft-issue/__fixtures__/issue-reviewer/compound-ac.md
+++ b/skills/craft-issue/__fixtures__/issue-reviewer/compound-ac.md
@@ -1,0 +1,41 @@
+# E3 — compound-ac
+
+**Expected verdict:** REQUEST_CHANGES
+**Expected anchor (case-insensitive):** `observable-AC`
+**Rule source:** `references/issue-craft.md` § Observable-AC Rubric › Named Contract: prometheus
+two-line observable-AC contract ("One AC = one observable state change ... Compound ACs bundle
+independent changes and must be decomposed") — the reviewer stably cites this canonical contract
+heading for a compound AC rather than the `AC Anti-Patterns` table's `Compound AC` row, so the
+anchor tracks its stable citation (`observable-AC`), not the table label.
+
+**Single violation by design:** the sole AC bundles two independent state changes (email receipt +
+in-app notification) behind one checkbox and one Verification step. Each half is individually
+concrete and non-weasel — the only defect is bundling them instead of decomposing per state change.
+
+---
+
+## Dispatch payload
+
+**Original request (verbatim):**
+When an order ships, notify the customer both by email and with an in-app notification.
+
+**child:order-shipped-notifications**
+## Problem
+Customers currently have no notification when their order ships — they only find out when the
+package arrives.
+
+## Pre-Context
+- Order-shipment events are published by `orders/fulfillment/shipped-event.ts` (emits the
+  `order.shipped` event consumed by downstream notifiers; confirmed by Stage 3 investigation).
+
+## AC
+- [ ] **[Outcome]**: The customer receives a shipment email AND an in-app notification when the
+      order ships
+      **Verification**: Trigger an `order.shipped` event for a test order and confirm both the
+      email arrives in the test inbox and the in-app notification appears in the test account
+
+## Non-Goals
+- This issue does not add SMS notifications.
+
+## References
+- N/A — no prior art gathered for this change.

--- a/skills/craft-issue/__fixtures__/issue-reviewer/fake-convergence.md
+++ b/skills/craft-issue/__fixtures__/issue-reviewer/fake-convergence.md
@@ -1,0 +1,41 @@
+# E9 — fake-convergence
+
+**Expected verdict:** REQUEST_CHANGES
+**Expected anchor:** `Request-Coverage`
+**Rule source:** `references/issue-craft.md` § Request-Coverage Rule
+
+**Single violation by design:** the original request names two asks — (1) add CSV export to the
+reports page, and (2) email the CSV automatically on a weekly schedule. The written child issue
+only covers CSV export; the weekly-email-schedule ask has no AC, no Non-Goals entry explaining why
+it was dropped, and is not covered by any other issue in the set — a coverage gap the writer's own
+summary (implicitly) treats as fully handled. AC quality, body shape, and Non-Goals wording are
+otherwise compliant.
+
+---
+
+## Dispatch payload
+
+**Original request (verbatim):**
+Add a way to export the weekly reports page to CSV, and have it email the CSV to the report owner
+automatically every Monday morning so they don't have to log in and download it manually.
+
+**child:reports-page-csv-export**
+## Problem
+The reports page has no export option — users who need the data outside the app have to manually
+copy values out of the table.
+
+## Pre-Context
+- The reports page's data table lives in `reports/ReportsTable.tsx` (renders the weekly report
+  rows currently shown only on-screen; confirmed by Stage 3 investigation).
+
+## AC
+- [ ] **[Outcome]**: Clicking "Export CSV" on the reports page downloads a CSV file containing every
+      row currently shown in the table
+      **Verification**: Load the reports page with test data, click "Export CSV", and confirm the
+      downloaded file's row count matches the on-screen row count
+
+## Non-Goals
+- This issue does not add export formats besides CSV (e.g., XLSX, PDF).
+
+## References
+- N/A — no prior art gathered for this change.

--- a/skills/craft-issue/__fixtures__/issue-reviewer/justified-complex-clean.md
+++ b/skills/craft-issue/__fixtures__/issue-reviewer/justified-complex-clean.md
@@ -1,0 +1,125 @@
+# E11 — justified-complex-clean
+
+**Expected verdict:** PASS (no findings, no `**Rule:**` line at all)
+**Rule source:** n/a — this is the negative control for the escalated Parent-Issue Body Shape
+
+**Known highest-risk fixture (per plan §5.E "E11 알려진 취약점"):** every heavy section below
+carries an explicit, individually-checkable trigger, unlike `over-scaffolding.md` (E8) where the
+same kind of sections appear with NO trigger. The initiative is deliberately chosen to decompose
+into **exactly two genuinely independent children with no shared mutable data model** — adding the
+Spanish locale and adding the German locale are parallel, self-contained, and neither depends on a
+field the other must persist — so the set has no hidden coverage gap of the kind a data-coupled
+initiative (e.g. multi-currency, which needs a distinct currency-persistence slice) would smuggle
+in. Read each annotation before treating this as a template — the point is that the trigger, not the
+section's mere presence, is what makes each heavy section legal:
+
+- **Parent-Issue Body Shape applies** (not Standard Body Shape) because Stage 5 slicing actually
+  fired and created two real children below — Background, Pre-Context, and References are *Required*
+  rows for a parent, not an escalation choice.
+- **Core Concept is Conditional, triggered**: both children rely on the same "localize UI chrome
+  strings only, not user-generated content or transactional email" boundary; if that boundary drifts
+  between the two children, one locale would translate things the other leaves in English. That is
+  exactly the trigger ("children share a term or model that must not drift").
+- **Decisions Needed is Conditional, triggered**: there is a real open product decision (the
+  fallback locale for an untranslated string) that shapes both children, and the entry names the
+  decision and its owner without stating any option as chosen — matching `- **No pre-solving**`.
+- **Post-Release Observation is Conditional, triggered**: the initiative moves a shared outcome
+  (share of sessions in a non-English locale — Form 1), declared once at the parent (Tier A) with
+  children referencing it rather than re-declaring.
+- **Affected Areas is stated as a hedged parent-level forecast** ("Expected to touch …; exact scope
+  confirmed per child"), per the code-touching-parent rule — not as flat confirmed child scope.
+- **No Evidence, User Value, User Flow, Scope of Application, or Notes sections appear** — none of
+  their triggers hold (non-bug, no user-facing value beyond Background, not a transition genre, no
+  provenance to record), so per Lean by Default they are correctly omitted.
+- Both children are lean Standard Body Shape issues with concrete, single-outcome, non-weasel ACs
+  and are each independently complete; together they fully cover the request (no Request-Coverage
+  gap, no missing third slice).
+
+---
+
+## Dispatch payload
+
+**Original request (verbatim):**
+Localize the app into Spanish and German so non-English users can use it in their own language. This
+is a bigger initiative — split it into separate issues if needed, and flag any open questions for
+product.
+
+**parent:app-localization-es-de**
+## Background
+The app ships English-only UI chrome today. Non-English users have asked to use it in their own
+language, and product has prioritized Spanish and German for this quarter as the first two locales
+of the internationalization initiative.
+
+## Core Concept
+This initiative localizes **UI chrome strings** (labels, buttons, menu items, and other
+app-authored interface text) only. **User-generated content** (names, comments, uploaded text) and
+**transactional email** are explicitly outside the boundary and stay as authored. Every child holds
+this same boundary — a child must never localize content outside UI chrome.
+
+## Pre-Context
+- **Affected Areas**:
+  - Expected to touch the i18n string catalog `i18n/strings.en.json` (the app's UI-string source of
+    truth) and per-locale catalogs registered beside it; exact scope confirmed per child (Stage 3
+    investigation).
+- **Premises**:
+  - The app already runs on an i18n framework with an active `en` locale, and adding a locale is a
+    matter of supplying a translated catalog and registering it (confirmed by Stage 3 investigation).
+  - The app already has a locale switcher that lists every registered locale, so a newly registered
+    locale appears in it automatically (confirmed by Stage 3 investigation).
+- **Blockers & Risks**:
+  - The translated-string source (professional translation vs. in-house) is `TBD — needs validation
+    via a conversation with the localization vendor`.
+
+## Post-Release Observation
+- **Outcome metric** — share of sessions using a non-English locale (Spanish or German).
+- **Target / direction** — increases versus the pre-release 4-week baseline (no fixed figure set
+  yet).
+- **Observation method + window** — Amplitude cohort comparison against the prior 4 weeks, read 4
+  weeks post-rollout. Children reference this parent-level observation rather than re-declaring it.
+
+## Decisions Needed
+- Which locale a string falls back to when it has no translation yet (English vs. the user's
+  next-preferred locale) — delegated to product for a decision.
+
+## References
+- N/A — no prior art gathered for this initiative.
+
+**child:add-spanish-locale**
+## Problem
+The app has no Spanish UI; Spanish-speaking users see English chrome throughout.
+
+## Pre-Context
+- `i18n/strings.en.json` (the English UI-string catalog a Spanish catalog is translated from;
+  confirmed by Stage 3 investigation).
+
+## AC
+- [ ] **[Outcome]**: A user who selects "Español" in the locale switcher sees the app's UI chrome
+      rendered in Spanish
+      **Verification**: In a test account, select "Español" in the locale switcher and confirm the
+      main navigation labels render in Spanish (e.g. the "Settings" item reads "Ajustes")
+
+## Non-Goals
+- This issue does not translate user-generated content or transactional email into Spanish.
+
+## References
+- See the parent issue for the UI-chrome-only localization boundary this child relies on.
+
+**child:add-german-locale**
+## Problem
+The app has no German UI; German-speaking users see English chrome throughout.
+
+## Pre-Context
+- `i18n/strings.en.json` (the English UI-string catalog a German catalog is translated from;
+  confirmed by Stage 3 investigation).
+
+## AC
+- [ ] **[Outcome]**: A user who selects "Deutsch" in the locale switcher sees the app's UI chrome
+      rendered in German
+      **Verification**: In a test account, select "Deutsch" in the locale switcher and confirm the
+      main navigation labels render in German (e.g. the "Settings" item reads "Einstellungen")
+
+## Non-Goals
+- This issue does not translate user-generated content or transactional email into German.
+
+## References
+- See the parent issue for the UI-chrome-only localization boundary this child relies on.

--- a/skills/craft-issue/__fixtures__/issue-reviewer/lean-clean.md
+++ b/skills/craft-issue/__fixtures__/issue-reviewer/lean-clean.md
@@ -1,0 +1,39 @@
+# E10 — lean-clean
+
+**Expected verdict:** PASS (no findings, no `**Rule:**` line at all)
+**Rule source:** n/a — this is the negative control for the lean-default shape
+
+**Why it is clean:** a small, single-issue, non-bug feature request in the minimal Lean-by-Default
+shape — Problem → flat Pre-Context → AC → Non-Goals → References, nothing more, nothing less. The
+sole AC is concrete and single-outcome, no weasel words appear, Non-Goals is present, the Pre-Context
+bullet carries an investigation citation, and the request has exactly one ask, fully covered by the
+one AC (no Request-Coverage gap).
+
+---
+
+## Dispatch payload
+
+**Original request (verbatim):**
+Add a "copy link" button next to each item in the shared-list view so people can grab a direct link
+to one item without selecting and copying the URL by hand.
+
+**child:shared-list-copy-link-button**
+## Problem
+Users viewing a shared list have no quick way to get a direct link to a single item — they have to
+open the item and manually copy the browser URL.
+
+## Pre-Context
+- The shared-list item row component is `lists/SharedListItem.tsx` (renders each item's title and
+  action icons; confirmed by Stage 3 investigation).
+
+## AC
+- [ ] **[Outcome]**: Clicking the "Copy link" icon on a shared-list item copies that item's direct
+      URL to the clipboard
+      **Verification**: Open a shared list with a test item, click "Copy link" on it, and confirm
+      the clipboard contents equal the item's direct URL (`/lists/<id>/items/<itemId>`)
+
+## Non-Goals
+- This issue does not add a "copy link" action to the list itself, only to individual items.
+
+## References
+- N/A — no prior art gathered for this change.

--- a/skills/craft-issue/__fixtures__/issue-reviewer/manual-verification-ac-clean.md
+++ b/skills/craft-issue/__fixtures__/issue-reviewer/manual-verification-ac-clean.md
@@ -1,0 +1,43 @@
+# E12 — manual-verification-ac-clean
+
+**Expected verdict:** PASS (no findings, no `**Rule:**` line at all)
+**Rule source:** n/a — this is the negative control for A5 (verification-method breadth)
+
+**Why it is clean, and what it is guarding against:** the sole AC's Verification step is a manual
+human step, not an agent-executable command — but it is fully **defined and usable** (named device,
+named screen, named physical action, named observable result), which is exactly what A5 requires the
+reviewer to accept: "a test, a query, or a manual step are ALL valid verification methods... Do not
+apply an agent-executable-only standard." A reviewer that penalizes this AC for not being scriptable
+would be a false positive this fixture exists to catch. Contrast with a genuinely vague manual step
+like "have someone check it looks right" (the `AC Anti-Patterns` › `Vague verification` row) — this
+one names the exact device, the exact screen, and the exact physical trigger.
+
+---
+
+## Dispatch payload
+
+**Original request (verbatim):**
+Add haptic feedback (a short vibration) when a user long-presses a card in the mobile app's list
+view, so there's tactile confirmation the long-press was registered.
+
+**child:mobile-list-longpress-haptic**
+## Problem
+Long-pressing a card in the mobile app's list view has no tactile confirmation, so users cannot
+tell by feel whether the long-press registered before the context menu appears.
+
+## Pre-Context
+- The list-view card component is `mobile/components/ListCard.tsx` (handles the long-press gesture
+  today with no haptic call; confirmed by Stage 3 investigation).
+
+## AC
+- [ ] **[Outcome]**: Long-pressing a card in the list view on a physical iOS or Android device
+      triggers a short haptic vibration at the moment the context menu opens
+      **Verification**: On a physical test device (not a simulator, which cannot render haptics),
+      open the app's list view and long-press any card; confirm by feel that a short vibration
+      pulse occurs at the same moment the context menu appears
+
+## Non-Goals
+- This issue does not add haptic feedback to any gesture besides the list-view long-press.
+
+## References
+- N/A — no prior art gathered for this change.

--- a/skills/craft-issue/__fixtures__/issue-reviewer/missing-body-payload.md
+++ b/skills/craft-issue/__fixtures__/issue-reviewer/missing-body-payload.md
@@ -1,0 +1,26 @@
+# E16 — missing-body-payload
+
+**Expected verdict:** REQUEST_CHANGES, and PASS is forbidden (the reviewer must not attempt to
+review a partial payload as if it were complete)
+**Expected anchor:** `payload contract` (the literal `**Rule:** payload contract` value)
+**Rule source:** `agents/issue-reviewer.md` § Payload Contract (dispatch precondition) — "...one
+child body per child issue in the set. One labeled block per child... An incomplete payload (any of
+the three blocks missing) is a payload contract violation."
+
+**Single violation by design:** this is the mirror of E14 — here the **Original request (verbatim)**
+block IS present, but the issue set being written has exactly one issue and its
+`child:<title-slug>` body block is entirely absent from the dispatch. There is a request describing
+what should be built, but nothing to check it against. Dispatch exactly what appears under
+"Dispatch payload" below — do not add a child body block when reproducing this fixture; its absence
+is the point.
+
+---
+
+## Dispatch payload
+
+**Original request (verbatim):**
+Let users mute notifications for a specific project from the project settings page.
+
+<!-- OMITTED ON PURPOSE: no "child:<title-slug>" block follows. The request above describes a
+     single, unsliced ask, so exactly one child body block is expected and none is supplied — this
+     is the fixture's single defect. -->

--- a/skills/craft-issue/__fixtures__/issue-reviewer/missing-non-goals.md
+++ b/skills/craft-issue/__fixtures__/issue-reviewer/missing-non-goals.md
@@ -1,0 +1,44 @@
+# E5 — missing-non-goals
+
+**Expected verdict:** REQUEST_CHANGES
+**Expected anchor:** `Standard Body Shape`
+**Rule source:** `references/issue-craft.md` § Standard Body Shape (Non-Goals row) + § Lean by Default
+(the minimal default set — Problem → 사전 확인 → AC → Non-Goals → References — names Non-Goals as a
+genre-agnostic member, not an omittable escalation)
+
+**Single violation by design:** a bulk-action feature with obvious, un-fenced adjacent scope —
+bulk-*unarchive*, bulk-*delete*, and select-all-across-pages all sit one step away from "bulk
+archive" and a reader cannot tell which are in scope without a Non-Goals fence. The body is
+otherwise a clean lean-default issue with a single-outcome, concrete, non-weasel AC and a glossed
+symbol; the Non-Goals section is simply absent, leaving the scope-creep boundary undrawn. (An
+earlier trivial-feature draft let the reviewer treat Non-Goals as legitimately omittable for a
+self-contained capability; a bulk-action with visible neighboring operations makes the missing fence
+unambiguous.)
+
+---
+
+## Dispatch payload
+
+**Original request (verbatim):**
+Add a "bulk archive" action to the reports list so users can archive several old reports at once
+instead of one at a time.
+
+**child:reports-bulk-archive**
+## Problem
+Users can archive reports only one at a time; with dozens of stale reports this is tedious.
+Archiving hides a report from the default list without deleting it — archived reports stay
+retrievable under the "Archived" filter, and the list also supports bulk-unarchive and bulk-delete
+on individual rows today, so a bulk action's exact boundary is not self-evident.
+
+## Pre-Context
+- The reports list is `reports/ReportsList.tsx` (renders the report rows and the current per-row
+  archive/unarchive/delete actions; confirmed by Stage 3 investigation).
+
+## AC
+- [ ] **[Outcome]**: Selecting several reports and clicking "Bulk archive" moves every selected
+      report out of the default list into the archived state in a single action.
+      **Verification**: In a test account with 3 active reports, select all 3, click "Bulk archive",
+      and confirm all 3 leave the default list and appear under the "Archived" filter.
+
+## References
+- N/A — no prior art gathered for this change.

--- a/skills/craft-issue/__fixtures__/issue-reviewer/missing-request-payload.md
+++ b/skills/craft-issue/__fixtures__/issue-reviewer/missing-request-payload.md
@@ -1,0 +1,42 @@
+# E14 — missing-request-payload
+
+**Expected verdict:** REQUEST_CHANGES, and PASS is forbidden (the reviewer must not attempt to
+review a partial payload as if it were complete)
+**Expected anchor:** `payload contract` (the literal `**Rule:** payload contract` value — the one
+`**Rule:**` value the agent contract reserves for a payload defect rather than a rule-file citation)
+**Rule source:** `agents/issue-reviewer.md` § Payload Contract (dispatch precondition) — "The
+dispatch payload contains exactly three kinds of labeled blocks: the original raw request... An
+incomplete payload (any of the three blocks missing) is a payload contract violation."
+
+**Single violation by design:** the child body below is itself fully compliant (concrete AC, no
+weasel words, Non-Goals present, correctly triggered body shape) — the only defect is that the
+**Original request (verbatim)** block, required by the payload contract, is entirely absent from
+the dispatch. Dispatch exactly what appears under "Dispatch payload" below — do not add a request
+block when reproducing this fixture; its absence is the point.
+
+---
+
+## Dispatch payload
+
+<!-- OMITTED ON PURPOSE: no "Original request (verbatim):" block precedes the child body below.
+     This is the fixture's single defect — reproduce it by dispatching only the block that follows. -->
+
+**child:profile-avatar-upload**
+## Problem
+Users cannot upload a custom avatar image; the profile page only shows a generated initials icon.
+
+## Pre-Context
+- The profile page's avatar renderer is `profile/AvatarIcon.tsx` (renders the initials fallback
+  today; confirmed by Stage 3 investigation).
+
+## AC
+- [ ] **[Outcome]**: A user who uploads a JPEG or PNG under 5MB on the profile page sees that image
+      as their avatar instead of the initials icon, on the next page load
+      **Verification**: Upload a 200KB PNG as a test account, reload the profile page, and confirm
+      the rendered avatar's `src` points to the uploaded image, not the initials icon
+
+## Non-Goals
+- This issue does not add avatar cropping or resizing controls.
+
+## References
+- N/A — no prior art gathered for this change.

--- a/skills/craft-issue/__fixtures__/issue-reviewer/model-a-violation.md
+++ b/skills/craft-issue/__fixtures__/issue-reviewer/model-a-violation.md
@@ -1,0 +1,43 @@
+# E7 — model-a-violation
+
+**Expected verdict:** REQUEST_CHANGES
+**Expected anchor:** `Model-A Purity`
+**Rule source:** `references/issue-craft.md` § Model A INVEST Slice Rubric › Model-A Purity Rules
+
+**Single violation by design:** a Pre-Context bullet prescribes HOW the work will be implemented —
+enforcing expiry by attaching a time-to-live to each stored session and dropping it on expiry — a
+fixed-implementation commitment that belongs to `prometheus`/`sisyphus` downstream, not a WHAT-stage
+issue. The bullet is deliberately *cited* (so no Pre-Context unbacked-assertion finding piggybacks),
+names no code symbol (so no symbol-gloss finding piggybacks), and the AC declares Cleanup + a
+randomized ID (so no Action/Expected/Verification state-mutation finding piggybacks) — leaving the
+Model-A intent-ban violation as the only thing to cite.
+
+---
+
+## Dispatch payload
+
+**Original request (verbatim):**
+Sessions should expire after 30 days of inactivity instead of never expiring.
+
+**child:session-inactivity-expiry**
+## Problem
+User sessions currently never expire, so a stolen or leaked session token remains valid
+indefinitely.
+
+## Pre-Context
+- The session read path is `auth/session/read.ts` (validates the session token on every
+  authenticated request; confirmed by Stage 3 investigation).
+- Expiry will be enforced by attaching a 30-day time-to-live to each stored session and dropping it
+  on expiry, rather than sweeping a database column (approach recorded in the Stage 2 design note).
+
+## AC
+- [ ] **[Outcome]**: A session with no activity for 30 days is rejected on the next request.
+      **Verification**: Create a test session with a randomized ID, backdate its last-activity
+      timestamp by 31 days, confirm the next authenticated request returns HTTP 401, then delete the
+      test session.
+
+## Non-Goals
+- This issue does not add a user-facing "you were logged out due to inactivity" message.
+
+## References
+- N/A — no prior art gathered for this change.

--- a/skills/craft-issue/__fixtures__/issue-reviewer/over-scaffolding.md
+++ b/skills/craft-issue/__fixtures__/issue-reviewer/over-scaffolding.md
@@ -1,0 +1,54 @@
+# E8 — over-scaffolding
+
+**Expected verdict:** REQUEST_CHANGES
+**Expected anchor:** `Lean by Default`
+**Rule source:** `references/issue-craft.md` § Lean by Default, Escalate on Need (escalation table +
+Red Flag paragraph)
+
+**Single violation by design:** a small, single-fact, non-bug feature request emits three
+escalation sections with none of their triggers met: a separate **Evidence** section (trigger is
+bug-genre only — this is a plain feature), a structured 3-sub-item **Pre-Context** (trigger is
+parent/umbrella or >~5 cross-cutting facts — this issue has exactly one fact total), and a **Notes**
+section with no provenance content (trigger is superseded attempts / deep-interview artifact path —
+neither applies). All three manifestations cite the same rule (`### Lean by Default`), so this is
+still one violation by rule-section, matching the Red Flag: "several Conditional sections... landing
+in the same issue at once is a signal to stop." The AC itself is concrete and clean, contrast this
+with `justified-complex-clean.md` (E11), where the same kind of heavy sections DO carry a real
+trigger each.
+
+---
+
+## Dispatch payload
+
+**Original request (verbatim):**
+Add a dark mode toggle to the settings page.
+
+**child:dark-mode-toggle**
+## Problem
+Users cannot switch the app to a dark color scheme; the settings page has no toggle for it.
+
+## Evidence
+- N/A — this is a feature request, not a bug; there is no log or trace to attach.
+
+## Pre-Context
+- **Affected Areas**:
+  - `settings/ThemeToggle.tsx` (does not exist yet; the settings page has no theme control today).
+- **Premises**:
+  - The app already has a CSS custom-property theme layer that a dark palette can plug into.
+- **Blockers & Risks**:
+  - None identified.
+
+## AC
+- [ ] **[Outcome]**: Toggling "Dark mode" in settings switches the app's background and text colors
+      to the dark palette immediately, without a page reload
+      **Verification**: Open settings, toggle dark mode, and confirm the background color changes
+      to the dark palette's hex value within the same render
+
+## Non-Goals
+- This issue does not add a system-preference auto-detect for dark mode.
+
+## Notes
+- N/A.
+
+## References
+- N/A — no prior art gathered for this change.

--- a/skills/craft-issue/__fixtures__/issue-reviewer/pre-solved-decision.md
+++ b/skills/craft-issue/__fixtures__/issue-reviewer/pre-solved-decision.md
@@ -1,0 +1,44 @@
+# E15 — pre-solved-decision
+
+**Expected verdict:** REQUEST_CHANGES
+**Expected anchor (case-insensitive):** `pre-solv`
+**Rule source:** `references/issue-craft.md` § Decisions Needed › `- **No pre-solving** — ...`
+
+**Single violation by design:** the Decisions Needed section has a genuine open decision (whether
+to retire the legacy discount-code path for existing users), but the entry states the answer as
+already chosen ("Legacy discount codes will be retired for existing users; see `DESIGN-142` for
+details") instead of naming the decision and its owner. The Decisions Needed section is genuinely
+triggered here (a real open product decision blocks/shapes the work), so this is purely a
+content-quality defect inside a present section, not a missing-section or over-scaffolding defect.
+
+---
+
+## Dispatch payload
+
+**Original request (verbatim):**
+Launch the new discount-code format for new signups. There's an open question about what happens
+to existing users' legacy codes — product hasn't decided yet.
+
+**child:new-discount-code-format**
+## Problem
+New signups need the new discount-code format; the launch is blocked on writing the issue, not on
+the legacy-code question, but that open decision must be recorded so it isn't lost.
+
+## Pre-Context
+- The discount-code validation path lives in `promotions/discount-codes/validate.ts` (validates
+  both legacy and new-format codes today; confirmed by Stage 3 investigation).
+
+## AC
+- [ ] **[Outcome]**: A new signup entering a new-format discount code at checkout receives the
+      correct discount amount for that code
+      **Verification**: Create a test new-format code worth 10%, complete a test checkout as a new
+      signup, and confirm the applied discount equals 10% of the order subtotal
+
+## Decisions Needed
+- Legacy discount codes will be retired for existing users; see `DESIGN-142` for details.
+
+## Non-Goals
+- This issue does not change how legacy-format codes are validated for existing users.
+
+## References
+- N/A — no prior art gathered for this change.

--- a/skills/craft-issue/__fixtures__/issue-reviewer/research-backed-decision-clean.md
+++ b/skills/craft-issue/__fixtures__/issue-reviewer/research-backed-decision-clean.md
@@ -1,0 +1,69 @@
+# E13 — research-backed-decision-clean
+
+**Expected verdict:** PASS (no findings, no `**Rule:**` line at all)
+**Rule source:** n/a — this is the negative control for the Decisions Needed
+`- **Research-backed alternatives**` carve-out
+
+**Why it is clean:** the Decisions Needed entry below carries a full alternatives table (option /
+pros / cons / source URL) and a recommendation — but the recommendation is explicitly labeled
+`proposal — not decided in this issue`, and no option is stated as chosen anywhere in the body. This
+is the legal shape the carve-out describes: "an alternatives table... and a recommendation are
+permitted; a decision is not. Record the recommendation as a `proposal — not decided in this
+issue`, never as the entry's chosen answer." A reviewer that flagged this as pre-solving (E15's
+violation) would be a false positive this fixture exists to catch — contrast the phrasing here with
+`pre-solved-decision.md`, which states the outcome as already decided.
+
+**Why the envelope is safe:** the carve-out under test rides a pure additive capability — a QR code
+newly rendered in the share sheet. It adds a new element alongside the existing share actions rather
+than changing a traversed path (non-transition, so no User Flow field is owed), delivers all its
+value at acceptance (no measurable outcome to watch and no prod log/data/state to confirm, so
+Post-Release Observation is correctly omitted), and its single AC is verified by decoding the
+displayed QR — a read-only observation that mutates no persistent state (so no Setup/Cleanup is
+owed). The only section that could draw a finding is Decisions Needed, which is exactly the axis
+this control isolates.
+
+---
+
+## Dispatch payload
+
+**Original request (verbatim):**
+Let people share an item by QR code — add a QR to the share sheet so someone can scan it in person
+instead of sending a link. Evaluate how we should generate the QR and file the issue with your
+recommendation, but don't lock in the approach yet since the platform team hasn't weighed in on
+client-bundle vs server-side.
+
+**child:share-sheet-qr-code**
+## Problem
+The share sheet offers a link and a "Copy link" action but no QR code, so there is no way to share
+an item to someone standing nearby by having them scan it.
+
+## Pre-Context
+- The share sheet is `share/ShareSheet.tsx` (the client-rendered panel that lists the existing
+  share actions today; confirmed by Stage 3 investigation).
+
+## AC
+- [ ] **[Outcome]**: Opening the share sheet for an item displays a QR code that encodes that item's
+      public share URL (the same URL the existing "Copy link" action produces)
+      **Verification**: Open the share sheet for a test item, decode the displayed QR with a
+      QR-decoder, and confirm the decoded text equals the item's "Copy link" URL
+
+## Decisions Needed
+- How to generate the QR image — `proposal — not decided in this issue`, delegated to the platform
+  team for a decision. Options gathered at Stage 2 (librarian research):
+
+  | Option | Pros | Cons | Source |
+  |---|---|---|---|
+  | Bundle a client-side QR library | Renders offline, no new infra, no round-trip | Adds ~20KB to the web bundle | https://github.com/soldair/node-qrcode |
+  | Add a server-side QR image endpoint | Zero client-bundle cost, cacheable across users | New backend route to operate plus a network round-trip | https://github.com/skip2/go-qrcode |
+  | Use a managed QR image service | No code to maintain | Third-party dependency and per-call cost | https://goqr.me/api/ |
+
+  Recommendation (`proposal — not decided in this issue`): the client-side library, since the share
+  sheet is already client-rendered and the bundle cost is modest — final call belongs to the
+  platform team.
+
+## Non-Goals
+- This issue does not add QR codes anywhere outside the share sheet, and does not add branded or
+  color-styled QR rendering.
+
+## References
+- N/A — no prior art gathered for this change beyond the Decisions Needed research above.

--- a/skills/craft-issue/__fixtures__/issue-reviewer/task-restatement-ac.md
+++ b/skills/craft-issue/__fixtures__/issue-reviewer/task-restatement-ac.md
@@ -1,0 +1,40 @@
+# E2 — task-restatement-ac
+
+**Expected verdict:** REQUEST_CHANGES
+**Expected anchor:** `Task restatement`
+**Rule source:** `references/issue-craft.md` § Observable-AC Rubric › AC Anti-Patterns → `Task restatement`
+
+**Single violation by design:** the sole AC's outcome line restates the task ("The `--dry-run` flag
+is implemented") instead of naming an observable consumer-facing outcome. The Verification line is
+itself concrete (prints planned actions, exits 0, does not invoke the pipeline), no weasel words are
+used, the AC is not compound, and — because this is a pure-capability CLI flag (non-transition, no
+measurable outcome to watch post-release) — no User Flow or Post-Release Observation section is
+owed. So the only thing left to cite is the task-restatement outcome.
+
+---
+
+## Dispatch payload
+
+**Original request (verbatim):**
+Add a `--dry-run` flag to the `deploy` CLI so operators can preview the planned actions without
+executing them.
+
+**child:deploy-dry-run-flag**
+## Problem
+The `deploy` CLI has no way to preview what it will do; operators must run it for real to see the
+plan, which risks unintended changes to production.
+
+## Pre-Context
+- The deploy CLI entrypoint is `cli/deploy.ts` (parses flags and runs the deploy pipeline; confirmed
+  by Stage 3 investigation).
+
+## AC
+- [ ] **[Outcome]**: The `--dry-run` flag is implemented for the deploy CLI.
+      **Verification**: Run `deploy --dry-run` against a test config and confirm it prints the
+      planned actions and exits 0 without invoking the deploy pipeline.
+
+## Non-Goals
+- This issue does not add a `--dry-run` flag to any CLI other than `deploy`.
+
+## References
+- N/A — no prior art gathered for this flag.

--- a/skills/craft-issue/__fixtures__/issue-reviewer/unbacked-precontext.md
+++ b/skills/craft-issue/__fixtures__/issue-reviewer/unbacked-precontext.md
@@ -1,0 +1,47 @@
+# E4 — unbacked-precontext
+
+**Expected verdict:** REQUEST_CHANGES
+**Expected anchor:** `Pre-Context Rules` (and must NOT also cite `Standard Body Shape` on the same
+finding — the Pre-Context section is present and correctly labeled, only one bullet's content is
+unbacked)
+**Rule source:** `references/issue-craft.md` § Pre-Context Rules
+
+**Single violation by design:** a pure-capability infra endpoint issue with a lean flat Pre-Context
+list of exactly two bullets. The first bullet carries an evidence citation; the second is a bare
+factual assertion about the current system with neither an evidence citation nor a
+`TBD — needs validation via {method}` marker — the unbacked-assertion violation of Pre-Context
+Rules. The unbacked bullet names no code symbol (so no symbol-gloss defect can piggyback on it), the
+AC is a single observable outcome, coverage holds, and because this is a pure-capability endpoint
+(non-transition, no post-release outcome to watch) no other section is owed — so the reviewer has
+only the unbacked bullet to cite.
+
+---
+
+## Dispatch payload
+
+**Original request (verbatim):**
+Add a `/version` endpoint that returns the running build's git commit SHA so operators can confirm
+which build a host is serving.
+
+**child:version-endpoint**
+## Problem
+There is no way to check which build a running instance is serving; operators cannot confirm a
+deploy reached a given host without shelling into it.
+
+## Pre-Context
+- The HTTP router is `server/router.ts` (registers all top-level routes; confirmed by Stage 3
+  investigation).
+- The build's git commit SHA is already injected into the process environment at build time, so the
+  endpoint only needs to read it back and return it.
+
+## AC
+- [ ] **[Outcome]**: A GET to `/version` returns HTTP 200 with a JSON body whose `sha` field is the
+      running build's 40-character git commit SHA.
+      **Verification**: Start the service, run `curl -s localhost:8080/version`, and confirm the
+      `sha` field equals the output of `git rev-parse HEAD` for the deployed commit.
+
+## Non-Goals
+- This issue does not add the build timestamp or branch name to the response.
+
+## References
+- N/A — no prior art gathered for this endpoint.

--- a/skills/craft-issue/__fixtures__/issue-reviewer/unsliced-parent.md
+++ b/skills/craft-issue/__fixtures__/issue-reviewer/unsliced-parent.md
@@ -1,0 +1,64 @@
+# E6 — unsliced-parent
+
+**Expected verdict:** REQUEST_CHANGES
+**Expected anchor (case-insensitive):** `Candidate-seam`
+**Rule source:** `references/issue-craft.md` § Model A INVEST Slice Rubric › Candidate-seam
+heuristics ("Issue touches genuinely unrelated concerns, each independently valuable → split by
+concern") — the reviewer stably cites the Candidate-seam heuristic for a bundle of unrelated
+concerns rather than the `Slice Gate` heading, so the anchor tracks its stable citation.
+
+**Single violation by design:** the request bundles four genuinely unrelated, each-independently-
+valuable pure capabilities (a dark-mode toggle, a CSV export button, custom-avatar upload, and a
+health-check endpoint) into one issue with no children created — the classic "candidate-seam: issue
+touches genuinely unrelated concerns, each independently valuable → split by concern" case, left
+un-sliced. Each capability is a pure feature (non-transition, no measurable outcome to watch
+post-release), and each individual AC is concrete, single-outcome, and non-weasel — so the only
+defect is the failure to slice, not AC quality, a genre-section omission, or a coverage gap.
+
+---
+
+## Dispatch payload
+
+**Original request (verbatim):**
+Knock out four small unrelated improvements this sprint: add a dark-mode toggle to settings, add a
+CSV export button to the reports tab, let users upload a custom avatar on their profile, and add a
+`/healthz` endpoint so the load balancer can check whether the service is up.
+
+**child:sprint-misc-improvements**
+## Problem
+Four unrelated user-facing gaps are slated for this sprint: settings has no dark-mode toggle, the
+reports tab has no CSV export, the profile page has no custom-avatar upload, and there is no
+health-check endpoint for the load balancer.
+
+## Pre-Context
+- `settings/ThemeToggle.tsx` (the dark-mode control; does not exist yet; confirmed by Stage 3
+  investigation).
+- `reports/ReportsTable.tsx` (the reports grid to be exported; confirmed by Stage 3 investigation).
+- `profile/AvatarIcon.tsx` (the avatar renderer showing the initials fallback today; confirmed by
+  Stage 3 investigation).
+- `server/router.ts` (the HTTP router where the new endpoint registers; confirmed by Stage 3
+  investigation).
+
+## AC
+- [ ] **[Outcome]**: Toggling "Dark mode" in settings switches the app to the dark palette without a
+      page reload
+      **Verification**: Open settings, toggle dark mode, and confirm the background changes to the
+      dark palette's hex value within the same render
+- [ ] **[Outcome]**: Clicking "Export CSV" on the reports tab downloads a CSV file whose row count
+      matches the on-screen row count
+      **Verification**: Load the reports tab with test data, click "Export CSV", and confirm the
+      downloaded file's row count equals the on-screen count
+- [ ] **[Outcome]**: Uploading a PNG under 5MB on the profile page shows that image as the avatar on
+      the next page load
+      **Verification**: Upload a 200KB PNG as a test account, reload the profile page, and confirm
+      the avatar's `src` points to the uploaded image
+- [ ] **[Outcome]**: A GET to `/healthz` returns HTTP 200 when the service is up
+      **Verification**: Start the service and confirm `curl -s -o /dev/null -w "%{http_code}"
+      localhost:8080/healthz` prints `200`
+
+## Non-Goals
+- This issue does not add dark-mode system-preference auto-detect, CSV alternatives (XLSX/PDF),
+  avatar cropping controls, or a readiness probe.
+
+## References
+- N/A — no prior art gathered for this sprint work.

--- a/skills/craft-issue/__fixtures__/issue-reviewer/weasel-word-ac.md
+++ b/skills/craft-issue/__fixtures__/issue-reviewer/weasel-word-ac.md
@@ -1,0 +1,40 @@
+# E1 — weasel-word-ac
+
+**Expected verdict:** REQUEST_CHANGES
+**Expected anchor (case-insensitive):** `weasel`
+**Rule source:** `references/issue-craft.md` § Observable-AC Rubric › Weasel-Word Prohibition
+
+**Single violation by design:** the request does not itself hand over a measurable basis (it asks
+only that the load balancer can tell the service is up), so making the outcome observable is the
+AC author's job — and they weaseled out with the banned word `correctly` instead of naming a status
+code or body assertion. Coverage is intact (the AC is squarely about the `/healthz` up-check the
+request asked for), the Verification names a concrete `curl` command, and every other section
+(Pre-Context evidence, Non-Goals, References, body shape, single atomic slice) is compliant — so the
+only thing left for the reviewer to cite is the weasel word standing in for a measurable basis.
+
+---
+
+## Dispatch payload
+
+**Original request (verbatim):**
+Add a `/healthz` endpoint so the load balancer can tell whether the service instance is up.
+
+**child:healthz-endpoint**
+## Problem
+There is no health-check endpoint, so the load balancer cannot tell whether a service instance is
+up and keeps routing traffic to instances that are still booting.
+
+## Pre-Context
+- The HTTP router is defined in `server/router.ts` (registers all top-level routes; confirmed by
+  Stage 3 investigation).
+
+## AC
+- [ ] **[Outcome]**: The `/healthz` endpoint responds correctly when the service is healthy.
+      **Verification**: Start the service, run `curl -s localhost:8080/healthz`, and confirm it
+      responds correctly.
+
+## Non-Goals
+- This issue does not add a readiness probe or downstream dependency health checks (DB, cache).
+
+## References
+- N/A — no prior art gathered for this endpoint.

--- a/skills/craft-issue/references/issue-craft.md
+++ b/skills/craft-issue/references/issue-craft.md
@@ -321,11 +321,21 @@ owns a distinct sub-outcome.
 
 A **Decisions Needed** section is a list of open product or policy decisions that block or shape work. Each entry names the decision and the issue or owner it is delegated to for resolution.
 
-**Entries must not pre-solve.** The Model-A intent ban applies: naming the open question and its owner is allowed; embedding the answer is not. "Whether method B cards should be retired for existing users — delegated to `[design-issue-id]`" is a valid entry. "Method B cards will be retired; see `[design-issue-id]` for details" is a violation.
+- **No pre-solving** — name the decision and the issue or owner it is delegated to; do not state any option as chosen. "Whether method B cards should be retired for existing users — delegated to `[design-issue-id]`" is a valid entry. "Method B cards will be retired; see `[design-issue-id]` for details" is a violation. The Model-A intent ban applies: naming the open question and its owner is allowed; embedding the answer is not.
+- **Research-backed alternatives** — an alternatives table (option / pros / cons / source URL) and a recommendation are permitted; a decision is not. Record the recommendation as a `proposal — not decided in this issue`, never as the entry's chosen answer.
+- **Distinguish from `TBD`** — `TBD — needs validation via {method}` marks a missing **fact** in a body field (a premise that can be confirmed by investigation). Decisions Needed lists open **decisions** that require a product or policy call, not just investigation. The two mechanisms are complementary — a Decisions Needed entry may reference a TBD that will be resolved once the decision is made.
+- **Placement** — at the parent level, Decisions Needed lists decisions that affect multiple children. At the child level, a Decisions Needed entry is permitted when a decision affects only that child and has not yet been resolved.
 
-**Distinguish from `TBD`:** `TBD — needs validation via {method}` marks a missing **fact** in a body field (a premise that can be confirmed by investigation). Decisions Needed lists open **decisions** that require a product or policy call, not just investigation. The two mechanisms are complementary — a Decisions Needed entry may reference a TBD that will be resolved once the decision is made.
+### Request-Coverage Rule
 
-At the parent level, Decisions Needed lists decisions that affect multiple children. At the child level, a Decisions Needed entry is permitted when a decision affects only that child and has not yet been resolved.
+Before filing, compare the **issue set actually being written** (the single issue, or the parent plus every child) against the **original raw request** captured at Stage 1 — not against gathered documents, and not against a parent issue's own restated scope. This catches fake convergence: a writer summary that claims full coverage while the request itself has an element with no home in the written set.
+
+- **Coverage** — every distinct requirement or ask named in the original raw request maps to at least one AC, Non-Goal, or child issue in the set being written; a request element with no home anywhere in the set is a coverage gap.
+- **Non-Goals justification** — a request element deliberately left out of the issue set is named in Non-Goals with a reason, not silently dropped.
+- **Standalone scoring** — score coverage against the request text alone; the writer's own "all requirements handled" summary is not itself evidence of coverage.
+- **Delta from Coverage gap** — the slice-seam row compares the child set against the parent's own requirements; this rule compares the original request against the issue set.
+
+Cite only one.
 
 ### Anti-Fluff Rule
 

--- a/tools/lib/sync-directory.test.ts
+++ b/tools/lib/sync-directory.test.ts
@@ -182,6 +182,30 @@ describe("syncDirectory", () => {
 			expect(await exists(path.join(tgt, ".pytest_cache/CACHEDIR.TAG"))).toBe(false);
 			expect(await exists(path.join(tgt, "pkg/__pycache__/sub.cpython-312.pyc"))).toBe(false);
 		});
+
+		it("prunes __fixtures__ with the default exclude (no options passed)", async () => {
+			await writeFile(path.join(src, "helper.ts"), "export const x = 1;");
+			await writeFile(path.join(src, "__fixtures__/sample.md"), "fixture content");
+
+			await syncDirectory(src, tgt);
+
+			expect(await exists(path.join(tgt, "helper.ts"))).toBe(true);
+			expect(await exists(path.join(tgt, "__fixtures__/sample.md"))).toBe(false);
+		});
+
+		it("prunes __fixtures__ even when a custom exclude is passed", async () => {
+			// Regression: callers like { exclude: ["*.test.ts"] } must not lose
+			// __fixtures__ pruning, mirroring the PY_CACHE_EXCLUDE union above.
+			await writeFile(path.join(src, "helper.ts"), "export const x = 1;");
+			await writeFile(path.join(src, "helper.test.ts"), "import './helper.ts'");
+			await writeFile(path.join(src, "__fixtures__/sample.md"), "fixture content");
+
+			await syncDirectory(src, tgt, { exclude: ["*.test.ts"] });
+
+			expect(await exists(path.join(tgt, "helper.ts"))).toBe(true);
+			expect(await exists(path.join(tgt, "helper.test.ts"))).toBe(false);
+			expect(await exists(path.join(tgt, "__fixtures__/sample.md"))).toBe(false);
+		});
 	});
 
 	describe("실행 권한 보존", () => {

--- a/tools/lib/sync-directory.ts
+++ b/tools/lib/sync-directory.ts
@@ -5,7 +5,13 @@ import { detectBareImports } from "../adapters/ts-lib-deps.ts";
 /** Python cache patterns that are always excluded, regardless of any caller-supplied list. */
 export const PY_CACHE_EXCLUDE = ["__pycache__", ".pytest_cache", "*.pyc"];
 
-export const DEFAULT_EXCLUDE = [...PY_CACHE_EXCLUDE, "*.test.ts"];
+/**
+ * Names never deployed, regardless of any caller-supplied exclude list.
+ * Note: __fixtures__ is also pruned from collectFiles' default walk, so a .ts file
+ * under __fixtures__ would be skipped by the bare-import scan (lib-imports.ts).
+ */
+export const ALWAYS_PRUNE = [...PY_CACHE_EXCLUDE, "__fixtures__"];
+export const DEFAULT_EXCLUDE = [...ALWAYS_PRUNE, "*.test.ts"];
 
 function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
 	return typeof err === "object" && err !== null && "code" in err;
@@ -227,9 +233,10 @@ export async function syncDirectory(
 	target: string,
 	options?: { exclude?: string[]; platformRoot?: string },
 ): Promise<void> {
-	// PY_CACHE_EXCLUDE is always prepended so callers that supply a custom list
-	// (e.g. { exclude: ["*.test.ts"] }) do not accidentally lose Python cache pruning.
-	const exclude = [...PY_CACHE_EXCLUDE, ...(options?.exclude ?? ["*.test.ts"])];
+	// ALWAYS_PRUNE is always prepended so callers that supply a custom list
+	// (e.g. { exclude: ["*.test.ts"] }) do not accidentally lose Python cache pruning
+	// or __fixtures__ pruning.
+	const exclude = [...ALWAYS_PRUNE, ...(options?.exclude ?? ["*.test.ts"])];
 	const platformRoot = options?.platformRoot;
 
 	// 1. Ensure target directory exists


### PR DESCRIPTION
## 📌 Summary

craft-issue가 이슈를 쓰기 직전, READ-ONLY `issue-reviewer` 서브에이전트로 **규칙 파일을 dispatch 시점에 라이브로 읽어(SSOT-at-dispatch)** 이슈 초안을 체크리스트 대조하는 게이트를 추가한다. 게이트용 행동검증 픽스처(`__fixtures__`)가 배포 타깃에 새지 않도록 sync에 상시 프룬도 함께 도입한다.

---

## 🔧 Changes

### 체크리스트 리뷰 게이트 (커밋 `f8b07b38`)

- 신규 `agents/issue-reviewer.md` — READ-ONLY(`tools: Read, Glob, Grep`) 체크리스트 리뷰어. 규칙 텍스트를 자체 복사하지 않고 dispatch 시점에 `SKILL.md` + `references/issue-craft.md`를 라이브로 읽어 판정.
- `skills/craft-issue/SKILL.md` — write 직전 `Checklist Review Gate` 배선(Plain-Language Gate → 게이트 → write 순서), 루프 계약(`max_cycles=5`·`Same-Rule-3x`·종단 write-anyway+caller 통보), Stage 3 설계 대안 사전 리서치 트리거.
- `skills/craft-issue/references/issue-craft.md` — `Request-Coverage Rule` 신설 + `Decisions Needed` 재구조화(researched-alternatives carve-out: 대안 표·추천은 허용, 결정은 금지).
- 행동검증 픽스처 16종 + README(`__fixtures__/issue-reviewer/`), `SKILL.test.ts`, `projects/oh-my-toong/sync.yaml` 등록, 문서(에이전트 11→14).

**영향 범위**
- 신규 서브에이전트 추가 + craft-issue 파이프라인에 게이트 1단 삽입. 기존 스킬/에이전트 동작 불변. `make sync`로 `~/.claude/`에 배포됨.

### 배포 픽스처 상시 프룬 (커밋 `80cc30a5`)

- `tools/lib/sync-directory.ts` — `ALWAYS_PRUNE` 도입, `__fixtures__`를 모든 배포 타깃에서 상시 제외. `DEFAULT_EXCLUDE = [...ALWAYS_PRUNE, "*.test.ts"]`로 재정의, 호출자 exclude 리스트와 무관하게 prepend.
- `tools/lib/sync-directory.test.ts` — 단위 2케이스(폴백/명시-exclude).

**영향 범위**
- 배포 walk에서 `__fixtures__` 이름 디렉터리를 임의 depth에서 프룬. 기존 11개 `syncDirectory` 호출부 전부 `__fixtures__` 보존 의도 없음 → 전역 프룬 안전. orphan cleanup이 기배포분도 회수.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. SSOT-at-dispatch — 리뷰어가 규칙을 복사하지 않고 라이브로 읽는다

**배경 및 문제 상황:** 체크리스트 리뷰어가 규칙 텍스트를 자체 프롬프트에 복사하면, writer가 참조하는 규칙(`issue-craft.md`)과 reviewer가 검사하는 규칙이 시간이 지나며 물리적으로 drift한다.

**해결 방안:** 리뷰어는 규칙을 **한 글자도 담지 않고**, dispatch 시점에 두 규칙 파일의 절대경로를 전달받아 라이브로 읽는다. 체크리스트 출처가 단일 파일이라 기준 drift가 구조적으로 불가능.

**구현 세부사항:** 게이트 첫 스텝의 `RULES_RESOLVED` bash가 `\${CLAUDE_SKILL_DIR}`로 두 규칙 파일 절대경로를 해소해 출력하고, 미출력 시 dispatch/write를 막는다. `issue-reviewer.md`에는 `Do not copy rule text into this file. Read the rule files at dispatch time.` 가드가 박혀 있다.

**선택과 트레이드오프:** 라이브 read는 매 dispatch에 파일 I/O를 추가하지만, 기준 단일화가 그 비용보다 크다. 대안(규칙 스냅샷 임베드)은 drift를 재도입하므로 기각.

### 2. 음성 대조군은 검출 대조군보다 취약하다 — 그래서 최종 코퍼스 재검증을 넣었다

**배경 및 문제 상황:** "무조건 REQUEST_CHANGES를 찍는 리뷰어"도 위반 픽스처는 100% 통과시킨다. 검출만으로는 게이트와 소음 발생기를 구분 못 한다. 그래서 **규칙을 다 지킨 깨끗한 이슈에 지적 0건(PASS)** 인 음성 대조군을 필수로 넣었다.

**해결 방안:** 픽스처 16종 = 검출 12 + 음성 4. 각 2회 독립 dispatch. 게이트 텍스트를 SKILL.md에 추가한 **뒤** 음성 대조군을 최종 코퍼스로 재실행해 게이트 추가가 오탐을 유발하지 않았는지 확인.

**구현 세부사항:** 이 재검증에서 음성 대조군 하나(연구-기반 결정)가 **잠복 compound-AC 결함**을 안고 있던 게 드러났다(초기 검출 라운드는 리뷰어 관용 편차로 false-clean 통과). 근본원인은 시나리오("백그라운드 잡 도입")가 본질적으로 transition + 측정 outcome + post-release 상태를 끌고 들어와 안전-봉투 원칙을 위반한 것 → 순수 추가 capability(QR 공유시트)로 봉투를 교체해 해결.

**선택과 트레이드오프:** 픽스처의 "테스트 대상 축(Decisions Needed carve-out)"과 "봉투 축(feature genre)"을 직교시켜 단일-변수로 유지하는 게 음성 대조군 설계의 핵심 교훈. 리뷰어를 튜닝하지 않고 픽스처를 고친 것 — 실패의 근본원인이 규칙/리뷰어가 아니라 픽스처였기 때문.

### 3. 두 커밋 분리 — A는 B의 선행 precedent

**배경 및 문제 상황:** 게이트(B)가 도입하는 `__fixtures__/`는 테스트 전용이라 배포 타깃에 새면 안 된다. 기존 sync는 이를 프룬하지 않았다.

**해결 방안:** 프룬 인프라(A)를 게이트(B)와 별도 커밋으로 분리. A는 리뷰어와 무관한 순수 배포 로직이라 독립 검증·롤백이 가능.

**선택과 트레이드오프:** 단일 PR·2커밋 유지. A는 B가 도입하는 `__fixtures__` 없이는 무의미하므로 독립 thesis가 아니라 결합 종속 — 별도 PR로 쪼개는 건 과분할.

### 4. E-SMOKE 검증 — 마지막 한 레그는 미검증(투명 공개)

**배경 및 문제 상황:** 게이트가 실제 파이프라인에서 끝까지(이슈 저장까지) 작동하는지 확인하는 E-SMOKE는 판정 3개로 구성된다.

**구현 세부사항:**
- **Judgment 1** (규칙 경로 라이브 해소) ✅ — 배포본 `\${CLAUDE_SKILL_DIR}`가 2개 절대경로로 해소.
- **Judgment 2** (게이트가 리뷰어 dispatch) ✅ — 배선 확인 + 검증 과정에서 리뷰어 48회 라이브 dispatch 성공.
- **Judgment 3** (실제 `save_issue`까지) ⛔ **미검증** — 실제 외부(Linear) 쓰기가 필요해, 긍정 승인 없이 자율 실행하지 않고 fallback으로 남김.

**선택과 트레이드오프:** 배선 자체는 Judgment 1·2 + 48회 dispatch로 강하게 입증됨. Judgment 3는 코드/커밋과 독립인 런타임 액션이라 추후 라이브 write로 사후 실측 가능.

---

## ✅ Checklist

### 리뷰어 계약
- [ ] `issue-reviewer`는 READ-ONLY다 (`tools: Read, Glob, Grep`만, `Write`/`Edit`/`Bash` 미포함)
  - `agents/issue-reviewer.md`
- [ ] 리뷰어 파일에 규칙 텍스트가 복사돼 있지 않다 (dispatch 시점 라이브 read)
  - `agents/issue-reviewer.md`

### 게이트 배선
- [ ] 게이트 순서가 Plain-Language Gate → Checklist Review Gate → write 순이다
  - `skills/craft-issue/SKILL.md`
- [ ] `RULES_RESOLVED`가 두 규칙 파일 절대경로를 출력하지 못하면 dispatch/write가 막힌다
  - `skills/craft-issue/SKILL.md`

### 배포 프룬
- [ ] `__fixtures__` 디렉터리가 모든 배포 타깃에서 제외된다
  - `tools/lib/sync-directory.ts`
- [ ] 단위 테스트가 폴백·명시-exclude 두 경로 모두에서 `__fixtures__` 프룬을 검증한다
  - `tools/lib/sync-directory.test.ts`

### 회귀
- [ ] `make test`·`make validate`가 green이다 (전체 스위트 통과, 문서 에이전트 카운트 14 일치)

---

## 📎 References
- 외부 이슈 트래커 없음 — OMT 하네스 내부 도구 작업(플랜 기반). 변경은 커밋 \`80cc30a5\`(배포 프룬) + \`f8b07b38\`(게이트)로 구성.