### PR TITLE
fix: ultragoal 무장 공백으로 인한 조용한 정지 차단

### DIFF
--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -74,11 +74,16 @@ If no candidates exist, say so and proceed fresh. The branch never renames on it
 
 Ultragoal does not reimplement execution. It decomposes the objective into the Six Slots and auto-generates a Story set itself — see `references/planning.md` — then, once the user bulk-approves via `confirm-all-stories`, dispatches the confirmed stories to sisyphus **one story at a time, in sequence**:
 
-1. Derive the **current story** — the first `confirmed` story (in stored order) that does not yet carry an `APPROVE` per-story verdict in `ultragoal-verdict-{sid}.json`. No separate "current story" state field exists; it is always re-derived from the verdict artifact, never stored.
-2. Dispatch ONLY that one story to sisyphus: `Skill(skill: "sisyphus")` with that story's WHAT statement, acceptance criteria, and verification surface — never the whole Story set at once.
-3. After sisyphus returns, run the per-story completion audit (see `references/completion-gate.md`) and re-derive that story's verdict.
-4. **Advance only on APPROVE.** A non-APPROVE per-story verdict re-dispatches `Skill(skill: "sisyphus")` at the SAME story — the loop does not proceed to the next story until this one reads APPROVE.
-5. Once the current story is APPROVE, repeat from step 1 for the next confirmed story. When every confirmed story carries an APPROVE verdict, proceed to the final code-review lane (see Completion Gate).
+1. **Arm the loop before dispatching.** Run:
+   ```
+   bun ${CLAUDE_SKILL_DIR}/scripts/ultragoal-state.ts set --phase pursuing
+   ```
+   This must run BEFORE the first `Skill(skill: "sisyphus")` call below — the persistent-mode Stop hook only refuses to stop while `phase=pursuing`, so dispatching first leaves that story's entire execution window unguarded.
+2. Derive the **current story** — the first `confirmed` story (in stored order) that does not yet carry an `APPROVE` per-story verdict in `ultragoal-verdict-{sid}.json`. No separate "current story" state field exists; it is always re-derived from the verdict artifact, never stored.
+3. Dispatch ONLY that one story to sisyphus: `Skill(skill: "sisyphus")` with that story's WHAT statement, acceptance criteria, and verification surface — never the whole Story set at once.
+4. After sisyphus returns, run the per-story completion audit (see `references/completion-gate.md`) and re-derive that story's verdict.
+5. **Advance only on APPROVE.** A non-APPROVE per-story verdict re-dispatches `Skill(skill: "sisyphus")` at the SAME story — the loop does not proceed to the next story until this one reads APPROVE.
+6. Once the current story is APPROVE, repeat from step 2 for the next confirmed story. When every confirmed story carries an APPROVE verdict, proceed to the final code-review lane (see Completion Gate).
 
 sisyphus stays the sole executor throughout this loop — ultragoal never swaps sisyphus for goal and never invokes the goal skill at runtime.
 
@@ -91,12 +96,12 @@ The autonomous loop blocks ONLY when `phase=pursuing`. Set the phase around deco
   bun ${CLAUDE_SKILL_DIR}/scripts/ultragoal-state.ts set --phase planning
   ```
   `--phase planning` also clears the verdict to `absent`, so a stale APPROVE can never survive a re-plan.
-- **After the first sisyphus dispatch** — once pursuit (sequential execution) begins — run:
+- **Before the first sisyphus dispatch** — see step 1 of the Execution Dispatch list above — run:
   ```
   bun ${CLAUDE_SKILL_DIR}/scripts/ultragoal-state.ts set --phase pursuing
   ```
 
-Initial path: `set --phase planning` (seed slots) → auto-generate the Story set → user bulk-approves via `confirm-all-stories` → dispatch story #1 to sisyphus → `set --phase pursuing`. Re-plan loop-back: `set --phase planning` (clears the verdict) → re-generate or steer the Story set (`add-story`/`revise-story`/`retire-story`/`reorder-stories`) → `set --phase pursuing` after the fresh sisyphus dispatch.
+Initial path: `set --phase planning` (seed slots) → auto-generate the Story set → user bulk-approves via `confirm-all-stories` → `set --phase pursuing` → dispatch story #1 to sisyphus. Re-plan loop-back: `set --phase planning` (clears the verdict) → re-generate or steer the Story set (`add-story`/`revise-story`/`retire-story`/`reorder-stories`) → `set --phase pursuing` → dispatch the fresh sisyphus call.
 
 ---
 

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -101,7 +101,7 @@ The autonomous loop blocks ONLY when `phase=pursuing`. Set the phase around deco
   bun ${CLAUDE_SKILL_DIR}/scripts/ultragoal-state.ts set --phase pursuing
   ```
 
-Initial path: `set --phase planning` (seed slots) → auto-generate the Story set → user bulk-approves via `confirm-all-stories` → `set --phase pursuing` → dispatch story #1 to sisyphus. Re-plan loop-back: `set --phase planning` (clears the verdict) → re-generate or steer the Story set (`add-story`/`revise-story`/`retire-story`/`reorder-stories`) → `confirm-all-stories` → `set --phase pursuing` → dispatch the fresh sisyphus call.
+Initial path: `set --phase planning` (seed slots) → auto-generate the Story set → user bulk-approves via `confirm-all-stories` → `set --phase pursuing` → dispatch story #1 to sisyphus. Re-plan loop-back: `set --phase planning` (clears the verdict) → re-generate or steer the Story set (`add-story`/`revise-story`/`retire-story`/`reorder-stories`) → user re-approves via `confirm-all-stories` → `set --phase pursuing` → dispatch the fresh sisyphus call.
 
 ---
 

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -101,7 +101,7 @@ The autonomous loop blocks ONLY when `phase=pursuing`. Set the phase around deco
   bun ${CLAUDE_SKILL_DIR}/scripts/ultragoal-state.ts set --phase pursuing
   ```
 
-Initial path: `set --phase planning` (seed slots) → auto-generate the Story set → user bulk-approves via `confirm-all-stories` → `set --phase pursuing` → dispatch story #1 to sisyphus. Re-plan loop-back: `set --phase planning` (clears the verdict) → re-generate or steer the Story set (`add-story`/`revise-story`/`retire-story`/`reorder-stories`) → `set --phase pursuing` → dispatch the fresh sisyphus call.
+Initial path: `set --phase planning` (seed slots) → auto-generate the Story set → user bulk-approves via `confirm-all-stories` → `set --phase pursuing` → dispatch story #1 to sisyphus. Re-plan loop-back: `set --phase planning` (clears the verdict) → re-generate or steer the Story set (`add-story`/`revise-story`/`retire-story`/`reorder-stories`) → `confirm-all-stories` → `set --phase pursuing` → dispatch the fresh sisyphus call.
 
 ---
 

--- a/skills/ultragoal/SKILL.test.ts
+++ b/skills/ultragoal/SKILL.test.ts
@@ -279,9 +279,10 @@ describe("identity: frontmatter and state-namespace point at ultragoal, not goal
 // ---------------------------------------------------------------------------
 
 describe("Stop-hook arming gap: pursuing transition precedes first dispatch", () => {
-	// Scoped to the numbered list itself, not the whole Execution Dispatch
-	// section — the section also contains the "### Phase transitions"
-	// subsection, which carried a `set --phase pursuing` mention before the
+	// Scoped to "## Execution Dispatch" up to (not including) "### Phase
+	// transitions" — the slice carries the section heading, its lead-in
+	// paragraph, and the numbered list, but excludes "### Phase transitions"
+	// itself, which carried a `set --phase pursuing` mention before the
 	// "ultragoal phase 전환을 첫 sisyphus 디스패치 전으로 승격" commit (at the
 	// wrong point in the loop; SKILL.md:99 now correctly reads "Before the
 	// first sisyphus dispatch"). Reproduced against the pre-change SKILL.md
@@ -291,9 +292,9 @@ describe("Stop-hook arming gap: pursuing transition precedes first dispatch", ()
 	// The ordering assertion would NOT have — the mention lives in
 	// "### Phase transitions", which sits AFTER the "Dispatch ONLY that one
 	// story" instruction, so it still fails under the widened scope at base.
-	// The containment assertion alone is enough to justify keeping the scope
-	// on the numbered list: the step being absent from the numbered list an
-	// agent reads to drive the dispatch loop is what the widened scope would
+	// The containment assertion alone is enough to justify excluding "### Phase
+	// transitions" from the scope: a step's absence from the numbered list an
+	// agent reads to drive the dispatch loop is what the wider scope would
 	// hide.
 	const numberedList = skillMd.slice(
 		skillMd.indexOf("## Execution Dispatch"),

--- a/skills/ultragoal/SKILL.test.ts
+++ b/skills/ultragoal/SKILL.test.ts
@@ -269,3 +269,62 @@ describe("identity: frontmatter and state-namespace point at ultragoal, not goal
 		expect(skillMd).not.toMatch(/(?<!ultra)goal-state\.ts/);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Stop-hook arming gap: the persistent-mode Stop hook only refuses to stop
+// while `phase === "pursuing"`. The Execution Dispatch numbered list must
+// carry the `set --phase pursuing` transition BEFORE the first sisyphus
+// dispatch step, or an agent that follows the list verbatim leaves the first
+// story's entire execution window unarmed. Scoped to the Execution Dispatch
+// section specifically — `Skill(skill: "sisyphus")` first appears at the Role
+// section's "Single-story degrade" paragraph, which is not this loop.
+// ---------------------------------------------------------------------------
+
+describe("Stop-hook arming gap: pursuing transition precedes first dispatch", () => {
+	// Scoped to the numbered list itself, not the whole Execution Dispatch
+	// section — the section also contains the "### Phase transitions"
+	// subsection, which already carries a `set --phase pursuing` mention
+	// today (just at the wrong point in the loop). Widening the scope to the
+	// whole section would let AC1/AC2 pass at HEAD on that pre-existing
+	// mention, missing the actual defect: the step is absent from the
+	// numbered list an agent reads to drive the dispatch loop.
+	const numberedList = skillMd.slice(
+		skillMd.indexOf("## Execution Dispatch"),
+		skillMd.indexOf("### Phase transitions"),
+	);
+
+	test("the Execution Dispatch numbered list carries a set --phase pursuing step", () => {
+		expect(numberedList).toContain("set --phase pursuing");
+	});
+
+	test("the pursuing transition is positioned before the sisyphus dispatch instruction", () => {
+		expect(numberedList.indexOf("set --phase pursuing")).toBeGreaterThan(-1);
+		expect(numberedList.indexOf('Skill(skill: "sisyphus")')).toBeGreaterThan(
+			-1,
+		);
+		expect(numberedList.indexOf("set --phase pursuing")).toBeLessThan(
+			numberedList.indexOf('Skill(skill: "sisyphus")'),
+		);
+	});
+
+	test("the stale 'After the first sisyphus dispatch' ordering no longer appears", () => {
+		expect(skillMd).not.toContain("After the first sisyphus dispatch");
+	});
+
+	test("the narrative arrow order reads set --phase pursuing before dispatch story #1", () => {
+		// Scoped to the "Initial path" narrative sentence specifically — a bare
+		// whole-file indexOf comparison would pass spuriously even at HEAD,
+		// since the Phase-transitions code block's `set --phase pursuing`
+		// mention sits earlier in the file than the narrative's "dispatch
+		// story #1", despite the narrative's own arrow order being reversed.
+		const initialPath = skillMd.slice(
+			skillMd.indexOf("Initial path:"),
+			skillMd.indexOf("Re-plan loop-back:"),
+		);
+		expect(initialPath.indexOf("dispatch story #1")).toBeGreaterThan(-1);
+		expect(initialPath.indexOf("set --phase pursuing")).toBeGreaterThan(-1);
+		expect(initialPath.indexOf("set --phase pursuing")).toBeLessThan(
+			initialPath.indexOf("dispatch story #1"),
+		);
+	});
+});

--- a/skills/ultragoal/SKILL.test.ts
+++ b/skills/ultragoal/SKILL.test.ts
@@ -284,11 +284,17 @@ describe("Stop-hook arming gap: pursuing transition precedes first dispatch", ()
 	// subsection, which carried a `set --phase pursuing` mention before the
 	// "ultragoal phase 전환을 첫 sisyphus 디스패치 전으로 승격" commit (at the
 	// wrong point in the loop; SKILL.md:99 now correctly reads "Before the
-	// first sisyphus dispatch"). Widening the
-	// scope to the whole section would have let AC1/AC2 pass on that
-	// pre-existing mention even while it sat at the wrong point, missing the
-	// actual defect: the step being absent from the numbered list an agent
-	// reads to drive the dispatch loop.
+	// first sisyphus dispatch"). Reproduced against the pre-change SKILL.md
+	// (worktree at commit cc219293) with the scope widened to the whole
+	// section: the containment assertion (`toContain('set --phase
+	// pursuing')`) would have passed spuriously on that pre-existing mention.
+	// The ordering assertion would NOT have — the mention lives in
+	// "### Phase transitions", which sits AFTER the "Dispatch ONLY that one
+	// story" instruction, so it still fails under the widened scope at base.
+	// The containment assertion alone is enough to justify keeping the scope
+	// on the numbered list: the step being absent from the numbered list an
+	// agent reads to drive the dispatch loop is what the widened scope would
+	// hide.
 	const numberedList = skillMd.slice(
 		skillMd.indexOf("## Execution Dispatch"),
 		skillMd.indexOf("### Phase transitions"),

--- a/skills/ultragoal/SKILL.test.ts
+++ b/skills/ultragoal/SKILL.test.ts
@@ -283,11 +283,13 @@ describe("identity: frontmatter and state-namespace point at ultragoal, not goal
 describe("Stop-hook arming gap: pursuing transition precedes first dispatch", () => {
 	// Scoped to the numbered list itself, not the whole Execution Dispatch
 	// section — the section also contains the "### Phase transitions"
-	// subsection, which already carries a `set --phase pursuing` mention
-	// today (just at the wrong point in the loop). Widening the scope to the
-	// whole section would let AC1/AC2 pass at HEAD on that pre-existing
-	// mention, missing the actual defect: the step is absent from the
-	// numbered list an agent reads to drive the dispatch loop.
+	// subsection, which carried a `set --phase pursuing` mention at HEAD
+	// before this commit (at the wrong point in the loop; SKILL.md:99 now
+	// correctly reads "Before the first sisyphus dispatch"). Widening the
+	// scope to the whole section would have let AC1/AC2 pass on that
+	// pre-existing mention even while it sat at the wrong point, missing the
+	// actual defect: the step being absent from the numbered list an agent
+	// reads to drive the dispatch loop.
 	const numberedList = skillMd.slice(
 		skillMd.indexOf("## Execution Dispatch"),
 		skillMd.indexOf("### Phase transitions"),
@@ -298,12 +300,19 @@ describe("Stop-hook arming gap: pursuing transition precedes first dispatch", ()
 	});
 
 	test("the pursuing transition is positioned before the sisyphus dispatch instruction", () => {
+		// Anchored to "Dispatch ONLY that one story" (step 3's actual dispatch
+		// instruction), not a bare `Skill(skill: "sisyphus")` lookup — that
+		// string's FIRST occurrence in numberedList is step 1's own
+		// self-referential sentence ("This must run BEFORE the first
+		// `Skill(skill: "sisyphus")` call below"), not step 3's dispatch. A
+		// bare-string anchor would still pass if step 3's actual dispatch
+		// instruction were deleted and only step 1's self-reference remained.
 		expect(numberedList.indexOf("set --phase pursuing")).toBeGreaterThan(-1);
-		expect(numberedList.indexOf('Skill(skill: "sisyphus")')).toBeGreaterThan(
-			-1,
-		);
+		expect(
+			numberedList.indexOf("Dispatch ONLY that one story"),
+		).toBeGreaterThan(-1);
 		expect(numberedList.indexOf("set --phase pursuing")).toBeLessThan(
-			numberedList.indexOf('Skill(skill: "sisyphus")'),
+			numberedList.indexOf("Dispatch ONLY that one story"),
 		);
 	});
 
@@ -313,10 +322,13 @@ describe("Stop-hook arming gap: pursuing transition precedes first dispatch", ()
 
 	test("the narrative arrow order reads set --phase pursuing before dispatch story #1", () => {
 		// Scoped to the "Initial path" narrative sentence specifically — a bare
-		// whole-file indexOf comparison would pass spuriously even at HEAD,
-		// since the Phase-transitions code block's `set --phase pursuing`
-		// mention sits earlier in the file than the narrative's "dispatch
-		// story #1", despite the narrative's own arrow order being reversed.
+		// whole-file indexOf comparison would have passed spuriously even at
+		// HEAD before this commit's fix, since the Phase-transitions code
+		// block's `set --phase pursuing` mention sits earlier in the file than
+		// the narrative's "dispatch story #1", regardless of the narrative
+		// sentence's own arrow order — which, at that point, was reversed (now
+		// corrected to `set --phase pursuing` → `dispatch story #1`,
+		// SKILL.md:104).
 		const initialPath = skillMd.slice(
 			skillMd.indexOf("Initial path:"),
 			skillMd.indexOf("Re-plan loop-back:"),
@@ -325,6 +337,33 @@ describe("Stop-hook arming gap: pursuing transition precedes first dispatch", ()
 		expect(initialPath.indexOf("set --phase pursuing")).toBeGreaterThan(-1);
 		expect(initialPath.indexOf("set --phase pursuing")).toBeLessThan(
 			initialPath.indexOf("dispatch story #1"),
+		);
+	});
+
+	test("the Re-plan loop-back narrative reads confirm-all-stories before set --phase pursuing before dispatch", () => {
+		// Sliced from "Re-plan loop-back:" through the next section boundary
+		// ("## Completion Gate") — reading SKILL.md directly (line 104)
+		// confirms this slice contains exactly one Re-plan loop-back sentence
+		// and stops before the next section, so it does not repeat the scope
+		// trap the four tests above guard against (a slice wide enough to let
+		// an incidentally-ordered mention elsewhere in the file pass
+		// spuriously).
+		const replanLoopBack = skillMd.slice(
+			skillMd.indexOf("Re-plan loop-back:"),
+			skillMd.indexOf("## Completion Gate"),
+		);
+		expect(replanLoopBack.indexOf("confirm-all-stories")).toBeGreaterThan(-1);
+		expect(replanLoopBack.indexOf("set --phase pursuing")).toBeGreaterThan(
+			-1,
+		);
+		expect(
+			replanLoopBack.indexOf("dispatch the fresh sisyphus call"),
+		).toBeGreaterThan(-1);
+		expect(replanLoopBack.indexOf("confirm-all-stories")).toBeLessThan(
+			replanLoopBack.indexOf("set --phase pursuing"),
+		);
+		expect(replanLoopBack.indexOf("set --phase pursuing")).toBeLessThan(
+			replanLoopBack.indexOf("dispatch the fresh sisyphus call"),
 		);
 	});
 });

--- a/skills/ultragoal/SKILL.test.ts
+++ b/skills/ultragoal/SKILL.test.ts
@@ -275,17 +275,16 @@ describe("identity: frontmatter and state-namespace point at ultragoal, not goal
 // while `phase === "pursuing"`. The Execution Dispatch numbered list must
 // carry the `set --phase pursuing` transition BEFORE the first sisyphus
 // dispatch step, or an agent that follows the list verbatim leaves the first
-// story's entire execution window unarmed. Scoped to the Execution Dispatch
-// section specifically — `Skill(skill: "sisyphus")` first appears at the Role
-// section's "Single-story degrade" paragraph, which is not this loop.
+// story's entire execution window unarmed.
 // ---------------------------------------------------------------------------
 
 describe("Stop-hook arming gap: pursuing transition precedes first dispatch", () => {
 	// Scoped to the numbered list itself, not the whole Execution Dispatch
 	// section — the section also contains the "### Phase transitions"
-	// subsection, which carried a `set --phase pursuing` mention at HEAD
-	// before this commit (at the wrong point in the loop; SKILL.md:99 now
-	// correctly reads "Before the first sisyphus dispatch"). Widening the
+	// subsection, which carried a `set --phase pursuing` mention before the
+	// "ultragoal phase 전환을 첫 sisyphus 디스패치 전으로 승격" commit (at the
+	// wrong point in the loop; SKILL.md:99 now correctly reads "Before the
+	// first sisyphus dispatch"). Widening the
 	// scope to the whole section would have let AC1/AC2 pass on that
 	// pre-existing mention even while it sat at the wrong point, missing the
 	// actual defect: the step being absent from the numbered list an agent
@@ -322,8 +321,9 @@ describe("Stop-hook arming gap: pursuing transition precedes first dispatch", ()
 
 	test("the narrative arrow order reads set --phase pursuing before dispatch story #1", () => {
 		// Scoped to the "Initial path" narrative sentence specifically — a bare
-		// whole-file indexOf comparison would have passed spuriously even at
-		// HEAD before this commit's fix, since the Phase-transitions code
+		// whole-file indexOf comparison would have passed spuriously even
+		// before the "ultragoal phase 전환을 첫 sisyphus 디스패치 전으로 승격"
+		// commit's fix, since the Phase-transitions code
 		// block's `set --phase pursuing` mention sits earlier in the file than
 		// the narrative's "dispatch story #1", regardless of the narrative
 		// sentence's own arrow order — which, at that point, was reversed (now

--- a/skills/ultragoal/scripts/ultragoal-state.test.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.test.ts
@@ -2945,8 +2945,9 @@ describe("mid-flight steering: --evidence/--rationale required (TODO 10)", () =>
 // `set --phase pursuing --completion-evidence`를 건너뛴 완료 시퀀스뿐이다(최후의
 // 그물). 실행 구간(첫 스토리 디스패치)의 진짜 방어선은 문서 층(SKILL.md 1단계)이며,
 // 그 쪽은 두 갈래 근거로 뒷받침된다: SKILL.test.ts는 문서가 그 순서를 갖는지를
-// 정적 문자열 순서 단언(toContain/indexOf)으로 고정할 뿐 실행도 RED/GREEN도 없고,
-// 실제 RED 0/3 → GREEN 3/3 행동 측정은 서브에이전트 압박 시나리오 실행에서
+// 정적 문자열 순서 단언(toContain/indexOf)으로 고정하며(그 단언들 자체는 구현 전
+// HEAD에서 실패하는 정상적인 RED/GREEN을 거쳤다), 서브에이전트 행동 측정은 여기
+// 없고, 실제 RED 0/3 → GREEN 3/3 행동 측정은 서브에이전트 압박 시나리오 실행에서
 // 나왔으며 그 기록은 레포 밖에 있다(~/.omt/oh-my-toong-playground/
 // ultragoal-arming-gap-red.md, -green.md). 자세한 근거는 ultragoal-state.ts의
 // set-verdict 핸들러 주석(같은 인용 포함)을 참조.

--- a/skills/ultragoal/scripts/ultragoal-state.test.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.test.ts
@@ -9,7 +9,7 @@ import {
 	appendFileSync,
 	unlinkSync,
 } from "fs";
-import { execSync } from "child_process";
+import { execSync, spawnSync } from "child_process";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -892,6 +892,20 @@ function runCli(args: string, env?: Record<string, string>): string {
 		encoding: "utf8",
 		env: { ...process.env, ...env },
 	});
+}
+
+/** Like runCli but never throws and captures stderr + exit status separately —
+ * needed to assert on stderr text (e.g. "phase auto-advanced") that runCli's
+ * stdout-only, throw-on-nonzero capture cannot make visible. */
+function runCliCaptured(
+	args: string,
+	env?: Record<string, string>,
+): { stdout: string; stderr: string; status: number | null } {
+	const result = spawnSync("bun", [script, ...args.split(" ")], {
+		encoding: "utf8",
+		env: { ...process.env, ...env },
+	});
+	return { stdout: result.stdout, stderr: result.stderr, status: result.status };
 }
 
 describe("adoption: list-others + adopt (goal CLI)", () => {
@@ -2911,5 +2925,126 @@ describe("mid-flight steering: --evidence/--rationale required (TODO 10)", () =>
 
 		// A genuinely missing value (last token) must still be refused.
 		expect(() => runCli("retire-story story-1 --evidence")).toThrow();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// set-verdict phase auto-advance (recovery device — ultragoal-arming-gap)
+//
+// persistent-mode Stop 훅의 ultragoal 분기는 phase === "pursuing"일 때만 정지를
+// 거부한다(lib/persistent-mode-core/decision.ts:408). SKILL.md는 그 전환을 첫
+// 디스패치 "이후"에 실행하라고 지시해 첫 스토리 실행 구간 전체가 무방비할 수
+// 있다. set-verdict CLI 핸들러가 phase === "planning"을 감지하면 기존
+// setGoalState({phase:"pursuing"}) 경로를 경유해 자동으로 올리고 stderr로
+// 보고한다 — 예방(문서)이 실패해도 두 번째 verdict 기록부터는 복구된다.
+// ---------------------------------------------------------------------------
+
+describe("set-verdict phase auto-advance (recovery)", () => {
+	// AC1: planning(스토리 전부 confirmed 또는 스토리 없음)에서 set-verdict 실행 후
+	// phase가 pursuing으로 오른다.
+	test("AC1: set-verdict from planning auto-advances phase to pursuing", () => {
+		// beforeEach seeds S with phase=planning, stories=[] (the no-stories case)
+		runCli("set-verdict --verdict APPROVE");
+		expect(readGoalState(S)!.phase).toBe("pursuing");
+	});
+
+	// AC2: 같은 실행의 stderr에 "phase auto-advanced"가 포함된다.
+	test("AC2: auto-advance execution reports 'phase auto-advanced' on stderr", () => {
+		const result = runCliCaptured("set-verdict --verdict APPROVE");
+		expect(result.stderr).toContain("phase auto-advanced");
+	});
+
+	// AC3: complete/blocked/budget_limited에서는 phase가 그대로이고 active도 false로
+	// 유지된다 (예산·차단 브레이크 보존 회귀 가드). 세 상태 각각을 덮는다.
+	test("AC3: terminal phases (complete/blocked/budget_limited) are untouched by set-verdict", () => {
+		// complete — via the real request-complete gate, mirroring the "terminal
+		// phases set active false" fixture above.
+		const Sc = "terminal-complete";
+		seedGoalFile(Sc);
+		setGoalState(Sc, { phase: "planning", outcome: "x", verification_surface: "v" });
+		setSingleStory(Sc);
+		setGoalState(Sc, { phase: "pursuing", completion_evidence_paths: [`${tmpDir}/p`] });
+		setVerdict(Sc, "APPROVE");
+		writeFileSync(
+			`${tmpDir}/ultragoal-verdict-${Sc}.json`,
+			JSON.stringify({
+				objective_verdict: "APPROVE",
+				stories: [{ id: "S1", verdict: "APPROVE", evidence_refs: ["p"] }],
+				verifier: "orchestrator",
+				at: "2026-06-12T00:00:00",
+			}),
+			"utf8",
+		);
+		writeCodeReviewArtifact(Sc, {
+			status: "COMPLETE",
+			findings: [],
+			reviewer: "code-reviewer",
+			at: "2026-06-12T00:00:00",
+		});
+		expect(requestComplete(Sc)).toBe(true);
+		expect(rawStateOf(Sc).phase).toBe("complete");
+		runCli("set-verdict --verdict APPROVE", { OMT_SESSION_ID: Sc });
+		expect(rawStateOf(Sc).phase).toBe("complete");
+		expect(rawStateOf(Sc).active).toBe(false);
+
+		// budget_limited
+		const Sb = "terminal-budget";
+		seedGoalFile(Sb);
+		setGoalState(Sb, { phase: "pursuing" });
+		setBudgetLimited(Sb);
+		runCli("set-verdict --verdict APPROVE", { OMT_SESSION_ID: Sb });
+		expect(rawStateOf(Sb).phase).toBe("budget_limited");
+		expect(rawStateOf(Sb).active).toBe(false);
+
+		// blocked
+		const Sk = "terminal-blocked";
+		seedGoalFile(Sk);
+		setGoalState(Sk, { phase: "pursuing" });
+		setBlocked(Sk, "no path");
+		runCli("set-verdict --verdict APPROVE", { OMT_SESSION_ID: Sk });
+		expect(rawStateOf(Sk).phase).toBe("blocked");
+		expect(rawStateOf(Sk).active).toBe(false);
+	});
+
+	// AC4: phase가 이미 pursuing이면 auto-advance 문구가 나오지 않는다 (불필요한 잡음 방지).
+	test("AC4: no auto-advance report when phase is already pursuing", () => {
+		setGoalState(S, { phase: "pursuing" });
+		const result = runCliCaptured("set-verdict --verdict APPROVE");
+		expect(result.stderr).not.toContain("phase auto-advanced");
+		expect(readGoalState(S)!.phase).toBe("pursuing");
+	});
+
+	// AC5: unconfirmed 스토리가 남은 planning에서 set-verdict를 실행하면 기존
+	// unconfirmed 가드 메시지와 함께 실패한다(가드 우회 금지).
+	test("AC5: unconfirmed story guard still refuses set-verdict from planning", () => {
+		setGoalState(S, { phase: "planning", outcome: "A", verification_surface: "v" });
+		setStories(S, [
+			{
+				id: "S1",
+				story: "s1",
+				acceptance_criteria: ["ac"],
+				verification_surface: "v",
+				status: "unconfirmed",
+			},
+		]);
+		const stateBefore = readFileSync(resolveStatePath(S), "utf8");
+		const result = runCliCaptured("set-verdict --verdict APPROVE");
+		expect(result.status).not.toBe(0);
+		expect(result.stderr).toContain("pursuing refused");
+		expect(result.stderr).toContain("unconfirmed");
+		expect(result.stderr).toContain("S1");
+		// State must be unchanged — the guard throw fires before mergeWrite.
+		expect(readFileSync(resolveStatePath(S), "utf8")).toBe(stateBefore);
+	});
+
+	// AC6: objective_verdict 값 자체는 자동 전환 여부와 무관하게 요청한 값 그대로 기록된다.
+	test("AC6: objective_verdict is recorded as requested regardless of auto-advance", () => {
+		// planning path (auto-advance fires)
+		runCli("set-verdict --verdict REQUEST_CHANGES");
+		expect(readGoalState(S)!.objective_verdict).toBe("REQUEST_CHANGES");
+
+		// pursuing path (no auto-advance — phase is already pursuing after the call above)
+		runCli("set-verdict --verdict COMMENT");
+		expect(readGoalState(S)!.objective_verdict).toBe("COMMENT");
 	});
 });

--- a/skills/ultragoal/scripts/ultragoal-state.test.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.test.ts
@@ -2944,18 +2944,28 @@ describe("mid-flight steering: --evidence/--rationale required (TODO 10)", () =>
 // 않는다 — 이 핸들러가 실제로 발동하는 유일한 문서 경로는 completion-gate.md:59의
 // `set --phase pursuing --completion-evidence`를 건너뛴 완료 시퀀스뿐이다(최후의
 // 그물). 실행 구간(첫 스토리 디스패치)의 진짜 방어선은 문서 층(SKILL.md 1단계)이며,
-// 그 쪽은 RED 0/3 → GREEN 3/3로 SKILL.test.ts에서 별도로 실측됐다. 자세한 근거는
-// ultragoal-state.ts의 set-verdict 핸들러 주석(같은 인용 포함)을 참조.
+// 그 쪽은 두 갈래 근거로 뒷받침된다: SKILL.test.ts는 문서가 그 순서를 갖는지를
+// 정적 문자열 순서 단언(toContain/indexOf)으로 고정할 뿐 실행도 RED/GREEN도 없고,
+// 실제 RED 0/3 → GREEN 3/3 행동 측정은 서브에이전트 압박 시나리오 실행에서
+// 나왔으며 그 기록은 레포 밖에 있다(~/.omt/oh-my-toong-playground/
+// ultragoal-arming-gap-red.md, -green.md). 자세한 근거는 ultragoal-state.ts의
+// set-verdict 핸들러 주석(같은 인용 포함)을 참조.
 //
 // 아래 AC 중 AC1·AC2·AC5는 구현 전 HEAD에서 진짜 RED였다(기능 부재로 실패). 반면
 // AC3·AC4·AC6은 보존 가드(terminal phase 불변 / 이미 pursuing이면 무보고 /
 // verdict 값 보존)라서 구현 전에도 HEAD에서 통과하는 것이 정상이다 — 애초에 이
 // 핸들러가 "고칠" 대상이 아니라 "건드리지 않아야 할" 대상을 검증하기 때문이다.
 // 이 셋의 비공허성은 HEAD 통과 여부가 아니라 뮤턴트 주입으로 확인했다: 조건을
-// `prior.phase === "planning"` → `prior.phase !== "pursuing"`으로 바꾼 변형과,
-// `readPrior`를 `readGoalState(sessionId) ?? {}`로 바꾼 변형 둘 다 AC3을
-// `Expected "complete", Received "pursuing"`으로 실패시켰다 — 즉 이 assertion들은
-// 실제로 뭔가를 검사하고 있다.
+// `prior.phase === "planning"` → `prior.phase !== "pursuing"`으로 바꾼 변형은
+// 단독으로 AC3을 `Expected "complete", Received "pursuing"`으로 실패시킨다 — AC3
+// 비공허성의 증거다. `readPrior`를 `readGoalState(sessionId) ?? {}`로 바꾼 변형(리더
+// 교체)은 단독으로는 AC3을 깨뜨리지 않는다: readGoalState가 active:false 상태를
+// null로 접으므로(:311) `?? {}`를 거치면 prior.phase가 undefined가 되고
+// `=== "planning"` 조건이 거짓이 되어 terminal phase를 건드리지 않는다 — 즉 리더
+// 교체는 조건이 함께 넓어질 때에만 위험해진다. (참고: 비앵커 위치인 setGoalState
+// 내부의 const prior(:229)를 잘못 건드렸을 때도 AC3은 실패했지만 메시지는
+// `Received "planning"`으로 달랐다 — 즉 위에 인용한 실패 메시지는 그 자리의 것이
+// 아니다.)
 // ---------------------------------------------------------------------------
 
 describe("set-verdict phase auto-advance (recovery)", () => {

--- a/skills/ultragoal/scripts/ultragoal-state.test.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.test.ts
@@ -2932,11 +2932,30 @@ describe("mid-flight steering: --evidence/--rationale required (TODO 10)", () =>
 // set-verdict phase auto-advance (recovery device — ultragoal-arming-gap)
 //
 // persistent-mode Stop 훅의 ultragoal 분기는 phase === "pursuing"일 때만 정지를
-// 거부한다(lib/persistent-mode-core/decision.ts:408). SKILL.md는 그 전환을 첫
-// 디스패치 "이후"에 실행하라고 지시해 첫 스토리 실행 구간 전체가 무방비할 수
-// 있다. set-verdict CLI 핸들러가 phase === "planning"을 감지하면 기존
-// setGoalState({phase:"pursuing"}) 경로를 경유해 자동으로 올리고 stderr로
-// 보고한다 — 예방(문서)이 실패해도 두 번째 verdict 기록부터는 복구된다.
+// 거부한다(lib/persistent-mode-core/decision.ts:408). set-verdict CLI 핸들러가
+// phase === "planning"을 감지하면 기존 setGoalState({phase:"pursuing"}) 경로를
+// 경유해 자동으로 올리고 stderr로 보고한다.
+//
+// 실제 도달 범위: SKILL.md의 Execution Dispatch 1단계가 디스패치 "전"에 phase를
+// 올리도록 이미 재배치됐고(git 히스토리 "ultragoal phase 전환을 첫 sisyphus
+// 디스패치 전으로 승격"), per-story verdict는 이 CLI를 경유하지 않고 오케스트레이터가
+// `$OMT_DIR/ultragoal-verdict-{sid}.json`에 직접 쓴다(completion-gate.md 16번째
+// 줄). 따라서 `prior.phase === "planning"`은 문서화된 실행 경로에서 참이 되지
+// 않는다 — 이 핸들러가 실제로 발동하는 유일한 문서 경로는 completion-gate.md:59의
+// `set --phase pursuing --completion-evidence`를 건너뛴 완료 시퀀스뿐이다(최후의
+// 그물). 실행 구간(첫 스토리 디스패치)의 진짜 방어선은 문서 층(SKILL.md 1단계)이며,
+// 그 쪽은 RED 0/3 → GREEN 3/3로 SKILL.test.ts에서 별도로 실측됐다. 자세한 근거는
+// ultragoal-state.ts의 set-verdict 핸들러 주석(같은 인용 포함)을 참조.
+//
+// 아래 AC 중 AC1·AC2·AC5는 구현 전 HEAD에서 진짜 RED였다(기능 부재로 실패). 반면
+// AC3·AC4·AC6은 보존 가드(terminal phase 불변 / 이미 pursuing이면 무보고 /
+// verdict 값 보존)라서 구현 전에도 HEAD에서 통과하는 것이 정상이다 — 애초에 이
+// 핸들러가 "고칠" 대상이 아니라 "건드리지 않아야 할" 대상을 검증하기 때문이다.
+// 이 셋의 비공허성은 HEAD 통과 여부가 아니라 뮤턴트 주입으로 확인했다: 조건을
+// `prior.phase === "planning"` → `prior.phase !== "pursuing"`으로 바꾼 변형과,
+// `readPrior`를 `readGoalState(sessionId) ?? {}`로 바꾼 변형 둘 다 AC3을
+// `Expected "complete", Received "pursuing"`으로 실패시켰다 — 즉 이 assertion들은
+// 실제로 뭔가를 검사하고 있다.
 // ---------------------------------------------------------------------------
 
 describe("set-verdict phase auto-advance (recovery)", () => {
@@ -2952,6 +2971,8 @@ describe("set-verdict phase auto-advance (recovery)", () => {
 	test("AC2: auto-advance execution reports 'phase auto-advanced' on stderr", () => {
 		const result = runCliCaptured("set-verdict --verdict APPROVE");
 		expect(result.stderr).toContain("phase auto-advanced");
+		// Reporting is stderr-only — stdout is reserved for machine-readable payload.
+		expect(result.stdout).not.toContain("auto-advanced");
 	});
 
 	// AC3: complete/blocked/budget_limited에서는 phase가 그대로이고 active도 false로
@@ -3046,5 +3067,19 @@ describe("set-verdict phase auto-advance (recovery)", () => {
 		// pursuing path (no auto-advance — phase is already pursuing after the call above)
 		runCli("set-verdict --verdict COMMENT");
 		expect(readGoalState(S)!.objective_verdict).toBe("COMMENT");
+	});
+
+	// AC7: --verdict absent (SKILL.md:33의 유효값)도 다른 verdict 값과 똑같이
+	// planning→pursuing 자동 전환을 무장시킨다. 핸들러는 planning에서의 "어떤"
+	// verdict 기록에도 무장하도록 짜여 있고(v 값을 조건에서 참조하지 않음), 그래서
+	// 의미상 리셋인 absent 기록조차 phase를 pursuing으로 올리고 active:true로
+	// 만든다. 이것은 의도적으로 재설계할 대상이 아니라 — 이번 리뷰에서 사용자가
+	// "복구 층의 설계는 바꾸지 않는다"고 결정했다 — 현재 동작을 계약으로 고정해
+	// 다음 변경이 조용히 이 부수효과를 바꾸지 못하게 잠그는 회귀 가드다.
+	test("AC7: --verdict absent also arms the planning-to-pursuing auto-advance (current-behavior lock, not an endorsement)", () => {
+		// beforeEach seeds S with phase=planning, stories=[] (the no-stories case)
+		runCli("set-verdict --verdict absent");
+		expect(readGoalState(S)!.phase).toBe("pursuing");
+		expect(readGoalState(S)!.objective_verdict).toBe("absent");
 	});
 });

--- a/skills/ultragoal/scripts/ultragoal-state.test.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.test.ts
@@ -2951,10 +2951,12 @@ describe("mid-flight steering: --evidence/--rationale required (TODO 10)", () =>
 // ultragoal-arming-gap-red.md, -green.md). 자세한 근거는 ultragoal-state.ts의
 // set-verdict 핸들러 주석(같은 인용 포함)을 참조.
 //
-// 아래 AC 중 AC1·AC2·AC5는 구현 전 HEAD에서 진짜 RED였다(기능 부재로 실패). 반면
-// AC3·AC4·AC6은 보존 가드(terminal phase 불변 / 이미 pursuing이면 무보고 /
-// verdict 값 보존)라서 구현 전에도 HEAD에서 통과하는 것이 정상이다 — 애초에 이
-// 핸들러가 "고칠" 대상이 아니라 "건드리지 않아야 할" 대상을 검증하기 때문이다.
+// 아래 AC 중 AC1·AC2·AC5·AC7은 구현 전 HEAD에서 진짜 RED였다(기능 부재로 실패) —
+// AC7도 마찬가지로 자동 전환 자체가 없던 시점에는 `--verdict absent` 기록이
+// phase를 pursuing으로 올리지 않았다. 반면 AC3·AC4·AC6은 보존 가드(terminal
+// phase 불변 / 이미 pursuing이면 무보고 / verdict 값 보존)라서 구현 전에도
+// HEAD에서 통과하는 것이 정상이다 — 애초에 이 핸들러가 "고칠" 대상이 아니라
+// "건드리지 않아야 할" 대상을 검증하기 때문이다.
 // 이 셋의 비공허성은 HEAD 통과 여부가 아니라 뮤턴트 주입으로 확인했다: 조건을
 // `prior.phase === "planning"` → `prior.phase !== "pursuing"`으로 바꾼 변형은
 // 단독으로 AC3을 `Expected "complete", Received "pursuing"`으로 실패시킨다 — AC3

--- a/skills/ultragoal/scripts/ultragoal-state.test.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.test.ts
@@ -2931,26 +2931,7 @@ describe("mid-flight steering: --evidence/--rationale required (TODO 10)", () =>
 // ---------------------------------------------------------------------------
 // set-verdict phase auto-advance (recovery device — ultragoal-arming-gap)
 //
-// persistent-mode Stop 훅의 ultragoal 분기는 phase === "pursuing"일 때만 정지를
-// 거부한다(lib/persistent-mode-core/decision.ts:408). set-verdict CLI 핸들러가
-// phase === "planning"을 감지하면 기존 setGoalState({phase:"pursuing"}) 경로를
-// 경유해 자동으로 올리고 stderr로 보고한다.
-//
-// 실제 도달 범위: SKILL.md의 Execution Dispatch 1단계가 디스패치 "전"에 phase를
-// 올리도록 이미 재배치됐고(git 히스토리 "ultragoal phase 전환을 첫 sisyphus
-// 디스패치 전으로 승격"), per-story verdict는 이 CLI를 경유하지 않고 오케스트레이터가
-// `$OMT_DIR/ultragoal-verdict-{sid}.json`에 직접 쓴다(completion-gate.md 16번째
-// 줄). 따라서 `prior.phase === "planning"`은 문서화된 실행 경로에서 참이 되지
-// 않는다 — 이 핸들러가 실제로 발동하는 유일한 문서 경로는 completion-gate.md:59의
-// `set --phase pursuing --completion-evidence`를 건너뛴 완료 시퀀스뿐이다(최후의
-// 그물). 실행 구간(첫 스토리 디스패치)의 진짜 방어선은 문서 층(SKILL.md 1단계)이며,
-// 그 쪽은 두 갈래 근거로 뒷받침된다: SKILL.test.ts는 문서가 그 순서를 갖는지를
-// 정적 문자열 순서 단언(toContain/indexOf)으로 고정하며(그 단언들 자체는 구현 전
-// HEAD에서 실패하는 정상적인 RED/GREEN을 거쳤다), 서브에이전트 행동 측정은 여기
-// 없고, 실제 RED 0/3 → GREEN 3/3 행동 측정은 서브에이전트 압박 시나리오 실행에서
-// 나왔으며 그 기록은 레포 밖에 있다(~/.omt/oh-my-toong-playground/
-// ultragoal-arming-gap-red.md, -green.md). 자세한 근거는 ultragoal-state.ts의
-// set-verdict 핸들러 주석(같은 인용 포함)을 참조.
+// 이 핸들러의 도달 범위·측정 출처: ultragoal-state.ts의 set-verdict 핸들러 주석 참조.
 //
 // 아래 AC 중 AC1·AC2·AC5·AC7은 구현 전 HEAD에서 진짜 RED였다(기능 부재로 실패) —
 // AC7도 마찬가지로 자동 전환 자체가 없던 시점에는 `--verdict absent` 기록이
@@ -2965,7 +2946,7 @@ describe("mid-flight steering: --evidence/--rationale required (TODO 10)", () =>
 // 교체)은 단독으로는 AC3을 깨뜨리지 않는다: readGoalState가 active:false 상태를
 // null로 접으므로(:311) `?? {}`를 거치면 prior.phase가 undefined가 되고
 // `=== "planning"` 조건이 거짓이 되어 terminal phase를 건드리지 않는다 — 즉 리더
-// 교체는 조건이 함께 넓어질 때에만 위험해진다. (참고: 비앵커 위치인 setGoalState
+// 교체는 조건이 함께 넓어질 때에만 위험해진다. (참고: 비앵커 위치인 mergeWrite
 // 내부의 const prior(:229)를 잘못 건드렸을 때도 AC3은 실패했지만 메시지는
 // `Received "planning"`으로 달랐다 — 즉 위에 인용한 실패 메시지는 그 자리의 것이
 // 아니다.)

--- a/skills/ultragoal/scripts/ultragoal-state.test.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.test.ts
@@ -896,7 +896,11 @@ function runCli(args: string, env?: Record<string, string>): string {
 
 /** Like runCli but never throws and captures stderr + exit status separately —
  * needed to assert on stderr text (e.g. "phase auto-advanced") that runCli's
- * stdout-only, throw-on-nonzero capture cannot make visible. */
+ * stdout-only, throw-on-nonzero capture cannot make visible. Also differs in
+ * argument handling: runCli hands the whole command string to execSync's
+ * shell, which honors quoting, while this naively splits `args` on spaces
+ * into spawnSync's argv — a quoted argument containing a space would be split
+ * into separate tokens. No current caller passes one. */
 function runCliCaptured(
 	args: string,
 	env?: Record<string, string>,
@@ -2950,6 +2954,13 @@ describe("mid-flight steering: --evidence/--rationale required (TODO 10)", () =>
 // 내부의 const prior(:229)를 잘못 건드렸을 때도 AC3은 실패했지만 메시지는
 // `Received "planning"`으로 달랐다 — 즉 위에 인용한 실패 메시지는 그 자리의 것이
 // 아니다.)
+// AC4와 AC6도 같은 방식으로 확인했다(각각 주입 후 실행, 실패 메시지 채증, 원복).
+// 조건을 `if (prior.phase === "planning")` → `if (true)`로 바꾼 변형은 AC4를
+// `Expected to not contain: "phase auto-advanced", Received: "set-verdict: phase
+// auto-advanced planning -> pursuing\n"`으로 실패시킨다(같은 변형이 AC3도 함께
+// 깨뜨린다 — AC4 비공허성의 증거로는 그 실패로 충분하다). `setVerdict(sessionId, v)`를
+// `setVerdict(sessionId, "APPROVE")`로 바꾼 변형은 AC6을 `Expected: "REQUEST_CHANGES",
+// Received: "APPROVE"`로 실패시킨다(AC7도 함께 깨진다) — AC6 비공허성의 증거다.
 // ---------------------------------------------------------------------------
 
 describe("set-verdict phase auto-advance (recovery)", () => {

--- a/skills/ultragoal/scripts/ultragoal-state.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.ts
@@ -1377,14 +1377,12 @@ function main(): void {
 			// Dispatch step 1 running the phase flip before dispatch. Two separate artifacts
 			// back this, not one: SKILL.test.ts's static string-order assertions (`toContain`/
 			// `indexOf` on the markdown) pin that the prose *has* this ordering — those
-			// assertions themselves went through an ordinary RED/GREEN, but the GREEN boundary
-			// is not a single commit: four of the five assertions in that describe block turn
-			// green at the "ultragoal phase 전환을 첫 sisyphus 디스패치 전으로 승격" commit
-			// (172647ff); the fifth — the Re-plan loop-back narrative-order assertion — stays
-			// red there and only turns green at the later "재계획 누락 단계 보완과 복구장치
-			// 주석 정직화" commit (515c7e9d), which added the missing `confirm-all-stories`
-			// step to that loop-back sentence. No subagent-behavioral RED/GREEN happens at
-			// either boundary. The actual RED 0/3 → GREEN 3/3
+			// assertions' RED/GREEN was established by replaying HEAD's `SKILL.test.ts`
+			// against pre-change `SKILL.md` snapshots — not by a lived RED/GREEN at every
+			// assertion's own historical commit — which is a different method from the
+			// subagent-behavioral RED/GREEN below; see this describe block's own per-test
+			// comments in `SKILL.test.ts` for the per-assertion snapshot detail. The actual
+			// RED 0/3 → GREEN 3/3
 			// behavioral count came from a faithful-reproduction subagent scenario with a
 			// byte-identical prompt, run 3x per arm (6 runs total): RED against the
 			// /tmp/ultragoal-before snapshot, GREEN against /tmp/ultragoal-after. Those are

--- a/skills/ultragoal/scripts/ultragoal-state.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.ts
@@ -1372,8 +1372,13 @@ function main(): void {
 			// alone, catching only the case where `completion-gate.md:59`'s own
 			// `set --phase pursuing` step was itself skipped. The real defense for the execution
 			// window (first story dispatch) is the documentation layer — SKILL.md's Execution
-			// Dispatch step 1 running the phase flip before dispatch — verified by RED 0/3 →
-			// GREEN 3/3 in SKILL.test.ts's prose assertions, not by this code path.
+			// Dispatch step 1 running the phase flip before dispatch. Two separate artifacts
+			// back this, not one: SKILL.test.ts's static string-order assertions (`toContain`/
+			// `indexOf` on the markdown) pin that the prose *has* this ordering — no execution,
+			// no RED/GREEN there. The actual RED 0/3 → GREEN 3/3 behavioral count came from a
+			// subagent pressure-scenario measurement recorded outside this repo, not by this
+			// code path — see `~/.omt/oh-my-toong-playground/ultragoal-arming-gap-red.md` and
+			// `-green.md`.
 			//
 			// readPrior (not readGoalState) — readGoalState folds any active:false state to
 			// null, so it can't see phase in a terminal state. Condition is exactly

--- a/skills/ultragoal/scripts/ultragoal-state.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.ts
@@ -1375,12 +1375,13 @@ function main(): void {
 			// Dispatch step 1 running the phase flip before dispatch. Two separate artifacts
 			// back this, not one: SKILL.test.ts's static string-order assertions (`toContain`/
 			// `indexOf` on the markdown) pin that the prose *has* this ordering — those
-			// assertions themselves went through an ordinary RED/GREEN (failing pre-
-			// implementation at HEAD), but no subagent-behavioral RED/GREEN happens there.
-			// The actual RED 0/3 → GREEN 3/3 behavioral count came from a subagent
-			// pressure-scenario measurement recorded outside this repo, not by this
-			// code path — see `~/.omt/oh-my-toong-playground/ultragoal-arming-gap-red.md` and
-			// `-green.md`.
+			// assertions themselves went through an ordinary RED/GREEN (failing before the
+			// "ultragoal phase 전환을 첫 sisyphus 디스패치 전으로 승격" commit), but no
+			// subagent-behavioral RED/GREEN happens there. The actual RED 0/3 → GREEN 3/3
+			// behavioral count came from a faithful-reproduction subagent scenario — the
+			// same scenario run 3x against the /tmp/ultragoal-before snapshot, not by this
+			// code path — see `~/.omt/oh-my-toong-playground/ultragoal-arming-gap-red.md`
+			// and `-green.md`.
 			//
 			// readPrior (not readGoalState) — readGoalState folds any active:false state to
 			// null, so it can't see phase in a terminal state. Condition is exactly

--- a/skills/ultragoal/scripts/ultragoal-state.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.ts
@@ -1374,9 +1374,11 @@ function main(): void {
 			// window (first story dispatch) is the documentation layer — SKILL.md's Execution
 			// Dispatch step 1 running the phase flip before dispatch. Two separate artifacts
 			// back this, not one: SKILL.test.ts's static string-order assertions (`toContain`/
-			// `indexOf` on the markdown) pin that the prose *has* this ordering — no execution,
-			// no RED/GREEN there. The actual RED 0/3 → GREEN 3/3 behavioral count came from a
-			// subagent pressure-scenario measurement recorded outside this repo, not by this
+			// `indexOf` on the markdown) pin that the prose *has* this ordering — those
+			// assertions themselves went through an ordinary RED/GREEN (failing pre-
+			// implementation at HEAD), but no subagent-behavioral RED/GREEN happens there.
+			// The actual RED 0/3 → GREEN 3/3 behavioral count came from a subagent
+			// pressure-scenario measurement recorded outside this repo, not by this
 			// code path — see `~/.omt/oh-my-toong-playground/ultragoal-arming-gap-red.md` and
 			// `-green.md`.
 			//

--- a/skills/ultragoal/scripts/ultragoal-state.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.ts
@@ -1348,6 +1348,24 @@ function main(): void {
 				);
 				process.exit(1);
 			}
+			// Recovery device (ultragoal-arming-gap): the persistent-mode Stop hook's ultragoal
+			// branch refuses to stop only while phase === "pursuing". SKILL.md instructs the
+			// pursuing transition to run AFTER the first story dispatch, so the first story can
+			// run unarmed if that step is missed. Detect the miss here and self-heal on the
+			// first verdict recording — planning-only fires it once per pursuit and re-plans
+			// return to planning, so the sequence self-limits without extra state.
+			//
+			// readPrior (not readGoalState) — readGoalState folds any active:false state to
+			// null, so it can't see phase in a terminal state. Condition is exactly
+			// === "planning" — setGoalState always writes active:true, so firing it from a
+			// terminal state (complete/blocked/budget_limited) would resurrect a finished goal
+			// and defeat the budget/blocked brakes. Routed through setGoalState (not a direct
+			// mergeWrite) so the unconfirmed-story pursuing guard still applies.
+			const prior = readPrior(sessionId);
+			if (prior.phase === "planning") {
+				setGoalState(sessionId, { phase: "pursuing" });
+				process.stderr.write("set-verdict: phase auto-advanced planning -> pursuing\n");
+			}
 			setVerdict(sessionId, v);
 		} else if (subcommand === "set-budget-limited") {
 			setBudgetLimited(sessionId);

--- a/skills/ultragoal/scripts/ultragoal-state.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.ts
@@ -1377,9 +1377,14 @@ function main(): void {
 			// Dispatch step 1 running the phase flip before dispatch. Two separate artifacts
 			// back this, not one: SKILL.test.ts's static string-order assertions (`toContain`/
 			// `indexOf` on the markdown) pin that the prose *has* this ordering — those
-			// assertions themselves went through an ordinary RED/GREEN (failing before the
-			// "ultragoal phase 전환을 첫 sisyphus 디스패치 전으로 승격" commit), but no
-			// subagent-behavioral RED/GREEN happens there. The actual RED 0/3 → GREEN 3/3
+			// assertions themselves went through an ordinary RED/GREEN, but the GREEN boundary
+			// is not a single commit: four of the five assertions in that describe block turn
+			// green at the "ultragoal phase 전환을 첫 sisyphus 디스패치 전으로 승격" commit
+			// (172647ff); the fifth — the Re-plan loop-back narrative-order assertion — stays
+			// red there and only turns green at the later "재계획 누락 단계 보완과 복구장치
+			// 주석 정직화" commit (515c7e9d), which added the missing `confirm-all-stories`
+			// step to that loop-back sentence. No subagent-behavioral RED/GREEN happens at
+			// either boundary. The actual RED 0/3 → GREEN 3/3
 			// behavioral count came from a faithful-reproduction subagent scenario with a
 			// byte-identical prompt, run 3x per arm (6 runs total): RED against the
 			// /tmp/ultragoal-before snapshot, GREEN against /tmp/ultragoal-after. Those are

--- a/skills/ultragoal/scripts/ultragoal-state.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.ts
@@ -1378,10 +1378,12 @@ function main(): void {
 			// assertions themselves went through an ordinary RED/GREEN (failing before the
 			// "ultragoal phase 전환을 첫 sisyphus 디스패치 전으로 승격" commit), but no
 			// subagent-behavioral RED/GREEN happens there. The actual RED 0/3 → GREEN 3/3
-			// behavioral count came from a faithful-reproduction subagent scenario — the
-			// same scenario run 3x against the /tmp/ultragoal-before snapshot, not by this
-			// code path — see `~/.omt/oh-my-toong-playground/ultragoal-arming-gap-red.md`
-			// and `-green.md`.
+			// behavioral count came from a faithful-reproduction subagent scenario with a
+			// byte-identical prompt, run 3x per arm (6 runs total): RED against the
+			// /tmp/ultragoal-before snapshot, GREEN against /tmp/ultragoal-after — the
+			// snapshot path is the only variable between the two arms, not this code path
+			// — see `~/.omt/oh-my-toong-playground/ultragoal-arming-gap-red.md` and
+			// `-green.md`.
 			//
 			// readPrior (not readGoalState) — readGoalState folds any active:false state to
 			// null, so it can't see phase in a terminal state. Condition is exactly

--- a/skills/ultragoal/scripts/ultragoal-state.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.ts
@@ -1349,11 +1349,31 @@ function main(): void {
 				process.exit(1);
 			}
 			// Recovery device (ultragoal-arming-gap): the persistent-mode Stop hook's ultragoal
-			// branch refuses to stop only while phase === "pursuing". SKILL.md instructs the
-			// pursuing transition to run AFTER the first story dispatch, so the first story can
-			// run unarmed if that step is missed. Detect the miss here and self-heal on the
-			// first verdict recording — planning-only fires it once per pursuit and re-plans
-			// return to planning, so the sequence self-limits without extra state.
+			// branch refuses to stop only while phase === "pursuing". SKILL.md USED TO instruct
+			// the pursuing transition to run AFTER the first story dispatch, which let the first
+			// story run unarmed if that step was missed — this handler was written to detect the
+			// miss and self-heal on the first verdict recording. SKILL.md's Execution Dispatch
+			// step 1 has since been reordered to run `set --phase pursuing` BEFORE dispatch (see
+			// git history around the "ultragoal phase 전환을 첫 sisyphus 디스패치 전으로 승격"
+			// commit), so the prose-layer gap this device was built against no longer exists on
+			// the documented path.
+			//
+			// Actual reach of this handler, precisely stated: `set-verdict` is called from
+			// exactly one documented place, `references/completion-gate.md`'s completion
+			// sequence, and the line immediately before it there already runs
+			// `set --phase pursuing --completion-evidence …` — so by the time this handler's
+			// own `prior.phase === "planning"` check runs on that path, phase is already
+			// "pursuing" and the branch is a no-op. The PER-STORY verdict (the thing whose
+			// timing this device was originally guarding) is never recorded through this CLI at
+			// all — per completion-gate.md's "Per-story re-derivation" section, the orchestrator
+			// writes `$OMT_DIR/ultragoal-verdict-{sid}.json` directly as a file artifact, bypassing
+			// this handler entirely. So `prior.phase === "planning"` cannot go true on any
+			// documented call path today; this is a last-resort net for the completion sequence
+			// alone, catching only the case where `completion-gate.md:59`'s own
+			// `set --phase pursuing` step was itself skipped. The real defense for the execution
+			// window (first story dispatch) is the documentation layer — SKILL.md's Execution
+			// Dispatch step 1 running the phase flip before dispatch — verified by RED 0/3 →
+			// GREEN 3/3 in SKILL.test.ts's prose assertions, not by this code path.
 			//
 			// readPrior (not readGoalState) — readGoalState folds any active:false state to
 			// null, so it can't see phase in a terminal state. Condition is exactly

--- a/skills/ultragoal/scripts/ultragoal-state.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.ts
@@ -1350,9 +1350,11 @@ function main(): void {
 			}
 			// Recovery device (ultragoal-arming-gap): the persistent-mode Stop hook's ultragoal
 			// branch refuses to stop only while phase === "pursuing". SKILL.md USED TO instruct
-			// the pursuing transition to run AFTER the first story dispatch, which let the first
-			// story run unarmed if that step was missed — this handler was written to detect the
-			// miss and self-heal on the first verdict recording. SKILL.md's Execution Dispatch
+			// the pursuing transition to run AFTER the first story dispatch — under that
+			// ordering the first story's entire execution window ran unarmed structurally, not
+			// just when a step was skipped: even an agent following the list perfectly still hit
+			// the dispatch instruction before the phase flip. This handler was written to detect
+			// that gap and self-heal on the first verdict recording. SKILL.md's Execution Dispatch
 			// step 1 has since been reordered to run `set --phase pursuing` BEFORE dispatch (see
 			// git history around the "ultragoal phase 전환을 첫 sisyphus 디스패치 전으로 승격"
 			// commit), so the prose-layer gap this device was built against no longer exists on
@@ -1380,8 +1382,19 @@ function main(): void {
 			// subagent-behavioral RED/GREEN happens there. The actual RED 0/3 → GREEN 3/3
 			// behavioral count came from a faithful-reproduction subagent scenario with a
 			// byte-identical prompt, run 3x per arm (6 runs total): RED against the
-			// /tmp/ultragoal-before snapshot, GREEN against /tmp/ultragoal-after — the
-			// snapshot path is the only variable between the two arms, not this code path
+			// /tmp/ultragoal-before snapshot, GREEN against /tmp/ultragoal-after. Those are
+			// full `cp -r` directory captures, not single-file diffs — `diff -rq` shows five
+			// files differ (SKILL.md, SKILL.test.ts, scripts/ultragoal-state.ts,
+			// scripts/ultragoal-state.test.ts, tsconfig.json), and this very handler is one of
+			// them: the "phase auto-advanced" branch exists only in -after's
+			// ultragoal-state.ts, not in -before's. So the snapshot path was not the only
+			// variable, and this code path did differ between arms. What still ties the
+			// observed RED 0/3 → GREEN 3/3 to SKILL.md rather than to this handler: both
+			// records scope every trial to stop at a simulated `DISPATCH:` marker before any
+			// sisyphus dispatch, which is before `references/completion-gate.md`'s completion
+			// sequence where `set-verdict` is actually invoked — so none of the 6 trials ever
+			// reached this handler. The causal claim rests on the subagent reading SKILL.md's
+			// reordered instructions, not on this code path being exercised.
 			// — see `~/.omt/oh-my-toong-playground/ultragoal-arming-gap-red.md` and
 			// `-green.md`.
 			//


### PR DESCRIPTION
## 📌 Summary

ultragoal이 첫 스토리를 실행하는 동안 persistent-mode Stop 훅이 무장되지 않아, 할 일이 남았는데도 턴이 조용히 끝날 수 있었습니다. `SKILL.md`가 `set --phase pursuing`을 **첫 디스패치 이후**에 실행하도록 지시한 것이 근본 원인입니다. 문서 예방(디스패치보다 앞으로 승격)과 코드 복구(`set-verdict`의 phase 자동 전환) 2층으로 닫았습니다.

---

## 🔧 Changes

### skills/ultragoal/SKILL.md — 예방 층

- Execution Dispatch 번호매김 목록에 **1단계**로 `set --phase pursuing` 실행을 추가하고, 첫 `Skill(skill: "sisyphus")` 호출보다 앞에 둔다는 근거를 명시
- `### Phase transitions`의 **"After the first sisyphus dispatch"** → **"Before the first sisyphus dispatch"**
- Initial path 내러티브의 화살표 순서를 `set --phase pursuing` → `dispatch story #1`로 정정
- Re-plan 루프백 내러티브에 빠져 있던 `confirm-all-stories` 단계를 보완하고, Initial path와 동일하게 `user re-approves via`로 human gate임을 명시

Stop 훅의 ultragoal 분기는 `phase === "pursuing"`일 때만 정지를 거부합니다(`lib/persistent-mode-core/decision.ts:408`). 문서가 디스패치 후 전환을 지시하면 완벽히 순종하는 에이전트조차 첫 스토리 실행 창 전체를 무방비로 둡니다.

**영향 범위**
문서 전용. 런타임 동작 변화 없음. 배포본(`$HOME/.claude/skills/ultragoal/`)은 `make sync`로 갱신됨. 이미 진행 중인 pursuit의 상태 파일에는 영향 없음.

### skills/ultragoal/scripts/ultragoal-state.ts — 복구 층

- `set-verdict` 핸들러가 `prior.phase === "planning"`을 감지하면 기존 `setGoalState({ phase: "pursuing" })` 경로를 경유해 자동 전환하고 stderr로 보고

**영향 범위**
`set-verdict` 서브커맨드 한정. stdout(기계 판독 payload)은 불변 — 보고는 stderr 전용. `complete`/`blocked`/`budget_limited` 터미널 상태는 조건에서 제외되어 브레이크가 보존됨. `lib/persistent-mode-core/decision.ts`와 `skills/goal/`은 미변경.

### 테스트

- `SKILL.test.ts`: 프로즈 계약 검증 5건 추가(문서 순서를 문자열 순서 단언으로 고정)
- `ultragoal-state.test.ts`: 코드 AC 7건 + stderr 캡처용 `runCliCaptured` 헬퍼 추가

**영향 범위**
기존 테스트 무수정. `skills/ultragoal/` 179 pass / 0 fail, `make test` 4012 pass / 0 fail.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 복구 층이 실행 구간에 도달하지 못한다 — 의도된 한계인가, 옮겨야 하는가

**배경 및 문제 상황:**

스펙은 2층 방어를 설계했습니다. 문서 층이 예방하고, 코드 층이 놓친 경우를 복구합니다. 그런데 code-review가 복구 층의 도달 범위를 검증하면서 전제가 무너졌습니다.

`set-verdict`는 문서화된 호출 지점이 **정확히 한 곳**(`references/completion-gate.md:60`, 완료 시퀀스)뿐입니다. 그리고 그 직전 줄(`:59`)이 이미 `set --phase pursuing --completion-evidence`를 실행합니다. 한편 per-story verdict는 CLI를 경유하지 않고 오케스트레이터가 아티팩트 파일에 직접 씁니다(`completion-gate.md:16`). 즉 **실행 구간(스토리 디스패치 루프)에서는 `set-verdict`가 한 번도 호출되지 않습니다.**

**해결 방안:**

설계를 유지하되 한계를 주석에 정직하게 기록하는 쪽을 택했습니다. 복구 층을 도달 가능한 지점(예: per-story verdict 기록 경로)으로 옮기는 것은 오케스트레이터의 아티팩트 쓰기 경로 자체를 CLI로 흡수해야 하는 별개 작업이라, 이번 변경의 범위를 넘습니다.

**구현 세부사항:**

`set-verdict` 핸들러 위 주석이 이 한계를 명시합니다 — 도달하는 유일한 경로는 `:59`를 건너뛴 완료 시퀀스뿐이며, 실행 구간의 진짜 방어선은 문서 층이라는 것. 조건을 `=== "planning"`으로 좁게 유지한 것도 이 맥락입니다: `setGoalState`는 `active: true`를 무조건 쓰므로(`:417`), 조건을 넓히면 터미널 상태를 되살려 budget/blocked 브레이크를 무력화합니다.

**선택과 트레이드오프:**

지금 형태의 복구 층은 "완료 시퀀스에서 `:59`가 실패했을 때의 최후의 그물"입니다. 좁지만 0은 아닙니다.

리뷰어께 열어두고 싶은 질문: **이 장치를 이 자리에 유지하는 게 맞을까요, 아니면 도달 가능한 지점으로 옮기거나(별도 PR) 아예 빼는 게 나을까요?** 유지 쪽 논거는 비용이 사실상 0(코드 6줄, 터미널 상태 보존 회귀 가드 포함)이고 완료 시퀀스가 부분 실패했을 때 실제로 발동한다는 점입니다. 제거 쪽 논거는 "2층 방어"라는 서술이 실제 도달 범위보다 강하게 들린다는 점입니다.

### 2. `decision.ts`를 고치지 않고 문서를 고친 이유

**배경 및 문제 상황:**

가장 직관적인 수정은 훅 쪽입니다. `phase === "pursuing"` 대신 `active`만으로 무장하면 planning 구간도 덮입니다. 실제로 prometheus의 대응 분기가 그 형태입니다.

그런데 이 결함은 **이중 사각**입니다. 주 가드(ultragoal 분기)가 무장되지 않은 동시에, non-pristine ultragoal 상태가 baseline todo 가드까지 억제합니다(`decision.ts:460-461`). 백업 가드도 근무 중이 아닌 상태죠.

**해결 방안:**

`decision.ts`는 건드리지 않기로 했습니다. prometheus의 "active만으로 무장" 패턴을 이식하면 `decision.test.ts` 9건이 깨지고, pristine 상태에서 `NaN` 결함이 하나 추가됩니다(`iteration`/`max_iterations`가 미시드 상태에서 비교되므로). 그 9건을 고치는 것은 훅의 판정 계약을 바꾸는 일이고, 이번 결함의 원인은 훅이 아니라 문서입니다.

**선택과 트레이드오프:**

문서 층은 코드 게이트보다 약합니다 — 에이전트가 지시를 안 따르면 뚫립니다. 그래서 문서 변경을 **행동 측정으로 검증**했습니다:

| | RED (`/tmp/ultragoal-before`) | GREEN (`/tmp/ultragoal-after`) |
|---|---|---|
| 첫 디스패치 전 전환 호출 | **0/3** | **3/3** |

바이트 동일 프롬프트, arm당 3회, 스냅샷 경로가 독립변수입니다. 사전 등록한 반증 조건(RED 0/3 누락이면 문서 변경을 철회하고 코드만 진행)과 통과 기준(3/3만 통과, 2/3 이하는 문서 강화 후 재측정)을 먼저 기록하고 측정했습니다.

인정하는 한계: **n=3은 통계적으로 약합니다.** 준수율 50% 가정 하 3/3이 우연히 나올 확률은 12.5%입니다. RED가 0/3이었기에 두 측정을 합치면 우연 설명력이 크게 떨어지지만, 단독으로는 약한 증거입니다.

### 3. 커밋 11개 중 9개가 주석 정정인 이유 — 반복 결함의 구동자와 그 폐쇄

**배경 및 문제 상황:**

실질 변경은 커밋 2개(`feb4ec65` 코드, `410faba0` 문서)입니다. 나머지 9개는 독립 code-review 대응이고, `b4abfcda` 이후는 전부 주석 전용입니다.

**문서 정확성 결함이 7패스 연속으로 검출됐습니다** — 시제 오류, 잘못된 커밋 참조, 잘못된 방법 명칭, 잘못된 소속 함수, 잘못된 스냅샷 귀속, 재현 불가능한 반사실 주장, 과잉 귀속된 뮤턴트 증거. 그중 **3회는 수정 커밋이 고치고 있던 바로 그 문장에서 다음 결함을 낳았습니다.**

**구현 세부사항:**

원인은 표현이 아니라 구조였습니다. 두 가지가 겹쳤습니다.

첫째, **동일 서술이 두 파일에 손으로 복제**돼 있었습니다(`ultragoal-state.ts` 핸들러 주석 + `ultragoal-state.test.ts` 미러). 네 차례 수정이 매번 양쪽을 고쳐야 했고, 한쪽만 고치면 조용히 어긋납니다. → `ultragoal-state.ts`를 단일 출처로 삼고 테스트 파일은 자체 AC/뮤턴트 근거만 남긴 채 한 줄 포인터로 대체(`78d4e993`).

둘째, **주석이 커밋별 증거 원장을 유지**하려 들었습니다. 원장은 커밋이 추가될 때마다 변하는데 주석 텍스트는 고정입니다. 실제로 "다섯 번째 단언이 `515c7e9d`에서 green이 됐다"는 주장이 거짓으로 판명됐습니다 — 그 단언은 `3878dcb5`에서 **이미 green인 채로 태어났고** 두 커밋 어디에도 존재하지 않았습니다. → 시간 불변인 *측정 방법*만 남기고 커밋 열거를 제거(`3aa02556`).

**선택과 트레이드오프:**

주석을 또 고치는 대신 **고칠 자리를 없애는** 쪽을 택했습니다. 8차 리뷰가 CONFIRMED 0건을 반환했습니다.

트레이드오프: 주석이 여전히 깁니다(~40줄). 복구 층의 도달 한계를 정직하게 문서화하기로 한 결정(Review Point 1)의 직접적 비용입니다. 짧은 주석은 그 한계를 담지 못하고, 담지 않으면 다음 독자가 "2층 방어"를 액면가로 읽습니다.

리뷰어 판단을 구합니다: **이 정도 분량의 근거 주석이 소스에 있는 게 적절한지, 아니면 `docs/`로 빼고 주석은 포인터만 남기는 게 나은지.**

---

## ✅ Checklist

### 예방 층 (문서 순서)
- [ ] Execution Dispatch 번호매김 목록 안에 `set --phase pursuing` 실행 단계가 존재한다
  - `skills/ultragoal/SKILL.md`
- [ ] 그 단계의 위치가 `Dispatch ONLY that one story` 지시보다 앞이다
  - `skills/ultragoal/SKILL.test.ts`
- [ ] `"After the first sisyphus dispatch"` 문구가 `SKILL.md`에 더 이상 존재하지 않는다
  - `skills/ultragoal/SKILL.test.ts`
- [ ] Initial path 내러티브가 `set --phase pursuing` → `dispatch story #1` 순서로 읽힌다
  - `skills/ultragoal/SKILL.test.ts`
- [ ] Re-plan 루프백 내러티브가 `confirm-all-stories` → `set --phase pursuing` → dispatch 순서로 읽힌다
  - `skills/ultragoal/SKILL.test.ts`

### 복구 층 (phase 자동 전환)
- [ ] planning 상태에서 `set-verdict` 실행 후 `get().phase === "pursuing"`이다
  - `skills/ultragoal/scripts/ultragoal-state.test.ts`
- [ ] 같은 실행의 stderr에 `phase auto-advanced` 문구가 포함되고, stdout에는 포함되지 않는다
  - `skills/ultragoal/scripts/ultragoal-state.test.ts`
- [ ] `complete`/`blocked`/`budget_limited` 상태에서 `set-verdict` 실행 시 phase가 변하지 않고 `active`도 `false`로 유지된다
  - `skills/ultragoal/scripts/ultragoal-state.test.ts`
- [ ] 이미 `pursuing`인 상태에서 실행하면 auto-advanced 보고가 나오지 않는다
  - `skills/ultragoal/scripts/ultragoal-state.test.ts`
- [ ] unconfirmed 스토리가 남은 planning 상태에서는 기존 가드 메시지와 함께 실패한다(가드 우회 없음)
  - `skills/ultragoal/scripts/ultragoal-state.test.ts`
- [ ] `objective_verdict`는 자동 전환 여부와 무관하게 요청한 값으로 기록된다
  - `skills/ultragoal/scripts/ultragoal-state.test.ts`

### 회귀 및 제약
- [ ] `lib/persistent-mode-core/decision.ts`가 이 브랜치에서 미변경이다
  - `lib/persistent-mode-core/decision.ts`
- [ ] `skills/goal/`이 이 브랜치에서 미변경이다
  - `skills/goal/`
- [ ] 기존 테스트 파일의 assertion이 제거되거나 약화되지 않았다
  - `skills/ultragoal/scripts/ultragoal-state.test.ts`
- [ ] `make test`와 `make validate`가 통과한다
  - `Makefile`
