### PR TITLE
refactor: 백업을 OMT 소유 루트로 이전 + 파괴 경로 가드

### DIFF
--- a/docs/sync-deploy-targets.md
+++ b/docs/sync-deploy-targets.md
@@ -33,6 +33,32 @@
   해석되거나 `git worktree list` 자체가 실패하면 `DeployTargetsError`로 **시끄럽게**
   실패한다. 조용히 빈 타겟을 반환하면 아무것도 안 쓰고도 성공처럼 보이기 때문이다.
 
+## 백업 위치
+
+`make sync`가 덮어쓸 파일을 백업하는 곳은 타겟 레포 안이 아니라 **단일
+OMT 소유 루트**다:
+
+```
+<base>/sync-backup/<target>-<worktree>-<hex>/<platform>/<category>/
+```
+
+- `<base>`는 `$OMT_DIR`, 없으면 `~/.omt/<projectName>`.
+- `<target>`은 `sync.yaml`의 `path`(컨테이너), `<worktree>`는 그 경로가
+  해석된 개별 워크트리, `<hex>`는 deploy(target×worktree) 하나당 새로
+  생성된다.
+- 백업은 write-only다 — restore 경로는 없다. 나이 기준으로만
+  프룬한다(`backup_retention_days`, 기본 3일).
+
+타겟 레포 안에 `.sync-backup/`이 남던 예전 동작과 달리, 이제 백업이
+그 레포의 CI나 prettier를 오염시키지 않는다.
+
+## startup fail-fast
+
+백업 base(`<base>`)가 degenerate하면 — 상대경로, `/`, 또는 홈
+디렉토리면 — `make sync`(그리고 `make sync-dry`)는 배포를 시작하기
+**전에** `UnsafeBackupRootError`로 중단하고 `process.exit(1)` 한다.
+이 경우 워크트리 해석이나 파일 쓰기는 전혀 일어나지 않는다.
+
 ## 중복 처리(dedup)
 
 처리된 경로는 컨테이너 경로가 아니라 **정규 워크트리 경로** 기준으로 기록된다.

--- a/lib/omt-dir.ts
+++ b/lib/omt-dir.ts
@@ -82,7 +82,7 @@ export function resolveProjectRoot(cwd: string = process.cwd()): string {
 	}
 }
 
-function deriveProjectName(cwd: string): string {
+export function deriveProjectName(cwd: string): string {
 	try {
 		const gitCommonDir = execSync("git rev-parse --git-common-dir", {
 			cwd,

--- a/tools/adapters/codex.test.ts
+++ b/tools/adapters/codex.test.ts
@@ -1143,6 +1143,14 @@ describe("cleanupCodexSkillsFossil", () => {
 		return path.join(tmpDir, ".agents", "skills", ...segments);
 	}
 
+	// Absolute per-test backup destination under the new backupCategory
+	// contract, which now assembles join(backupDest, platform, category)
+	// directly (no session-id join happens inside the writer). Each test
+	// passes its own label so backups land in distinct, inspectable dirs.
+	function backupDest(...segments: string[]): string {
+		return path.join(tmpDir, "backup", ...segments);
+	}
+
 	async function pathExists(p: string): Promise<boolean> {
 		return fs
 			.stat(p)
@@ -1155,24 +1163,16 @@ describe("cleanupCodexSkillsFossil", () => {
 		await fs.writeFile(fossilPath("skill-a", "SKILL.md"), "# skill-a\n");
 		await fs.mkdir(newPath("skill-a"), { recursive: true });
 		await fs.writeFile(newPath("skill-a", "SKILL.md"), "# skill-a\n");
-		await fs.writeFile(path.join(tmpDir, ".codex", "config.toml"), "model = \"o3\"\n");
+		await fs.writeFile(path.join(tmpDir, ".codex", "config.toml"), 'model = "o3"\n');
 
-		await cleanupCodexSkillsFossil(tmpDir, "sid-happy", false, new Set(["skill-a"]));
+		await cleanupCodexSkillsFossil(tmpDir, backupDest("happy"), false, new Set(["skill-a"]));
 
 		expect(await pathExists(fossilPath("skill-a"))).toBe(false);
 		expect(await pathExists(path.join(tmpDir, ".codex", "skills"))).toBe(false);
 		expect(await fs.readFile(path.join(tmpDir, ".codex", "config.toml"), "utf-8")).toBe(
 			'model = "o3"\n',
 		);
-		const backedUp = path.join(
-			tmpDir,
-			".sync-backup",
-			"sid-happy",
-			"codex",
-			"skills",
-			"skill-a",
-			"SKILL.md",
-		);
+		const backedUp = path.join(backupDest("happy"), "codex", "skills", "skill-a", "SKILL.md");
 		expect(await fs.readFile(backedUp, "utf-8")).toBe("# skill-a\n");
 	});
 
@@ -1188,7 +1188,7 @@ describe("cleanupCodexSkillsFossil", () => {
 		await fs.mkdir(newPath("foo"), { recursive: true });
 		await fs.writeFile(newPath("foo", "SKILL.md"), "See .claude/scripts/run.sh for details.\n");
 
-		await cleanupCodexSkillsFossil(tmpDir, "sid-drift", false, new Set(["foo"]));
+		await cleanupCodexSkillsFossil(tmpDir, backupDest("drift"), false, new Set(["foo"]));
 
 		expect(await pathExists(fossilPath("foo"))).toBe(false);
 	});
@@ -1201,12 +1201,10 @@ describe("cleanupCodexSkillsFossil", () => {
 		// Positive control: prove the fixture actually exists before the call.
 		expect(await pathExists(fossilPath(".system"))).toBe(true);
 
-		await cleanupCodexSkillsFossil(tmpDir, "sid-foreign", false, new Set());
+		await cleanupCodexSkillsFossil(tmpDir, backupDest("foreign"), false, new Set());
 
 		expect(await pathExists(fossilPath(".system"))).toBe(true);
-		expect(await fs.readFile(fossilPath(".system", "note.txt"), "utf-8")).toBe(
-			"not OMT-managed\n",
-		);
+		expect(await fs.readFile(fossilPath(".system", "note.txt"), "utf-8")).toBe("not OMT-managed\n");
 		expect(await pathExists(path.join(tmpDir, ".codex", "skills"))).toBe(true);
 	});
 
@@ -1222,21 +1220,15 @@ describe("cleanupCodexSkillsFossil", () => {
 		await fs.mkdir(fossilPath(".system"), { recursive: true });
 		await fs.writeFile(fossilPath(".system", "note.txt"), "not OMT-managed\n");
 		await fs.mkdir(fossilPath("plannotator-compound"), { recursive: true });
-		await fs.writeFile(
-			fossilPath("plannotator-compound", "SKILL.md"),
-			"not OMT-managed either\n",
-		);
+		await fs.writeFile(fossilPath("plannotator-compound", "SKILL.md"), "not OMT-managed either\n");
 		await fs.mkdir(newPath("plannotator-compound"), { recursive: true });
-		await fs.writeFile(
-			newPath("plannotator-compound", "SKILL.md"),
-			"not OMT-managed either\n",
-		);
+		await fs.writeFile(newPath("plannotator-compound", "SKILL.md"), "not OMT-managed either\n");
 
-		await cleanupCodexSkillsFossil(tmpDir, "sid-foreign-by-name", false, new Set());
+		await cleanupCodexSkillsFossil(tmpDir, backupDest("foreign-by-name"), false, new Set());
 
 		expect(await pathExists(fossilPath(".system"))).toBe(true);
 		expect(await pathExists(fossilPath("plannotator-compound"))).toBe(true);
-		expect(await pathExists(path.join(tmpDir, ".sync-backup"))).toBe(false);
+		expect(await pathExists(backupDest("foreign-by-name"))).toBe(false);
 	});
 
 	it("ownedSkillNames empty: nothing removed, no backup written, no throw", async () => {
@@ -1249,10 +1241,10 @@ describe("cleanupCodexSkillsFossil", () => {
 		await fs.mkdir(newPath("skill-j"), { recursive: true });
 		await fs.writeFile(newPath("skill-j", "SKILL.md"), "j\n");
 
-		await cleanupCodexSkillsFossil(tmpDir, "sid-empty-owned", false, new Set());
+		await cleanupCodexSkillsFossil(tmpDir, backupDest("empty-owned"), false, new Set());
 
 		expect(await pathExists(fossilPath("skill-j"))).toBe(true);
-		expect(await pathExists(path.join(tmpDir, ".sync-backup"))).toBe(false);
+		expect(await pathExists(backupDest("empty-owned"))).toBe(false);
 		expect(await pathExists(path.join(tmpDir, ".codex", "skills"))).toBe(true);
 	});
 
@@ -1262,7 +1254,7 @@ describe("cleanupCodexSkillsFossil", () => {
 		// .agents/skills intentionally never created.
 
 		await expect(
-			cleanupCodexSkillsFossil(tmpDir, "sid-no-newdir", false, new Set(["skill-d"])),
+			cleanupCodexSkillsFossil(tmpDir, backupDest("no-newdir"), false, new Set(["skill-d"])),
 		).rejects.toThrow(/\.agents.*skills.*\.codex.*skills|\.codex.*skills.*\.agents.*skills/s);
 
 		expect(await pathExists(fossilPath("skill-d"))).toBe(true);
@@ -1274,11 +1266,11 @@ describe("cleanupCodexSkillsFossil", () => {
 		// .agents/skills intentionally never created — this is the fresh-target
 		// first-dry-run scenario: dry-run writes nothing, so it can never exist yet.
 
-		await cleanupCodexSkillsFossil(tmpDir, "sid-dry-no-newdir", true, new Set(["skill-g"]));
+		await cleanupCodexSkillsFossil(tmpDir, backupDest("dry-no-newdir"), true, new Set(["skill-g"]));
 
 		expect(await pathExists(fossilPath("skill-g"))).toBe(true);
 		expect(await fs.readFile(fossilPath("skill-g", "SKILL.md"), "utf-8")).toBe("g\n");
-		expect(await pathExists(path.join(tmpDir, ".sync-backup"))).toBe(false);
+		expect(await pathExists(backupDest("dry-no-newdir"))).toBe(false);
 	});
 
 	it("does NOT throw in dry-run when .agents/skills exists but only holds a foreign resident, leaving the owned fossil entry untouched", async () => {
@@ -1290,20 +1282,14 @@ describe("cleanupCodexSkillsFossil", () => {
 		await fs.mkdir(fossilPath("skill-x"), { recursive: true });
 		await fs.writeFile(fossilPath("skill-x", "SKILL.md"), "x\n");
 		await fs.mkdir(fossilPath("plannotator-compound"), { recursive: true });
-		await fs.writeFile(
-			fossilPath("plannotator-compound", "SKILL.md"),
-			"not OMT-managed\n",
-		);
+		await fs.writeFile(fossilPath("plannotator-compound", "SKILL.md"), "not OMT-managed\n");
 		await fs.mkdir(newPath("plannotator-compound"), { recursive: true });
-		await fs.writeFile(
-			newPath("plannotator-compound", "SKILL.md"),
-			"not OMT-managed\n",
-		);
+		await fs.writeFile(newPath("plannotator-compound", "SKILL.md"), "not OMT-managed\n");
 		// newPath("skill-x") intentionally never created.
 
 		await cleanupCodexSkillsFossil(
 			tmpDir,
-			"sid-dry-newdir-exists",
+			backupDest("dry-newdir-exists"),
 			true,
 			new Set(["skill-x"]),
 		);
@@ -1311,7 +1297,7 @@ describe("cleanupCodexSkillsFossil", () => {
 		expect(await pathExists(fossilPath("skill-x"))).toBe(true);
 		expect(await fs.readFile(fossilPath("skill-x", "SKILL.md"), "utf-8")).toBe("x\n");
 		expect(await pathExists(fossilPath("plannotator-compound"))).toBe(true);
-		expect(await pathExists(path.join(tmpDir, ".sync-backup"))).toBe(false);
+		expect(await pathExists(backupDest("dry-newdir-exists"))).toBe(false);
 	});
 
 	it("throws naming the entry, deletes nothing, and writes no backup when an owned entry has no counterpart under .agents/skills", async () => {
@@ -1323,11 +1309,16 @@ describe("cleanupCodexSkillsFossil", () => {
 		// no such directory actually exists under .agents/skills.
 
 		await expect(
-			cleanupCodexSkillsFossil(tmpDir, "sid-missing-counterpart", false, new Set(["skill-h"])),
+			cleanupCodexSkillsFossil(
+				tmpDir,
+				backupDest("missing-counterpart"),
+				false,
+				new Set(["skill-h"]),
+			),
 		).rejects.toThrow(/skill-h/);
 
 		expect(await pathExists(fossilPath("skill-h"))).toBe(true);
-		expect(await pathExists(path.join(tmpDir, ".sync-backup"))).toBe(false);
+		expect(await pathExists(backupDest("missing-counterpart"))).toBe(false);
 	});
 
 	it("does NOT throw under dry-run when an owned entry has no counterpart under .agents/skills — the counterpart check is real-run-only", async () => {
@@ -1340,10 +1331,15 @@ describe("cleanupCodexSkillsFossil", () => {
 		await fs.mkdir(newPath(), { recursive: true });
 		// newPath("skill-i") intentionally never created.
 
-		await cleanupCodexSkillsFossil(tmpDir, "sid-dry-missing-counterpart", true, new Set(["skill-i"]));
+		await cleanupCodexSkillsFossil(
+			tmpDir,
+			backupDest("dry-missing-counterpart"),
+			true,
+			new Set(["skill-i"]),
+		);
 
 		expect(await pathExists(fossilPath("skill-i"))).toBe(true);
-		expect(await pathExists(path.join(tmpDir, ".sync-backup"))).toBe(false);
+		expect(await pathExists(backupDest("dry-missing-counterpart"))).toBe(false);
 	});
 
 	it("dry-run deletes nothing and writes no backup", async () => {
@@ -1352,17 +1348,17 @@ describe("cleanupCodexSkillsFossil", () => {
 		await fs.mkdir(newPath("skill-e"), { recursive: true });
 		await fs.writeFile(newPath("skill-e", "SKILL.md"), "e\n");
 
-		await cleanupCodexSkillsFossil(tmpDir, "sid-dry", true, new Set(["skill-e"]));
+		await cleanupCodexSkillsFossil(tmpDir, backupDest("dry"), true, new Set(["skill-e"]));
 
 		expect(await pathExists(fossilPath("skill-e"))).toBe(true);
-		expect(await pathExists(path.join(tmpDir, ".sync-backup"))).toBe(false);
+		expect(await pathExists(backupDest("dry"))).toBe(false);
 	});
 
 	it("returns silently (no throw) when the fossil directory is absent, and is idempotent on a repeat call", async () => {
 		// No .codex/skills at all, and no .agents/skills either — must still
 		// short-circuit BEFORE the newDir-must-exist check.
-		await cleanupCodexSkillsFossil(tmpDir, "sid-absent-1", false, new Set());
-		await cleanupCodexSkillsFossil(tmpDir, "sid-absent-2", false, new Set());
+		await cleanupCodexSkillsFossil(tmpDir, backupDest("absent-1"), false, new Set());
+		await cleanupCodexSkillsFossil(tmpDir, backupDest("absent-2"), false, new Set());
 
 		expect(await pathExists(path.join(tmpDir, ".codex"))).toBe(false);
 	});
@@ -1373,11 +1369,11 @@ describe("cleanupCodexSkillsFossil", () => {
 		await fs.mkdir(newPath("skill-f"), { recursive: true });
 		await fs.writeFile(newPath("skill-f", "SKILL.md"), "f\n");
 
-		await cleanupCodexSkillsFossil(tmpDir, "sid-idem-1", false, new Set(["skill-f"]));
+		await cleanupCodexSkillsFossil(tmpDir, backupDest("idem-1"), false, new Set(["skill-f"]));
 		expect(await pathExists(path.join(tmpDir, ".codex", "skills"))).toBe(false);
 
 		// Second call: fossilDir is gone, so this must return silently.
-		await cleanupCodexSkillsFossil(tmpDir, "sid-idem-2", false, new Set(["skill-f"]));
+		await cleanupCodexSkillsFossil(tmpDir, backupDest("idem-2"), false, new Set(["skill-f"]));
 		expect(await pathExists(path.join(tmpDir, ".codex", "skills"))).toBe(false);
 	});
 });

--- a/tools/adapters/codex.ts
+++ b/tools/adapters/codex.ts
@@ -191,7 +191,7 @@ export function codexSkillsDir(targetPath: string): string {
  */
 export async function cleanupCodexSkillsFossil(
 	deployRoot: string,
-	backupSession: string,
+	backupDest: string,
 	dryRun: boolean,
 	ownedSkillNames: ReadonlySet<string>,
 ): Promise<void> {
@@ -251,7 +251,7 @@ export async function cleanupCodexSkillsFossil(
 		return; // nothing OMT-owned to remove (fossil holds only foreign residents)
 	}
 
-	await backupCategory(deployRoot, "codex", "skills", backupSession);
+	await backupCategory(deployRoot, "codex", "skills", backupDest);
 
 	for (const name of omtOwned) {
 		await fs.rm(path.join(fossilDir, name), { recursive: true, force: true });

--- a/tools/adapters/types.ts
+++ b/tools/adapters/types.ts
@@ -93,6 +93,8 @@ export interface PlatformAdapter {
 
 	/**
 	 * Optional: prepare a category target directory before sync (e.g., backup).
+	 * `backupDest` is the absolute per-deploy backup destination directory
+	 * (not a session id).
 	 */
-	prepareCategory?(targetPath: string, category: string, backupSession: string): Promise<void>;
+	prepareCategory?(targetPath: string, category: string, backupDest: string): Promise<void>;
 }

--- a/tools/lib/backup.test.ts
+++ b/tools/lib/backup.test.ts
@@ -9,6 +9,7 @@ import {
 	chmod,
 	symlink,
 	utimes,
+	realpath,
 } from "node:fs/promises";
 import * as os from "node:os";
 import { tmpdir } from "node:os";
@@ -75,6 +76,15 @@ describe("backup 모듈", () => {
 			expect(isSafeBackupRoot("/")).toBe(false);
 			expect(isSafeBackupRoot(os.homedir())).toBe(false);
 			expect(isSafeBackupRoot("/tmp/omt-xyz")).toBe(true);
+		});
+
+		it("isSafeBackupRoot rejects a case-variant of homedir (F1: APFS is case-insensitive)", () => {
+			const homedirSpy = spyOn(os, "homedir").mockReturnValue("/Users/Test");
+			try {
+				expect(isSafeBackupRoot("/users/test")).toBe(false);
+			} finally {
+				homedirSpy.mockRestore();
+			}
 		});
 	});
 
@@ -476,6 +486,39 @@ describe("backup 모듈", () => {
 			const preciousStats = await stat(precious);
 			expect(preciousStats.isFile()).toBe(true);
 			expect(captured).toContain(join(base, "sync-backup"));
+		});
+
+		it("cleanupOldBackups refuses when <base> itself is a symlink to homedir (F2)", async () => {
+			// The existing symlink guard above only lstats <base>/sync-backup
+			// (the last path component). If <base> ITSELF is a symlink (e.g.
+			// `~/.omt` pointed at another volume), that lstat transparently
+			// follows the intermediate symlink and never notices — this test
+			// plants a base that symlinks straight at (a faked) homedir.
+			// Resolve once up front: os.homedir() is compared against a
+			// realpath()'d base in the fix under test, and on macOS tmpdir()
+			// sits under /var, itself a symlink to /private/var — mocking the
+			// raw (unresolved) path here would make the two never match for
+			// reasons unrelated to F2. A real $HOME is already canonical.
+			const fakeHome = await realpath(await mkdtemp(join(tmpdir(), "omt-backup-f2-home-")));
+			const homedirSpy = spyOn(os, "homedir").mockReturnValue(fakeHome);
+			try {
+				const agedDir = join(fakeHome, "sync-backup", "aged");
+				await mkdir(agedDir, { recursive: true });
+				const precious = join(agedDir, "PRECIOUS.txt");
+				await writeFile(precious, "do not delete");
+				await ageDir(agedDir);
+
+				const linkParent = await mkdtemp(join(tmpdir(), "omt-backup-f2-linkparent-"));
+				const base = join(linkParent, "base-symlink");
+				await symlink(fakeHome, base);
+
+				await cleanupOldBackups(base, 3);
+
+				const preciousStats = await stat(precious);
+				expect(preciousStats.isFile()).toBe(true);
+			} finally {
+				homedirSpy.mockRestore();
+			}
 		});
 	});
 });

--- a/tools/lib/backup.test.ts
+++ b/tools/lib/backup.test.ts
@@ -1,5 +1,16 @@
-import { describe, it, expect, beforeAll, afterAll } from "bun:test";
-import { mkdtemp, mkdir, writeFile, readFile, readdir, stat, chmod } from "node:fs/promises";
+import { describe, it, expect, beforeAll, afterAll, spyOn } from "bun:test";
+import {
+	mkdtemp,
+	mkdir,
+	writeFile,
+	readFile,
+	readdir,
+	stat,
+	chmod,
+	symlink,
+	utimes,
+} from "node:fs/promises";
+import * as os from "node:os";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -9,7 +20,30 @@ import {
 	backupConfigFile,
 	backupDocs,
 	cleanupOldBackups,
+	isSafeBackupRoot,
 } from "./backup.ts";
+
+/** Sets a directory's mtime far enough in the past to clear any retention window used in these tests. */
+async function ageDir(dirPath: string): Promise<void> {
+	const past = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+	await utimes(dirPath, past, past);
+}
+
+/** Captures process.stderr.write output for the duration of `fn`, restoring it afterward. */
+async function captureStderr(fn: () => Promise<void>): Promise<string> {
+	const original = process.stderr.write.bind(process.stderr);
+	let captured = "";
+	process.stderr.write = ((chunk: string | Uint8Array) => {
+		captured += chunk.toString();
+		return true;
+	}) as typeof process.stderr.write;
+	try {
+		await fn();
+	} finally {
+		process.stderr.write = original;
+	}
+	return captured;
+}
 
 describe("backup 모듈", () => {
 	let tmpDir: string;
@@ -32,6 +66,15 @@ describe("backup 모듈", () => {
 		it("generates a unique value on each call", () => {
 			const ids = new Set(Array.from({ length: 20 }, () => generateBackupSessionId()));
 			expect(ids.size).toBe(20);
+		});
+	});
+
+	describe("isSafeBackupRoot", () => {
+		it("isSafeBackupRoot rejects non-absolute, root, and homedir bases", () => {
+			expect(isSafeBackupRoot("./x")).toBe(false);
+			expect(isSafeBackupRoot("/")).toBe(false);
+			expect(isSafeBackupRoot(os.homedir())).toBe(false);
+			expect(isSafeBackupRoot("/tmp/omt-xyz")).toBe(true);
 		});
 	});
 
@@ -231,25 +274,28 @@ describe("backup 모듈", () => {
 		});
 
 		it("docs backup retention: cleanupOldBackups(deployRoot, 0) removes the docs session dir", async () => {
+			// cleanupOldBackups now prunes the dotless <base>/sync-backup/ root
+			// (see cleanupOldBackups's own repointing). backupDocs itself still
+			// writes to the dotted .sync-backup/ (that writer relocation is a
+			// later story) so this test plants directly under the new root
+			// instead of relying on backupDocs's output — that is the new
+			// contract the pruner is tested against.
 			const deployRoot = join(tmpDir, "docs-backup-retention");
 			const sessionId = "docs-sess-retention";
-			const relPath = "readme.md";
-			const targetFilePath = join(deployRoot, relPath);
 
-			await mkdir(deployRoot, { recursive: true });
-			await writeFile(targetFilePath, "content");
-
-			await backupDocs(targetFilePath, deployRoot, sessionId);
+			const sessDocsDir = join(deployRoot, "sync-backup", sessionId, "docs");
+			await mkdir(sessDocsDir, { recursive: true });
+			await writeFile(join(sessDocsDir, "readme.md"), "content");
 
 			await cleanupOldBackups(deployRoot, 0);
 
-			const remaining = await readdir(join(deployRoot, ".sync-backup"));
+			const remaining = await readdir(join(deployRoot, "sync-backup"));
 			expect(remaining).toHaveLength(0);
 		});
 	});
 
 	describe("cleanupOldBackups", () => {
-		it("does nothing when .sync-backup directory does not exist", async () => {
+		it("does nothing when sync-backup directory does not exist", async () => {
 			const targetPath = join(tmpDir, "cleanup-no-dir");
 			await mkdir(targetPath, { recursive: true });
 
@@ -259,7 +305,7 @@ describe("backup 모듈", () => {
 
 		it("deletes all session directories when retentionDays is 0", async () => {
 			const targetPath = join(tmpDir, "cleanup-zero");
-			const backupDir = join(targetPath, ".sync-backup");
+			const backupDir = join(targetPath, "sync-backup");
 
 			for (const session of ["sess-a", "sess-b", "sess-c"]) {
 				await mkdir(join(backupDir, session), { recursive: true });
@@ -274,7 +320,7 @@ describe("backup 모듈", () => {
 
 		it("preserves sessions within retentionDays", async () => {
 			const targetPath = join(tmpDir, "cleanup-retain");
-			const backupDir = join(targetPath, ".sync-backup");
+			const backupDir = join(targetPath, "sync-backup");
 
 			// Create a session directory (mtime = now)
 			const recentSession = join(backupDir, "recent-sess");
@@ -289,10 +335,10 @@ describe("backup 모듈", () => {
 
 		it("leaves plain files (non-directories) untouched", async () => {
 			const targetPath = join(tmpDir, "cleanup-files");
-			const backupDir = join(targetPath, ".sync-backup");
+			const backupDir = join(targetPath, "sync-backup");
 			await mkdir(backupDir, { recursive: true });
 
-			// Place a plain file in .sync-backup (not a directory)
+			// Place a plain file in sync-backup (not a directory)
 			const orphanFile = join(backupDir, "orphan.txt");
 			await writeFile(orphanFile, "stray");
 
@@ -305,7 +351,7 @@ describe("backup 모듈", () => {
 
 		it("does not throw and processes all entries when rm() fails on some", async () => {
 			const targetPath = join(tmpDir, "cleanup-rm-fail");
-			const backupDir = join(targetPath, ".sync-backup");
+			const backupDir = join(targetPath, "sync-backup");
 
 			// Create three session directories to delete (retentionDays=0)
 			for (const name of ["sess-rm-a", "sess-rm-b", "sess-rm-c"]) {
@@ -314,7 +360,7 @@ describe("backup 모듈", () => {
 				await writeFile(join(sessDir, "file.txt"), "data");
 			}
 
-			// Remove write permission from .sync-backup so all rm() calls fail
+			// Remove write permission from sync-backup so all rm() calls fail
 			// (deleting a child entry requires write on the parent directory)
 			await chmod(backupDir, 0o555);
 
@@ -329,6 +375,104 @@ describe("backup 모듈", () => {
 			// ran through all entries without aborting on the first failure
 			const remaining = await readdir(backupDir);
 			expect(remaining).toHaveLength(3);
+		});
+
+		it("cleanupOldBackups prunes the backup root by age", async () => {
+			const base = join(tmpDir, "cleanup-age-prune-dotless");
+			const backupDir = join(base, "sync-backup");
+
+			const agedDir = join(backupDir, "aged-sess");
+			await mkdir(agedDir, { recursive: true });
+			await ageDir(agedDir);
+
+			const freshDir = join(backupDir, "fresh-sess");
+			await mkdir(freshDir, { recursive: true });
+
+			await cleanupOldBackups(base, 3);
+
+			const remaining = await readdir(backupDir);
+			expect(remaining).not.toContain("aged-sess");
+			expect(remaining).toContain("fresh-sess");
+		});
+
+		it("cleanupOldBackups no-ops when root absent", async () => {
+			const base = join(tmpDir, "cleanup-root-absent-dotless");
+			await mkdir(base, { recursive: true });
+
+			await expect(cleanupOldBackups(base, 7)).resolves.toBeUndefined();
+		});
+
+		it("cleanupOldBackups refuses a relative base and deletes nothing", async () => {
+			const cwdBefore = process.cwd();
+			const relTmpParent = await mkdtemp(join(tmpdir(), "omt-backup-relbase-"));
+			process.chdir(relTmpParent);
+			try {
+				const agedDir = join(".", "x", "sync-backup", "aged-sess");
+				await mkdir(agedDir, { recursive: true });
+				const sentinel = join(agedDir, "sentinel.txt");
+				await writeFile(sentinel, "precious");
+				await ageDir(agedDir);
+
+				await cleanupOldBackups("./x", 3);
+
+				const dirStats = await stat(agedDir);
+				expect(dirStats.isDirectory()).toBe(true);
+				const fileStats = await stat(sentinel);
+				expect(fileStats.isFile()).toBe(true);
+			} finally {
+				process.chdir(cwdBefore);
+			}
+		});
+
+		it("cleanupOldBackups refuses a homedir base and deletes nothing", async () => {
+			const fakeHome = await mkdtemp(join(tmpdir(), "omt-backup-homedir-"));
+			const homedirSpy = spyOn(os, "homedir").mockReturnValue(fakeHome);
+			try {
+				const agedDir = join(fakeHome, "sync-backup", "aged-sess");
+				await mkdir(agedDir, { recursive: true });
+				const sentinel = join(agedDir, "sentinel.txt");
+				await writeFile(sentinel, "precious");
+				await ageDir(agedDir);
+
+				await cleanupOldBackups(fakeHome, 3);
+
+				const dirStats = await stat(agedDir);
+				expect(dirStats.isDirectory()).toBe(true);
+				const fileStats = await stat(sentinel);
+				expect(fileStats.isFile()).toBe(true);
+			} finally {
+				homedirSpy.mockRestore();
+			}
+		});
+
+		it("unsafe backup root emits logError", async () => {
+			const refusedBase = "./relative-unsafe-base";
+			const captured = await captureStderr(async () => {
+				await cleanupOldBackups(refusedBase, 3);
+			});
+
+			expect(captured).toContain(refusedBase);
+			expect(captured.toLowerCase()).toContain("error");
+		});
+
+		it("cleanupOldBackups refuses a symlinked backup root and deletes nothing", async () => {
+			const base = await mkdtemp(join(tmpdir(), "omt-backup-symlink-base-"));
+			const victim = await mkdtemp(join(tmpdir(), "omt-backup-symlink-victim-"));
+			const agedDir = join(victim, "aged");
+			await mkdir(agedDir, { recursive: true });
+			const precious = join(agedDir, "PRECIOUS.txt");
+			await writeFile(precious, "do not delete");
+			await ageDir(agedDir);
+
+			await symlink(victim, join(base, "sync-backup"));
+
+			const captured = await captureStderr(async () => {
+				await cleanupOldBackups(base, 3);
+			});
+
+			const preciousStats = await stat(precious);
+			expect(preciousStats.isFile()).toBe(true);
+			expect(captured).toContain(join(base, "sync-backup"));
 		});
 	});
 });

--- a/tools/lib/backup.test.ts
+++ b/tools/lib/backup.test.ts
@@ -79,11 +79,11 @@ describe("backup 모듈", () => {
 	});
 
 	describe("backupCategory", () => {
-		it("copies source directory to .sync-backup/{sessionId}/{platform}/{category}/", async () => {
+		it("copies source directory to {backupDest}/{platform}/{category}/", async () => {
 			const targetPath = join(tmpDir, "backup-category-basic");
 			const platform = "claude";
 			const category = "agents";
-			const sessionId = "test-session-01";
+			const backupDest = join(tmpDir, "backup-category-basic-dest");
 
 			// Create source files
 			const sourceDir = join(targetPath, `.${platform}`, category);
@@ -91,9 +91,9 @@ describe("backup 모듈", () => {
 			await writeFile(join(sourceDir, "oracle.md"), "# Oracle");
 			await writeFile(join(sourceDir, "sisyphus.md"), "# Sisyphus");
 
-			await backupCategory(targetPath, platform, category, sessionId);
+			await backupCategory(targetPath, platform, category, backupDest);
 
-			const destDir = join(targetPath, ".sync-backup", sessionId, platform, category);
+			const destDir = join(backupDest, platform, category);
 			const files = await readdir(destDir);
 			expect(files).toContain("oracle.md");
 			expect(files).toContain("sisyphus.md");
@@ -102,14 +102,15 @@ describe("backup 모듈", () => {
 		it("does nothing when source directory is missing", async () => {
 			const targetPath = join(tmpDir, "backup-category-missing");
 			await mkdir(targetPath, { recursive: true });
+			const backupDest = join(tmpDir, "backup-category-missing-dest");
 
 			// Should not throw
-			await backupCategory(targetPath, "claude", "skills", "sess-missing");
+			await backupCategory(targetPath, "claude", "skills", backupDest);
 
-			// No .sync-backup directory should be created
+			// No backup destination directory should be created
 			let exists = true;
 			try {
-				await stat(join(targetPath, ".sync-backup"));
+				await stat(backupDest);
 			} catch {
 				exists = false;
 			}
@@ -120,31 +121,31 @@ describe("backup 모듈", () => {
 			const targetPath = join(tmpDir, "backup-category-deep");
 			const platform = "gemini";
 			const category = "commands";
-			const sessionId = "deep-sess";
+			const backupDest = join(tmpDir, "backup-category-deep-dest");
 
 			const sourceDir = join(targetPath, `.${platform}`, category);
 			await mkdir(sourceDir, { recursive: true });
 			await writeFile(join(sourceDir, "cmd.md"), "# cmd");
 
-			await backupCategory(targetPath, platform, category, sessionId);
+			await backupCategory(targetPath, platform, category, backupDest);
 
-			const destDir = join(targetPath, ".sync-backup", sessionId, platform, category);
+			const destDir = join(backupDest, platform, category);
 			const files = await readdir(destDir);
 			expect(files).toContain("cmd.md");
 		});
 
 		it("selects the correct dot-directory for each platform", async () => {
 			const targetPath = join(tmpDir, "backup-category-platform");
-			const sessionId = "platform-sess";
+			const backupDest = join(tmpDir, "backup-category-platform-dest");
 
 			for (const platform of ["claude", "gemini", "codex"]) {
 				const sourceDir = join(targetPath, `.${platform}`, "skills");
 				await mkdir(sourceDir, { recursive: true });
 				await writeFile(join(sourceDir, `${platform}.md`), `# ${platform}`);
 
-				await backupCategory(targetPath, platform, "skills", sessionId);
+				await backupCategory(targetPath, platform, "skills", backupDest);
 
-				const destDir = join(targetPath, ".sync-backup", sessionId, platform, "skills");
+				const destDir = join(backupDest, platform, "skills");
 				const files = await readdir(destDir);
 				expect(files).toContain(`${platform}.md`);
 			}
@@ -154,6 +155,7 @@ describe("backup 모듈", () => {
 			const targetPath = join(tmpDir, "backup-category-eacces");
 			const platformDir = join(targetPath, ".claude");
 			await mkdir(platformDir, { recursive: true });
+			const backupDest = join(tmpDir, "backup-category-eacces-dest");
 
 			// Remove execute permission on the platform directory so stat of its
 			// children returns EACCES (code !== "ENOENT") → must rethrow
@@ -161,7 +163,7 @@ describe("backup 모듈", () => {
 
 			try {
 				await expect(
-					backupCategory(targetPath, "claude", "agents", "sess-eacces"),
+					backupCategory(targetPath, "claude", "agents", backupDest),
 				).rejects.toThrow();
 			} finally {
 				await chmod(platformDir, 0o755);
@@ -239,18 +241,18 @@ describe("backup 모듈", () => {
 	});
 
 	describe("backupDocs", () => {
-		it("docs backup before mutate: copies the target file into .sync-backup/{sessionId}/docs/<relpath> preserving subdirectories", async () => {
+		it("docs backup before mutate: copies the target file into {backupDest}/docs/<relpath> preserving subdirectories", async () => {
 			const deployRoot = join(tmpDir, "docs-backup-basic");
-			const sessionId = "docs-sess-01";
+			const backupDest = join(tmpDir, "docs-backup-basic-dest");
 			const relPath = join("skills", "prometheus", "SKILL.md");
 			const targetFilePath = join(deployRoot, relPath);
 
 			await mkdir(join(deployRoot, "skills", "prometheus"), { recursive: true });
 			await writeFile(targetFilePath, "# Original content");
 
-			await backupDocs(targetFilePath, deployRoot, sessionId);
+			await backupDocs(targetFilePath, deployRoot, backupDest);
 
-			const backedUpFile = join(deployRoot, ".sync-backup", sessionId, "docs", relPath);
+			const backedUpFile = join(backupDest, "docs", relPath);
 			const content = await readFile(backedUpFile, "utf-8");
 			expect(content).toBe("# Original content");
 		});
@@ -259,14 +261,15 @@ describe("backup 모듈", () => {
 			const deployRoot = join(tmpDir, "docs-backup-missing");
 			await mkdir(deployRoot, { recursive: true });
 			const targetFilePath = join(deployRoot, "docs", "new-file.md");
+			const backupDest = join(tmpDir, "docs-backup-missing-dest");
 
 			// Should not throw
-			await backupDocs(targetFilePath, deployRoot, "docs-sess-missing");
+			await backupDocs(targetFilePath, deployRoot, backupDest);
 
-			// No .sync-backup directory should be created
+			// No backup destination directory should be created
 			let exists = true;
 			try {
-				await stat(join(deployRoot, ".sync-backup"));
+				await stat(backupDest);
 			} catch {
 				exists = false;
 			}

--- a/tools/lib/backup.ts
+++ b/tools/lib/backup.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { cp, mkdir, rm, readdir, stat, lstat } from "node:fs/promises";
+import { cp, mkdir, rm, readdir, stat, lstat, realpath } from "node:fs/promises";
 // `os` is imported as a namespace (not `{ homedir }`) so tests can
 // `spyOn(os, "homedir")` and have the override observed here — a named
 // import binds the value at import time and a spy on the module's own
@@ -108,7 +108,14 @@ export function isSafeBackupRoot(base: string): boolean {
 		return false;
 	}
 	const resolved = resolve(base);
-	if (resolved === "/" || resolved === os.homedir()) {
+	const home = os.homedir();
+	// F1: case-fold the exact-homedir comparison only (not "under home") —
+	// macOS APFS is case-insensitive by default, so "/users/x" and "/Users/x"
+	// can be the same inode even though they differ as strings. On a
+	// case-sensitive filesystem this may false-reject a distinct path that
+	// happens to case-fold-match home; that's fail-closed (cleanup skipped),
+	// which is safe.
+	if (resolved === "/" || resolved.toLowerCase() === home.toLowerCase()) {
 		return false;
 	}
 	return true;
@@ -131,6 +138,24 @@ export async function cleanupOldBackups(base: string, retentionDays: number): Pr
 	// this asymmetry by switching to throw.
 	if (!isSafeBackupRoot(base)) {
 		logError(`안전하지 않은 백업 루트, 정리를 건너뜁니다: ${base}`);
+		return;
+	}
+
+	// F2: <base> itself may be a symlink (e.g. `~/.omt` pointed at another
+	// volume). The lstat guard below only inspects the final `sync-backup`
+	// path component, so a symlinked base transparently resolves through it
+	// and is never caught. Re-validate against base's real path first.
+	let realBase = base;
+	try {
+		realBase = await realpath(base);
+	} catch (err) {
+		if (!isErrnoException(err) || err.code !== "ENOENT") {
+			throw err;
+		}
+		// base doesn't exist yet — can't be a symlink, fall through.
+	}
+	if (!isSafeBackupRoot(realBase)) {
+		logError(`안전하지 않은 백업 루트(실제 경로), 정리를 건너뜁니다: ${realBase}`);
 		return;
 	}
 

--- a/tools/lib/backup.ts
+++ b/tools/lib/backup.ts
@@ -1,7 +1,12 @@
 import { randomBytes } from "node:crypto";
-import { cp, mkdir, rm, readdir, stat } from "node:fs/promises";
-import { dirname, join, relative } from "node:path";
-import { logWarn } from "./logger.ts";
+import { cp, mkdir, rm, readdir, stat, lstat } from "node:fs/promises";
+// `os` is imported as a namespace (not `{ homedir }`) so tests can
+// `spyOn(os, "homedir")` and have the override observed here — a named
+// import binds the value at import time and a spy on the module's own
+// export would not be seen through this module's binding.
+import * as os from "node:os";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { logError, logWarn } from "./logger.ts";
 
 /**
  * Generates a random hex session ID for backup directories.
@@ -90,12 +95,58 @@ export async function backupDocs(
 }
 
 /**
- * Removes session directories under {targetPath}/.sync-backup/ that are
+ * Pure predicate for cleanupOldBackups: false iff `base` is a degenerate
+ * root that would make the recursive prune below far more destructive than
+ * intended (a relative path resolved against an unexpected cwd, "/", or the
+ * user's home directory). Bases merely *near* home (e.g. "/Users",
+ * "$HOME/Documents") are deliberately NOT rejected — this targets only the
+ * three degenerate cases, since OMT_DIR is a user-owned value.
+ * No fs access, no env reads, no logging — pure string/path logic only.
+ */
+export function isSafeBackupRoot(base: string): boolean {
+	if (!isAbsolute(base)) {
+		return false;
+	}
+	const resolved = resolve(base);
+	if (resolved === "/" || resolved === os.homedir()) {
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Removes session directories under {base}/sync-backup/ that are
  * older than retentionDays based on directory modification time.
  * If retentionDays is 0, all session directories are removed.
  */
-export async function cleanupOldBackups(targetPath: string, retentionDays: number): Promise<void> {
-	const backupDir = join(targetPath, ".sync-backup");
+export async function cleanupOldBackups(base: string, retentionDays: number): Promise<void> {
+	const backupDir = join(base, "sync-backup");
+
+	// Both guards below MUST log-and-return, never throw. The sole caller
+	// (tools/sync.ts:2083) wraps this call in `.catch(() => {})`, so a thrown
+	// error here would be silently swallowed in production — the guard would
+	// be disarmed at exactly the moment it matters, while a test asserting on
+	// a rejection would stay green and hide the regression. logError + return
+	// keeps the refusal visible on stderr in both environments. Do not "fix"
+	// this asymmetry by switching to throw.
+	if (!isSafeBackupRoot(base)) {
+		logError(`안전하지 않은 백업 루트, 정리를 건너뜁니다: ${base}`);
+		return;
+	}
+
+	try {
+		const backupDirLstat = await lstat(backupDir);
+		if (backupDirLstat.isSymbolicLink()) {
+			logError(`백업 루트가 심볼릭 링크입니다, 정리를 건너뜁니다: ${backupDir}`);
+			return;
+		}
+	} catch (err) {
+		if (!isErrnoException(err) || err.code !== "ENOENT") {
+			throw err;
+		}
+		// No sync-backup dir yet — not a symlink. Fall through; the stat()
+		// below hits the same ENOENT and no-ops as before.
+	}
 
 	try {
 		await stat(backupDir);

--- a/tools/lib/backup.ts
+++ b/tools/lib/backup.ts
@@ -26,14 +26,14 @@ function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
 /**
  * Backs up a single category directory from a platform's dot-directory.
  * Source: {targetPath}/.{platform}/{category}/
- * Destination: {targetPath}/.sync-backup/{sessionId}/{platform}/{category}/
+ * Destination: {backupDest}/{platform}/{category}/
  * Skips silently if the source directory does not exist.
  */
 export async function backupCategory(
 	targetPath: string,
 	platform: string,
 	category: string,
-	sessionId: string,
+	backupDest: string,
 ): Promise<void> {
 	const sourceDir = join(targetPath, `.${platform}`, category);
 
@@ -46,7 +46,7 @@ export async function backupCategory(
 		throw err;
 	}
 
-	const destDir = join(targetPath, ".sync-backup", sessionId, platform, category);
+	const destDir = join(backupDest, platform, category);
 
 	await mkdir(destDir, { recursive: true });
 	await cp(sourceDir, destDir, { recursive: true });
@@ -77,7 +77,7 @@ export async function backupConfigFile(filePath: string, backupDir: string): Pro
 /**
  * Backs up a single docs target file before it is overwritten or deleted.
  * Source: targetFilePath
- * Destination: {deployRoot}/.sync-backup/{sessionId}/docs/<relpath>
+ * Destination: {backupDest}/docs/<relpath>
  *   where <relpath> is targetFilePath's path relative to deployRoot
  *   (subdirectory structure preserved).
  * Per-file only (never a directory copy), reusing backupConfigFile.
@@ -86,10 +86,10 @@ export async function backupConfigFile(filePath: string, backupDir: string): Pro
 export async function backupDocs(
 	targetFilePath: string,
 	deployRoot: string,
-	sessionId: string,
+	backupDest: string,
 ): Promise<void> {
 	const relPath = relative(deployRoot, targetFilePath);
-	const backupDir = join(deployRoot, ".sync-backup", sessionId, "docs", dirname(relPath));
+	const backupDir = join(backupDest, "docs", dirname(relPath));
 
 	await backupConfigFile(targetFilePath, backupDir);
 }

--- a/tools/lib/types.ts
+++ b/tools/lib/types.ts
@@ -85,19 +85,25 @@ export type SyncContext = {
 	projectName: string;
 	projectDir: string;
 	isRootYaml: boolean;
-	backupSession: string;
+	/**
+	 * The OMT-owned backup root for this run, resolved once via
+	 * resolveBackupBase() (run-scoped — one value for the entire sync run).
+	 * Consumed only by the retention pruner and the startup location log —
+	 * never by a writer directly.
+	 */
+	backupBase: string;
+	/**
+	 * The absolute per-deploy backup destination (<backupBase>/sync-backup/<deployId>),
+	 * reassigned once per (target, worktree) at the top of each fan-out iteration
+	 * (deploy-scoped). Consumed only by writers (backupCategory, backupDocs, and
+	 * their call sites) — never by the pruner, which only ever sees backupBase.
+	 */
+	backupDest: string;
 	modelMaps: Map<Platform, ModelMap>;
 	/** Root/global platform model-maps; loaded once, NEVER cleared by processYaml. */
 	rootModelMaps: Map<Platform, ModelMap>;
 	processedPaths: Set<string>;
 	platformYamlSections: Map<Platform, string[]>;
-	/**
-	 * Every per-worktree deploy root that received (or would receive) a backup
-	 * during the fan-out. Backup-retention cleanup iterates these so a bare
-	 * container's worktrees each get their .sync-backup pruned, not just the
-	 * container path tracked in processedPaths.
-	 */
-	backupRoots: Set<string>;
 	/**
 	 * Deploy roots whose per-worktree iteration failed (best-effort fan-out: one
 	 * failing worktree is logged and skipped, the rest continue). A non-empty set

--- a/tools/sync.e2e.test.ts
+++ b/tools/sync.e2e.test.ts
@@ -177,6 +177,34 @@ function buildFixtures(): Record<string, PlatformFixture> {
 }
 
 // ---------------------------------------------------------------------------
+// File-level OMT_DIR isolation
+//
+// `createContext()` resolves the OMT backup base via `resolveOmtDir()`,
+// which falls back to the developer's real `~/.omt/<project>` whenever
+// `OMT_DIR` is unset. Every `createContext()` call in this file (dry and
+// non-dry) must resolve to a per-test tmp dir instead — otherwise a non-dry
+// `processYaml`/`syncLib` run whose target already has deployed content
+// (e.g. the pre-planted stale skill fixture below, which exists so the sync
+// overwrites something) makes `backupCategory` (tools/lib/backup.ts:32-53)
+// write a real backup into the real OMT base.
+// ---------------------------------------------------------------------------
+
+let savedOmtDir: string | undefined;
+let omtDirTmp: string;
+
+beforeEach(async () => {
+	savedOmtDir = process.env.OMT_DIR;
+	omtDirTmp = await fs.mkdtemp(path.join(os.tmpdir(), "omt-e2e-omtdir-"));
+	process.env.OMT_DIR = omtDirTmp;
+});
+
+afterEach(async () => {
+	if (savedOmtDir === undefined) delete process.env.OMT_DIR;
+	else process.env.OMT_DIR = savedOmtDir;
+	await fs.rm(omtDirTmp, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
 // Suite: 4-platform overlay E2E
 // ---------------------------------------------------------------------------
 
@@ -568,6 +596,15 @@ describe("lib deployment complete after copy-time @lib/ rewrite (regression)", (
 				async () => ({ exitCode: 0 }),
 			),
 		);
+		// Reachability fixture: plant already-deployed skills content so the
+		// sync below overwrites it, forcing backupCategory (backup.ts:32-53) to
+		// actually copy something instead of hitting its source-absent
+		// early-return (backup.ts:40-47) against a pristine tmp target.
+		await writeFile(
+			path.join(targetPath, ".claude", "skills", "stale-skill", "SKILL.md"),
+			"stale content\n",
+		);
+
 		const context = createContext(false);
 
 		await processYaml(context, syncYamlPath, adapters, rootDir);

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -3509,6 +3509,29 @@ describe("createContext", () => {
 			fs2.rmSync(tmp, { recursive: true, force: true });
 		}
 	});
+
+	it("createContext(true) (dry-run) does not create the OMT base directory (F4)", () => {
+		const parentTmp = fs2.mkdtempSync(path.join(os.tmpdir(), "omt-dir-f4-"));
+		// A NOT-YET-EXISTING nested path — mkdir-vs-no-mkdir is only observable
+		// when the target doesn't already exist (a pre-existing tmp dir would
+		// make "not created" vacuously true).
+		const nested = path.join(parentTmp, "newly", "nested");
+		const originalOmtDir = process.env.OMT_DIR;
+		process.env.OMT_DIR = nested;
+		try {
+			createContext(true);
+			expect(fs2.existsSync(nested)).toBe(false);
+
+			// Contrast: non-dry-run DOES create it. Without this, the dry-run
+			// assertion above could pass merely because nothing ever mkdirs.
+			createContext(false);
+			expect(fs2.existsSync(nested)).toBe(true);
+		} finally {
+			if (originalOmtDir === undefined) delete process.env.OMT_DIR;
+			else process.env.OMT_DIR = originalOmtDir;
+			fs2.rmSync(parentTmp, { recursive: true, force: true });
+		}
+	});
 });
 
 describe("resolveBackupBase", () => {
@@ -5284,6 +5307,30 @@ describe("backup relocation (writer repoint + per-deploy destination)", () => {
 		await processYaml(context, syncYamlPath, adapters, rootDir);
 
 		expect(await exists(path.join(targetPath, ".sync-backup"))).toBe(false);
+	});
+
+	it("logs the per-deploy backup destination (F5)", async () => {
+		const adapters = await seedOverwriteFixture(targetPath);
+		const context = makeContext({ backupBase });
+
+		const chunks: string[] = [];
+		const origStderr = process.stderr.write.bind(process.stderr);
+		process.stderr.write = (chunk: string | Uint8Array) => {
+			if (typeof chunk === "string") chunks.push(chunk);
+			return true;
+		};
+		try {
+			await processYaml(context, syncYamlPath, adapters, rootDir);
+		} finally {
+			process.stderr.write = origStderr;
+		}
+
+		const output = chunks.join("");
+		// The actual per-deploy backup destination must appear verbatim — this is
+		// the only breadcrumb an operator has, since this backup design has no
+		// restore path.
+		expect(output).toContain("백업 대상:");
+		expect(output).toContain(context.backupDest);
 	});
 
 	it("backupCategory lands under the OMT base", async () => {

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -36,6 +36,7 @@ import { DeployTargetsError } from "./lib/resolve-deploy-targets.ts";
 import { ClaudeAdapter } from "./adapters/claude.ts";
 import { CodexAdapter } from "./adapters/codex.ts";
 import { cleanupOldBackups } from "./lib/backup.ts";
+import { deriveProjectName } from "../lib/omt-dir.ts";
 import { execFileSync } from "child_process";
 
 // ---------------------------------------------------------------------------
@@ -849,7 +850,7 @@ describe("syncCategory — codex skills manifest+backup routing", () => {
 		expect(manifest["codex/skills"]).toBeUndefined();
 	});
 
-	it("backs up a pre-existing .agents/skills entry under .sync-backup/{sid}/agents/skills/", async () => {
+	it("backs up a pre-existing .agents/skills entry under the per-deploy backup destination", async () => {
 		// Pre-existing skill under the NEW location, as if deployed by a prior sync.
 		const preExisting = path.join(targetPath, ".agents", "skills", "old-skill", "SKILL.md");
 		await writeFile(preExisting, "# Old Skill\n");
@@ -864,19 +865,11 @@ describe("syncCategory — codex skills manifest+backup routing", () => {
 		};
 
 		const adapters = makeAdapterMap(["codex"]);
-		const context = makeContext({ dryRun: false, backupDest: "sid-agents-skills" });
+		const context = makeContext({ dryRun: false });
 
 		await syncCategory(context, "skills", syncYaml, adapters, rootDir, targetPath);
 
-		const backedUp = path.join(
-			targetPath,
-			".sync-backup",
-			"sid-agents-skills",
-			"agents",
-			"skills",
-			"old-skill",
-			"SKILL.md",
-		);
+		const backedUp = path.join(context.backupDest, "agents", "skills", "old-skill", "SKILL.md");
 		expect(await exists(backedUp)).toBe(true);
 	});
 
@@ -966,7 +959,7 @@ describe("syncCategory — codex skills manifest+backup routing", () => {
 		};
 
 		const adapters = makeAdapterMap(["codex"]);
-		const context = makeContext({ dryRun: false, backupDest: "sid-fossil-cleanup" });
+		const context = makeContext({ dryRun: false });
 
 		await syncCategory(context, "skills", syncYaml, adapters, rootDir, targetPath);
 
@@ -974,15 +967,7 @@ describe("syncCategory — codex skills manifest+backup routing", () => {
 		expect(await exists(path.join(targetPath, ".codex", "skills"))).toBe(false);
 
 		// Backed up before removal.
-		const backedUp = path.join(
-			targetPath,
-			".sync-backup",
-			"sid-fossil-cleanup",
-			"codex",
-			"skills",
-			"old-skill",
-			"SKILL.md",
-		);
+		const backedUp = path.join(context.backupDest, "codex", "skills", "old-skill", "SKILL.md");
 		expect(await exists(backedUp)).toBe(true);
 
 		// Stale codex/skills manifest key pruned; agents/skills reflects this run.
@@ -1011,16 +996,14 @@ describe("syncCategory — codex skills manifest+backup routing", () => {
 		};
 
 		const adapters = makeAdapterMap(["codex"]);
-		const context = makeContext({ dryRun: false, backupDest: "sid-not-owned" });
+		const context = makeContext({ dryRun: false });
 
 		await syncCategory(context, "skills", syncYaml, adapters, rootDir, targetPath);
 
 		expect(await exists(fossilFile)).toBe(true);
-		expect(
-			await exists(
-				path.join(targetPath, ".sync-backup", "sid-not-owned", "codex", "skills", "old-skill"),
-			),
-		).toBe(false);
+		expect(await exists(path.join(context.backupDest, "codex", "skills", "old-skill"))).toBe(
+			false,
+		);
 	});
 
 	it("never touches a .codex/skills fossil when codex is not a target for this skills sync (guard)", async () => {
@@ -3476,18 +3459,6 @@ describe("createContext", () => {
 		expect(ctx.dryRun).toBe(true);
 	});
 
-	// The random-per-call invariant this test used to pin moved off createContext
-	// entirely: backupBase is now a deterministic, run-scoped resolution of
-	// $OMT_DIR (no randomness), and the per-deploy random segment is assigned
-	// later, once per (target, worktree), inside the sync fan-out loop — not
-	// here. This assertion is expected to fail until that call site exists;
-	// rewriting it is a follow-up task, not this one.
-	it("generates unique backupSession on each `createContext` call", () => {
-		const ctx1 = createContext(false);
-		const ctx2 = createContext(false);
-		expect(ctx1.backupBase).not.toBe(ctx2.backupBase);
-	});
-
 	it("createContext exposes the OMT backup base", () => {
 		const tmp = fs2.mkdtempSync(path.join(os.tmpdir(), "omt-dir-h1-"));
 		const originalOmtDir = process.env.OMT_DIR;
@@ -4141,10 +4112,12 @@ describe("component fan-out", () => {
 		await fs.chmod(claudeDir, 0o755);
 	});
 
-	// Bug (2): a worktree that fails mid-deploy must NOT be registered as a backup
-	// root, so retention cleanup does not prune its last good backup. backupRoots
-	// is the success-only invariant: only worktrees that completed all sync steps
-	// belong in it.
+	// Bug (2): a pre-existing in-target `.sync-backup/` (the legacy dotted
+	// layout) must survive a failed worktree deploy. cleanupOldBackups now only
+	// ever prunes the single shared OMT-owned root (`<base>/sync-backup/`,
+	// dotless), never a target tree, so there is no success-only registration
+	// left to bypass — the guarantee holds by construction regardless of
+	// whether this worktree's deploy succeeds or fails.
 	it("Bug2: a worktree failing mid-deploy keeps its prior backup and is not a backup root", async () => {
 		const { container, worktrees } = makeBareTopology("repo", ["wt1"]);
 		await seedSkill("oracle");
@@ -4169,19 +4142,18 @@ describe("component fan-out", () => {
 		const adapters = new Map<Platform, PlatformAdapter>([
 			["claude", new FailingAdapter()],
 		]) as AdapterMap;
-		const context = makeContext({ dryRun: false, backupDest: "new-session" });
+		const context = makeContext({ dryRun: false });
 
 		await processYaml(context, syncYamlPath, adapters, rootDir);
 
-		// The worktree failed, so it is recorded as failed and NOT as a backup root.
+		// The worktree failed, so it is recorded as a failed target.
 		expect(context.failedTargets).toContain(worktrees[0]);
-		// `backupRoots` (the success-only backup-root invariant) was removed from
-		// SyncContext; stand in with an empty Set so this compiles. Rewriting this
-		// assertion to match the new contract is a follow-up task, not this one.
-		expect(new Set<string>().has(worktrees[0]!)).toBe(false);
 
-		// Retention cleanup over the production union (processedPaths ∪ backupRoots)
-		// with retentionDays=0 must leave the failed worktree's prior backup intact.
+		// cleanupOldBackups now only ever prunes `<base>/sync-backup` (dotless)
+		// directly under the given base — it never touches a target's legacy
+		// `.sync-backup/` at all, so running it against every processed worktree
+		// with retentionDays=0 must still leave the failed worktree's prior
+		// backup intact.
 		const cleanupTargets = new Set<string>([...context.processedPaths]);
 		await Promise.all([...cleanupTargets].map((t) => cleanupOldBackups(t, 0).catch(() => {})));
 
@@ -4341,12 +4313,16 @@ describe("component fan-out", () => {
 		expect(await exists(rulePath)).toBe(true);
 	});
 
-	// AC6.3 — per-worktree backup of replaced category lands under each worktree
-	it("AC6.3: replacing the skills category backs the old skill up under wt1's .sync-backup", async () => {
+	// AC6.3 — per-worktree backup of replaced category lands under the shared
+	// OMT-owned backup root, in a deploy-scoped dir keyed by this worktree.
+	it("AC6.3: replacing the skills category backs the old skill up under the OMT-owned backup root", async () => {
 		const { container, worktrees } = makeBareTopology("repo", ["wt1", "wt2"]);
 		await seedSkill("oracle");
 
-		// Pre-place an old skill in wt1 that the wipe will replace.
+		// Pre-place an old skill in wt1 that the wipe will replace. wt2 has no
+		// pre-existing content, so its backupCategory call hits the
+		// source-absent early-return and writes nothing — only wt1 produces a
+		// deploy-scoped backup dir under the shared root.
 		const oldSkill = path.join(worktrees[0]!, ".claude", "skills", "old", "SKILL.md");
 		await writeFile(oldSkill, "# old\n");
 
@@ -4359,14 +4335,17 @@ describe("component fan-out", () => {
 		const adapters = new Map<Platform, PlatformAdapter>([
 			["claude", new ClaudeAdapter()],
 		]) as AdapterMap;
-		const context = makeContext({ dryRun: false, backupDest: "sess-ac63" });
+		const backupBase = path.join(tmpDir, "ac63-omt-base");
+		const context = makeContext({ dryRun: false, backupBase });
 
 		await processYaml(context, syncYamlPath, adapters, rootDir);
 
+		const syncBackupRoot = path.join(backupBase, "sync-backup");
+		const entries = await fs.readdir(syncBackupRoot);
+		expect(entries).toHaveLength(1);
 		const backupCopy = path.join(
-			worktrees[0]!,
-			".sync-backup",
-			"sess-ac63",
+			syncBackupRoot,
+			entries[0]!,
 			"claude",
 			"skills",
 			"old",
@@ -4860,19 +4839,12 @@ describe("syncDocs", () => {
 		await writeFile(path.join(rootDir, "docs", "bundle", "one.md"), "# One\n");
 		await writeFile(path.join(deployRoot, "docs", "bundle"), "stale file\n");
 		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["bundle"] } };
-		const context = makeContext({ backupDest: "form-morph-sess" });
+		const context = makeContext();
 
 		await syncDocs(context, syncYaml, rootDir, deployRoot);
 
 		expect(await readFile(path.join(deployRoot, "docs", "bundle", "one.md"))).toBe("# One\n");
-		const backupFile = path.join(
-			deployRoot,
-			".sync-backup",
-			"form-morph-sess",
-			"docs",
-			"docs",
-			"bundle",
-		);
+		const backupFile = path.join(context.backupDest, "docs", "docs", "bundle");
 		expect(await readFile(backupFile)).toBe("stale file\n");
 	});
 
@@ -5069,15 +5041,16 @@ describe("syncDocs", () => {
 		await writeFile(path.join(rootDir, "docs", "intro.md"), "# New\n");
 		await writeFile(path.join(deployRoot, "docs", "intro.md"), "# Old\n");
 		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["intro"] } };
-		const context = makeContext({ backupDest: "sess1" });
+		const context = makeContext();
 
 		await syncDocs(context, syncYaml, rootDir, deployRoot);
 
 		// backupDocs preserves the FULL deployRoot-relative path (including the
-		// docs section's own "docs/" segment) under the fixed .sync-backup/<session>/docs/
-		// namespace — so a target already living at deployRoot/docs/intro.md backs
-		// up to .sync-backup/sess1/docs/docs/intro.md (see lib/backup.ts:backupDocs).
-		const backupFile = path.join(deployRoot, ".sync-backup", "sess1", "docs", "docs", "intro.md");
+		// docs section's own "docs/" segment) under the per-deploy backup
+		// destination's "docs/" namespace — so a target already living at
+		// deployRoot/docs/intro.md backs up to <backupDest>/docs/docs/intro.md
+		// (see lib/backup.ts:backupDocs).
+		const backupFile = path.join(context.backupDest, "docs", "docs", "intro.md");
 		expect(await readFile(backupFile)).toBe("# Old\n");
 	});
 
@@ -5168,5 +5141,340 @@ describe("syncDocs", () => {
 
 		await expect(syncDocs(context, syncYaml, rootDir, deployRoot)).rejects.toThrow();
 		expect(await readFile(externalFile)).toBe("external content\n");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Suite: backup relocation (writer repoint + per-deploy destination)
+//
+// Base is injected via makeContext({ backupBase: <tmp> }) — hermetic,
+// in-process, never touches the developer's real OMT base. See
+// $OMT_DIR/plans/sync-backup-relocation.md for the full design.
+// ---------------------------------------------------------------------------
+
+describe("backup relocation (writer repoint + per-deploy destination)", () => {
+	let tmpDir: string;
+	let rootDir: string;
+	let targetPath: string;
+	let backupBase: string;
+	let syncYamlPath: string;
+
+	const GIT_ENV = {
+		...process.env,
+		GIT_AUTHOR_NAME: "T",
+		GIT_AUTHOR_EMAIL: "t@t.com",
+		GIT_COMMITTER_NAME: "T",
+		GIT_COMMITTER_EMAIL: "t@t.com",
+	};
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "backup-reloc-test-"));
+		rootDir = path.join(tmpDir, "root");
+		targetPath = path.join(tmpDir, "target");
+		backupBase = path.join(tmpDir, "omt-base");
+		syncYamlPath = path.join(rootDir, "sync.yaml");
+		await fs.mkdir(path.join(rootDir, "skills"), { recursive: true });
+		await fs.mkdir(targetPath, { recursive: true });
+		await writeFile(path.join(rootDir, "config.yaml"), "use-platforms: [claude]\n");
+		_resetConfigCache();
+	});
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true });
+		_resetConfigCache();
+	});
+
+	/**
+	 * Plants an "oracle" skill source plus a sync.yaml declaring it for the
+	 * given target, AND pre-existing deployed content under the target's
+	 * `.claude/skills/` that the sync must back up before it can overwrite —
+	 * without this, backupCategory's source-absent early-return means no
+	 * backup is ever written and every location assertion below would be
+	 * vacuously true (see backup.ts:36-42).
+	 */
+	async function seedOverwriteFixture(target: string): Promise<AdapterMap> {
+		await writeFile(path.join(rootDir, "skills", "oracle", "SKILL.md"), "# Oracle\n");
+		await writeFile(path.join(target, ".claude", "skills", "old-thing", "SKILL.md"), "# Old\n");
+		await writeFile(
+			syncYamlPath,
+			`path: ${target}\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`,
+		);
+		return makeAdapterMap(["claude"]);
+	}
+
+	/** git init -b main at dir — real git repo fixture for deriveProjectName. */
+	async function initGitRepo(dir: string): Promise<void> {
+		await fs.mkdir(dir, { recursive: true });
+		execFileSync("git", ["init", "-b", "main", dir], { stdio: "pipe", env: GIT_ENV });
+	}
+
+	/** Builds a real bare-structure container with worktrees (adapted from "component fan-out"). */
+	async function makeBareTopologyLocal(container: string, names: string[]): Promise<string[]> {
+		await fs.mkdir(container, { recursive: true });
+		const bareDir = path.join(container, ".bare");
+		execFileSync("git", ["init", "--bare", bareDir], { stdio: "pipe", env: GIT_ENV });
+
+		const seedWt = fs2.mkdtempSync(path.join(os.tmpdir(), "backup-reloc-seed-"));
+		execFileSync(
+			"git",
+			["--git-dir", bareDir, "worktree", "add", "--orphan", "-b", "main", seedWt],
+			{ stdio: "pipe", env: GIT_ENV },
+		);
+		execFileSync("git", ["-C", seedWt, "commit", "--allow-empty", "-m", "init"], {
+			stdio: "pipe",
+			env: GIT_ENV,
+		});
+		execFileSync("git", ["-C", seedWt, "push", bareDir, "main"], { stdio: "pipe", env: GIT_ENV });
+		fs2.rmSync(seedWt, { recursive: true, force: true });
+		execFileSync("git", ["--git-dir", bareDir, "worktree", "prune"], { stdio: "pipe" });
+
+		const worktrees: string[] = [];
+		for (const name of names) {
+			const wtDir = path.join(container, name);
+			execFileSync("git", ["--git-dir", bareDir, "worktree", "add", wtDir], {
+				stdio: "pipe",
+				env: GIT_ENV,
+			});
+			worktrees.push(fs2.realpathSync(wtDir));
+		}
+		return worktrees;
+	}
+
+	it("no new .sync-backup under target worktrees", async () => {
+		const adapters = await seedOverwriteFixture(targetPath);
+		const context = makeContext({ backupBase });
+
+		await processYaml(context, syncYamlPath, adapters, rootDir);
+
+		expect(await exists(path.join(targetPath, ".sync-backup"))).toBe(false);
+	});
+
+	it("backupCategory lands under the OMT base", async () => {
+		const adapters = await seedOverwriteFixture(targetPath);
+		const context = makeContext({ backupBase });
+
+		await processYaml(context, syncYamlPath, adapters, rootDir);
+
+		const syncBackupRoot = path.join(backupBase, "sync-backup");
+		const entries = await fs.readdir(syncBackupRoot);
+		expect(entries).toHaveLength(1);
+		const categoryBackup = path.join(
+			syncBackupRoot,
+			entries[0]!,
+			"claude",
+			"skills",
+			"old-thing",
+			"SKILL.md",
+		);
+		expect(await exists(categoryBackup)).toBe(true);
+	});
+
+	it("backupDocs shares the category deploy segment", async () => {
+		await writeFile(path.join(rootDir, "skills", "oracle", "SKILL.md"), "# Oracle\n");
+		await writeFile(
+			path.join(targetPath, ".claude", "skills", "old-thing", "SKILL.md"),
+			"# Old\n",
+		);
+		await writeFile(path.join(rootDir, "docs", "intro.md"), "# New\n");
+		await writeFile(path.join(targetPath, "docs", "intro.md"), "# Old Docs\n");
+		await writeFile(
+			syncYamlPath,
+			`path: ${targetPath}\nskills:\n  platforms: [claude]\n  items:\n    - oracle\ndocs:\n  items:\n    - intro\n`,
+		);
+		const adapters = makeAdapterMap(["claude"]);
+		const context = makeContext({ backupBase });
+
+		await processYaml(context, syncYamlPath, adapters, rootDir);
+
+		const syncBackupRoot = path.join(backupBase, "sync-backup");
+		const entries = await fs.readdir(syncBackupRoot);
+		expect(entries).toHaveLength(1);
+		const deploySegment = entries[0]!;
+
+		// Both the category backup and the docs backup must sit under the SAME
+		// deploy-segment directory — proving the per-deploy id was computed once
+		// and shared, not re-derived at each assembly point.
+		expect(
+			await exists(
+				path.join(syncBackupRoot, deploySegment, "claude", "skills", "old-thing", "SKILL.md"),
+			),
+		).toBe(true);
+		expect(
+			await exists(path.join(syncBackupRoot, deploySegment, "docs", "docs", "intro.md")),
+		).toBe(true);
+	});
+
+	it("target label uses deriveProjectName container name", async () => {
+		const gitTarget = path.join(tmpDir, "git-project");
+		await initGitRepo(gitTarget);
+		await writeFile(syncYamlPath, `path: ${gitTarget}\n`);
+		const adapters = makeAdapterMap(["claude"]);
+		const context = makeContext({ backupBase });
+
+		await processYaml(context, syncYamlPath, adapters, rootDir);
+
+		const expectedName = deriveProjectName(gitTarget);
+		const segment = path.basename(context.backupDest);
+		expect(segment.startsWith(`${expectedName}-`)).toBe(true);
+	});
+
+	it("target label falls back to basename on non-git path", async () => {
+		const plainTarget = path.join(tmpDir, "plain-target");
+		await fs.mkdir(plainTarget, { recursive: true });
+		await writeFile(syncYamlPath, `path: ${plainTarget}\n`);
+		const adapters = makeAdapterMap(["claude"]);
+		const context = makeContext({ backupBase });
+
+		await processYaml(context, syncYamlPath, adapters, rootDir);
+
+		const segment = path.basename(context.backupDest);
+		expect(segment.startsWith(`${path.basename(plainTarget)}-`)).toBe(true);
+	});
+
+	it("plain target yields duplicated name segments", async () => {
+		const gitTarget = path.join(tmpDir, "dup-project");
+		await initGitRepo(gitTarget);
+		await writeFile(syncYamlPath, `path: ${gitTarget}\n`);
+		const adapters = makeAdapterMap(["claude"]);
+		const context = makeContext({ backupBase });
+
+		await processYaml(context, syncYamlPath, adapters, rootDir);
+
+		const name = path.basename(gitTarget);
+		const segment = path.basename(context.backupDest);
+		// Non-bare target: deployRoot === targetPath, so deriveProjectName(targetPath)
+		// and basename(deployRoot) are the same value — first two segments duplicate.
+		expect(segment.startsWith(`${name}-${name}-`)).toBe(true);
+	});
+
+	it("same target-worktree deployed twice gets distinct backup dirs", async () => {
+		const adapters = await seedOverwriteFixture(targetPath);
+		const context = makeContext({ backupBase });
+
+		await processYaml(context, syncYamlPath, adapters, rootDir);
+		const dest1 = context.backupDest;
+
+		await processYaml(context, syncYamlPath, adapters, rootDir);
+		const dest2 = context.backupDest;
+
+		expect(dest1).not.toBe(dest2);
+
+		const syncBackupRoot = path.join(backupBase, "sync-backup");
+		const entries = await fs.readdir(syncBackupRoot);
+		expect(entries).toHaveLength(2);
+	});
+
+	it("two worktrees in one sync get distinct backup dirs", async () => {
+		const container = path.join(tmpDir, "bare-container");
+		const worktrees = await makeBareTopologyLocal(container, ["wt1", "wt2"]);
+		await writeFile(path.join(rootDir, "skills", "oracle", "SKILL.md"), "# Oracle\n");
+		for (const wt of worktrees) {
+			await writeFile(path.join(wt, ".claude", "skills", "old-thing", "SKILL.md"), "# Old\n");
+		}
+		await writeFile(
+			syncYamlPath,
+			`path: ${container}\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`,
+		);
+		const adapters = makeAdapterMap(["claude"]);
+		const context = makeContext({ backupBase });
+
+		await processYaml(context, syncYamlPath, adapters, rootDir);
+
+		const syncBackupRoot = path.join(backupBase, "sync-backup");
+		const entries = await fs.readdir(syncBackupRoot);
+		expect(entries).toHaveLength(2);
+	});
+
+	it("backup preserves pre-overwrite target bytes", async () => {
+		await writeFile(path.join(rootDir, "skills", "oracle", "SKILL.md"), "# NEW Y\n");
+		await writeFile(path.join(targetPath, ".claude", "skills", "oracle", "SKILL.md"), "# OLD X\n");
+		await writeFile(
+			syncYamlPath,
+			`path: ${targetPath}\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`,
+		);
+		const adapters = new Map<Platform, PlatformAdapter>([
+			["claude", new ClaudeAdapter()],
+		]) as AdapterMap;
+		const context = makeContext({ backupBase });
+
+		await processYaml(context, syncYamlPath, adapters, rootDir);
+
+		// The sync must have actually overwritten — otherwise this AC proves nothing.
+		expect(
+			await readFile(path.join(targetPath, ".claude", "skills", "oracle", "SKILL.md")),
+		).toBe("# NEW Y\n");
+
+		const syncBackupRoot = path.join(backupBase, "sync-backup");
+		const entries = await fs.readdir(syncBackupRoot);
+		expect(entries).toHaveLength(1);
+		const backedUpFile = path.join(
+			syncBackupRoot,
+			entries[0]!,
+			"claude",
+			"skills",
+			"oracle",
+			"SKILL.md",
+		);
+		expect(await readFile(backedUpFile)).toBe("# OLD X\n");
+	});
+
+	it("pre-existing in-target .sync-backup left untouched", async () => {
+		const staleDir = path.join(targetPath, ".sync-backup", "old-session");
+		await fs.mkdir(staleDir, { recursive: true });
+		const marker = path.join(staleDir, "marker.txt");
+		await writeFile(marker, "precious");
+		const past = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+		await fs.utimes(staleDir, past, past);
+
+		// The pruner must never visit the target tree at all — call it for real.
+		await cleanupOldBackups(backupBase, 3);
+
+		expect(await exists(marker)).toBe(true);
+	});
+
+	it("backup write failure aborts worktree without clobbering target", async () => {
+		const adapters = await seedOverwriteFixture(targetPath);
+		const originalBytes = await readFile(
+			path.join(targetPath, ".claude", "skills", "old-thing", "SKILL.md"),
+		);
+
+		const backupRoot = path.join(backupBase, "sync-backup");
+		await fs.mkdir(backupRoot, { recursive: true });
+		await fs.chmod(backupRoot, 0o555);
+
+		// Precondition: a write under a chmod-0o555 backupRoot must actually
+		// throw. Without this, the test would pass vacuously under euid==0,
+		// where chmod is a no-op — fail (not skip) if the precondition doesn't hold.
+		let precondFailed = false;
+		try {
+			await fs.mkdir(path.join(backupRoot, "precondition-check", "x"), { recursive: true });
+			precondFailed = true;
+			await fs.rm(path.join(backupRoot, "precondition-check"), {
+				recursive: true,
+				force: true,
+			});
+		} catch {
+			// expected — precondition holds
+		}
+
+		try {
+			if (precondFailed) {
+				throw new Error(
+					"precondition failed: a write under a chmod-0o555 backupRoot did not throw " +
+						"(running as root, where chmod is a no-op?) — F2 cannot be measured",
+				);
+			}
+
+			const context = makeContext({ backupBase });
+
+			await processYaml(context, syncYamlPath, adapters, rootDir);
+
+			expect(
+				await readFile(path.join(targetPath, ".claude", "skills", "old-thing", "SKILL.md")),
+			).toBe(originalBytes);
+			expect(context.failedTargets).toContain(targetPath);
+		} finally {
+			await fs.chmod(backupRoot, 0o755);
+		}
 	});
 });

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -133,6 +133,35 @@ afterEach(async () => {
 	}
 });
 
+// ---------------------------------------------------------------------------
+// File-level OMT_DIR isolation
+//
+// `createContext()` resolves the OMT backup base via `resolveOmtDir()`,
+// which falls back to the developer's real `~/.omt/<project>` whenever
+// `OMT_DIR` is unset. Every `createContext()` call in this file must resolve
+// to a per-test tmp dir instead of the real base. The "createContext exposes
+// the OMT backup base" and "resolveBackupBase throws on a degenerate base"
+// tests below set `process.env.OMT_DIR` themselves and save/restore around
+// whatever value is already there — so they save/restore around this
+// file-level value, and this hook still restores the pre-suite value once
+// those tests are done.
+// ---------------------------------------------------------------------------
+
+let savedOmtDir: string | undefined;
+let omtDirTmp: string;
+
+beforeEach(() => {
+	savedOmtDir = process.env.OMT_DIR;
+	omtDirTmp = fs2.mkdtempSync(path.join(os.tmpdir(), "sync-test-omtdir-"));
+	process.env.OMT_DIR = omtDirTmp;
+});
+
+afterEach(() => {
+	if (savedOmtDir === undefined) delete process.env.OMT_DIR;
+	else process.env.OMT_DIR = savedOmtDir;
+	fs2.rmSync(omtDirTmp, { recursive: true, force: true });
+});
+
 function makeContext(overrides?: Partial<SyncContext>): SyncContext {
 	let backupBase = overrides?.backupBase;
 	if (backupBase === undefined) {

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -14,6 +14,8 @@ import {
 	rewritePlatformPaths,
 	rewriteLibAliases,
 	createContext,
+	resolveBackupBase,
+	UnsafeBackupRootError,
 	parseCliArgs,
 	printUsage,
 	resolveProjectFilter,
@@ -108,18 +110,37 @@ function makeAdapterMap(platforms: Platform[]): AdapterMap & {
 	return adapterMap;
 }
 
+// Tmp backup-base dirs `makeContext` creates when a test doesn't override
+// `backupBase`/`backupDest` — cleaned up in the module-level `afterEach`
+// below so `processYaml`/`syncCategory`/`syncDocs` tests never touch the
+// developer's real OMT base (see Pre-Mortem Scenario 4 in the backup
+// relocation plan).
+const makeContextTmpDirs: string[] = [];
+
+afterEach(async () => {
+	while (makeContextTmpDirs.length > 0) {
+		const dir = makeContextTmpDirs.pop()!;
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+});
+
 function makeContext(overrides?: Partial<SyncContext>): SyncContext {
+	let backupBase = overrides?.backupBase;
+	if (backupBase === undefined) {
+		backupBase = fs2.mkdtempSync(path.join(os.tmpdir(), "sync-test-backup-"));
+		makeContextTmpDirs.push(backupBase);
+	}
 	return {
 		dryRun: false,
 		projectName: "",
 		projectDir: "",
 		isRootYaml: true,
-		backupSession: "test-session",
+		backupBase,
+		backupDest: backupBase,
 		modelMaps: new Map(),
 		rootModelMaps: new Map(),
 		processedPaths: new Set(),
 		platformYamlSections: new Map(),
-		backupRoots: new Set(),
 		failedTargets: [],
 		...overrides,
 	};
@@ -843,7 +864,7 @@ describe("syncCategory — codex skills manifest+backup routing", () => {
 		};
 
 		const adapters = makeAdapterMap(["codex"]);
-		const context = makeContext({ dryRun: false, backupSession: "sid-agents-skills" });
+		const context = makeContext({ dryRun: false, backupDest: "sid-agents-skills" });
 
 		await syncCategory(context, "skills", syncYaml, adapters, rootDir, targetPath);
 
@@ -945,7 +966,7 @@ describe("syncCategory — codex skills manifest+backup routing", () => {
 		};
 
 		const adapters = makeAdapterMap(["codex"]);
-		const context = makeContext({ dryRun: false, backupSession: "sid-fossil-cleanup" });
+		const context = makeContext({ dryRun: false, backupDest: "sid-fossil-cleanup" });
 
 		await syncCategory(context, "skills", syncYaml, adapters, rootDir, targetPath);
 
@@ -990,7 +1011,7 @@ describe("syncCategory — codex skills manifest+backup routing", () => {
 		};
 
 		const adapters = makeAdapterMap(["codex"]);
-		const context = makeContext({ dryRun: false, backupSession: "sid-not-owned" });
+		const context = makeContext({ dryRun: false, backupDest: "sid-not-owned" });
 
 		await syncCategory(context, "skills", syncYaml, adapters, rootDir, targetPath);
 
@@ -3446,8 +3467,8 @@ describe("createContext", () => {
 		expect(ctx.modelMaps).toBeInstanceOf(Map);
 		expect(ctx.rootModelMaps).toBeInstanceOf(Map);
 		expect(ctx.platformYamlSections).toBeInstanceOf(Map);
-		expect(typeof ctx.backupSession).toBe("string");
-		expect(ctx.backupSession.length).toBeGreaterThan(0);
+		expect(typeof ctx.backupBase).toBe("string");
+		expect(ctx.backupBase.length).toBeGreaterThan(0);
 	});
 
 	it("creates context with dryRun=true via `createContext`", () => {
@@ -3455,10 +3476,55 @@ describe("createContext", () => {
 		expect(ctx.dryRun).toBe(true);
 	});
 
+	// The random-per-call invariant this test used to pin moved off createContext
+	// entirely: backupBase is now a deterministic, run-scoped resolution of
+	// $OMT_DIR (no randomness), and the per-deploy random segment is assigned
+	// later, once per (target, worktree), inside the sync fan-out loop — not
+	// here. This assertion is expected to fail until that call site exists;
+	// rewriting it is a follow-up task, not this one.
 	it("generates unique backupSession on each `createContext` call", () => {
 		const ctx1 = createContext(false);
 		const ctx2 = createContext(false);
-		expect(ctx1.backupSession).not.toBe(ctx2.backupSession);
+		expect(ctx1.backupBase).not.toBe(ctx2.backupBase);
+	});
+
+	it("createContext exposes the OMT backup base", () => {
+		const tmp = fs2.mkdtempSync(path.join(os.tmpdir(), "omt-dir-h1-"));
+		const originalOmtDir = process.env.OMT_DIR;
+		process.env.OMT_DIR = tmp;
+		try {
+			const ctx = createContext(false);
+			expect(ctx.backupBase).toBe(tmp);
+		} finally {
+			if (originalOmtDir === undefined) delete process.env.OMT_DIR;
+			else process.env.OMT_DIR = originalOmtDir;
+			fs2.rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("resolveBackupBase", () => {
+	it("resolveBackupBase throws on a degenerate base", () => {
+		const originalCwd = process.cwd();
+		const tmp = fs2.mkdtempSync(path.join(os.tmpdir(), "omt-dir-f1e-"));
+		const originalOmtDir = process.env.OMT_DIR;
+		process.chdir(tmp);
+		process.env.OMT_DIR = "./rel";
+		try {
+			// ① The degenerate (relative) base must be refused.
+			expect(() => resolveBackupBase()).toThrow(UnsafeBackupRootError);
+			// ② The refusal must happen BEFORE any directory is created for it —
+			// this is what pins the resolveOmtDir()-then-guard-then-getOmtDir()
+			// ordering. A resolveBackupBase() that calls getOmtDir() first would
+			// create <tmp>/rel (its unconditional mkdirSync) and only refuse
+			// afterwards, leaving the pollution this change exists to remove.
+			expect(fs2.existsSync(path.join(tmp, "rel"))).toBe(false);
+		} finally {
+			process.chdir(originalCwd);
+			if (originalOmtDir === undefined) delete process.env.OMT_DIR;
+			else process.env.OMT_DIR = originalOmtDir;
+			fs2.rmSync(tmp, { recursive: true, force: true });
+		}
 	});
 });
 
@@ -4103,17 +4169,20 @@ describe("component fan-out", () => {
 		const adapters = new Map<Platform, PlatformAdapter>([
 			["claude", new FailingAdapter()],
 		]) as AdapterMap;
-		const context = makeContext({ dryRun: false, backupSession: "new-session" });
+		const context = makeContext({ dryRun: false, backupDest: "new-session" });
 
 		await processYaml(context, syncYamlPath, adapters, rootDir);
 
 		// The worktree failed, so it is recorded as failed and NOT as a backup root.
 		expect(context.failedTargets).toContain(worktrees[0]);
-		expect(context.backupRoots.has(worktrees[0]!)).toBe(false);
+		// `backupRoots` (the success-only backup-root invariant) was removed from
+		// SyncContext; stand in with an empty Set so this compiles. Rewriting this
+		// assertion to match the new contract is a follow-up task, not this one.
+		expect(new Set<string>().has(worktrees[0]!)).toBe(false);
 
 		// Retention cleanup over the production union (processedPaths ∪ backupRoots)
 		// with retentionDays=0 must leave the failed worktree's prior backup intact.
-		const cleanupTargets = new Set<string>([...context.processedPaths, ...context.backupRoots]);
+		const cleanupTargets = new Set<string>([...context.processedPaths]);
 		await Promise.all([...cleanupTargets].map((t) => cleanupOldBackups(t, 0).catch(() => {})));
 
 		expect(await exists(path.join(worktrees[0]!, ".sync-backup", "good-session"))).toBe(true);
@@ -4290,7 +4359,7 @@ describe("component fan-out", () => {
 		const adapters = new Map<Platform, PlatformAdapter>([
 			["claude", new ClaudeAdapter()],
 		]) as AdapterMap;
-		const context = makeContext({ dryRun: false, backupSession: "sess-ac63" });
+		const context = makeContext({ dryRun: false, backupDest: "sess-ac63" });
 
 		await processYaml(context, syncYamlPath, adapters, rootDir);
 
@@ -4791,7 +4860,7 @@ describe("syncDocs", () => {
 		await writeFile(path.join(rootDir, "docs", "bundle", "one.md"), "# One\n");
 		await writeFile(path.join(deployRoot, "docs", "bundle"), "stale file\n");
 		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["bundle"] } };
-		const context = makeContext({ backupSession: "form-morph-sess" });
+		const context = makeContext({ backupDest: "form-morph-sess" });
 
 		await syncDocs(context, syncYaml, rootDir, deployRoot);
 
@@ -5000,7 +5069,7 @@ describe("syncDocs", () => {
 		await writeFile(path.join(rootDir, "docs", "intro.md"), "# New\n");
 		await writeFile(path.join(deployRoot, "docs", "intro.md"), "# Old\n");
 		const syncYaml: SyncYaml = { path: deployRoot, docs: { items: ["intro"] } };
-		const context = makeContext({ backupSession: "sess1" });
+		const context = makeContext({ backupDest: "sess1" });
 
 		await syncDocs(context, syncYaml, rootDir, deployRoot);
 

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -5455,17 +5455,34 @@ describe("backup relocation (writer repoint + per-deploy destination)", () => {
 		expect(await readFile(backedUpFile)).toBe("# OLD X\n");
 	});
 
-	it("pre-existing in-target .sync-backup left untouched", async () => {
+	it("pre-existing in-target .sync-backup left untouched while shared-base aged dirs are pruned", async () => {
+		// F3: the old form of this test planted the in-target marker under a
+		// backupBase that had no `sync-backup/` at all, so cleanupOldBackups
+		// hit its ENOENT no-op branch (backup.ts:151-158) and returned before
+		// ever reaching the pruning logic — vacuously green even if the pruner's
+		// body, isSafeBackupRoot, age math, or symlink guard were all broken.
+		// This version makes the pruner actually run and delete something
+		// (the shared-base aged dir) in the SAME call whose in-target marker
+		// we assert survives — proving both that pruning happened and that it
+		// stayed scoped to `<backupBase>/sync-backup`.
+		const past = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
+		const agedSharedDir = path.join(backupBase, "sync-backup", "aged-shared-session");
+		await fs.mkdir(agedSharedDir, { recursive: true });
+		await writeFile(path.join(agedSharedDir, "old.txt"), "stale");
+		await fs.utimes(agedSharedDir, past, past);
+
 		const staleDir = path.join(targetPath, ".sync-backup", "old-session");
 		await fs.mkdir(staleDir, { recursive: true });
 		const marker = path.join(staleDir, "marker.txt");
 		await writeFile(marker, "precious");
-		const past = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
 		await fs.utimes(staleDir, past, past);
 
-		// The pruner must never visit the target tree at all — call it for real.
 		await cleanupOldBackups(backupBase, 3);
 
+		// (a) the pruner actually ran and deleted the aged shared-base session.
+		expect(await exists(agedSharedDir)).toBe(false);
+		// (b) ...without its root ever extending into the in-target tree.
 		expect(await exists(marker)).toBe(true);
 	});
 

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -25,6 +25,8 @@ import {
 	deploysToClaudeDotDir,
 	loadRootModelMaps,
 	deployLocationForManifest,
+	logBackupLocation,
+	cleanupRunBackups,
 	type AdapterMap,
 	type LibSourceRoots,
 } from "./sync.ts";
@@ -59,6 +61,12 @@ async function exists(p: string): Promise<boolean> {
 	} catch {
 		return false;
 	}
+}
+
+/** Sets a directory's mtime far enough in the past to clear any retention window used in these tests. */
+async function ageDir(dirPath: string): Promise<void> {
+	const past = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+	await fs.utimes(dirPath, past, past);
 }
 
 /**
@@ -5476,5 +5484,166 @@ describe("backup relocation (writer repoint + per-deploy destination)", () => {
 		} finally {
 			await fs.chmod(backupRoot, 0o755);
 		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Suite: CLI wiring extraction (logBackupLocation, cleanupRunBackups)
+//
+// These cover the two pieces pulled out of the `import.meta.main` CLI block
+// so they're independently testable — see $OMT_DIR/plans (T-4 story) for the
+// full design. cleanupRunBackups is the ONLY caller of the destructive
+// rm -rf pruner (cleanupOldBackups) reachable from the CLI, so every guard
+// (dry-run gate, retention resolution, best-effort catch) must live inside it.
+// ---------------------------------------------------------------------------
+
+describe("CLI wiring extraction (logBackupLocation, cleanupRunBackups)", () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "cli-wiring-test-"));
+	});
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("cleanup prunes the shared root and never the target tree", async () => {
+		const base = path.join(tmpDir, "omt-base");
+		const worktree = path.join(tmpDir, "target-worktree");
+
+		const sharedAged = path.join(base, "sync-backup", "aged-session");
+		await fs.mkdir(sharedAged, { recursive: true });
+		await ageDir(sharedAged);
+
+		const targetAged = path.join(worktree, ".sync-backup", "old-session");
+		await fs.mkdir(targetAged, { recursive: true });
+		await ageDir(targetAged);
+
+		await cleanupRunBackups(base, false);
+
+		expect(await exists(sharedAged)).toBe(false);
+		expect(await exists(targetAged)).toBe(true);
+	});
+
+	it("age prune removes backups of untouched targets", async () => {
+		const rootDir = path.join(tmpDir, "root");
+		const targetPath = path.join(tmpDir, "target");
+		const backupBase = path.join(tmpDir, "omt-base");
+		const syncYamlPath = path.join(rootDir, "sync.yaml");
+		await fs.mkdir(path.join(rootDir, "skills"), { recursive: true });
+		await fs.mkdir(targetPath, { recursive: true });
+		await writeFile(path.join(rootDir, "config.yaml"), "use-platforms: [claude]\n");
+		_resetConfigCache();
+
+		await writeFile(path.join(rootDir, "skills", "oracle", "SKILL.md"), "# Oracle\n");
+		await writeFile(path.join(targetPath, ".claude", "skills", "old-thing", "SKILL.md"), "# Old\n");
+		await writeFile(
+			syncYamlPath,
+			`path: ${targetPath}\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`,
+		);
+		const adapters = makeAdapterMap(["claude"]);
+		const context = makeContext({ backupBase });
+
+		await processYaml(context, syncYamlPath, adapters, rootDir);
+
+		const syncBackupRoot = path.join(backupBase, "sync-backup");
+		const untouchedDir = path.join(syncBackupRoot, "y-untouched-session");
+		await fs.mkdir(untouchedDir, { recursive: true });
+		await ageDir(untouchedDir);
+
+		await cleanupRunBackups(backupBase, false);
+
+		expect(await exists(untouchedDir)).toBe(false);
+		_resetConfigCache();
+	});
+
+	it("failed worktree keeps this run's backup after cleanup", async () => {
+		const rootDir = path.join(tmpDir, "root");
+		const targetPath = path.join(tmpDir, "target");
+		const backupBase = path.join(tmpDir, "omt-base");
+		const syncYamlPath = path.join(rootDir, "sync.yaml");
+		await fs.mkdir(path.join(rootDir, "skills"), { recursive: true });
+		await fs.mkdir(targetPath, { recursive: true });
+		await writeFile(path.join(rootDir, "config.yaml"), "use-platforms: [claude]\n");
+		_resetConfigCache();
+
+		await writeFile(path.join(rootDir, "skills", "oracle", "SKILL.md"), "# Oracle\n");
+		await writeFile(path.join(targetPath, ".claude", "skills", "old-thing", "SKILL.md"), "# Old\n");
+		await writeFile(
+			syncYamlPath,
+			`path: ${targetPath}\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`,
+		);
+		const adapters = makeAdapterMap(["claude"]);
+		adapters.getAdapter("claude")!.syncSkillsDirect = async () => {
+			throw new Error("simulated deploy failure");
+		};
+		const context = makeContext({ backupBase });
+
+		await processYaml(context, syncYamlPath, adapters, rootDir);
+
+		expect(context.failedTargets).toContain(targetPath);
+
+		const syncBackupRoot = path.join(backupBase, "sync-backup");
+		expect(await fs.readdir(syncBackupRoot)).toHaveLength(1);
+
+		await cleanupRunBackups(backupBase, false);
+
+		expect(await fs.readdir(syncBackupRoot)).toHaveLength(1);
+		_resetConfigCache();
+	});
+
+	it("prune runs even when no target was processed", async () => {
+		const base = path.join(tmpDir, "omt-base");
+		const agedDir = path.join(base, "sync-backup", "aged-session");
+		await fs.mkdir(agedDir, { recursive: true });
+		await ageDir(agedDir);
+
+		await cleanupRunBackups(base, false);
+
+		expect(await exists(agedDir)).toBe(false);
+	});
+
+	it("cleanupRunBackups resolves even when the prune throws", async () => {
+		const base = path.join(tmpDir, "omt-base");
+		await writeFile(path.join(base, "sync-backup"), "not a directory");
+
+		// Precondition: readdir on a non-directory sync-backup path must actually
+		// reject — otherwise this test would pass vacuously even with the
+		// `.catch(() => {})` inside cleanupRunBackups removed.
+		await expect(cleanupOldBackups(base, 3)).rejects.toThrow();
+
+		await expect(cleanupRunBackups(base, false)).resolves.toBeUndefined();
+	});
+
+	it("cleanupRunBackups prunes nothing when dryRun is true", async () => {
+		const base = path.join(tmpDir, "omt-base");
+		const agedDir = path.join(base, "sync-backup", "aged-session");
+		await fs.mkdir(agedDir, { recursive: true });
+		await ageDir(agedDir);
+
+		await cleanupRunBackups(base, true);
+
+		expect(await exists(agedDir)).toBe(true);
+	});
+
+	it("logBackupLocation reports the OMT sync-backup root", () => {
+		const base = path.join(tmpDir, "omt-base");
+
+		const chunks: string[] = [];
+		const origStderr = process.stderr.write.bind(process.stderr);
+		process.stderr.write = (chunk: string | Uint8Array) => {
+			if (typeof chunk === "string") chunks.push(chunk);
+			return true;
+		};
+		try {
+			logBackupLocation(base);
+		} finally {
+			process.stderr.write = origStderr;
+		}
+
+		const output = chunks.join("");
+		expect(output).toContain(`${base}/sync-backup`);
+		expect(output).not.toContain("/.sync-backup/");
 	});
 });

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -37,7 +37,7 @@ import { ProjectKeyError, deriveClaudeProjectKey } from "./lib/git-key.ts";
 import { DeployTargetsError } from "./lib/resolve-deploy-targets.ts";
 import { ClaudeAdapter } from "./adapters/claude.ts";
 import { CodexAdapter } from "./adapters/codex.ts";
-import { cleanupOldBackups } from "./lib/backup.ts";
+import { cleanupOldBackups, isSafeBackupRoot } from "./lib/backup.ts";
 import { deriveProjectName } from "../lib/omt-dir.ts";
 import { execFileSync } from "child_process";
 
@@ -3552,6 +3552,35 @@ describe("resolveBackupBase", () => {
 			expect(fs2.existsSync(path.join(tmp, "rel"))).toBe(false);
 		} finally {
 			process.chdir(originalCwd);
+			if (originalOmtDir === undefined) delete process.env.OMT_DIR;
+			else process.env.OMT_DIR = originalOmtDir;
+			fs2.rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("resolveBackupBase throws when the base is a symlink whose real path is degenerate", () => {
+		// The string spelling of an absolute symlink is not degenerate, so the
+		// pure isSafeBackupRoot() check accepts it. But its real target here is
+		// "/", where the write path (context.backupDest → backup writers) would
+		// dump backups and the prune path already refuses to clean up. Startup
+		// must realpath-resolve and fail-fast — mirroring cleanupOldBackups's
+		// F2 guard — so neither `make sync` nor `make sync-dry` proceeds.
+		const tmp = fs2.mkdtempSync(path.join(os.tmpdir(), "omt-dir-symlink-"));
+		const link = path.join(tmp, "link_to_root");
+		fs2.symlinkSync("/", link);
+		const originalOmtDir = process.env.OMT_DIR;
+		process.env.OMT_DIR = link;
+		try {
+			// ① The symlink spelling itself is NOT string-degenerate — this is
+			// exactly why the pure predicate cannot catch it and a realpath
+			// re-validation is required.
+			expect(isSafeBackupRoot(link)).toBe(true);
+			// ② Real (write) run must fail-fast.
+			expect(() => resolveBackupBase()).toThrow(UnsafeBackupRootError);
+			// ③ Dry run (make sync-dry) must fail-fast too — the finding calls
+			// out both paths explicitly.
+			expect(() => resolveBackupBase(true)).toThrow(UnsafeBackupRootError);
+		} finally {
 			if (originalOmtDir === undefined) delete process.env.OMT_DIR;
 			else process.env.OMT_DIR = originalOmtDir;
 			fs2.rmSync(tmp, { recursive: true, force: true });

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -4307,52 +4307,22 @@ describe("component fan-out", () => {
 	});
 
 	// AC6.4 — fanned-out worktree backups are retention-pruned
-	it("AC6.4: retention cleanup removes stale backup sessions from each worktree's .sync-backup", async () => {
-		const { container, worktrees } = makeBareTopology("repo", ["wt1", "wt2"]);
-		await seedSkill("oracle");
+	it("AC6.4: retention cleanup removes stale backup sessions from the backup root", async () => {
+		const { worktrees } = makeBareTopology("repo", ["wt1", "wt2"]);
 
-		const syncYamlPath = path.join(rootDir, "sync.yaml");
-		await writeFile(
-			syncYamlPath,
-			`path: ${container}\nskills:\n  platforms: [claude]\n  items:\n    - oracle\n`,
-		);
+		// Plant a stale backup session directly under each worktree's backup root
+		// (cleanupOldBackups prunes <base>/sync-backup, no leading dot).
+		const oldBk0 = path.join(worktrees[0]!, "sync-backup", "old-session");
+		const oldBk1 = path.join(worktrees[1]!, "sync-backup", "old-session");
+		await writeFile(path.join(oldBk0, "marker"), "old\n");
+		await writeFile(path.join(oldBk1, "marker"), "old\n");
 
-		const adapters = new Map<Platform, PlatformAdapter>([
-			["claude", new ClaudeAdapter()],
-		]) as AdapterMap;
-
-		// Pre-place old content in both worktrees so cycle 1 has something to back up.
-		await writeFile(path.join(worktrees[0]!, ".claude", "skills", "old", "SKILL.md"), "# old\n");
-		await writeFile(path.join(worktrees[1]!, ".claude", "skills", "old", "SKILL.md"), "# old\n");
-
-		// Cycle 1: backs up the pre-placed content into "old-session" in each worktree.
-		const context1 = makeContext({ dryRun: false, backupSession: "old-session" });
-		await processYaml(context1, syncYamlPath, adapters, rootDir);
-
-		// Confirm old-session backup exists in both worktrees before cleanup.
-		const oldBk0 = path.join(worktrees[0]!, ".sync-backup", "old-session");
-		const oldBk1 = path.join(worktrees[1]!, ".sync-backup", "old-session");
 		expect(await exists(oldBk0)).toBe(true);
 		expect(await exists(oldBk1)).toBe(true);
 
-		// Verify the OLD behavior (processedPaths-only) does NOT reach the worktree backups:
-		// processedPaths holds only the container path for bare structures.
-		await Promise.all(
-			[...context1.processedPaths].map((t) => cleanupOldBackups(t, 0).catch(() => {})),
-		);
-		expect(await exists(oldBk0)).toBe(true); // still present — container-only cleanup misses worktrees
-		expect(await exists(oldBk1)).toBe(true);
+		// retentionDays=0 prunes every session directory under each worktree's backup root.
+		await Promise.all([worktrees[0]!, worktrees[1]!].map((t) => cleanupOldBackups(t, 0)));
 
-		// Cycle 2: oracle is now present in each worktree, so it gets backed up as "new-session".
-		const context2 = makeContext({ dryRun: false, backupSession: "new-session" });
-		await processYaml(context2, syncYamlPath, adapters, rootDir);
-
-		// Run cleanup on the union of processedPaths + backupRoots (retention=0 prunes all sessions).
-		// This mirrors the production loop after the TODO-3 fix.
-		const cleanupTargets = new Set<string>([...context2.processedPaths, ...context2.backupRoots]);
-		await Promise.all([...cleanupTargets].map((t) => cleanupOldBackups(t, 0).catch(() => {})));
-
-		// Both worktrees' old-session dirs must now be removed.
 		expect(await exists(oldBk0)).toBe(false);
 		expect(await exists(oldBk1)).toBe(false);
 	});

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -12,7 +12,7 @@
 
 import fs from "fs/promises";
 import path from "path";
-import { existsSync } from "fs";
+import { existsSync, realpathSync } from "fs";
 import { execFileSync } from "node:child_process";
 
 import type {
@@ -1774,6 +1774,25 @@ export function resolveBackupBase(dryRun = false): string {
 	const base = resolveOmtDir();
 	if (!isSafeBackupRoot(base)) {
 		throw new UnsafeBackupRootError(`안전하지 않은 백업 루트: ${base}`);
+	}
+	// The string guard above accepts a non-degenerate *spelling*, but base may
+	// be an absolute symlink whose real target is "/" or $HOME. The write path
+	// (context.backupDest → backup writers) follows that symlink and dumps
+	// backups into the degenerate location, which cleanupOldBackups's F2 guard
+	// then refuses to prune — so backups pile up unreachable. Re-validate the
+	// real path here so both `make sync` and `make sync-dry` fail-fast, exactly
+	// as cleanupOldBackups does before pruning.
+	let realBase = base;
+	try {
+		realBase = realpathSync(base);
+	} catch (err) {
+		// base doesn't exist yet (first run) — can't be a symlink, fall through.
+		if (!(err instanceof Error) || (err as NodeJS.ErrnoException).code !== "ENOENT") {
+			throw err;
+		}
+	}
+	if (!isSafeBackupRoot(realBase)) {
+		throw new UnsafeBackupRootError(`안전하지 않은 백업 루트(실제 경로): ${realBase}`);
 	}
 	return dryRun ? base : getOmtDir();
 }

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -36,8 +36,14 @@ import { parseCodexVersion, assertCodexVersionAllowed } from "./lib/codex-versio
 import { readAndExpandSyncYaml } from "./lib/parse-sync-yaml.ts";
 import { parseAndMergePlatformYaml } from "./lib/parse-platform-yaml.ts";
 import { resolvePlatforms, resolveComponentPath, setProjectContext } from "./lib/resolver.ts";
-import { backupCategory, backupDocs, cleanupOldBackups, isSafeBackupRoot } from "./lib/backup.ts";
-import { resolveOmtDir, getOmtDir } from "../lib/omt-dir.ts";
+import {
+	backupCategory,
+	backupDocs,
+	cleanupOldBackups,
+	generateBackupSessionId,
+	isSafeBackupRoot,
+} from "./lib/backup.ts";
+import { resolveOmtDir, getOmtDir, deriveProjectName } from "../lib/omt-dir.ts";
 import { reconcilePairManifest, removeManifestPair } from "./lib/deploy-manifest.ts";
 import { resolveDocsTarget, detectDocsTargetCollisions } from "./lib/path-utils.ts";
 import { logInfo, logWarn, logError, logDry, logSuccess } from "./lib/logger.ts";
@@ -1598,6 +1604,20 @@ export async function processYaml(
 
 	for (const deployRoot of deployRoots) {
 		try {
+			// Per-deploy backup destination (D-5): computed once per (target,
+			// worktree), before any deploy step. This is the only site that holds
+			// targetPath (the container) and deployRoot (the worktree)
+			// simultaneously, so it is the only site where the id CAN be computed —
+			// generating it lower (e.g. inside backupDocs, called from 6+ places)
+			// would scatter one deploy's backups across 6+ random directories.
+			// Writers read this back off the context exactly as they read
+			// context.backupDest at HEAD, so their signatures never change.
+			context.backupDest = path.join(
+				context.backupBase,
+				"sync-backup",
+				`${deriveProjectName(targetPath)}-${path.basename(deployRoot)}-${generateBackupSessionId()}`,
+			);
+
 			// Each worktree's deploy is independent — fresh source-root accumulator so
 			// syncLib targets this deployRoot's .{platform}/lib only.
 			const libSourceRoots: LibSourceRoots = new Map();

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -1617,6 +1617,11 @@ export async function processYaml(
 				"sync-backup",
 				`${deriveProjectName(targetPath)}-${path.basename(deployRoot)}-${generateBackupSessionId()}`,
 			);
+			// This deploy's actual backup directory — the only breadcrumb an
+			// operator has to recover from a clobber, since this backup design
+			// has no restore path (logBackupLocation only prints the shared
+			// parent, not this per-deploy destination).
+			logInfo(`백업 대상: ${context.backupDest}`);
 
 			// Each worktree's deploy is independent — fresh source-root accumulator so
 			// syncLib targets this deployRoot's .{platform}/lib only.
@@ -1758,13 +1763,19 @@ export class UnsafeBackupRootError extends Error {}
  * unconditional mkdirSync ever runs. Calling getOmtDir() first would create
  * the degenerate directory (e.g. <cwd>/rel/ for a relative OMT_DIR) and then
  * refuse to prune it — exactly the pollution this function exists to avoid.
+ * The guard runs regardless of dryRun, so a degenerate root still throws
+ * during a dry run.
+ *
+ * @param dryRun - When true, skip getOmtDir()'s mkdirSync and return the
+ *                 already-computed path instead — a dry run must not create
+ *                 the base directory as a side effect.
  */
-export function resolveBackupBase(): string {
+export function resolveBackupBase(dryRun = false): string {
 	const base = resolveOmtDir();
 	if (!isSafeBackupRoot(base)) {
 		throw new UnsafeBackupRootError(`안전하지 않은 백업 루트: ${base}`);
 	}
-	return getOmtDir();
+	return dryRun ? base : getOmtDir();
 }
 
 // ---------------------------------------------------------------------------
@@ -1775,7 +1786,7 @@ export function resolveBackupBase(): string {
  * Create an initial SyncContext for a sync run.
  */
 export function createContext(dryRun: boolean): SyncContext {
-	const backupBase = resolveBackupBase();
+	const backupBase = resolveBackupBase(dryRun);
 	return {
 		dryRun,
 		projectName: "",

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -36,7 +36,8 @@ import { parseCodexVersion, assertCodexVersionAllowed } from "./lib/codex-versio
 import { readAndExpandSyncYaml } from "./lib/parse-sync-yaml.ts";
 import { parseAndMergePlatformYaml } from "./lib/parse-platform-yaml.ts";
 import { resolvePlatforms, resolveComponentPath, setProjectContext } from "./lib/resolver.ts";
-import { generateBackupSessionId, backupCategory, backupDocs, cleanupOldBackups } from "./lib/backup.ts";
+import { backupCategory, backupDocs, cleanupOldBackups, isSafeBackupRoot } from "./lib/backup.ts";
+import { resolveOmtDir, getOmtDir } from "../lib/omt-dir.ts";
 import { reconcilePairManifest, removeManifestPair } from "./lib/deploy-manifest.ts";
 import { resolveDocsTarget, detectDocsTargetCollisions } from "./lib/path-utils.ts";
 import { logInfo, logWarn, logError, logDry, logSuccess } from "./lib/logger.ts";
@@ -349,7 +350,7 @@ export async function syncCategory(
 					deployRoot,
 					deployLocationForManifest(platform, category),
 					category,
-					context.backupSession,
+					context.backupDest,
 				);
 				preparedKeys.add(prepKey);
 			}
@@ -407,7 +408,7 @@ export async function syncCategory(
 	if (category === "skills" && deployedNames.has("agents")) {
 		await cleanupCodexSkillsFossil(
 			deployRoot,
-			context.backupSession,
+			context.backupDest,
 			context.dryRun,
 			deployedNames.get("agents") ?? new Set(),
 		);
@@ -935,7 +936,7 @@ export async function syncDocs(
 				managedTargets.add(candidate);
 				logDry(`docs: would remove ${candidate}`);
 			} else {
-				await deleteDocsTarget(candidate, deployRoot, context.backupSession);
+				await deleteDocsTarget(candidate, deployRoot, context.backupDest);
 			}
 			continue;
 		}
@@ -947,7 +948,7 @@ export async function syncDocs(
 				managedTargets.add(plan.finalTarget);
 				logDry(`docs: would write ${plan.finalTarget}`);
 			} else {
-				await deployDocsFile(plan.sourceFile, plan.finalTarget, deployRoot, context.backupSession);
+				await deployDocsFile(plan.sourceFile, plan.finalTarget, deployRoot, context.backupDest);
 			}
 			continue;
 		}
@@ -961,7 +962,7 @@ export async function syncDocs(
 				logDry(`docs: would write ${dest}`);
 			}
 		} else {
-			await deployDocsDir(plan.absTarget, plan.files, deployRoot, context.backupSession);
+			await deployDocsDir(plan.absTarget, plan.files, deployRoot, context.backupDest);
 		}
 	}
 
@@ -1647,12 +1648,6 @@ export async function processYaml(
 			// project (no CATEGORIES items, no .claude) must still deploy its docs.
 			await syncDocs(context, syncYaml, rootDir, deployRoot);
 
-			// Record this worktree as a backup root ONLY after all sync steps succeeded.
-			// Registering before the steps (or on failure) would let retention cleanup
-			// prune the last good backup of a worktree whose deploy threw — it must hold
-			// a success-only invariant: failed worktrees go to failedTargets, not here.
-			context.backupRoots.add(deployRoot);
-
 			// Rewrite platform paths for non-claude platforms
 			const nonClaudePlatforms: Platform[] = ["gemini", "codex", "opencode"];
 			for (const platform of nonClaudePlatforms) {
@@ -1725,6 +1720,33 @@ export async function loadRootModelMaps(rootDir: string): Promise<Map<Platform, 
 	return out;
 }
 
+/**
+ * Thrown by resolveBackupBase() when the resolved OMT_DIR would make the
+ * backup-retention pruner's recursive rm far more destructive than intended
+ * (relative path, "/", or the user's home directory). Never process.exit —
+ * that would kill the in-process test runner. The CLI entry point is
+ * responsible for catching this and exiting non-zero.
+ */
+export class UnsafeBackupRootError extends Error {}
+
+/**
+ * Resolves the OMT-owned backup root for this run and guarantees the
+ * directory exists — WITHOUT ever creating a degenerate root first.
+ *
+ * Order is load-bearing: resolveOmtDir() only computes the path (no fs
+ * writes), so isSafeBackupRoot() can reject it BEFORE getOmtDir()'s
+ * unconditional mkdirSync ever runs. Calling getOmtDir() first would create
+ * the degenerate directory (e.g. <cwd>/rel/ for a relative OMT_DIR) and then
+ * refuse to prune it — exactly the pollution this function exists to avoid.
+ */
+export function resolveBackupBase(): string {
+	const base = resolveOmtDir();
+	if (!isSafeBackupRoot(base)) {
+		throw new UnsafeBackupRootError(`안전하지 않은 백업 루트: ${base}`);
+	}
+	return getOmtDir();
+}
+
 // ---------------------------------------------------------------------------
 // createContext
 // ---------------------------------------------------------------------------
@@ -1733,17 +1755,23 @@ export async function loadRootModelMaps(rootDir: string): Promise<Map<Platform, 
  * Create an initial SyncContext for a sync run.
  */
 export function createContext(dryRun: boolean): SyncContext {
+	const backupBase = resolveBackupBase();
 	return {
 		dryRun,
 		projectName: "",
 		projectDir: "",
 		isRootYaml: true,
-		backupSession: generateBackupSessionId(),
+		backupBase,
+		// Initialized to backupBase, never "" — an empty string would make
+		// join("", platform, category) relative, so any reader that ran before
+		// the fan-out assignment (sync.ts fan-out loop) would write into the
+		// process cwd. No such reader exists today (every writer runs inside
+		// the fan-out loop); this is a cheap seatbelt against that defect class.
+		backupDest: backupBase,
 		modelMaps: new Map(),
 		rootModelMaps: new Map(),
 		processedPaths: new Set(),
 		platformYamlSections: new Map(),
-		backupRoots: new Set(),
 		failedTargets: [],
 	};
 }
@@ -2012,8 +2040,7 @@ if (import.meta.main) {
 	const context = createContext(dryRun);
 	context.rootModelMaps = await loadRootModelMaps(rootDir);
 
-	logInfo(`백업 세션: ${context.backupSession}`);
-	logInfo(`백업 위치: ${rootDir}/.sync-backup/${context.backupSession}/`);
+	logInfo(`백업 위치: ${context.backupBase}/sync-backup`);
 
 	const adapters: AdapterMap = new Map<Platform, PlatformAdapter>();
 	adapters.set("claude", new ClaudeAdapter());
@@ -2075,13 +2102,13 @@ if (import.meta.main) {
 		const cleanupPromises: Promise<void>[] = [];
 		if (!dryRun) {
 			const retentionDays = await getBackupRetentionDays();
-			// Union of processedPaths (container, drives deploy dedup) and backupRoots (per-worktree
-			// deploy roots populated during fan-out). Set-union ensures a non-bare path present in
-			// both is cleaned exactly once.
-			const cleanupTargets = new Set<string>([...context.processedPaths, ...context.backupRoots]);
-			for (const target of cleanupTargets) {
-				cleanupPromises.push(cleanupOldBackups(target, retentionDays).catch(() => {}));
-			}
+			// Prune the single shared OMT-owned root only — no longer a union with
+			// the per-worktree deploy-root set. This deliberately gives up the
+			// prior success-only invariant (only worktrees that finished cleanly
+			// were pruned): the shared root is pruned unconditionally now, by age.
+			// See the plan's ACCEPTED CONSEQUENCES — backups are write-only and
+			// git-recoverable, so this trade is accepted.
+			cleanupPromises.push(cleanupOldBackups(context.backupBase, retentionDays).catch(() => {}));
 		}
 
 		if (dryRun) {

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -2039,6 +2039,27 @@ export async function assertCodexVersionIfTargeted(
 	assertCodexVersionAllowed(observed, allowed);
 }
 
+/**
+ * Logs the OMT-owned sync-backup root for this run.
+ */
+export function logBackupLocation(base: string): void {
+	logInfo(`백업 위치: ${base}/sync-backup`);
+}
+
+/**
+ * Prunes old backups under the OMT-owned shared root. Prune the single shared
+ * OMT-owned root only — no longer a union with the per-worktree deploy-root
+ * set. This deliberately gives up the prior success-only invariant (only
+ * worktrees that finished cleanly were pruned): the shared root is pruned
+ * unconditionally now, by age. See the plan's ACCEPTED CONSEQUENCES — backups
+ * are write-only and git-recoverable, so this trade is accepted.
+ */
+export async function cleanupRunBackups(base: string, dryRun: boolean): Promise<void> {
+	if (dryRun) return;
+	const retentionDays = await getBackupRetentionDays();
+	await cleanupOldBackups(base, retentionDays).catch(() => {});
+}
+
 // ---------------------------------------------------------------------------
 // CLI entry point
 // ---------------------------------------------------------------------------
@@ -2057,10 +2078,19 @@ if (import.meta.main) {
 		process.exit(1);
 	}
 
-	const context = createContext(dryRun);
+	let context: SyncContext;
+	try {
+		context = createContext(dryRun);
+	} catch (err) {
+		if (err instanceof UnsafeBackupRootError) {
+			logError(err.message);
+			process.exit(1);
+		}
+		throw err;
+	}
 	context.rootModelMaps = await loadRootModelMaps(rootDir);
 
-	logInfo(`백업 위치: ${context.backupBase}/sync-backup`);
+	logBackupLocation(context.backupBase);
 
 	const adapters: AdapterMap = new Map<Platform, PlatformAdapter>();
 	adapters.set("claude", new ClaudeAdapter());
@@ -2118,26 +2148,13 @@ if (import.meta.main) {
 			}
 		}
 
-		// 오래된 백업 정리
-		const cleanupPromises: Promise<void>[] = [];
-		if (!dryRun) {
-			const retentionDays = await getBackupRetentionDays();
-			// Prune the single shared OMT-owned root only — no longer a union with
-			// the per-worktree deploy-root set. This deliberately gives up the
-			// prior success-only invariant (only worktrees that finished cleanly
-			// were pruned): the shared root is pruned unconditionally now, by age.
-			// See the plan's ACCEPTED CONSEQUENCES — backups are write-only and
-			// git-recoverable, so this trade is accepted.
-			cleanupPromises.push(cleanupOldBackups(context.backupBase, retentionDays).catch(() => {}));
-		}
-
 		if (dryRun) {
 			logWarn("========== DRY-RUN 완료 ==========");
 		} else {
 			logSuccess("========== 동기화 완료 ==========");
 		}
 
-		await Promise.all(cleanupPromises);
+		await cleanupRunBackups(context.backupBase, dryRun);
 		// Any worktree that failed during the best-effort fan-out forces a non-zero
 		// exit: an unwritable worktree must never be reported as a clean sync.
 		if (context.failedTargets.length > 0) {


### PR DESCRIPTION
## 📌 Summary

`make sync`가 덮어쓸 파일을 백업할 때 **타겟 레포 내부**(`<deployRoot>/.sync-backup/`)에 쓰던 것을, OMT가 소유한 단일 루트(`<base>/sync-backup/<target>-<worktree>-<hex>/`)로 이전합니다. 타겟 레포의 `prettier --check`·CI가 백업 파일로 오염되던 문제를 해소하고, 유일한 파괴 경로인 프룬의 `rm -rf`를 우회 불가능한 이중 가드로 경계 짓습니다.

---

## 🔧 Changes

### 백업 목적지 이전 (`tools/lib/backup.ts`, `tools/sync.ts`, `tools/lib/types.ts`)

- `SyncContext`의 `backupSession` 단일 필드를 `backupBase`(run-scoped) + `backupDest`(deploy-scoped) 두 필드로 분할
- fan-out 루프에서 deploy(target×worktree)당 한 번 `backupDest = <base>/sync-backup/<target>-<worktree>-<hex>` 할당
- 모든 writer(카테고리·docs·codex fossil 정리)가 새 목적지를 가리키도록 재지정
- `<base>` = `$OMT_DIR`, 없으면 `~/.omt/<projectName>`

백업이 타겟 레포 밖으로 나가면서, 그 레포의 CI/prettier가 더 이상 백업 파일을 보지 않습니다.

**영향 범위**: `make sync`/`make sync-dry`의 백업 쓰기 위치 변경(사용자 관측 가능). 백업은 write-only(restore 경로 없음)라 읽기 측 하위호환 이슈 없음. 기존에 타겟 레포에 쌓인 `.sync-backup/`은 건드리지 않고 그대로 둠(범위 밖).

### 파괴 경로 가드 (`tools/lib/backup.ts`)

- `cleanupOldBackups` 진입부에 이중 가드: `isSafeBackupRoot` 문자열 술어(상대경로/`/`/홈 거부) + `<base>/sync-backup` 심볼릭 링크 containment
- 두 가드 모두 `logError` + `return`(never throw) — 유일 호출자가 `.catch(() => {})`로 감싸기 때문
- `isSafeBackupRoot`의 홈 비교를 대소문자 무시로(macOS APFS 우회 차단), base가 심링크일 때 `realpath` 재검증

**영향 범위**: 파괴 함수 `rm -rf`의 blast radius를 `<base>/sync-backup/`의 자식으로 구조적으로 제한. degenerate base는 배포 전 `UnsafeBackupRootError`로 fail-fast(dry-run에도 발화).

### CLI 배선 + startup fail-fast (`tools/sync.ts`)

- `logBackupLocation`·`cleanupRunBackups`를 `if (import.meta.main)` 밖으로 추출해 테스트 가능화
- `cleanupRunBackups(base, dryRun)`가 dry-run 게이트·retention 해석·`.catch`를 모두 함수 내부에 품음
- `createContext`가 `UnsafeBackupRootError`에 graceful exit(1), dry-run은 base 디렉터리 생성 안 함

**영향 범위**: CLI 진입점 동작 보존, 내부 함수만 추출. `make sync-dry`가 실제 백업을 프룬하지 않음을 서브프로세스 검증.

### 문서 + 테스트 (`docs/sync-deploy-targets.md`, `tools/**/*.test.ts`, `lib/omt-dir.ts`, `tools/adapters/*`)

- sync SSOT 문서에 새 백업 위치·startup abort 절 추가
- 테스트 스위트 hermeticity: `process.env.OMT_DIR`을 per-test tmp로 격리(실제 `~/.omt` 미오염)
- `deriveProjectName`을 `lib/omt-dir.ts`에서 export

**영향 범위**: 테스트/문서/어댑터 시그니처 리네임. 런타임 동작 무변.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.

### 1. 파괴 함수의 가드는 왜 throw가 아니라 log-and-return인가

**배경 및 문제 상황:**
백업 루트를 per-target 디렉터리에서 **공유** 루트로 옮기면서, 프룬의 `rm -rf`가 잘못되면 한 타겟이 아니라 모든 프로젝트의 백업이 날아갑니다. 가드가 필수인데, 유일 호출자가 `cleanupRunBackups`에서 `.catch(() => {})`로 실패를 삼킵니다.

**해결 방안:**
가드를 throw로 만들면 프로덕션에서 그 `.catch`가 조용히 삼켜 **가드가 무장해제**되는데, 정작 `rejects.toThrow()` 단언은 그린으로 남습니다 — 테스트는 통과하는데 프로덕션은 무방비인 최악의 조합. 그래서 가드를 `logError` + `return`으로 만들어 거부가 양쪽 환경 모두에서 stderr로 보이게 했습니다.

**선택과 트레이드오프:**
`resolveBackupBase`(startup)는 throw로 fail-fast하고, `cleanupOldBackups`(파괴 함수)는 log-and-return하는 비대칭입니다. 언뜻 일관성이 없어 보이지만, 전자는 호출자가 잡아 exit(1)하고 후자는 호출자가 삼키므로 각각 다른 게 맞습니다. `backup.ts`에 이 비대칭을 "고치지 말라"는 주석을 남겼습니다.

### 2. 홈 디렉터리 거부를 순수 문자열 술어로 유지한 이유와 그 한계

**배경 및 문제 상황:**
`isSafeBackupRoot`는 상대경로/`/`/홈을 거부하는 순수 문자열 술어로 설계했습니다(fs 접근 없음). 그런데 독립 code-review가 inode 동일성으로 실증한 결함: macOS APFS는 기본 case-insensitive라 `OMT_DIR=/users/toong`이 진짜 홈(`/Users/toong`, 같은 inode)인데 `=== os.homedir()` 정확 비교를 빠져나갑니다.

**해결 방안:**
"홈인가?"라는 질문은 순수 문자열로 답할 수 없어 보이지만(같은 inode의 다른 문자열), **정확 동등 비교를 case-fold**하는 것으로 술어의 순수성을 지키며 닫힙니다. base가 심링크로 홈/`/`를 가리키는 경우만이 진짜 realpath(fs)를 요구해서, 그건 별도 fs 가드(`cleanupOldBackups` 내부)에 넣었습니다.

**선택과 트레이드오프:**
"under home"으로 확대하지 **않았습니다** — 기본 base `~/.omt/<project>`가 홈 아래이기 때문입니다. 홈 자체만 case-fold로 거부합니다. 두 가드의 역할 분리(문자열 술어 vs fs realpath)가 수정에서도 유지됩니다.

### 3. dry-run 게이트와 retention 해석을 파괴 함수 내부에 둔 이유

**배경 및 문제 상황:**
`cleanupRunBackups`의 시그니처가 `(base, dryRun: boolean)`이지 `(base, retentionDays: number)`가 아닌 것이 load-bearing입니다. raw 숫자를 받으면 호출자가 `0`을 넘길 수 있고, `retentionDays === 0` 분기는 **나이 체크 없이 무조건 `rm -rf`** 합니다.

**해결 방안:**
`if (dryRun) return`·`getBackupRetentionDays()`(config `days > 0` 바닥)·`.catch(() => {})`를 모두 함수 **내부**에 품게 했습니다. 게이트가 호출자에 있으면 새 호출자가 생길 때마다 다시 써야 하고 한 번 빠뜨리면 무방비지만, 함수 안에 있으면 모든 진입점이 자동으로 통과합니다.

**선택과 트레이드오프:**
`cleanupOldBackups`가 `"sync-backup"` 리터럴을 자기 안에서 join하는 것과 같은 구조적 containment 원리입니다 — 호출자가 pre-joined 루트를 넘길 수 없습니다.

---

## ✅ Checklist

### 백업 이전
- [ ] 싱크가 어떤 타겟 워크트리에도 새 `.sync-backup/`을 만들지 않는다
  - `tools/sync.ts`, `tools/lib/backup.ts`
- [ ] 모든 백업이 `<base>/sync-backup/<target>-<worktree>-<hex>/` 아래 deploy당 하나의 세그먼트를 공유한다
  - `tools/sync.ts`
- [ ] 백업된 바이트가 덮어쓰기 이전(pre-overwrite) 타겟 바이트다
  - `tools/lib/backup.ts`

### 파괴 경로 가드
- [ ] degenerate base(상대경로/`/`/홈, 홈은 대소문자 무시) 또는 심링크된 base는 아무것도 지우지 않고 stderr로 거부한다
  - `tools/lib/backup.ts`
- [ ] `make sync-dry`는 어떤 백업도 프룬하지 않는다
  - `tools/sync.ts`
- [ ] cleanup 실패(readdir ENOTDIR 등)가 sync를 실패시키지 않는다
  - `tools/sync.ts`

### 격리
- [ ] 테스트 스위트가 개발자의 실제 OMT base를 byte-identical하게 남긴다
  - `tools/sync.test.ts`, `tools/sync.e2e.test.ts`