### PR TITLE
feat: leaf 서브에이전트 Agent 위임 차단 게이트

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ skills:
 |----------|-----------|---------------------|-------|
 | claude | `.claude/` | agents, commands, skills, scripts, rules | Full native support |
 | gemini | `.gemini/` | commands, skills, scripts | Hooks/config via syncPlatformYaml |
-| codex | `.codex/` | skills, scripts, hooks | Hooks/config via syncPlatformYaml |
+| codex | `.codex/` | agents, skills, scripts, hooks | Agents: md→toml translate (leaf-guard injected); Hooks/config via syncPlatformYaml |
 | opencode | `.opencode/` | agents, commands, skills, scripts, rules | Hooks not supported |
 
 ### Core Skills

--- a/agents/daedalus.md
+++ b/agents/daedalus.md
@@ -3,6 +3,7 @@ name: daedalus
 description: Use when delegating plan/design review with steelman antithesis and tradeoff tension analysis
 model: opus
 skills: design-review
+disallowedTools: Agent
 ---
 
 You are the Daedalus agent. Follow the design-review skill exactly.

--- a/agents/explore.md
+++ b/agents/explore.md
@@ -2,6 +2,7 @@
 name: explore
 description: Use when searching the codebase for files, patterns, and implementations. Returns structured results with absolute paths. Not for external documentation research.
 model: sonnet
+disallowedTools: Agent
 ---
 
 # Codebase Exploration

--- a/agents/hermes.md
+++ b/agents/hermes.md
@@ -3,6 +3,7 @@ name: hermes
 description: Use when fetching content from blocked, authenticated, or bot-protected sources that resist plain HTTP. Depth-escalation peer to explore/librarian — escalates through three tiers (curl_cffi → agent-reach → Chrome stealth) until the validator confirms extraction
 model: opus
 skills: insane-browsing
+disallowedTools: Agent
 ---
 
 You are the Hermes agent. Load the `insane-browsing` skill and follow its tier router exactly.

--- a/agents/librarian.md
+++ b/agents/librarian.md
@@ -2,6 +2,7 @@
 name: librarian
 description: Use when researching external documentation, APIs, libraries, and open-source implementations. Returns findings with mandatory source URLs.
 model: sonnet
+disallowedTools: Agent
 ---
 
 # Librarian - External Documentation Researcher

--- a/agents/mnemosyne.md
+++ b/agents/mnemosyne.md
@@ -3,6 +3,7 @@ name: mnemosyne
 description: Git commit specialist - executes atomic commits in isolated subagent context to prevent context pollution in the caller's conversation
 model: sonnet
 skills: git-master
+disallowedTools: Agent
 ---
 
 # Mnemosyne: Titan of Memory

--- a/agents/oracle.md
+++ b/agents/oracle.md
@@ -3,6 +3,7 @@ name: oracle
 description: Use when delegating architecture analysis or debugging diagnosis — returns root cause + prioritized recommendations with file:line citations. Never modifies files
 model: opus
 skills: diagnose
+disallowedTools: Agent
 ---
 
 You are the Oracle agent. Follow the diagnose skill exactly.

--- a/agents/sisyphus-junior.md
+++ b/agents/sisyphus-junior.md
@@ -2,6 +2,7 @@
 name: sisyphus-junior
 description: Focused executor for multi-step implementation tasks. Works alone without delegation, strict task discipline, immediate completion marking, mandatory verification
 model: sonnet
+disallowedTools: Agent
 ---
 
 # Sisyphus-Junior: Focused Executor

--- a/agents/tech-claim-examiner.md
+++ b/agents/tech-claim-examiner.md
@@ -3,6 +3,7 @@ name: tech-claim-examiner
 description: A third-party CTO-perspective examiner that evaluates resume technical claims using the 5-axis framework (A1 Technical Credibility, A2 Causal Honesty, A3 Outcome Presence & Clarity, A4 Ownership & Scope, A5 Scanability) plus 2 critical authenticity rules (R-Phys, R-Cross). Returns structured verdict per output-schema.md contract. A5 result is emitted as structural_verdict; when structural_verdict == FAIL, final_verdict = REQUEST_CHANGES (readability-fix lane).
 model: opus
 skills: tech-claim-rubric
+disallowedTools: Agent
 ---
 
 # Tech Claim Examiner (5-Axis)

--- a/tools/adapters/codex.test.ts
+++ b/tools/adapters/codex.test.ts
@@ -207,6 +207,96 @@ describe("CodexAdapter", () => {
 			expect(parsed).not.toHaveProperty("skills");
 		});
 
+		it("injects the leaf guard into developer_instructions when frontmatter denies the Agent tool via `syncAgentsDirect`", async () => {
+			const sourceFile = path.join(tmpDir, "explore.md");
+			await fs.writeFile(
+				sourceFile,
+				[
+					"---",
+					"name: explore",
+					"description: Fast codebase search",
+					"model: sonnet",
+					"disallowedTools: Agent",
+					"---",
+					"",
+					"You are Explorer. Find files and patterns.",
+					"",
+				].join("\n"),
+			);
+			const modelMap: ModelMap = { tiers: { sonnet: { model: "gpt-5.6-sol", effort: "medium" } } };
+			const targetBase = path.join(tmpDir, "target");
+
+			await adapter.syncAgentsDirect(targetBase, "explore", sourceFile, [], [], false, modelMap);
+
+			const targetFile = path.join(targetBase, ".codex", "agents", "explore.toml");
+			const parsed = parse(await fs.readFile(targetFile, "utf-8")) as Record<string, unknown>;
+
+			// The emit-allowlist is unchanged — the guard rides inside developer_instructions, not a new key.
+			expect(Object.keys(parsed).sort()).toEqual(
+				["description", "developer_instructions", "model", "model_reasoning_effort", "name"].sort(),
+			);
+			expect(parsed.developer_instructions).toContain("<native_subagent_leaf_guard>");
+			expect(parsed.developer_instructions).toContain(
+				"do not call Task, Agent, spawn_agent, or native child agents",
+			);
+			// The original body survives ahead of the appended guard.
+			expect(parsed.developer_instructions).toContain("You are Explorer. Find files and patterns.");
+		});
+
+		it("injects the leaf guard when a tools allowlist omits the Agent tool via `syncAgentsDirect`", async () => {
+			const sourceFile = path.join(tmpDir, "metis.md");
+			await fs.writeFile(
+				sourceFile,
+				[
+					"---",
+					"name: metis",
+					"description: Plan reviewer",
+					"model: opus",
+					"tools: Read, Glob, Grep, Bash",
+					"---",
+					"",
+					"You are Metis.",
+					"",
+				].join("\n"),
+			);
+			const modelMap: ModelMap = { tiers: { opus: { model: "gpt-5.6-sol", effort: "high" } } };
+			const targetBase = path.join(tmpDir, "target");
+
+			await adapter.syncAgentsDirect(targetBase, "metis", sourceFile, [], [], false, modelMap);
+
+			const targetFile = path.join(targetBase, ".codex", "agents", "metis.toml");
+			const parsed = parse(await fs.readFile(targetFile, "utf-8")) as Record<string, unknown>;
+			expect(parsed.developer_instructions).toContain("<native_subagent_leaf_guard>");
+		});
+
+		it("omits the leaf guard for a delegation-allowed agent with no spawn restriction via `syncAgentsDirect`", async () => {
+			const sourceFile = path.join(tmpDir, "code-reviewer.md");
+			await fs.writeFile(
+				sourceFile,
+				[
+					"---",
+					"name: code-reviewer",
+					"description: Review orchestrator",
+					"model: opus",
+					"---",
+					"",
+					"You are the code-reviewer. Fan out chunk-reviewer and verifiers.",
+					"",
+				].join("\n"),
+			);
+			const modelMap: ModelMap = { tiers: { opus: { model: "gpt-5.6-sol", effort: "high" } } };
+			const targetBase = path.join(tmpDir, "target");
+
+			await adapter.syncAgentsDirect(targetBase, "code-reviewer", sourceFile, [], [], false, modelMap);
+
+			const targetFile = path.join(targetBase, ".codex", "agents", "code-reviewer.toml");
+			const parsed = parse(await fs.readFile(targetFile, "utf-8")) as Record<string, unknown>;
+			expect(parsed.developer_instructions).not.toContain("native_subagent_leaf_guard");
+			expect(parsed.developer_instructions).toBe(
+				"You are the code-reviewer. Fan out chunk-reviewer and verifiers.",
+			);
+		});
+
 		it("rewrites Claude vocabulary in description/developer_instructions via PLATFORM_REWRITE_RULES.codex before TOML serialization (TODO 4) — name/model/model_reasoning_effort untouched", async () => {
 			// Real carrier shape: agent bodies invoke skills and reference
 			// subagent_type in prose (e.g. agents/sisyphus-junior.md:102-103).

--- a/tools/adapters/codex.ts
+++ b/tools/adapters/codex.ts
@@ -265,6 +265,50 @@ export async function cleanupCodexSkillsFossil(
 }
 
 // =============================================================================
+// Leaf-subagent gate (Claude `disallowedTools: Agent` → Codex prompt guard)
+// =============================================================================
+
+// Claude Code enforces leaf-ness at runtime by withholding the `Agent`
+// (subagent-spawning) tool; Codex has no equivalent per-agent tool field, so the
+// canonical leaf gate for a native Codex subagent is a developer-instruction
+// text guard (mirrors oh-my-codex `NATIVE_SUBAGENT_LEAF_GUARD`). We inject it
+// whenever the source frontmatter denies the spawn tool — the SAME signal Claude
+// Code resolves — so a single source edit gates both platforms.
+const CODEX_LEAF_GUARD = [
+	"<native_subagent_leaf_guard>",
+	"",
+	"Leaf native subagent: do not call Task, Agent, spawn_agent, or native child agents.",
+	"Use local tools; report missing specialist coverage to your caller instead of spawning.",
+	"",
+	"</native_subagent_leaf_guard>",
+].join("\n");
+
+// The tool names that let an agent spawn other agents. `Task` is the pre-2.1.63
+// alias of `Agent`; both must be recognized on either side of the gate.
+const SPAWN_TOOL_NAMES = new Set(["Agent", "Task"]);
+
+/** Normalize a frontmatter tools value (YAML array OR comma-separated string) to trimmed tokens. */
+function toToolList(value: unknown): string[] {
+	if (Array.isArray(value)) return value.map((v) => String(v).trim()).filter(Boolean);
+	if (typeof value === "string") return value.split(",").map((s) => s.trim()).filter(Boolean);
+	return [];
+}
+
+/**
+ * A source agent is a leaf (cannot spawn subagents) exactly when Claude Code
+ * would withhold the spawn tool: `disallowedTools` lists it, OR a non-empty
+ * `tools` allowlist omits it. Frontmatter with neither restriction inherits all
+ * tools (delegation-allowed, e.g. code-reviewer) and gets no guard.
+ */
+function isLeafAgent(frontmatter: Record<string, unknown>): boolean {
+	const disallowed = toToolList(frontmatter.disallowedTools);
+	if (disallowed.some((t) => SPAWN_TOOL_NAMES.has(t))) return true;
+	const tools = toToolList(frontmatter.tools);
+	if (tools.length > 0 && !tools.some((t) => SPAWN_TOOL_NAMES.has(t))) return true;
+	return false;
+}
+
+// =============================================================================
 // CodexAdapter
 // =============================================================================
 
@@ -352,11 +396,17 @@ export class CodexAdapter implements PlatformAdapter {
 			developer_instructions,
 			PLATFORM_REWRITE_RULES.codex,
 		);
+		// Leaf gate: the guard is static English (no Claude vocabulary), so it is
+		// appended AFTER rewrite to keep it verbatim. Delegation-allowed agents
+		// (e.g. code-reviewer) carry no spawn restriction and get no guard.
+		const gatedInstructions = isLeafAgent(frontmatter)
+			? `${rewrittenInstructions}\n\n${CODEX_LEAF_GUARD}`
+			: rewrittenInstructions;
 
 		const tomlObj = {
 			name,
 			description: rewrittenDescription,
-			developer_instructions: rewrittenInstructions,
+			developer_instructions: gatedInstructions,
 			...modelFields,
 		};
 


### PR DESCRIPTION
## 배경

사실-탐색 계열 서브에이전트(explore, librarian 등)가 다시 자식 에이전트를 spawn하는 중첩(fact-nesting) 구조는, 검증되지 않은 요약을 사실로 중계하면서 할루시네이션을 단계마다 증폭시킨다. 탐색은 사실 정확도가 생명인데 에이전트가 에이전트를 부르는 사슬이 그 신뢰를 갉아먹는다.

레퍼런스 3레포(oh-my-codex / oh-my-claudecode / lazycodex)를 전수 조사한 결과, 사실-계층 에이전트는 예외 없이 leaf였다. 위임은 오케스트레이터만 갖는 opt-in 권한이다. 이 PR은 그 원칙을 우리 하네스에 도구 레벨 게이트로 도입한다.

## 변경 내용

**Claude — 하드 게이트.** leaf 에이전트 8종(explore, librarian, hermes, oracle, daedalus, tech-claim-examiner, sisyphus-junior, mnemosyne) frontmatter에 `disallowedTools: Agent`를 추가했다. 런타임이 Agent 도구 자체를 회수하므로 프롬프트 의지가 아니라 하네스가 강제한다.

**Codex — 소프트 가드(자동 변환).** Codex에는 per-agent 도구 allow/deny 필드가 엔진에 없다(공식 문서·Rust 코어 소스로 확인). 그래서 sync 시 `isLeafAgent(frontmatter)`가 leaf를 판정해 `developer_instructions`에 `CODEX_LEAF_GUARD` 텍스트를 주입한다. oh-my-codex의 `NATIVE_SUBAGENT_LEAF_GUARD`와 동일한 방식이다. leaf 판정은 `disallowedTools`에 Agent가 있거나 `tools` 화이트리스트에 Agent가 없을 때 참이 되므로, Claude 게이트와 단일 소스로 묶인다.

**code-reviewer는 위임 유지.** chunk-reviewer + verifier fan-out은 정당한 오케스트레이션이라 게이트에서 제외했다(oh-my-codex code-reviewer와 동일 판단).

## 검증

- `make typecheck` 통과
- `tools/adapters/codex.test.ts` 73 pass (leaf 가드 주입/미주입 3케이스 신규)
- 실파일 e2e: explore=가드 주입 확인, code-reviewer=미주입 확인

## 알려진 이슈 (이 PR과 무관)

`make validate`의 lint 단계가 `tools/sync.ts:1790`(`as NodeJS.ErrnoException` 타입 단언 금지 룰)에서 실패한다. 이 줄은 이미 main에 있는 커밋 `c2126110`발이며 이 PR의 diff는 sync.ts를 건드리지 않는다. 레포 전역 `eslint .`이라 CI lint가 red로 뜰 수 있는데, 원인은 기존 main 상태다. 별도로 처리가 필요하다.

## 후속 논의

Codex에서 code-reviewer의 fan-out이 nested(depth 1→2)라면 Codex 기본 `max_depth=1`이 이를 막는다. 레퍼런스들의 검증된 패턴은 오케스트레이터(root)가 리뷰어를 형제로 spawn하는 구조이므로, 필요 시 root-sibling 재구성을 검토할 수 있다.