### PR TITLE
feat: job config deny.skills로 worker 자기재귀 팬아웃 차단

### DIFF
--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -1941,7 +1941,7 @@ describe("assertDenyEnforceable", () => {
 		process.stdout.write = originalStdoutWrite;
 	});
 
-	test("deny 비어있음 + gemini member는 통과하고 stdout에 차단 미선언 한 줄을 남긴다", () => {
+	test("deny 비어있음 + gemini member는 통과하고 stderr에 차단 미선언 한 줄을 남긴다 (stdout은 비어있다)", () => {
 		expect(() =>
 			assertDenyEnforceable(
 				[{ name: "gemini-member", command: "gemini -p" }],
@@ -1950,7 +1950,8 @@ describe("assertDenyEnforceable", () => {
 				"/path/to/config.yaml",
 			),
 		).not.toThrow();
-		expect(stdoutOutput).toContain("no skill deny declared");
+		expect(stderrOutput).toContain("no skill deny declared");
+		expect(stdoutOutput).toBe("");
 	});
 
 	test("deny 선언 + gemini member는 exit 1이고 4개 구성요소를 모두 포함한다", () => {
@@ -2037,7 +2038,7 @@ describe("assertDenyEnforceable", () => {
 		).not.toThrow();
 	});
 
-	test("deny가 undefined면 [] 와 동일하게 통과하고 stdout에 차단 미선언 한 줄을 남긴다", () => {
+	test("deny가 undefined면 [] 와 동일하게 통과하고 stderr에 차단 미선언 한 줄을 남긴다 (stdout은 비어있다)", () => {
 		expect(() =>
 			assertDenyEnforceable(
 				[{ name: "gemini-member", command: "gemini -p" }],
@@ -2046,10 +2047,11 @@ describe("assertDenyEnforceable", () => {
 				"/path/to/config.yaml",
 			),
 		).not.toThrow();
-		expect(stdoutOutput).toContain("no skill deny declared");
+		expect(stderrOutput).toContain("no skill deny declared");
+		expect(stdoutOutput).toBe("");
 	});
 
-	test("deny가 null이면 [] 와 동일하게 통과하고 stdout에 차단 미선언 한 줄을 남긴다", () => {
+	test("deny가 null이면 [] 와 동일하게 통과하고 stderr에 차단 미선언 한 줄을 남긴다 (stdout은 비어있다)", () => {
 		expect(() =>
 			assertDenyEnforceable(
 				[{ name: "gemini-member", command: "gemini -p" }],
@@ -2058,7 +2060,8 @@ describe("assertDenyEnforceable", () => {
 				"/path/to/config.yaml",
 			),
 		).not.toThrow();
-		expect(stdoutOutput).toContain("no skill deny declared");
+		expect(stderrOutput).toContain("no skill deny declared");
+		expect(stdoutOutput).toBe("");
 	});
 });
 

--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -23,6 +23,7 @@ import {
 	cmdCollect,
 	cmdResumeMember,
 	assertMembersOrExit,
+	assertDenyEnforceable,
 } from "./generic-job.ts";
 
 // ---------------------------------------------------------------------------
@@ -1901,6 +1902,163 @@ describe("assertMembersOrExit", () => {
 		expect(() =>
 			assertMembersOrExit([{ name: "x" }], councilConfig, "/path/to/config.yaml"),
 		).not.toThrow();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// assertDenyEnforceable
+// ---------------------------------------------------------------------------
+
+describe("assertDenyEnforceable", () => {
+	let originalExit: typeof process.exit;
+	let originalStderrWrite: typeof process.stderr.write;
+	let originalStdoutWrite: typeof process.stdout.write;
+	let stderrOutput: string;
+	let stdoutOutput: string;
+
+	beforeEach(() => {
+		originalExit = process.exit;
+		originalStderrWrite = process.stderr.write;
+		originalStdoutWrite = process.stdout.write;
+		stderrOutput = "";
+		stdoutOutput = "";
+		(process as any).exit = (code?: number) => {
+			throw new Error(`process.exit(${code})`);
+		};
+		(process.stderr.write as any) = (chunk: string) => {
+			stderrOutput += chunk;
+			return true;
+		};
+		(process.stdout.write as any) = (chunk: string) => {
+			stdoutOutput += chunk;
+			return true;
+		};
+	});
+
+	afterEach(() => {
+		process.exit = originalExit;
+		process.stderr.write = originalStderrWrite;
+		process.stdout.write = originalStdoutWrite;
+	});
+
+	test("deny 비어있음 + gemini member는 통과하고 stdout에 차단 미선언 한 줄을 남긴다", () => {
+		expect(() =>
+			assertDenyEnforceable(
+				[{ name: "gemini-member", command: "gemini -p" }],
+				[],
+				councilConfig,
+				"/path/to/config.yaml",
+			),
+		).not.toThrow();
+		expect(stdoutOutput).toContain("no skill deny declared");
+	});
+
+	test("deny 선언 + gemini member는 exit 1이고 4개 구성요소를 모두 포함한다", () => {
+		expect(() =>
+			assertDenyEnforceable(
+				[{ name: "gemini-member", command: "gemini -p" }],
+				["some-skill"],
+				councilConfig,
+				"/path/to/config.yaml",
+			),
+		).toThrow("process.exit(1)");
+
+		// (a) configPath
+		expect(stderrOutput).toContain("/path/to/config.yaml");
+		// (b) 위반 member 이름과 감지된 cliType
+		expect(stderrOutput).toContain("gemini-member");
+		expect(stderrOutput).toContain("gemini");
+		// (c) 집행 가능 CLI 목록
+		expect(stderrOutput).toContain("Enforceable CLIs: codex, claude, opencode");
+		// (d) 고치는 방법 2가지 — 대체 / deny 제거
+		expect(stderrOutput).toContain("member");
+		expect(stderrOutput.toLowerCase()).toContain("deny");
+	});
+
+	test("deny 선언 + unknown cliType member는 exit 1이다", () => {
+		expect(() =>
+			assertDenyEnforceable(
+				[{ name: "mystery-member", command: "mycli run" }],
+				["some-skill"],
+				councilConfig,
+				"/path/to/config.yaml",
+			),
+		).toThrow("process.exit(1)");
+		expect(stderrOutput).toContain("mystery-member");
+		expect(stderrOutput).toContain("unknown");
+	});
+
+	test("위반 member가 2개 이상이면 에러 문자열에 둘 다 나열된다", () => {
+		expect(() =>
+			assertDenyEnforceable(
+				[
+					{ name: "gemini-member", command: "gemini -p" },
+					{ name: "mystery-member", command: "mycli run" },
+					{ name: "codex-member", command: "codex exec" },
+				],
+				["some-skill"],
+				councilConfig,
+				"/path/to/config.yaml",
+			),
+		).toThrow("process.exit(1)");
+		expect(stderrOutput).toContain("gemini-member");
+		expect(stderrOutput).toContain("mystery-member");
+	});
+
+	test("위반 member가 배열 마지막에 있어도 앞쪽 member에 부수효과가 없다 (spawn 없음, 순수 판정)", () => {
+		expect(() =>
+			assertDenyEnforceable(
+				[
+					{ name: "codex-member", command: "codex exec" },
+					{ name: "claude-member", command: "claude -p" },
+					{ name: "gemini-member", command: "gemini -p" },
+				],
+				["some-skill"],
+				councilConfig,
+				"/path/to/config.yaml",
+			),
+		).toThrow("process.exit(1)");
+		// 판정만 하고 spawn하지 않으므로 통과 member는 에러 문자열에 위반 원인으로 등장하지 않는다
+		expect(stderrOutput).toContain("gemini-member");
+	});
+
+	test("deny 선언 + 전 member가 집행 가능 CLI면 통과한다 (exit 없음)", () => {
+		expect(() =>
+			assertDenyEnforceable(
+				[
+					{ name: "codex-member", command: "codex exec" },
+					{ name: "claude-member", command: "claude -p" },
+					{ name: "opencode-member", command: "opencode run" },
+				],
+				["some-skill"],
+				councilConfig,
+				"/path/to/config.yaml",
+			),
+		).not.toThrow();
+	});
+
+	test("deny가 undefined면 [] 와 동일하게 통과하고 stdout에 차단 미선언 한 줄을 남긴다", () => {
+		expect(() =>
+			assertDenyEnforceable(
+				[{ name: "gemini-member", command: "gemini -p" }],
+				undefined,
+				councilConfig,
+				"/path/to/config.yaml",
+			),
+		).not.toThrow();
+		expect(stdoutOutput).toContain("no skill deny declared");
+	});
+
+	test("deny가 null이면 [] 와 동일하게 통과하고 stdout에 차단 미선언 한 줄을 남긴다", () => {
+		expect(() =>
+			assertDenyEnforceable(
+				[{ name: "gemini-member", command: "gemini -p" }],
+				null as unknown as undefined,
+				councilConfig,
+				"/path/to/config.yaml",
+			),
+		).not.toThrow();
+		expect(stdoutOutput).toContain("no skill deny declared");
 	});
 });
 

--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -7,6 +7,7 @@ import os from "os";
 
 import type { JobConfig, CmdResultsHooks, ResumeMemberOpts } from "./generic-job.ts";
 import type { RunOneTurnOpts } from "./worker-utils.ts";
+import { splitCommand } from "./worker-utils.ts";
 import {
 	detectCliType,
 	buildAugmentedCommand,
@@ -320,16 +321,80 @@ describe("buildAugmentedCommand", () => {
 		expect(resultEmpty.env.CLAUDECODE).toBe("");
 	});
 
-	test("codex: deny translates to -c skills.config with enabled=false entries", () => {
+	test("codex: deny translates to -c skills.config with enabled=false entries (quotes escaped for transport)", () => {
 		const result = buildAugmentedCommand({ command: "codex exec", deny: ["a", "b"] }, "codex");
 		expect(result.command).toContain(
-			'-c skills.config=[{name="a",enabled=false},{name="b",enabled=false}]',
+			'-c skills.config=[{name=\\"a\\",enabled=false},{name=\\"b\\",enabled=false}]',
 		);
 	});
 
-	test("claude: deny translates to --settings skillOverrides off", () => {
+	test("claude: deny translates to --settings skillOverrides off (quotes escaped for transport)", () => {
 		const result = buildAugmentedCommand({ command: "claude -p", deny: ["a"] }, "claude");
-		expect(result.command).toContain('--settings {"skillOverrides":{"a":"off"}}');
+		expect(result.command).toContain('--settings {\\"skillOverrides\\":{\\"a\\":\\"off\\"}}');
+	});
+
+	// ---------------------------------------------------------------------------
+	// Round-trip identity: buildAugmentedCommand's output must survive splitCommand
+	// re-tokenization unchanged, because spawnWorkers hands augmented.command to a
+	// worker as a --command argv, and the worker re-tokenizes it with splitCommand
+	// before spawning (no second shell parse exists anywhere in this pipeline).
+	// ---------------------------------------------------------------------------
+
+	test("round-trip: codex deny -c token survives splitCommand with quotes intact", () => {
+		const result = buildAugmentedCommand({ command: "codex exec", deny: ["a", "b"] }, "codex");
+		const tokens = splitCommand(result.command);
+		expect(tokens).not.toBeNull();
+		const cIndex = tokens!.indexOf("-c");
+		expect(cIndex).toBeGreaterThanOrEqual(0);
+		expect(tokens![cIndex + 1]).toBe(
+			'skills.config=[{name="a",enabled=false},{name="b",enabled=false}]',
+		);
+	});
+
+	test("round-trip: claude deny --settings token survives splitCommand as valid JSON", () => {
+		const result = buildAugmentedCommand({ command: "claude -p", deny: ["a"] }, "claude");
+		const tokens = splitCommand(result.command);
+		expect(tokens).not.toBeNull();
+		const settingsIndex = tokens!.indexOf("--settings");
+		expect(settingsIndex).toBeGreaterThanOrEqual(0);
+		const parsed = JSON.parse(tokens![settingsIndex + 1]);
+		expect(parsed.skillOverrides.a).toBe("off");
+	});
+
+	test("round-trip: codex deny with 2+ names has every quote pair escaped, not partial", () => {
+		const result = buildAugmentedCommand(
+			{ command: "codex exec", deny: ["alpha", "beta", "gamma"] },
+			"codex",
+		);
+		const tokens = splitCommand(result.command);
+		expect(tokens).not.toBeNull();
+		const cIndex = tokens!.indexOf("-c");
+		expect(tokens![cIndex + 1]).toBe(
+			'skills.config=[{name="alpha",enabled=false},{name="beta",enabled=false},{name="gamma",enabled=false}]',
+		);
+	});
+
+	test("round-trip: claude deny with 2+ names has every quote pair escaped, not partial", () => {
+		const result = buildAugmentedCommand({ command: "claude -p", deny: ["alpha", "beta"] }, "claude");
+		const tokens = splitCommand(result.command);
+		expect(tokens).not.toBeNull();
+		const settingsIndex = tokens!.indexOf("--settings");
+		const parsed = JSON.parse(tokens![settingsIndex + 1]);
+		expect(parsed.skillOverrides).toEqual({ alpha: "off", beta: "off" });
+	});
+
+	test("round-trip: opencode deny bypasses splitCommand entirely — env-only, no command trace", () => {
+		const result = buildAugmentedCommand({ command: "opencode run", deny: ["a"] }, "opencode");
+		expect(result.command).toBe("opencode run");
+		expect(result.command).not.toContain("a");
+		expect(result.env.OPENCODE_CONFIG_CONTENT).toBeTruthy();
+		const tokens = splitCommand(result.command);
+		expect(tokens).toEqual(["opencode", "run"]);
+	});
+
+	test("round-trip: no deny leaves splitCommand output unchanged from pre-escaping behavior", () => {
+		const result = buildAugmentedCommand({ command: "claude -p", model: "opus" }, "claude");
+		expect(splitCommand(result.command)).toEqual(["claude", "-p", "--model", "opus"]);
 	});
 
 	test("opencode: deny translates to OPENCODE_CONFIG_CONTENT env with permission.skill deny + wildcard allow", () => {
@@ -2079,6 +2144,34 @@ describe("cmdResumeMember", () => {
 			CLAUDE_CODE_EFFORT_LEVEL: "xhigh",
 			CUSTOM: "val",
 		});
+	});
+
+	test("round-trip: resume re-tokenizes a persisted deny command with quotes intact", async () => {
+		const entityDir = path.join(jobDir, "members", "codexmember");
+		const augmented = buildAugmentedCommand({ command: "codex exec", deny: ["a", "b"] }, "codex");
+		writeMemberStatus(entityDir, {
+			member: "codexmember",
+			state: "done",
+			sessionID: "ses_y",
+			resume_count: 0,
+			command: augmented.command,
+		});
+
+		let capturedOpts: RunOneTurnOpts | null = null;
+		const resumeOneTurnFn = async (_sid: string, opts: RunOneTurnOpts) => {
+			capturedOpts = opts;
+			return { state: "done" as const, sessionID: "ses_y", text: "", exitCode: 0 };
+		};
+
+		await cmdResumeMember(jobDir, "codexmember", "follow up", membersConfig, {
+			driverFactory: () => makeMockDriver(),
+			resumeOneTurnFn,
+		});
+
+		expect(capturedOpts).not.toBeNull();
+		expect(capturedOpts!.args).toContain(
+			'skills.config=[{name="a",enabled=false},{name="b",enabled=false}]',
+		);
 	});
 
 	test("cmdResumeMember restores workerEnv", async () => {

--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -319,6 +319,40 @@ describe("buildAugmentedCommand", () => {
 		const resultEmpty = buildAugmentedCommand({ command: "claude -p", env: {} }, "claude");
 		expect(resultEmpty.env.CLAUDECODE).toBe("");
 	});
+
+	test("codex: deny translates to -c skills.config with enabled=false entries", () => {
+		const result = buildAugmentedCommand({ command: "codex exec", deny: ["a", "b"] }, "codex");
+		expect(result.command).toContain(
+			'-c skills.config=[{name="a",enabled=false},{name="b",enabled=false}]',
+		);
+	});
+
+	test("claude: deny translates to --settings skillOverrides off", () => {
+		const result = buildAugmentedCommand({ command: "claude -p", deny: ["a"] }, "claude");
+		expect(result.command).toContain('--settings {"skillOverrides":{"a":"off"}}');
+	});
+
+	test("opencode: deny translates to OPENCODE_CONFIG_CONTENT env with permission.skill deny + wildcard allow", () => {
+		const result = buildAugmentedCommand({ command: "opencode run", deny: ["a"] }, "opencode");
+		expect(result.env.OPENCODE_CONFIG_CONTENT).toBeTruthy();
+		const parsed = JSON.parse(result.env.OPENCODE_CONFIG_CONTENT);
+		expect(parsed.permission.skill.a).toBe("deny");
+		expect(parsed.permission.skill["*"]).toBe("allow");
+	});
+
+	test("deny absent or empty is byte-identical to not passing deny at all (codex/claude/opencode)", () => {
+		for (const [command, cliType] of [
+			["codex exec", "codex"],
+			["claude -p", "claude"],
+			["opencode run", "opencode"],
+		] as const) {
+			const withoutDeny = buildAugmentedCommand({ command }, cliType);
+			const withUndefinedDeny = buildAugmentedCommand({ command, deny: undefined }, cliType);
+			const withEmptyDeny = buildAugmentedCommand({ command, deny: [] }, cliType);
+			expect(withUndefinedDeny).toEqual(withoutDeny);
+			expect(withEmptyDeny).toEqual(withoutDeny);
+		}
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -406,6 +406,39 @@ describe("buildAugmentedCommand", () => {
 		expect(parsed.permission.skill["*"]).toBe("allow");
 	});
 
+	// A plain object literal ({}) has Object.prototype as its prototype, so assigning
+	// a key literally named "__proto__" hits the inherited accessor instead of creating
+	// an own data property — the name silently vanishes from JSON.stringify. claude's
+	// skillOverrides and opencode's permission.skill must build on a null-prototype
+	// object (Object.create(null)) so a "__proto__"-named deny entry survives as a real key.
+	test("deny with a __proto__-named skill survives as an own key for claude and opencode", () => {
+		const claudeResult = buildAugmentedCommand(
+			{ command: "claude -p", deny: ["__proto__", "normal-skill"] },
+			"claude",
+		);
+		const claudeTokens = splitCommand(claudeResult.command);
+		expect(claudeTokens).not.toBeNull();
+		const settingsIndex = claudeTokens!.indexOf("--settings");
+		const claudeParsed = JSON.parse(claudeTokens![settingsIndex + 1]);
+		expect(Object.prototype.hasOwnProperty.call(claudeParsed.skillOverrides, "__proto__")).toBe(
+			true,
+		);
+		expect(claudeParsed.skillOverrides.__proto__).toBe("off");
+		expect(claudeParsed.skillOverrides["normal-skill"]).toBe("off");
+
+		const opencodeResult = buildAugmentedCommand(
+			{ command: "opencode run", deny: ["__proto__", "normal-skill"] },
+			"opencode",
+		);
+		const opencodeParsed = JSON.parse(opencodeResult.env.OPENCODE_CONFIG_CONTENT);
+		expect(
+			Object.prototype.hasOwnProperty.call(opencodeParsed.permission.skill, "__proto__"),
+		).toBe(true);
+		expect(opencodeParsed.permission.skill.__proto__).toBe("deny");
+		expect(opencodeParsed.permission.skill["normal-skill"]).toBe("deny");
+		expect(opencodeParsed.permission.skill["*"]).toBe("allow");
+	});
+
 	test("deny absent or empty is byte-identical to not passing deny at all (codex/claude/opencode)", () => {
 		for (const [command, cliType] of [
 			["codex exec", "codex"],

--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -1972,8 +1972,8 @@ describe("assertDenyEnforceable", () => {
 		// (c) 집행 가능 CLI 목록
 		expect(stderrOutput).toContain("Enforceable CLIs: codex, claude, opencode");
 		// (d) 고치는 방법 2가지 — 대체 / deny 제거
-		expect(stderrOutput).toContain("member");
-		expect(stderrOutput.toLowerCase()).toContain("deny");
+		expect(stderrOutput).toContain("(1) replacing these members with an enforceable CLI");
+		expect(stderrOutput).toContain("(2) removing this job's settings.deny.skills declaration");
 	});
 
 	test("deny 선언 + unknown cliType member는 exit 1이다", () => {
@@ -2006,7 +2006,7 @@ describe("assertDenyEnforceable", () => {
 		expect(stderrOutput).toContain("mystery-member");
 	});
 
-	test("위반 member가 배열 마지막에 있어도 앞쪽 member에 부수효과가 없다 (spawn 없음, 순수 판정)", () => {
+	test("위반 member가 배열 마지막에 있어도 빠짐없이 적발된다", () => {
 		expect(() =>
 			assertDenyEnforceable(
 				[
@@ -2019,7 +2019,7 @@ describe("assertDenyEnforceable", () => {
 				"/path/to/config.yaml",
 			),
 		).toThrow("process.exit(1)");
-		// 판정만 하고 spawn하지 않으므로 통과 member는 에러 문자열에 위반 원인으로 등장하지 않는다
+		// 배열 마지막 위치의 위반(gemini-member)도 검사를 빠져나가지 않는다
 		expect(stderrOutput).toContain("gemini-member");
 	});
 

--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -406,6 +406,79 @@ describe("buildAugmentedCommand", () => {
 		expect(parsed.permission.skill["*"]).toBe("allow");
 	});
 
+	// OPENCODE_CONFIG_CONTENT carries opencode's whole inline config, not just permissions,
+	// and reaches the CLI from two independent inputs. A bare assignment silently drops the
+	// member's provider/model/mcp settings, so both inputs are covered here — checking only
+	// the `env:` axis would leave the ambient-environment axis unmeasured.
+	describe("opencode deny preserves an inherited OPENCODE_CONFIG_CONTENT", () => {
+		const originalInherited = process.env.OPENCODE_CONFIG_CONTENT;
+		afterEach(() => {
+			if (originalInherited === undefined) delete process.env.OPENCODE_CONFIG_CONTENT;
+			else process.env.OPENCODE_CONFIG_CONTENT = originalInherited;
+		});
+
+		test("member `env:` axis — provider/model and other permission keys survive", () => {
+			const result = buildAugmentedCommand(
+				{
+					command: "opencode run",
+					deny: ["orchestrate-review"],
+					env: {
+						OPENCODE_CONFIG_CONTENT: JSON.stringify({
+							provider: { anthropic: { apiKey: "x" } },
+							model: "opencode-go/glm-5.2",
+							permission: { bash: "ask", skill: { "existing-skill": "allow" } },
+						}),
+					},
+				},
+				"opencode",
+			);
+			const parsed = JSON.parse(result.env.OPENCODE_CONFIG_CONTENT);
+			expect(parsed.provider).toEqual({ anthropic: { apiKey: "x" } });
+			expect(parsed.model).toBe("opencode-go/glm-5.2");
+			expect(parsed.permission.bash).toBe("ask");
+			expect(parsed.permission.skill["existing-skill"]).toBe("allow");
+			expect(parsed.permission.skill["orchestrate-review"]).toBe("deny");
+		});
+
+		test("ambient process.env axis — workerEnv wins at spawn, so it must merge here too", () => {
+			process.env.OPENCODE_CONFIG_CONTENT = JSON.stringify({ model: "ambient/model" });
+			const result = buildAugmentedCommand(
+				{ command: "opencode run", deny: ["agent-council"] },
+				"opencode",
+			);
+			const parsed = JSON.parse(result.env.OPENCODE_CONFIG_CONTENT);
+			expect(parsed.model).toBe("ambient/model");
+			expect(parsed.permission.skill["agent-council"]).toBe("deny");
+		});
+
+		test("an inherited '*: deny' default is not widened to allow", () => {
+			const result = buildAugmentedCommand(
+				{
+					command: "opencode run",
+					deny: ["orchestrate-review"],
+					env: {
+						OPENCODE_CONFIG_CONTENT: JSON.stringify({ permission: { skill: { "*": "deny" } } }),
+					},
+				},
+				"opencode",
+			);
+			const parsed = JSON.parse(result.env.OPENCODE_CONFIG_CONTENT);
+			expect(parsed.permission.skill["*"]).toBe("deny");
+			expect(parsed.permission.skill["orchestrate-review"]).toBe("deny");
+		});
+
+		test("unparseable inherited config still enforces deny", () => {
+			process.env.OPENCODE_CONFIG_CONTENT = "{not json";
+			const result = buildAugmentedCommand(
+				{ command: "opencode run", deny: ["agent-council"] },
+				"opencode",
+			);
+			const parsed = JSON.parse(result.env.OPENCODE_CONFIG_CONTENT);
+			expect(parsed.permission.skill["agent-council"]).toBe("deny");
+			expect(parsed.permission.skill["*"]).toBe("allow");
+		});
+	});
+
 	// A plain object literal ({}) has Object.prototype as its prototype, so assigning
 	// a key literally named "__proto__" hits the inherited accessor instead of creating
 	// an own data property — the name silently vanishes from JSON.stringify. claude's

--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -1957,7 +1957,7 @@ describe("assertDenyEnforceable", () => {
 	test("deny 선언 + gemini member는 exit 1이고 4개 구성요소를 모두 포함한다", () => {
 		expect(() =>
 			assertDenyEnforceable(
-				[{ name: "gemini-member", command: "gemini -p" }],
+				[{ name: "bob", command: "gemini -p" }],
 				["some-skill"],
 				councilConfig,
 				"/path/to/config.yaml",
@@ -1966,9 +1966,8 @@ describe("assertDenyEnforceable", () => {
 
 		// (a) configPath
 		expect(stderrOutput).toContain("/path/to/config.yaml");
-		// (b) 위반 member 이름과 감지된 cliType
-		expect(stderrOutput).toContain("gemini-member");
-		expect(stderrOutput).toContain("gemini");
+		// (b) 위반 member 이름과 감지된 cliType의 렌더 쌍
+		expect(stderrOutput).toContain("bob (gemini)");
 		// (c) 집행 가능 CLI 목록
 		expect(stderrOutput).toContain("Enforceable CLIs: codex, claude, opencode");
 		// (d) 고치는 방법 2가지 — 대체 / deny 제거

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -154,6 +154,7 @@ export function buildAugmentedCommand(
 		effort_level?: unknown;
 		output_format?: unknown;
 		env?: Record<string, string>;
+		deny?: unknown;
 	},
 	cliType: string,
 ): { command: string; env: Record<string, string> } {
@@ -179,6 +180,25 @@ export function buildAugmentedCommand(
 	// nested session guard
 	if (cliType === "claude") {
 		env.CLAUDECODE = "";
+	}
+
+	// deny — invocation-scoped skill block, translated per cliType. No-op when deny is
+	// absent/empty: skill names come solely from entity.deny, never hardcoded here.
+	const denySkills = Array.isArray(entity.deny) ? entity.deny.map((name) => String(name)) : [];
+	if (denySkills.length > 0) {
+		if (cliType === "codex") {
+			const entries = denySkills.map((name) => `{name="${name}",enabled=false}`).join(",");
+			parts.push("-c", `skills.config=[${entries}]`);
+		} else if (cliType === "claude") {
+			const skillOverrides: Record<string, string> = {};
+			for (const name of denySkills) skillOverrides[name] = "off";
+			parts.push("--settings", JSON.stringify({ skillOverrides }));
+		} else if (cliType === "opencode") {
+			const skill: Record<string, string> = { "*": "allow" };
+			for (const name of denySkills) skill[name] = "deny";
+			env.OPENCODE_CONFIG_CONTENT = JSON.stringify({ permission: { skill } });
+		}
+		// gemini/unknown: no enforceable lever here — enforceability is a job-start gate's job, not this translator's.
 	}
 
 	// effort_level

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -296,11 +296,40 @@ export function buildAugmentedCommand(
 			// re-tokenization doesn't strip them and produce invalid JSON on the receiving end.
 			parts.push("--settings", JSON.stringify({ skillOverrides }).replace(/"/g, '\\"'));
 		} else if (cliType === "opencode") {
+			// This env var is not a deny-only channel — it carries opencode's ENTIRE inline
+			// config (provider, model, mcp, other permissions). It reaches the CLI from two
+			// inputs, so both must be preserved: the member's own `env:` (seeded above) and
+			// the ambient environment, since workerEnv is spread LAST over process.env at
+			// spawn time (lib/worker-utils.ts) and would therefore win over an inherited
+			// value. Merge into whichever is present rather than replacing it.
+			const inherited = env.OPENCODE_CONFIG_CONTENT ?? process.env.OPENCODE_CONFIG_CONTENT;
+			let base: Record<string, unknown> = {};
+			if (inherited) {
+				try {
+					const parsed: unknown = JSON.parse(inherited);
+					if (isRecord(parsed)) base = parsed;
+				} catch {
+					// Unparseable inherited config — opencode itself would reject it, so there is
+					// nothing worth preserving. Fall through to an empty base and still enforce deny.
+				}
+			}
+			const permission: Record<string, unknown> = isRecord(base.permission) ? base.permission : {};
 			// Same null-prototype reasoning as claude's skillOverrides above.
 			const skill: Record<string, string> = Object.create(null);
-			skill["*"] = "allow";
+			if (isRecord(permission.skill)) {
+				for (const [name, decision] of Object.entries(permission.skill)) {
+					skill[name] = String(decision);
+				}
+			}
+			// Default the wildcard only when the inherited config states no policy of its own:
+			// writing "allow" unconditionally would WIDEN an inherited '*: deny' default, turning
+			// a config-preserving merge into a permission grant.
+			if (skill["*"] === undefined) skill["*"] = "allow";
 			for (const name of denySkills) skill[name] = "deny";
-			env.OPENCODE_CONFIG_CONTENT = JSON.stringify({ permission: { skill } });
+			env.OPENCODE_CONFIG_CONTENT = JSON.stringify({
+				...base,
+				permission: { ...permission, skill },
+			});
 		}
 		// gemini/unknown: no enforceable lever here — enforceability is a job-start gate's job, not this translator's.
 	}

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -164,7 +164,7 @@ export function assertDenyEnforceable(
 ): void {
 	const deny = denySkills ?? [];
 	if (deny.length === 0) {
-		process.stdout.write(
+		process.stderr.write(
 			`start: this job has no skill deny declared (settings.deny.skills is empty) — proceeding unguarded. config=${configPath}\n`,
 		);
 		return;

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -187,12 +187,17 @@ export function buildAugmentedCommand(
 	const denySkills = Array.isArray(entity.deny) ? entity.deny.map((name) => String(name)) : [];
 	if (denySkills.length > 0) {
 		if (cliType === "codex") {
-			const entries = denySkills.map((name) => `{name="${name}",enabled=false}`).join(",");
+			// splitCommand (the only re-tokenizer between here and the spawned CLI — see
+			// spawnWorkers/worker.ts) treats an unescaped '"' as a quote-mode toggle and drops
+			// it from the token. Escape so the quote survives as a literal byte in the TOML value.
+			const entries = denySkills.map((name) => `{name=\\"${name}\\",enabled=false}`).join(",");
 			parts.push("-c", `skills.config=[${entries}]`);
 		} else if (cliType === "claude") {
 			const skillOverrides: Record<string, string> = {};
 			for (const name of denySkills) skillOverrides[name] = "off";
-			parts.push("--settings", JSON.stringify({ skillOverrides }));
+			// Same reason as codex above: escape every quote in the JSON so splitCommand's
+			// re-tokenization doesn't strip them and produce invalid JSON on the receiving end.
+			parts.push("--settings", JSON.stringify({ skillOverrides }).replace(/"/g, '\\"'));
 		} else if (cliType === "opencode") {
 			const skill: Record<string, string> = { "*": "allow" };
 			for (const name of denySkills) skill[name] = "deny";

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -286,13 +286,19 @@ export function buildAugmentedCommand(
 			const entries = denySkills.map((name) => `{name=\\"${name}\\",enabled=false}`).join(",");
 			parts.push("-c", `skills.config=[${entries}]`);
 		} else if (cliType === "claude") {
-			const skillOverrides: Record<string, string> = {};
+			// Object.create(null): a plain {} literal has Object.prototype as its
+			// prototype, so a deny name of "__proto__" assigns through the prototype
+			// setter instead of creating an own property — it silently vanishes from
+			// the JSON.stringify output below. A null-prototype object has no such setter.
+			const skillOverrides: Record<string, string> = Object.create(null);
 			for (const name of denySkills) skillOverrides[name] = "off";
 			// Same reason as codex above: escape every quote in the JSON so splitCommand's
 			// re-tokenization doesn't strip them and produce invalid JSON on the receiving end.
 			parts.push("--settings", JSON.stringify({ skillOverrides }).replace(/"/g, '\\"'));
 		} else if (cliType === "opencode") {
-			const skill: Record<string, string> = { "*": "allow" };
+			// Same null-prototype reasoning as claude's skillOverrides above.
+			const skill: Record<string, string> = Object.create(null);
+			skill["*"] = "allow";
 			for (const name of denySkills) skill[name] = "deny";
 			env.OPENCODE_CONFIG_CONTENT = JSON.stringify({ permission: { skill } });
 		}

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -182,7 +182,7 @@ export function assertDenyEnforceable(
 	if (violations.length > 0) {
 		exitWithError(
 			`start: settings.deny.skills is declared but the following ${config.entityPlural} use a CLI with no enforcement lever: ${violations.join(", ")}. ` +
-				`Enforceable CLIs: codex, claude, opencode. ` +
+				`Enforceable CLIs: ${ENFORCEABLE_CLI_TYPES.join(", ")}. ` +
 				`Fix by either (1) replacing these ${config.entityPlural} with an enforceable CLI, or (2) removing this job's settings.deny.skills declaration. config=${configPath}`,
 		);
 	}

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -147,6 +147,47 @@ export function detectCliType(command: unknown): string {
 	return "unknown";
 }
 
+// ---------------------------------------------------------------------------
+// assertDenyEnforceable — job-start gate: declared deny × per-member cliType.
+// "선언가능 = 집행가능" invariant — a CLI with no invocation-scoped skill-deny
+// lever (gemini, unknown) must not be allowed to silently ignore a declared
+// deny. Reuses detectCliType's result; no new judgment logic.
+// ---------------------------------------------------------------------------
+
+const ENFORCEABLE_CLI_TYPES = ["codex", "claude", "opencode"];
+
+export function assertDenyEnforceable(
+	entities: unknown[],
+	denySkills: string[] | undefined,
+	config: JobConfig,
+	configPath: string,
+): void {
+	const deny = denySkills ?? [];
+	if (deny.length === 0) {
+		process.stdout.write(
+			`start: this job has no skill deny declared (settings.deny.skills is empty) — proceeding unguarded. config=${configPath}\n`,
+		);
+		return;
+	}
+
+	const violations: string[] = [];
+	for (const entity of entities) {
+		if (!isRecord(entity)) continue;
+		const cliType = detectCliType(entity.command);
+		if (!ENFORCEABLE_CLI_TYPES.includes(cliType)) {
+			violations.push(`${String(entity.name)} (${cliType})`);
+		}
+	}
+
+	if (violations.length > 0) {
+		exitWithError(
+			`start: settings.deny.skills is declared but the following ${config.entityPlural} use a CLI with no enforcement lever: ${violations.join(", ")}. ` +
+				`Enforceable CLIs: codex, claude, opencode. ` +
+				`Fix by either (1) replacing these ${config.entityPlural} with an enforceable CLI, or (2) removing this job's settings.deny.skills declaration. config=${configPath}`,
+		);
+	}
+}
+
 export function buildAugmentedCommand(
 	entity: {
 		command: unknown;

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -188,6 +188,58 @@ export function assertDenyEnforceable(
 	}
 }
 
+// ---------------------------------------------------------------------------
+// assertDenySkillsShape / extractDenySkills — settings.deny.skills format
+// validation + extraction, shared by every consumer's config parser. Deny is
+// FORMAT-validated only — skill-name reality is not checked here (a later
+// stage's assertDenyEnforceable covers reachability by reading the real
+// YAML). No baseline deny list is injected here: YAML remains the sole
+// source. Name characters are restricted to the class spawnWorkers already
+// enforces on entity names ([a-zA-Z0-9_-]) — the same set splitCommand's
+// re-tokenization can carry unmangled through the spawned CLI's argv.
+// ---------------------------------------------------------------------------
+
+/** Narrow to a plain object, excluding arrays (deny must be a mapping, not a list). */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function assertDenySkillsShape(
+	settings: Record<string, unknown>,
+	config: JobConfig,
+	configPath: string,
+): void {
+	const keyPrefix = config.configTopLevelKey;
+	const deny = settings.deny;
+	if (deny === null || deny === undefined) return;
+	if (!isPlainObject(deny)) {
+		exitWithError(
+			`Invalid config in ${configPath}: '${keyPrefix}.settings.deny' must be a mapping/object`,
+		);
+	}
+	const skills = deny.skills;
+	if (skills === null || skills === undefined) return;
+	if (!Array.isArray(skills)) {
+		exitWithError(
+			`Invalid config in ${configPath}: '${keyPrefix}.settings.deny.skills' must be a list/array of non-empty strings`,
+		);
+	}
+	for (const skill of skills) {
+		if (typeof skill !== "string" || !/^[a-zA-Z0-9_-]+$/.test(skill)) {
+			exitWithError(
+				`Invalid config in ${configPath}: '${keyPrefix}.settings.deny.skills' must contain only [a-zA-Z0-9_-] skill names, got: ${JSON.stringify(skill)}`,
+			);
+		}
+	}
+}
+
+/** Read settings.deny.skills, already format-validated by assertDenySkillsShape, as string[]. */
+export function extractDenySkills(settings: Record<string, unknown>): string[] {
+	const deny = settings.deny;
+	if (!isPlainObject(deny) || !Array.isArray(deny.skills)) return [];
+	return deny.skills.map((skill) => String(skill));
+}
+
 export function buildAugmentedCommand(
 	entity: {
 		command: unknown;

--- a/skills/agent-council/council.config.yaml
+++ b/skills/agent-council/council.config.yaml
@@ -1,6 +1,9 @@
 # Agent Council Configuration
 # Add or remove council members as needed.
-# Note: Missing CLIs will report `missing_cli` at runtime.
+# Note: an unavailable CLI reports `missing_cli` at runtime; but while
+# settings.deny.skills is declared below, a member whose CLI has no
+# skill-deny lever (gemini / unrecognized) makes `start` exit 1 before any
+# job directory is created.
 
 council:
   # Council members configuration

--- a/skills/agent-council/council.config.yaml
+++ b/skills/agent-council/council.config.yaml
@@ -41,3 +41,14 @@ council:
   settings:
     exclude_chairman_from_members: false  # Chairman also participates as a council member
     timeout: 1200                         # Timeout seconds per agent (0 to disable)
+    deny:
+      # Self-recursion fan-out guard: members run claude/codex/opencode CLIs
+      # that could themselves invoke a review/council skill, spawning another
+      # fan-out beneath this one. Blocks the 3 skills that can start one.
+      # `code-review` isn't deployed to codex today (no `platforms: [codex]`
+      # in its sync.yaml) — declared anyway so this self-activates the day
+      # that changes, instead of silently staying a no-op.
+      skills:
+        - orchestrate-review
+        - code-review
+        - agent-council

--- a/skills/agent-council/scripts/job.test.ts
+++ b/skills/agent-council/scripts/job.test.ts
@@ -1270,6 +1270,36 @@ describe("parseCouncilConfig settings.deny.skills", () => {
 		);
 		expectParseExitsWithError(configPath, `Invalid config in ${configPath}`);
 	});
+
+	test("exits 1 when deny.skills contains a name with an embedded space", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			["council:", "  settings:", "    deny:", "      skills:", "        - 'a b'"].join("\n"),
+			"utf8",
+		);
+		expectParseExitsWithError(configPath, `Invalid config in ${configPath}`);
+	});
+
+	test("exits 1 when deny.skills contains a name with a backslash", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			["council:", "  settings:", "    deny:", "      skills:", "        - 'a\\b'"].join("\n"),
+			"utf8",
+		);
+		expectParseExitsWithError(configPath, `Invalid config in ${configPath}`);
+	});
+
+	test("exits 1 when deny.skills contains a name with an embedded quote", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			["council:", "  settings:", "    deny:", "      skills:", '        - \'a"b\''].join("\n"),
+			"utf8",
+		);
+		expectParseExitsWithError(configPath, `Invalid config in ${configPath}`);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/skills/agent-council/scripts/job.test.ts
+++ b/skills/agent-council/scripts/job.test.ts
@@ -17,6 +17,25 @@ function makeTmpDir() {
 	return fs.mkdtempSync(path.join(os.tmpdir(), "council-job-test-"));
 }
 
+/**
+ * `start` spawns a detached worker (lib/generic-job.ts spawnWorkers) that inherits
+ * `env: process.env` and execs the member's real CLI command. A test whose config
+ * declares a real CLI name (claude/codex/gemini) so it can pass assertDenyEnforceable
+ * would otherwise spawn the actual billed CLI binary. This stub directory shadows all
+ * three CLI names on PATH with a no-op `exit 0` script — detectCliType still resolves
+ * the command's first token to "claude"/"codex"/"gemini" (so the enforceability gate
+ * still passes), but the process the worker execs is this harmless stub.
+ */
+function makeCliStubDir(): string {
+	const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), "deny-cli-stub-"));
+	for (const cli of ["claude", "codex", "gemini"]) {
+		const stubPath = path.join(stubDir, cli);
+		fs.writeFileSync(stubPath, "#!/bin/sh\nexit 0\n");
+		fs.chmodSync(stubPath, 0o755);
+	}
+	return stubDir;
+}
+
 // ---------------------------------------------------------------------------
 // buildUiPayload
 // ---------------------------------------------------------------------------
@@ -1309,13 +1328,16 @@ describe("parseCouncilConfig settings.deny.skills", () => {
 describe("start: settings.deny.skills recorded in job.json settings.denySkills", () => {
 	const SCRIPT = path.join(import.meta.dirname, "job.ts");
 	let tmpDir: string;
+	let stubDir: string;
 
 	beforeEach(() => {
 		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "council-job-test-"));
+		stubDir = makeCliStubDir();
 	});
 
 	afterEach(() => {
 		fs.rmSync(tmpDir, { recursive: true, force: true });
+		fs.rmSync(stubDir, { recursive: true, force: true });
 	});
 
 	test("job.json settings.denySkills matches the declared deny.skills array", () => {
@@ -1357,7 +1379,7 @@ describe("start: settings.deny.skills recorded in job.json settings.denySkills",
 				"--json",
 				"test prompt",
 			],
-			{ stdio: "pipe" },
+			{ stdio: "pipe", env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` } },
 		);
 		const output = JSON.parse(result.toString());
 		expect(output.settings.denySkills).toEqual(["orchestrate-review", "code-review", "agent-council"]);
@@ -1404,7 +1426,7 @@ describe("start: settings.deny.skills recorded in job.json settings.denySkills",
 				"--json",
 				"test prompt",
 			],
-			{ stdio: "pipe" },
+			{ stdio: "pipe", env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` } },
 		);
 		const output = JSON.parse(result.toString());
 		expect(output.settings.denySkills).toEqual([]);
@@ -1436,7 +1458,7 @@ describe("start: settings.deny.skills recorded in job.json settings.denySkills",
 				"--json",
 				"test prompt",
 			],
-			{ stdio: "pipe" },
+			{ stdio: "pipe", env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` } },
 		);
 		// stdout must be pure JSON — the informational "no skill deny declared"
 		// note (deny defaults to empty here) must not leak into the same stream.

--- a/skills/agent-council/scripts/job.test.ts
+++ b/skills/agent-council/scripts/job.test.ts
@@ -1,12 +1,13 @@
 #!/usr/bin/env bun
 
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import fs from "fs";
 import path from "path";
 import os from "os";
 import { execFileSync } from "child_process";
 
 import { buildUiPayload, parseCouncilConfig, computeStatus } from "./job.ts";
+import * as GenericJob from "@lib/generic-job";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1151,5 +1152,417 @@ describe("resume-member subcommand", () => {
 		expect(exitCode).not.toBe(0);
 		expect(output).toContain("missing");
 		expect(output).toContain("prompt");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// parseCouncilConfig — settings.deny.skills parsing + format validation
+// ---------------------------------------------------------------------------
+
+describe("parseCouncilConfig settings.deny.skills", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "council-job-test-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function expectParseExitsWithError(configPath: string, expectedSubstring: string) {
+		const scriptContent = `
+      const { parseCouncilConfig } = await import('${path.resolve(import.meta.dirname, "./job.ts").replace(/'/g, "\\'")}');
+      await parseCouncilConfig('${configPath.replace(/'/g, "\\'")}');
+    `;
+		try {
+			execFileSync(process.execPath, ["-e", scriptContent], {
+				encoding: "utf8",
+				stdio: ["pipe", "pipe", "pipe"],
+			});
+			throw new Error("Expected parseCouncilConfig subprocess to exit non-zero");
+		} catch (err) {
+			expect((err as any).status).toBe(1);
+			expect((err as any).stderr.toString()).toContain(expectedSubstring);
+		}
+	}
+
+	test("parses settings.deny.skills as a string array from real YAML", async () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			[
+				"council:",
+				"  settings:",
+				"    deny:",
+				"      skills:",
+				"        - orchestrate-review",
+				"        - code-review",
+				"        - agent-council",
+			].join("\n"),
+			"utf8",
+		);
+		const result = await parseCouncilConfig(configPath);
+		expect(result.council.settings.deny).toEqual({
+			skills: ["orchestrate-review", "code-review", "agent-council"],
+		});
+	});
+
+	test("fallback (missing config file) does not declare a deny key", async () => {
+		const result = await parseCouncilConfig(path.join(tmpDir, "missing.yaml"));
+		expect(result.council.settings.deny).toBeUndefined();
+	});
+
+	test("real YAML with no deny key leaves settings.deny undefined", async () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			["council:", "  settings:", "    timeout: 5"].join("\n"),
+			"utf8",
+		);
+		const result = await parseCouncilConfig(configPath);
+		expect(result.council.settings.deny).toBeUndefined();
+	});
+
+	test("deny: key with no value (null) does not throw and carries no skills", async () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(configPath, ["council:", "  settings:", "    deny:"].join("\n"), "utf8");
+		const result = await parseCouncilConfig(configPath);
+		expect(result.council.settings.deny).toBeNull();
+	});
+
+	test("exits 1 when deny.skills is not an array", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			["council:", "  settings:", "    deny:", '      skills: "not-an-array"'].join("\n"),
+			"utf8",
+		);
+		expectParseExitsWithError(configPath, `Invalid config in ${configPath}`);
+	});
+
+	test("exits 1 when deny.skills contains a non-string element", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			["council:", "  settings:", "    deny:", "      skills:", "        - 123"].join("\n"),
+			"utf8",
+		);
+		expectParseExitsWithError(configPath, `Invalid config in ${configPath}`);
+	});
+
+	test("exits 1 when deny.skills contains an empty string", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			["council:", "  settings:", "    deny:", "      skills:", '        - ""'].join("\n"),
+			"utf8",
+		);
+		expectParseExitsWithError(configPath, `Invalid config in ${configPath}`);
+	});
+
+	test("exits 1 when deny.skills contains a whitespace-only string", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			["council:", "  settings:", "    deny:", "      skills:", '        - "   "'].join("\n"),
+			"utf8",
+		);
+		expectParseExitsWithError(configPath, `Invalid config in ${configPath}`);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// start: settings.deny.skills → job.json settings.denySkills
+// ---------------------------------------------------------------------------
+
+describe("start: settings.deny.skills recorded in job.json settings.denySkills", () => {
+	const SCRIPT = path.join(import.meta.dirname, "job.ts");
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "council-job-test-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test("job.json settings.denySkills matches the declared deny.skills array", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			[
+				"council:",
+				"  chairman:",
+				"    role: none",
+				"  members:",
+				"    - name: alice",
+				"      command: claude -p",
+				"  settings:",
+				"    exclude_chairman_from_members: false",
+				"    timeout: 10",
+				"    deny:",
+				"      skills:",
+				"        - orchestrate-review",
+				"        - code-review",
+				"        - agent-council",
+			].join("\n"),
+			"utf8",
+		);
+		const jobsDir = path.join(tmpDir, "jobs");
+		fs.mkdirSync(jobsDir, { recursive: true });
+
+		const result = execFileSync(
+			process.execPath,
+			[
+				SCRIPT,
+				"start",
+				"--config",
+				configPath,
+				"--jobs-dir",
+				jobsDir,
+				"--chairman",
+				"none",
+				"--json",
+				"test prompt",
+			],
+			{ stdio: "pipe" },
+		);
+		const output = JSON.parse(result.toString());
+		expect(output.settings.denySkills).toEqual(["orchestrate-review", "code-review", "agent-council"]);
+
+		try {
+			execFileSync(process.execPath, [SCRIPT, "stop", output.jobDir], { stdio: "pipe" });
+		} catch {}
+		try {
+			execFileSync(process.execPath, [SCRIPT, "clean", output.jobDir], { stdio: "pipe" });
+		} catch {}
+	});
+
+	test("job.json settings.denySkills is an empty array when deny is not declared", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			[
+				"council:",
+				"  chairman:",
+				"    role: none",
+				"  members:",
+				"    - name: alice",
+				"      command: claude -p",
+				"  settings:",
+				"    exclude_chairman_from_members: false",
+				"    timeout: 10",
+			].join("\n"),
+			"utf8",
+		);
+		const jobsDir = path.join(tmpDir, "jobs");
+		fs.mkdirSync(jobsDir, { recursive: true });
+
+		const result = execFileSync(
+			process.execPath,
+			[
+				SCRIPT,
+				"start",
+				"--config",
+				configPath,
+				"--jobs-dir",
+				jobsDir,
+				"--chairman",
+				"none",
+				"--json",
+				"test prompt",
+			],
+			{ stdio: "pipe" },
+		);
+		const output = JSON.parse(result.toString());
+		expect(output.settings.denySkills).toEqual([]);
+
+		try {
+			execFileSync(process.execPath, [SCRIPT, "stop", output.jobDir], { stdio: "pipe" });
+		} catch {}
+		try {
+			execFileSync(process.execPath, [SCRIPT, "clean", output.jobDir], { stdio: "pipe" });
+		} catch {}
+	});
+
+	test("fallback config path: gemini in the default member set, deny defaults to empty and the gate passes", () => {
+		const jobsDir = path.join(tmpDir, "jobs");
+		fs.mkdirSync(jobsDir, { recursive: true });
+		const missingConfigPath = path.join(tmpDir, "does-not-exist.yaml");
+
+		const result = execFileSync(
+			process.execPath,
+			[
+				SCRIPT,
+				"start",
+				"--config",
+				missingConfigPath,
+				"--jobs-dir",
+				jobsDir,
+				"--chairman",
+				"none",
+				"--json",
+				"test prompt",
+			],
+			{ stdio: "pipe" },
+		);
+		// stdout must be pure JSON — the informational "no skill deny declared"
+		// note (deny defaults to empty here) must not leak into the same stream.
+		const stdout = result.toString();
+		expect(() => JSON.parse(stdout)).not.toThrow();
+		expect(stdout).not.toContain("no skill deny declared");
+
+		const output = JSON.parse(stdout);
+		expect(output.settings.denySkills).toEqual([]);
+		const memberNames = output.members.map((m: { name: string }) => m.name);
+		expect(memberNames).toContain("gemini");
+
+		try {
+			execFileSync(process.execPath, [SCRIPT, "stop", output.jobDir], { stdio: "pipe" });
+		} catch {}
+		try {
+			execFileSync(process.execPath, [SCRIPT, "clean", output.jobDir], { stdio: "pipe" });
+		} catch {}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// start: assertDenyEnforceable gate wiring (cmdStart calls it right after
+// assertMembersOrExit, before spawning workers)
+// ---------------------------------------------------------------------------
+
+describe("start: assertDenyEnforceable gate wiring", () => {
+	const SCRIPT = path.join(import.meta.dirname, "job.ts");
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "council-job-test-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test("deny declared + a gemini member present → exit 1 listing the violation and enforceable CLIs", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			[
+				"council:",
+				"  chairman:",
+				"    role: none",
+				"  members:",
+				"    - name: alice",
+				"      command: claude -p",
+				"    - name: bob",
+				"      command: gemini",
+				"  settings:",
+				"    exclude_chairman_from_members: false",
+				"    timeout: 10",
+				"    deny:",
+				"      skills:",
+				"        - orchestrate-review",
+			].join("\n"),
+			"utf8",
+		);
+		const jobsDir = path.join(tmpDir, "jobs");
+		fs.mkdirSync(jobsDir, { recursive: true });
+
+		let threw = false;
+		let err: any;
+		try {
+			execFileSync(
+				process.execPath,
+				[
+					SCRIPT,
+					"start",
+					"--config",
+					configPath,
+					"--jobs-dir",
+					jobsDir,
+					"--chairman",
+					"none",
+					"test prompt",
+				],
+				{ stdio: "pipe" },
+			);
+		} catch (e) {
+			threw = true;
+			err = e;
+		}
+
+		expect(threw).toBe(true);
+		expect(err.status).toBe(1);
+		const stderr = err.stderr.toString();
+		expect(stderr).toContain("Enforceable CLIs: codex, claude, opencode");
+		expect(stderr).toContain("bob (gemini)");
+
+		const jobDirs = fs.existsSync(jobsDir) ? fs.readdirSync(jobsDir) : [];
+		const jobJsonFound = jobDirs.some((d) => fs.existsSync(path.join(jobsDir, d, "job.json")));
+		expect(jobJsonFound).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// start → spawnWorkers wiring: declared deny reaches each dispatched entity
+// (AC6 — verified by spying on the shared lib's spawnWorkers, per the spec's
+// allowed fallback method since detached workers are not easily inspectable).
+// ---------------------------------------------------------------------------
+
+describe("start: deny reaches spawnWorkers entities (AC6 wiring)", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "council-job-test-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+		mock.restore();
+	});
+
+	test("each dispatched member entity carries the declared deny array", async () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			[
+				"council:",
+				"  chairman:",
+				"    role: none",
+				"  members:",
+				"    - name: alice",
+				"      command: claude -p",
+				"  settings:",
+				"    exclude_chairman_from_members: false",
+				"    timeout: 10",
+				"    deny:",
+				"      skills:",
+				"        - orchestrate-review",
+				"        - code-review",
+			].join("\n"),
+			"utf8",
+		);
+		const jobsDir = path.join(tmpDir, "jobs");
+		fs.mkdirSync(jobsDir, { recursive: true });
+
+		let capturedEntities: Array<Record<string, unknown>> | undefined;
+		mock.module("@lib/generic-job", () => ({
+			...GenericJob,
+			spawnWorkers: ({ entities }: { entities: Array<Record<string, unknown>> }) => {
+				capturedEntities = entities;
+			},
+		}));
+
+		const mod = await import(`./job.ts?ac6-agent-council=${Date.now()}-${Math.random()}`);
+		await mod.cmdStart(
+			{ config: configPath, "jobs-dir": jobsDir, chairman: "none", json: true },
+			"test prompt",
+		);
+
+		expect(capturedEntities).toBeDefined();
+		expect(capturedEntities?.length).toBe(1);
+		expect(capturedEntities?.[0].deny).toEqual(["orchestrate-review", "code-review"]);
 	});
 });

--- a/skills/agent-council/scripts/job.test.ts
+++ b/skills/agent-council/scripts/job.test.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, beforeAll, afterAll, mock } from "bun:test";
 import fs from "fs";
 import path from "path";
 import os from "os";
@@ -35,6 +35,22 @@ function makeCliStubDir(): string {
 	}
 	return stubDir;
 }
+
+// `start` spawns its worker detached; `execFileSync("start", …)` returns long before
+// that worker execs the member's CLI command (observed ~283ms later). A per-test
+// stub dir torn down right after `start` returns — even after `stop`/`clean` — races
+// that exec: PATH resolution doesn't fail closed when the stub disappears, it falls
+// through to the next PATH entry (a real, billed CLI binary). Suite-scoped lifetime
+// keeps the stub alive for every test in this file, past any worker's real exec.
+let sharedStubDir: string;
+
+beforeAll(() => {
+	sharedStubDir = makeCliStubDir();
+});
+
+afterAll(() => {
+	fs.rmSync(sharedStubDir, { recursive: true, force: true });
+});
 
 // ---------------------------------------------------------------------------
 // buildUiPayload
@@ -1328,16 +1344,13 @@ describe("parseCouncilConfig settings.deny.skills", () => {
 describe("start: settings.deny.skills recorded in job.json settings.denySkills", () => {
 	const SCRIPT = path.join(import.meta.dirname, "job.ts");
 	let tmpDir: string;
-	let stubDir: string;
 
 	beforeEach(() => {
 		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "council-job-test-"));
-		stubDir = makeCliStubDir();
 	});
 
 	afterEach(() => {
 		fs.rmSync(tmpDir, { recursive: true, force: true });
-		fs.rmSync(stubDir, { recursive: true, force: true });
 	});
 
 	test("job.json settings.denySkills matches the declared deny.skills array", () => {
@@ -1379,7 +1392,7 @@ describe("start: settings.deny.skills recorded in job.json settings.denySkills",
 				"--json",
 				"test prompt",
 			],
-			{ stdio: "pipe", env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` } },
+			{ stdio: "pipe", env: { ...process.env, PATH: `${sharedStubDir}:${process.env.PATH}` } },
 		);
 		const output = JSON.parse(result.toString());
 		expect(output.settings.denySkills).toEqual(["orchestrate-review", "code-review", "agent-council"]);
@@ -1426,7 +1439,7 @@ describe("start: settings.deny.skills recorded in job.json settings.denySkills",
 				"--json",
 				"test prompt",
 			],
-			{ stdio: "pipe", env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` } },
+			{ stdio: "pipe", env: { ...process.env, PATH: `${sharedStubDir}:${process.env.PATH}` } },
 		);
 		const output = JSON.parse(result.toString());
 		expect(output.settings.denySkills).toEqual([]);
@@ -1458,7 +1471,7 @@ describe("start: settings.deny.skills recorded in job.json settings.denySkills",
 				"--json",
 				"test prompt",
 			],
-			{ stdio: "pipe", env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` } },
+			{ stdio: "pipe", env: { ...process.env, PATH: `${sharedStubDir}:${process.env.PATH}` } },
 		);
 		// stdout must be pure JSON — the informational "no skill deny declared"
 		// note (deny defaults to empty here) must not leak into the same stream.

--- a/skills/agent-council/scripts/job.ts
+++ b/skills/agent-council/scripts/job.ts
@@ -19,6 +19,7 @@ import {
 import {
 	type JobConfig,
 	assertMembersOrExit,
+	assertDenyEnforceable,
 	computeStatus as frameworkComputeStatus,
 	buildUiPayload as frameworkBuildUiPayload,
 	spawnWorkers as frameworkSpawnWorkers,
@@ -98,6 +99,43 @@ interface CouncilConfig {
 	};
 }
 
+// ---------------------------------------------------------------------------
+// deny.skills format validation — settings.deny.skills, if declared, must be an
+// array of non-empty (non-whitespace-only) strings. This validates FORMAT only;
+// skill-name reality is not checked here (see spec non-goal — a later stage's
+// enforceability test covers typos by reading the real YAML). No baseline deny
+// list is injected here: YAML remains the sole source.
+// ---------------------------------------------------------------------------
+
+function assertDenySkillsShape(settings: Record<string, unknown>, configPath: string): void {
+	const deny = settings.deny;
+	if (isNullish(deny)) return;
+	if (!isPlainObject(deny)) {
+		exitWithError(`Invalid config in ${configPath}: 'council.settings.deny' must be a mapping/object`);
+	}
+	const skills = deny.skills;
+	if (isNullish(skills)) return;
+	if (!Array.isArray(skills)) {
+		exitWithError(
+			`Invalid config in ${configPath}: 'council.settings.deny.skills' must be a list/array of non-empty strings`,
+		);
+	}
+	for (const skill of skills) {
+		if (typeof skill !== "string" || skill.trim() === "") {
+			exitWithError(
+				`Invalid config in ${configPath}: 'council.settings.deny.skills' must contain only non-empty strings, got: ${JSON.stringify(skill)}`,
+			);
+		}
+	}
+}
+
+/** Read settings.deny.skills, already format-validated by assertDenySkillsShape, as string[]. */
+function extractDenySkills(settings: Record<string, unknown>): string[] {
+	const deny = settings.deny;
+	if (!isPlainObject(deny) || !Array.isArray(deny.skills)) return [];
+	return deny.skills.map((skill) => String(skill));
+}
+
 async function parseCouncilConfig(configPath: string): Promise<CouncilConfig> {
 	const fallback: CouncilConfig = {
 		council: {
@@ -165,6 +203,8 @@ async function parseCouncilConfig(configPath: string): Promise<CouncilConfig> {
 		}
 		merged.council.settings = { ...merged.council.settings, ...council.settings };
 	}
+
+	assertDenySkillsShape(merged.council.settings, configPath);
 
 	return merged;
 }
@@ -387,6 +427,9 @@ async function cmdStart(options: Record<string, unknown>, prompt: string) {
 	const members = requestedMembers.filter(filterMember);
 	assertMembersOrExit(members, COUNCIL_CONFIG, configPath);
 
+	const denySkills = extractDenySkills(config.council.settings);
+	assertDenyEnforceable(members, denySkills, COUNCIL_CONFIG, configPath);
+
 	const jobId = generateJobId();
 	const jobDir = path.join(jobsDir, `council-${jobId}`);
 	const membersDir = path.join(jobDir, "members");
@@ -403,6 +446,7 @@ async function cmdStart(options: Record<string, unknown>, prompt: string) {
 		settings: {
 			excludeChairmanFromMembers,
 			timeoutSec: timeoutSec || null,
+			denySkills,
 		},
 		members: members.map((m) => ({
 			name: String(m.name),
@@ -419,7 +463,7 @@ async function cmdStart(options: Record<string, unknown>, prompt: string) {
 
 	// Use framework spawnWorkers — it calls detectCliType + buildAugmentedCommand internally
 	frameworkSpawnWorkers({
-		entities: members,
+		entities: members.map((m) => ({ ...m, deny: denySkills })),
 		workerPath: WORKER_PATH,
 		jobDir,
 		entitiesDir: membersDir,
@@ -520,4 +564,4 @@ export {
 	generateJobId,
 } from "@lib/job-utils";
 
-export { buildUiPayload, parseCouncilConfig, computeStatus, COUNCIL_CONFIG };
+export { buildUiPayload, parseCouncilConfig, computeStatus, COUNCIL_CONFIG, cmdStart };

--- a/skills/agent-council/scripts/job.ts
+++ b/skills/agent-council/scripts/job.ts
@@ -20,6 +20,8 @@ import {
 	type JobConfig,
 	assertMembersOrExit,
 	assertDenyEnforceable,
+	assertDenySkillsShape,
+	extractDenySkills,
 	computeStatus as frameworkComputeStatus,
 	buildUiPayload as frameworkBuildUiPayload,
 	spawnWorkers as frameworkSpawnWorkers,
@@ -99,43 +101,6 @@ interface CouncilConfig {
 	};
 }
 
-// ---------------------------------------------------------------------------
-// deny.skills format validation — settings.deny.skills, if declared, must be an
-// array of non-empty (non-whitespace-only) strings. This validates FORMAT only;
-// skill-name reality is not checked here (see spec non-goal — a later stage's
-// enforceability test covers typos by reading the real YAML). No baseline deny
-// list is injected here: YAML remains the sole source.
-// ---------------------------------------------------------------------------
-
-function assertDenySkillsShape(settings: Record<string, unknown>, configPath: string): void {
-	const deny = settings.deny;
-	if (isNullish(deny)) return;
-	if (!isPlainObject(deny)) {
-		exitWithError(`Invalid config in ${configPath}: 'council.settings.deny' must be a mapping/object`);
-	}
-	const skills = deny.skills;
-	if (isNullish(skills)) return;
-	if (!Array.isArray(skills)) {
-		exitWithError(
-			`Invalid config in ${configPath}: 'council.settings.deny.skills' must be a list/array of non-empty strings`,
-		);
-	}
-	for (const skill of skills) {
-		if (typeof skill !== "string" || skill.trim() === "") {
-			exitWithError(
-				`Invalid config in ${configPath}: 'council.settings.deny.skills' must contain only non-empty strings, got: ${JSON.stringify(skill)}`,
-			);
-		}
-	}
-}
-
-/** Read settings.deny.skills, already format-validated by assertDenySkillsShape, as string[]. */
-function extractDenySkills(settings: Record<string, unknown>): string[] {
-	const deny = settings.deny;
-	if (!isPlainObject(deny) || !Array.isArray(deny.skills)) return [];
-	return deny.skills.map((skill) => String(skill));
-}
-
 async function parseCouncilConfig(configPath: string): Promise<CouncilConfig> {
 	const fallback: CouncilConfig = {
 		council: {
@@ -204,7 +169,7 @@ async function parseCouncilConfig(configPath: string): Promise<CouncilConfig> {
 		merged.council.settings = { ...merged.council.settings, ...council.settings };
 	}
 
-	assertDenySkillsShape(merged.council.settings, configPath);
+	assertDenySkillsShape(merged.council.settings, COUNCIL_CONFIG, configPath);
 
 	return merged;
 }

--- a/skills/orchestrate-review/orchestrate-review.config.yaml
+++ b/skills/orchestrate-review/orchestrate-review.config.yaml
@@ -9,9 +9,10 @@ chunk-review:
     #
     # Per-angle model: each member carries its own command/model, so any angle
     # can run on a different CLI/model. Today every angle runs on codex at gpt-5.6-sol,
-    # high reasoning effort. `model` + `effort_level` + `output_format` resolve
-    # (via buildAugmentedCommand) to:
-    #   codex exec -m gpt-5.6-sol -c model_reasoning_effort=high --json --skip-git-repo-check
+    # high reasoning effort. `model` + `effort_level` + `output_format` (below) plus
+    # `settings.deny.skills` (below) resolve (via buildAugmentedCommand) to:
+    #   codex exec -m gpt-5.6-sol -c skills.config=[…from settings.deny.skills below…] \
+    #     -c model_reasoning_effort=high --json --skip-git-repo-check
     # Note: codex uses bare model ids (no `openai/` prefix). Git history attests
     # codex with gpt-5.4 / gpt-5.3-codex (gpt-5.5 itself only ran via opencode);
     # if codex rejects `gpt-5.6-sol`, fall back to `gpt-5.5`.

--- a/skills/orchestrate-review/orchestrate-review.config.yaml
+++ b/skills/orchestrate-review/orchestrate-review.config.yaml
@@ -65,3 +65,15 @@ chunk-review:
     # No-op with the angle members above (no `claude` member to exclude); kept
     # for compatibility if a claude-hosted angle is added later.
     exclude_chairman_from_members: false
+    deny:
+      # Self-recursion fan-out guard: each dispatched angle runs `codex exec`,
+      # so without this it could itself invoke a review/council skill and
+      # spawn another fan-out beneath this one. Blocks the 3 skills that can
+      # start a review/council job. `code-review` has no codex-side SKILL.md
+      # today (not deployed to codex in any of its 4 scopes) — declared
+      # anyway so this guard self-activates the day `code-review`'s
+      # `platforms` config adds codex, instead of silently staying a no-op.
+      skills:
+        - orchestrate-review
+        - code-review
+        - agent-council

--- a/skills/orchestrate-review/scripts/codex-skill-deny-efficacy.test.ts
+++ b/skills/orchestrate-review/scripts/codex-skill-deny-efficacy.test.ts
@@ -157,6 +157,21 @@ describe("codex 축 실효성 — settings.deny.skills가 실제 프롬프트에
 			expect(controlCount).toBe(baselineCount);
 		}
 	});
+
+	test("과차단 대조군: 선언되지 않은 스킬의 카운트는 deny 적용 후에도 그대로다", () => {
+		const declared = new Set(declaredNames);
+		const surviving = new Set(
+			[...baselineOutput.matchAll(/\/([a-zA-Z0-9_-]+)\/SKILL\.md/g)]
+				.map((m) => m[1])
+				.filter((n) => !declared.has(n)),
+		);
+		// 이 대조군 자체가 공허하지 않음을 먼저 보장한다 —
+		// surviving이 비면 아래 루프가 0회 돌며 조용히 통과해버린다.
+		expect(surviving.size).toBeGreaterThan(0);
+		for (const name of surviving) {
+			expect(countSkillListings(denyAllOutput, name)).toBe(countSkillListings(baselineOutput, name));
+		}
+	});
 });
 
 /**

--- a/skills/orchestrate-review/scripts/codex-skill-deny-efficacy.test.ts
+++ b/skills/orchestrate-review/scripts/codex-skill-deny-efficacy.test.ts
@@ -189,6 +189,19 @@ function skillMdPath(name: string): string {
 	return path.join(REPO_ROOT, "skills", name, "SKILL.md");
 }
 
+/**
+ * Case-exact existence check. This repo lives on a case-insensitive filesystem
+ * (macOS default), so `fs.existsSync(skillMdPath("ORCHESTRATE-REVIEW"))` returns
+ * true even though the real directory on disk is spelled "orchestrate-review" —
+ * codex itself is case-sensitive, so a miscased deny name silently fails to
+ * suppress anything while this guard waves it through. readdirSync returns the
+ * actual on-disk spelling, so comparing against it (not just existsSync) catches
+ * a miscased name that existsSync alone would miss.
+ */
+function skillDirExists(name: string): boolean {
+	return fs.readdirSync(path.join(REPO_ROOT, "skills")).includes(name) && fs.existsSync(skillMdPath(name));
+}
+
 describe("오타 검출 — 선언된 이름이 실재하는 스킬인가", () => {
 	test("orchestrate-review.config.yaml과 council.config.yaml에 선언된 모든 deny.skills 이름은 skills/<name>/SKILL.md로 실재한다", () => {
 		const sources: Array<{ configPath: string; topLevelKey: string }> = [
@@ -200,7 +213,7 @@ describe("오타 검출 — 선언된 이름이 실재하는 스킬인가", () =
 		for (const { configPath, topLevelKey } of sources) {
 			const names = readDeclaredDenySkills(configPath, topLevelKey);
 			for (const name of names) {
-				if (!fs.existsSync(skillMdPath(name))) {
+				if (!skillDirExists(name)) {
 					missing.push(
 						`"${name}" (declared in ${configPath} at '${topLevelKey}.settings.deny.skills') ` +
 							`— ${skillMdPath(name)} not found. Possible typo?`,

--- a/skills/orchestrate-review/scripts/codex-skill-deny-efficacy.test.ts
+++ b/skills/orchestrate-review/scripts/codex-skill-deny-efficacy.test.ts
@@ -1,0 +1,199 @@
+#!/usr/bin/env bun
+
+/**
+ * Codex 축 실효성 실측 테스트.
+ *
+ * settings.deny.skills 선언이 실제로 codex 프롬프트에서 해당 스킬을 억제하는지를,
+ * 프로덕션 전송 경로(buildAugmentedCommand → splitCommand — spawnWorkers가 워커에
+ * --command로 넘긴 문자열을 워커가 재토큰화하는 것과 동일한 경로)를 통과한 실제 argv로
+ * `codex debug prompt-input`을 돌려 baseline(deny 미적용) / deny(적용) 쌍 비교로 검증한다.
+ *
+ * 측정 단위: 스킬은 프롬프트에 `- <name>: <설명> (file: <경로>/<name>/SKILL.md)` 형태로
+ * 열거된다. 원시 이름 문자열을 세면 무관한 본문의 우연한 일치가 섞여 들어간다 — 실측상
+ * "code-review"라는 문자열은 이 레포의 CLAUDE.md 본문에만도 12건 등장하고, 그 원시 카운트로는
+ * deny 적용 후에도 그대로 12건이라 오탐(빨간불)이 뜨지만 실제로는 억제가 정상 동작한 것이다.
+ * 그래서 반드시 `/<name>/SKILL.md`의 등장 횟수만 센다.
+ *
+ * job.test.ts와 별도 파일로 둔 이유: job.test.ts는 tmp 설정 + mock 기반의 빠른 단위 테스트만
+ * 담는 반면, 이 테스트는 실제 codex 프로세스를 3회 spawn하는(초 단위) 외부-바이너리 의존
+ * 통합 테스트라 성격이 다르다. orchestrate-review.config.yaml의 실제 선언값을 읽는 것이 이
+ * 테스트의 핵심이라 job.ts와 같은 디렉터리에 colocate한다.
+ */
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import fs from "fs";
+import path from "path";
+
+import { buildAugmentedCommand } from "@lib/generic-job";
+import { splitCommand } from "@lib/worker-utils";
+
+const CONFIG_PATH = path.join(import.meta.dir, "..", "orchestrate-review.config.yaml");
+const COUNCIL_CONFIG_PATH = path.join(
+	import.meta.dir,
+	"..",
+	"..",
+	"agent-council",
+	"council.config.yaml",
+);
+
+const codexPath = Bun.which("codex");
+
+/** 실 codex 프로세스 3회 spawn을 감당할 beforeAll 타임아웃 (bun:test 기본 5s보다 넉넉히). */
+const BEFORE_ALL_TIMEOUT_MS = 60_000;
+
+/** AC7: codex 부재는 skip이 아니라 명시적 실패다. */
+function requireCodex(): void {
+	if (!codexPath) {
+		throw new Error(
+			"codex binary not found on PATH — this test measures REAL codex-side suppression via " +
+				"`codex debug prompt-input`; skipping would silently hide a broken enforcement chain, " +
+				"so absence must fail, not skip.",
+		);
+	}
+}
+
+/** settings.deny.skills를 YAML 파일에서 직접 읽는다 — 값을 테스트에 하드코딩하지 않는다. */
+function readDeclaredDenySkills(configPath: string, topLevelKey: string): string[] {
+	const parsed = Bun.YAML.parse(fs.readFileSync(configPath, "utf8")) as Record<string, any>;
+	const skills = parsed?.[topLevelKey]?.settings?.deny?.skills;
+	if (!Array.isArray(skills) || skills.length === 0) {
+		throw new Error(`${configPath}: '${topLevelKey}.settings.deny.skills' must be a non-empty array`);
+	}
+	return skills.map((name: unknown) => String(name));
+}
+
+/**
+ * 프로덕션 전송 경로를 그대로 재현한다: buildAugmentedCommand(번역) → splitCommand(재토큰화).
+ * "codex exec"의 앞 두 토큰은 버리고 나머지만 반환한다 — 프로브가 "exec" 대신
+ * "debug prompt-input"을 쓰기 때문이다.
+ */
+function buildExtraArgs(denySkills: string[]): string[] {
+	const augmented = buildAugmentedCommand({ command: "codex exec", deny: denySkills }, "codex");
+	const tokens = splitCommand(augmented.command);
+	if (!tokens) throw new Error(`splitCommand failed to tokenize: ${augmented.command}`);
+	return tokens.slice(2);
+}
+
+async function probePromptInput(extraArgs: string[]): Promise<string> {
+	const proc = Bun.spawn(["codex", "debug", "prompt-input", ...extraArgs, "hi"], {
+		stdin: "ignore", // AC8: 안 닫으면 "Reading additional input from stdin..."에서 멈춘다
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const stdout = await new Response(proc.stdout).text();
+	const stderr = await new Response(proc.stderr).text();
+	const exitCode = await proc.exited;
+	if (exitCode !== 0) {
+		throw new Error(
+			`codex debug prompt-input exited ${exitCode} (extraArgs=${JSON.stringify(extraArgs)}): ${stderr.slice(0, 1000)}`,
+		);
+	}
+	return stdout;
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** 측정 단위: 원시 이름 문자열이 아니라 `/<name>/SKILL.md` 등장 횟수. */
+function countSkillListings(promptJson: string, skillName: string): number {
+	const pattern = new RegExp(`/${escapeRegExp(skillName)}/SKILL\\.md`, "g");
+	return (promptJson.match(pattern) || []).length;
+}
+
+describe("codex 축 실효성 — settings.deny.skills가 실제 프롬프트에서 스킬을 억제하는가", () => {
+	let declaredNames: string[];
+	let baselineOutput: string;
+	let denyAllOutput: string;
+	let controlOutput: string;
+
+	beforeAll(async () => {
+		requireCodex();
+
+		declaredNames = readDeclaredDenySkills(CONFIG_PATH, "chunk-review");
+
+		// baseline 1회 + declaredNames 전체를 한 번에 deny 적용 1회 + 대조군 1회 — 프로덕션에서도
+		// settings.deny.skills는 job 하나당 한 번에 전체가 적용되므로, 이 구성이 실제 사용 방식과
+		// 동일한 전송 단위다.
+		baselineOutput = await probePromptInput(buildExtraArgs([]));
+		denyAllOutput = await probePromptInput(buildExtraArgs(declaredNames));
+		controlOutput = await probePromptInput(buildExtraArgs(["__no_such_skill__"]));
+		// 3회 실 codex 프로세스 spawn(각 ~2-3초) 합산이 bun:test 기본 hook 타임아웃(5s)을
+		// 넘는다 — BEFORE_ALL_TIMEOUT_MS로 넉넉히 확장.
+	}, BEFORE_ALL_TIMEOUT_MS);
+
+	test("council.config.yaml은 orchestrate-review.config.yaml과 동일한 선언 집합을 갖는다 (각자 파일에서 읽음)", () => {
+		const councilNames = readDeclaredDenySkills(COUNCIL_CONFIG_PATH, "council");
+		expect([...councilNames].sort()).toEqual([...declaredNames].sort());
+	});
+
+	test("최소 1개 선언 이름은 baseline > 0이다 — 전부 측정 불가면 이 테스트는 아무것도 증명하지 못한다", () => {
+		const measurable = declaredNames.filter((name) => countSkillListings(baselineOutput, name) > 0);
+		expect(measurable.length).toBeGreaterThan(0);
+	});
+
+	test("baseline > 0인 선언 이름은 deny 적용 시 반드시 0이다 (baseline === 0인 이름은 측정 불가로 보고하고 단언에서 제외한다)", () => {
+		for (const name of declaredNames) {
+			const baselineCount = countSkillListings(baselineOutput, name);
+			if (baselineCount === 0) {
+				// AC5: 측정 불가는 테스트 실패가 아니라 정보 출력이다. 이 이름의 통과는
+				// 억제의 증거로 쓰이지 않는다 — 배포 스코프가 바뀌어도 조용히 통과하지 않도록
+				// 사유를 남긴다.
+				console.warn(
+					`[측정 불가] "${name}": baseline count 0 — codex 배포 스코프에 이 스킬 파일이 없어 ` +
+						"억제 여부를 판정할 수 없다.",
+				);
+				continue;
+			}
+			const denyCount = countSkillListings(denyAllOutput, name);
+			expect(denyCount).toBe(0);
+		}
+	});
+
+	test("대조군: 존재하지 않는 스킬명으로 억제를 시도하면 baseline과 동일하게 유지된다 (억제가 일어나지 않음)", () => {
+		for (const name of declaredNames) {
+			const baselineCount = countSkillListings(baselineOutput, name);
+			const controlCount = countSkillListings(controlOutput, name);
+			expect(controlCount).toBe(baselineCount);
+		}
+	});
+});
+
+/**
+ * 오타 검출 — 순수 파일시스템 검사, codex 불필요.
+ *
+ * 위 실효성 테스트는 baseline === 0인 이름을 "측정 불가"로 면제한다. 그래서
+ * orchestrate-reviewX 같은 오타를 두 config에 똑같이 넣으면(codex 배포 스코프에
+ * 당연히 없으므로 baseline 0) 실효성 단언은 통과하고, "두 config가 같은 집합"
+ * 단언만 깨진다 — 두 config에 같은 오타가 들어가면 아무것도 안 잡힌다. 이 테스트는
+ * 그 틈을 "baseline 0"과 "이름 자체가 존재하지 않음"을 분리해 메운다.
+ */
+const REPO_ROOT = path.join(import.meta.dir, "..", "..", "..");
+
+function skillMdPath(name: string): string {
+	return path.join(REPO_ROOT, "skills", name, "SKILL.md");
+}
+
+describe("오타 검출 — 선언된 이름이 실재하는 스킬인가", () => {
+	test("orchestrate-review.config.yaml과 council.config.yaml에 선언된 모든 deny.skills 이름은 skills/<name>/SKILL.md로 실재한다", () => {
+		const sources: Array<{ configPath: string; topLevelKey: string }> = [
+			{ configPath: CONFIG_PATH, topLevelKey: "chunk-review" },
+			{ configPath: COUNCIL_CONFIG_PATH, topLevelKey: "council" },
+		];
+
+		const missing: string[] = [];
+		for (const { configPath, topLevelKey } of sources) {
+			const names = readDeclaredDenySkills(configPath, topLevelKey);
+			for (const name of names) {
+				if (!fs.existsSync(skillMdPath(name))) {
+					missing.push(
+						`"${name}" (declared in ${configPath} at '${topLevelKey}.settings.deny.skills') ` +
+							`— ${skillMdPath(name)} not found. Possible typo?`,
+					);
+				}
+			}
+		}
+
+		expect(missing, missing.join("\n")).toEqual([]);
+	});
+});

--- a/skills/orchestrate-review/scripts/job.test.ts
+++ b/skills/orchestrate-review/scripts/job.test.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, beforeAll, afterAll, mock } from "bun:test";
 import fs from "fs";
 import path from "path";
 import os from "os";
@@ -43,6 +43,22 @@ function makeCliStubDir(): string {
 	}
 	return stubDir;
 }
+
+// `start` spawns its worker detached; `execFileSync("start", …)` returns long before
+// that worker execs the member's CLI command (observed ~283ms later). A per-test
+// stub dir torn down right after `start` returns — even after `stop`/`clean` — races
+// that exec: PATH resolution doesn't fail closed when the stub disappears, it falls
+// through to the next PATH entry (a real, billed CLI binary). Suite-scoped lifetime
+// keeps the stub alive for every test in this file, past any worker's real exec.
+let sharedStubDir: string;
+
+beforeAll(() => {
+	sharedStubDir = makeCliStubDir();
+});
+
+afterAll(() => {
+	fs.rmSync(sharedStubDir, { recursive: true, force: true });
+});
 
 // ---------------------------------------------------------------------------
 // parseChunkReviewConfig
@@ -3104,16 +3120,13 @@ describe("parseChunkReviewConfig settings.deny.skills", () => {
 describe("start: settings.deny.skills recorded in job.json settings.denySkills", () => {
 	const SCRIPT = path.join(import.meta.dirname, "job.ts");
 	let tmpDir: string;
-	let stubDir: string;
 
 	beforeEach(() => {
 		tmpDir = makeTmpDir();
-		stubDir = makeCliStubDir();
 	});
 
 	afterEach(() => {
 		fs.rmSync(tmpDir, { recursive: true, force: true });
-		fs.rmSync(stubDir, { recursive: true, force: true });
 	});
 
 	test("job.json settings.denySkills matches the declared deny.skills array", () => {
@@ -3153,7 +3166,7 @@ describe("start: settings.deny.skills recorded in job.json settings.denySkills",
 				"--json",
 				"test prompt",
 			],
-			{ stdio: "pipe", env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` } },
+			{ stdio: "pipe", env: { ...process.env, PATH: `${sharedStubDir}:${process.env.PATH}` } },
 		);
 		const output = JSON.parse(result.toString());
 		expect(output.settings.denySkills).toEqual(["orchestrate-review", "code-review"]);
@@ -3199,7 +3212,7 @@ describe("start: settings.deny.skills recorded in job.json settings.denySkills",
 				"--json",
 				"test prompt",
 			],
-			{ stdio: "pipe", env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` } },
+			{ stdio: "pipe", env: { ...process.env, PATH: `${sharedStubDir}:${process.env.PATH}` } },
 		);
 		const output = JSON.parse(result.toString());
 		expect(output.settings.denySkills).toEqual([]);
@@ -3309,30 +3322,25 @@ describe("start: assertDenyEnforceable gate wiring", () => {
 		fs.mkdirSync(jobsDir, { recursive: true });
 
 		// This member's command really is "gemini" and the gate passes (no deny
-		// declared), so start really spawns it — stub the CLI on PATH so the
-		// detached worker execs a harmless no-op instead of the real gemini binary.
-		const stubDir = makeCliStubDir();
-		let result: Buffer;
-		try {
-			result = execFileSync(
-				process.execPath,
-				[
-					SCRIPT,
-					"start",
-					"--config",
-					configPath,
-					"--jobs-dir",
-					jobsDir,
-					"--chairman",
-					"none",
-					"--json",
-					"test prompt",
-				],
-				{ stdio: "pipe", env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` } },
-			);
-		} finally {
-			fs.rmSync(stubDir, { recursive: true, force: true });
-		}
+		// declared), so start really spawns it — the suite-scoped stub on PATH
+		// makes the detached worker exec a harmless no-op instead of the real
+		// gemini binary.
+		const result = execFileSync(
+			process.execPath,
+			[
+				SCRIPT,
+				"start",
+				"--config",
+				configPath,
+				"--jobs-dir",
+				jobsDir,
+				"--chairman",
+				"none",
+				"--json",
+				"test prompt",
+			],
+			{ stdio: "pipe", env: { ...process.env, PATH: `${sharedStubDir}:${process.env.PATH}` } },
+		);
 		// stdout must be pure JSON — the informational "no skill deny declared"
 		// note (deny is not declared here) must not leak into the same stream.
 		const stdout = result.toString();

--- a/skills/orchestrate-review/scripts/job.test.ts
+++ b/skills/orchestrate-review/scripts/job.test.ts
@@ -25,6 +25,25 @@ function makeTmpDir() {
 	return fs.mkdtempSync(path.join(os.tmpdir(), "chunk-job-test-"));
 }
 
+/**
+ * `start` spawns a detached worker (lib/generic-job.ts spawnWorkers) that inherits
+ * `env: process.env` and execs the member's real CLI command. A test whose config
+ * declares a real CLI name (claude/codex/gemini) so it can pass assertDenyEnforceable
+ * would otherwise spawn the actual billed CLI binary. This stub directory shadows all
+ * three CLI names on PATH with a no-op `exit 0` script — detectCliType still resolves
+ * the command's first token to "claude"/"codex"/"gemini" (so the enforceability gate
+ * still passes), but the process the worker execs is this harmless stub.
+ */
+function makeCliStubDir(): string {
+	const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), "deny-cli-stub-"));
+	for (const cli of ["claude", "codex", "gemini"]) {
+		const stubPath = path.join(stubDir, cli);
+		fs.writeFileSync(stubPath, "#!/bin/sh\nexit 0\n");
+		fs.chmodSync(stubPath, 0o755);
+	}
+	return stubDir;
+}
+
 // ---------------------------------------------------------------------------
 // parseChunkReviewConfig
 // ---------------------------------------------------------------------------
@@ -3085,13 +3104,16 @@ describe("parseChunkReviewConfig settings.deny.skills", () => {
 describe("start: settings.deny.skills recorded in job.json settings.denySkills", () => {
 	const SCRIPT = path.join(import.meta.dirname, "job.ts");
 	let tmpDir: string;
+	let stubDir: string;
 
 	beforeEach(() => {
 		tmpDir = makeTmpDir();
+		stubDir = makeCliStubDir();
 	});
 
 	afterEach(() => {
 		fs.rmSync(tmpDir, { recursive: true, force: true });
+		fs.rmSync(stubDir, { recursive: true, force: true });
 	});
 
 	test("job.json settings.denySkills matches the declared deny.skills array", () => {
@@ -3131,7 +3153,7 @@ describe("start: settings.deny.skills recorded in job.json settings.denySkills",
 				"--json",
 				"test prompt",
 			],
-			{ stdio: "pipe" },
+			{ stdio: "pipe", env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` } },
 		);
 		const output = JSON.parse(result.toString());
 		expect(output.settings.denySkills).toEqual(["orchestrate-review", "code-review"]);
@@ -3177,7 +3199,7 @@ describe("start: settings.deny.skills recorded in job.json settings.denySkills",
 				"--json",
 				"test prompt",
 			],
-			{ stdio: "pipe" },
+			{ stdio: "pipe", env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` } },
 		);
 		const output = JSON.parse(result.toString());
 		expect(output.settings.denySkills).toEqual([]);
@@ -3286,22 +3308,31 @@ describe("start: assertDenyEnforceable gate wiring", () => {
 		const jobsDir = path.join(tmpDir, "jobs");
 		fs.mkdirSync(jobsDir, { recursive: true });
 
-		const result = execFileSync(
-			process.execPath,
-			[
-				SCRIPT,
-				"start",
-				"--config",
-				configPath,
-				"--jobs-dir",
-				jobsDir,
-				"--chairman",
-				"none",
-				"--json",
-				"test prompt",
-			],
-			{ stdio: "pipe" },
-		);
+		// This member's command really is "gemini" and the gate passes (no deny
+		// declared), so start really spawns it — stub the CLI on PATH so the
+		// detached worker execs a harmless no-op instead of the real gemini binary.
+		const stubDir = makeCliStubDir();
+		let result: Buffer;
+		try {
+			result = execFileSync(
+				process.execPath,
+				[
+					SCRIPT,
+					"start",
+					"--config",
+					configPath,
+					"--jobs-dir",
+					jobsDir,
+					"--chairman",
+					"none",
+					"--json",
+					"test prompt",
+				],
+				{ stdio: "pipe", env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` } },
+			);
+		} finally {
+			fs.rmSync(stubDir, { recursive: true, force: true });
+		}
 		// stdout must be pure JSON — the informational "no skill deny declared"
 		// note (deny is not declared here) must not leak into the same stream.
 		const stdout = result.toString();

--- a/skills/orchestrate-review/scripts/job.test.ts
+++ b/skills/orchestrate-review/scripts/job.test.ts
@@ -3049,6 +3049,33 @@ describe("parseChunkReviewConfig settings.deny.skills", () => {
 		);
 		expectParseExitsWithError(configPath, `Invalid config in ${configPath}`);
 	});
+
+	test("exits 1 when deny.skills contains a name with an embedded space", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			["chunk-review:", "  settings:", "    deny:", "      skills:", "        - 'a b'"].join("\n"),
+		);
+		expectParseExitsWithError(configPath, `Invalid config in ${configPath}`);
+	});
+
+	test("exits 1 when deny.skills contains a name with a backslash", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			["chunk-review:", "  settings:", "    deny:", "      skills:", "        - 'a\\b'"].join("\n"),
+		);
+		expectParseExitsWithError(configPath, `Invalid config in ${configPath}`);
+	});
+
+	test("exits 1 when deny.skills contains a name with an embedded quote", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			["chunk-review:", "  settings:", "    deny:", "      skills:", '        - \'a"b\''].join("\n"),
+		);
+		expectParseExitsWithError(configPath, `Invalid config in ${configPath}`);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/skills/orchestrate-review/scripts/job.test.ts
+++ b/skills/orchestrate-review/scripts/job.test.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import fs from "fs";
 import path from "path";
 import os from "os";
@@ -15,6 +15,7 @@ import {
 	buildAugmentedCommand,
 	gcStaleJobs,
 } from "./job.ts";
+import * as GenericJob from "@lib/generic-job";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -2940,5 +2941,417 @@ describe('exclude_chairman_from_members: 문자열 "no" (YAML 1.2) 회귀', () =
 		try {
 			execFileSync(process.execPath, [SCRIPT, "clean", output.jobDir], { stdio: "pipe" });
 		} catch {}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// parseChunkReviewConfig — settings.deny.skills parsing + format validation
+// ---------------------------------------------------------------------------
+
+describe("parseChunkReviewConfig settings.deny.skills", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = makeTmpDir();
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function expectParseExitsWithError(configPath: string, expectedSubstring: string) {
+		const scriptContent = `
+      const { parseChunkReviewConfig } = await import('${path.resolve(import.meta.dirname, "./job.ts").replace(/'/g, "\\'")}');
+      await parseChunkReviewConfig('${configPath.replace(/'/g, "\\'")}');
+    `;
+		try {
+			execFileSync(process.execPath, ["-e", scriptContent], {
+				encoding: "utf8",
+				stdio: ["pipe", "pipe", "pipe"],
+			});
+			throw new Error("Expected parseChunkReviewConfig subprocess to exit non-zero");
+		} catch (err) {
+			expect((err as any).status).toBe(1);
+			expect((err as any).stderr.toString()).toContain(expectedSubstring);
+		}
+	}
+
+	test("parses settings.deny.skills as a string array from real YAML", async () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			[
+				"chunk-review:",
+				"  settings:",
+				"    deny:",
+				"      skills:",
+				"        - orchestrate-review",
+				"        - code-review",
+			].join("\n"),
+		);
+		const result = await parseChunkReviewConfig(configPath);
+		expect(result["chunk-review"].settings.deny).toEqual({
+			skills: ["orchestrate-review", "code-review"],
+		});
+	});
+
+	test("fallback (missing config file) does not declare a deny key", async () => {
+		const result = await parseChunkReviewConfig(path.join(tmpDir, "missing.yaml"));
+		expect(result["chunk-review"].settings.deny).toBeUndefined();
+	});
+
+	test("real YAML with no deny key leaves settings.deny undefined", async () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(configPath, ["chunk-review:", "  settings:", "    timeout: 5"].join("\n"));
+		const result = await parseChunkReviewConfig(configPath);
+		expect(result["chunk-review"].settings.deny).toBeUndefined();
+	});
+
+	test("deny: key with no value (null) does not throw and carries no skills", async () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(configPath, ["chunk-review:", "  settings:", "    deny:"].join("\n"));
+		const result = await parseChunkReviewConfig(configPath);
+		expect(result["chunk-review"].settings.deny).toBeNull();
+	});
+
+	test("exits 1 when deny.skills is not an array", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			["chunk-review:", "  settings:", "    deny:", '      skills: "not-an-array"'].join("\n"),
+		);
+		expectParseExitsWithError(configPath, `Invalid config in ${configPath}`);
+	});
+
+	test("exits 1 when deny.skills contains a non-string element", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			["chunk-review:", "  settings:", "    deny:", "      skills:", "        - 123"].join("\n"),
+		);
+		expectParseExitsWithError(configPath, `Invalid config in ${configPath}`);
+	});
+
+	test("exits 1 when deny.skills contains an empty string", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			["chunk-review:", "  settings:", "    deny:", "      skills:", '        - ""'].join("\n"),
+		);
+		expectParseExitsWithError(configPath, `Invalid config in ${configPath}`);
+	});
+
+	test("exits 1 when deny.skills contains a whitespace-only string", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			["chunk-review:", "  settings:", "    deny:", "      skills:", '        - "   "'].join("\n"),
+		);
+		expectParseExitsWithError(configPath, `Invalid config in ${configPath}`);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// start: settings.deny.skills → job.json settings.denySkills
+// ---------------------------------------------------------------------------
+
+describe("start: settings.deny.skills recorded in job.json settings.denySkills", () => {
+	const SCRIPT = path.join(import.meta.dirname, "job.ts");
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = makeTmpDir();
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test("job.json settings.denySkills matches the declared deny.skills array", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			[
+				"chunk-review:",
+				"  chairman:",
+				"    role: none",
+				"  members:",
+				"    - name: alice",
+				"      command: claude -p",
+				"  settings:",
+				"    exclude_chairman_from_members: false",
+				"    timeout: 10",
+				"    deny:",
+				"      skills:",
+				"        - orchestrate-review",
+				"        - code-review",
+			].join("\n"),
+		);
+		const jobsDir = path.join(tmpDir, "jobs");
+		fs.mkdirSync(jobsDir, { recursive: true });
+
+		const result = execFileSync(
+			process.execPath,
+			[
+				SCRIPT,
+				"start",
+				"--config",
+				configPath,
+				"--jobs-dir",
+				jobsDir,
+				"--chairman",
+				"none",
+				"--json",
+				"test prompt",
+			],
+			{ stdio: "pipe" },
+		);
+		const output = JSON.parse(result.toString());
+		expect(output.settings.denySkills).toEqual(["orchestrate-review", "code-review"]);
+
+		try {
+			execFileSync(process.execPath, [SCRIPT, "stop", output.jobDir], { stdio: "pipe" });
+		} catch {}
+		try {
+			execFileSync(process.execPath, [SCRIPT, "clean", output.jobDir], { stdio: "pipe" });
+		} catch {}
+	});
+
+	test("job.json settings.denySkills is an empty array when deny is not declared", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			[
+				"chunk-review:",
+				"  chairman:",
+				"    role: none",
+				"  members:",
+				"    - name: alice",
+				"      command: claude -p",
+				"  settings:",
+				"    exclude_chairman_from_members: false",
+				"    timeout: 10",
+			].join("\n"),
+		);
+		const jobsDir = path.join(tmpDir, "jobs");
+		fs.mkdirSync(jobsDir, { recursive: true });
+
+		const result = execFileSync(
+			process.execPath,
+			[
+				SCRIPT,
+				"start",
+				"--config",
+				configPath,
+				"--jobs-dir",
+				jobsDir,
+				"--chairman",
+				"none",
+				"--json",
+				"test prompt",
+			],
+			{ stdio: "pipe" },
+		);
+		const output = JSON.parse(result.toString());
+		expect(output.settings.denySkills).toEqual([]);
+
+		try {
+			execFileSync(process.execPath, [SCRIPT, "stop", output.jobDir], { stdio: "pipe" });
+		} catch {}
+		try {
+			execFileSync(process.execPath, [SCRIPT, "clean", output.jobDir], { stdio: "pipe" });
+		} catch {}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// start: assertDenyEnforceable gate wiring (cmdStart calls it right after
+// assertMembersOrExit, before spawning workers)
+// ---------------------------------------------------------------------------
+
+describe("start: assertDenyEnforceable gate wiring", () => {
+	const SCRIPT = path.join(import.meta.dirname, "job.ts");
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = makeTmpDir();
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test("deny declared + a gemini member present → exit 1 listing the violation and enforceable CLIs", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			[
+				"chunk-review:",
+				"  chairman:",
+				"    role: none",
+				"  members:",
+				"    - name: alice",
+				"      command: claude -p",
+				"    - name: bob",
+				"      command: gemini",
+				"  settings:",
+				"    exclude_chairman_from_members: false",
+				"    timeout: 10",
+				"    deny:",
+				"      skills:",
+				"        - orchestrate-review",
+			].join("\n"),
+		);
+		const jobsDir = path.join(tmpDir, "jobs");
+		fs.mkdirSync(jobsDir, { recursive: true });
+
+		let threw = false;
+		let err: any;
+		try {
+			execFileSync(
+				process.execPath,
+				[
+					SCRIPT,
+					"start",
+					"--config",
+					configPath,
+					"--jobs-dir",
+					jobsDir,
+					"--chairman",
+					"none",
+					"test prompt",
+				],
+				{ stdio: "pipe" },
+			);
+		} catch (e) {
+			threw = true;
+			err = e;
+		}
+
+		expect(threw).toBe(true);
+		expect(err.status).toBe(1);
+		const stderr = err.stderr.toString();
+		expect(stderr).toContain("Enforceable CLIs: codex, claude, opencode");
+		expect(stderr).toContain("bob (gemini)");
+
+		// No job.json should have been written — the gate must block before spawn.
+		const jobDirs = fs.existsSync(jobsDir) ? fs.readdirSync(jobsDir) : [];
+		const jobJsonFound = jobDirs.some((d) => fs.existsSync(path.join(jobsDir, d, "job.json")));
+		expect(jobJsonFound).toBe(false);
+	});
+
+	test("deny not declared + a gemini member present → gate does not block", () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			[
+				"chunk-review:",
+				"  chairman:",
+				"    role: none",
+				"  members:",
+				"    - name: bob",
+				"      command: gemini",
+				"  settings:",
+				"    exclude_chairman_from_members: false",
+				"    timeout: 10",
+			].join("\n"),
+		);
+		const jobsDir = path.join(tmpDir, "jobs");
+		fs.mkdirSync(jobsDir, { recursive: true });
+
+		const result = execFileSync(
+			process.execPath,
+			[
+				SCRIPT,
+				"start",
+				"--config",
+				configPath,
+				"--jobs-dir",
+				jobsDir,
+				"--chairman",
+				"none",
+				"--json",
+				"test prompt",
+			],
+			{ stdio: "pipe" },
+		);
+		// stdout must be pure JSON — the informational "no skill deny declared"
+		// note (deny is not declared here) must not leak into the same stream.
+		const stdout = result.toString();
+		expect(() => JSON.parse(stdout)).not.toThrow();
+		expect(stdout).not.toContain("no skill deny declared");
+
+		const output = JSON.parse(stdout);
+		expect(output.settings.denySkills).toEqual([]);
+		const memberNames = output.members.map((m: { name: string }) => m.name);
+		expect(memberNames).toContain("bob");
+
+		try {
+			execFileSync(process.execPath, [SCRIPT, "stop", output.jobDir], { stdio: "pipe" });
+		} catch {}
+		try {
+			execFileSync(process.execPath, [SCRIPT, "clean", output.jobDir], { stdio: "pipe" });
+		} catch {}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// start → spawnWorkers wiring: declared deny reaches each dispatched entity
+// (AC6 — verified by spying on the shared lib's spawnWorkers, per the spec's
+// allowed fallback method since detached workers are not easily inspectable).
+// ---------------------------------------------------------------------------
+
+describe("start: deny reaches spawnWorkers entities (AC6 wiring)", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = makeTmpDir();
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+		mock.restore();
+	});
+
+	test("each dispatched member entity carries the declared deny array", async () => {
+		const configPath = path.join(tmpDir, "config.yaml");
+		fs.writeFileSync(
+			configPath,
+			[
+				"chunk-review:",
+				"  chairman:",
+				"    role: none",
+				"  members:",
+				"    - name: alice",
+				"      command: claude -p",
+				"  settings:",
+				"    exclude_chairman_from_members: false",
+				"    timeout: 10",
+				"    deny:",
+				"      skills:",
+				"        - orchestrate-review",
+				"        - code-review",
+			].join("\n"),
+		);
+		const jobsDir = path.join(tmpDir, "jobs");
+		fs.mkdirSync(jobsDir, { recursive: true });
+
+		let capturedEntities: Array<Record<string, unknown>> | undefined;
+		mock.module("@lib/generic-job", () => ({
+			...GenericJob,
+			spawnWorkers: ({ entities }: { entities: Array<Record<string, unknown>> }) => {
+				capturedEntities = entities;
+			},
+		}));
+
+		const mod = await import(`./job.ts?ac6-orchestrate-review=${Date.now()}-${Math.random()}`);
+		await mod.cmdStart(
+			{ config: configPath, "jobs-dir": jobsDir, chairman: "none", json: true },
+			"test prompt",
+		);
+
+		expect(capturedEntities).toBeDefined();
+		expect(capturedEntities?.length).toBe(1);
+		expect(capturedEntities?.[0].deny).toEqual(["orchestrate-review", "code-review"]);
 	});
 });

--- a/skills/orchestrate-review/scripts/job.ts
+++ b/skills/orchestrate-review/scripts/job.ts
@@ -24,6 +24,8 @@ import {
 	type JobConfig,
 	assertMembersOrExit,
 	assertDenyEnforceable,
+	assertDenySkillsShape,
+	extractDenySkills,
 	detectCliType,
 	buildAugmentedCommand,
 	gcStaleJobs as _gcStaleJobs,
@@ -231,45 +233,6 @@ interface ChunkReviewConfig {
 	"chunk-review": ChunkReviewSection;
 }
 
-// ---------------------------------------------------------------------------
-// deny.skills format validation — settings.deny.skills, if declared, must be an
-// array of non-empty (non-whitespace-only) strings. This validates FORMAT only;
-// skill-name reality is not checked here (see spec non-goal — a later stage's
-// enforceability test covers typos by reading the real YAML). No baseline deny
-// list is injected here: YAML remains the sole source.
-// ---------------------------------------------------------------------------
-
-function assertDenySkillsShape(settings: Record<string, unknown>, configPath: string): void {
-	const deny = settings.deny;
-	if (deny === null || deny === undefined) return;
-	if (!isRecord(deny)) {
-		exitWithError(
-			`Invalid config in ${configPath}: 'chunk-review.settings.deny' must be a mapping/object`,
-		);
-	}
-	const skills = deny.skills;
-	if (skills === null || skills === undefined) return;
-	if (!Array.isArray(skills)) {
-		exitWithError(
-			`Invalid config in ${configPath}: 'chunk-review.settings.deny.skills' must be a list/array of non-empty strings`,
-		);
-	}
-	for (const skill of skills) {
-		if (typeof skill !== "string" || skill.trim() === "") {
-			exitWithError(
-				`Invalid config in ${configPath}: 'chunk-review.settings.deny.skills' must contain only non-empty strings, got: ${JSON.stringify(skill)}`,
-			);
-		}
-	}
-}
-
-/** Read settings.deny.skills, already format-validated by assertDenySkillsShape, as string[]. */
-function extractDenySkills(settings: Record<string, unknown>): string[] {
-	const deny = settings.deny;
-	if (!isRecord(deny) || !Array.isArray(deny.skills)) return [];
-	return deny.skills.map((skill) => String(skill));
-}
-
 function parseChunkReviewConfig(configPath: string): ChunkReviewConfig {
 	const fallback: ChunkReviewConfig = {
 		"chunk-review": {
@@ -350,7 +313,7 @@ function parseChunkReviewConfig(configPath: string): ChunkReviewConfig {
 		};
 	}
 
-	assertDenySkillsShape(merged["chunk-review"].settings, configPath);
+	assertDenySkillsShape(merged["chunk-review"].settings, CHUNK_REVIEW_JOB_CONFIG, configPath);
 
 	return merged;
 }

--- a/skills/orchestrate-review/scripts/job.ts
+++ b/skills/orchestrate-review/scripts/job.ts
@@ -23,6 +23,7 @@ import { getOmtDir } from "@lib/omt-dir";
 import {
 	type JobConfig,
 	assertMembersOrExit,
+	assertDenyEnforceable,
 	detectCliType,
 	buildAugmentedCommand,
 	gcStaleJobs as _gcStaleJobs,
@@ -230,6 +231,45 @@ interface ChunkReviewConfig {
 	"chunk-review": ChunkReviewSection;
 }
 
+// ---------------------------------------------------------------------------
+// deny.skills format validation — settings.deny.skills, if declared, must be an
+// array of non-empty (non-whitespace-only) strings. This validates FORMAT only;
+// skill-name reality is not checked here (see spec non-goal — a later stage's
+// enforceability test covers typos by reading the real YAML). No baseline deny
+// list is injected here: YAML remains the sole source.
+// ---------------------------------------------------------------------------
+
+function assertDenySkillsShape(settings: Record<string, unknown>, configPath: string): void {
+	const deny = settings.deny;
+	if (deny === null || deny === undefined) return;
+	if (!isRecord(deny)) {
+		exitWithError(
+			`Invalid config in ${configPath}: 'chunk-review.settings.deny' must be a mapping/object`,
+		);
+	}
+	const skills = deny.skills;
+	if (skills === null || skills === undefined) return;
+	if (!Array.isArray(skills)) {
+		exitWithError(
+			`Invalid config in ${configPath}: 'chunk-review.settings.deny.skills' must be a list/array of non-empty strings`,
+		);
+	}
+	for (const skill of skills) {
+		if (typeof skill !== "string" || skill.trim() === "") {
+			exitWithError(
+				`Invalid config in ${configPath}: 'chunk-review.settings.deny.skills' must contain only non-empty strings, got: ${JSON.stringify(skill)}`,
+			);
+		}
+	}
+}
+
+/** Read settings.deny.skills, already format-validated by assertDenySkillsShape, as string[]. */
+function extractDenySkills(settings: Record<string, unknown>): string[] {
+	const deny = settings.deny;
+	if (!isRecord(deny) || !Array.isArray(deny.skills)) return [];
+	return deny.skills.map((skill) => String(skill));
+}
+
 function parseChunkReviewConfig(configPath: string): ChunkReviewConfig {
 	const fallback: ChunkReviewConfig = {
 		"chunk-review": {
@@ -310,6 +350,8 @@ function parseChunkReviewConfig(configPath: string): ChunkReviewConfig {
 		};
 	}
 
+	assertDenySkillsShape(merged["chunk-review"].settings, configPath);
+
 	return merged;
 }
 
@@ -383,6 +425,9 @@ async function cmdStart(options: Record<string, unknown>, prompt: string): Promi
 
 	assertMembersOrExit(members, CHUNK_REVIEW_JOB_CONFIG, configPath);
 
+	const denySkills = extractDenySkills(config["chunk-review"].settings);
+	assertDenyEnforceable(members, denySkills, CHUNK_REVIEW_JOB_CONFIG, configPath);
+
 	const jobId = generateJobId();
 	initLogger("chunk-review-job", getOmtDir(), jobId);
 	logStart();
@@ -404,6 +449,7 @@ async function cmdStart(options: Record<string, unknown>, prompt: string): Promi
 		settings: {
 			excludeChairmanFromMembers,
 			timeoutSec: timeoutSec || null,
+			denySkills,
 		},
 		members: members.map((r) => ({
 			name: String(r.name),
@@ -419,7 +465,7 @@ async function cmdStart(options: Record<string, unknown>, prompt: string): Promi
 	atomicWriteJson(path.join(jobDir, "job.json"), jobMeta);
 
 	_spawnWorkers({
-		entities: members,
+		entities: members.map((r) => ({ ...r, deny: denySkills })),
 		workerPath: WORKER_PATH,
 		jobDir,
 		entitiesDir: membersDir,
@@ -551,4 +597,5 @@ export {
 	detectCliType,
 	buildAugmentedCommand,
 	gcStaleJobs,
+	cmdStart,
 };


### PR DESCRIPTION
## 📌 Summary

`orchestrate-review`와 `agent-council`이 스폰하는 headless CLI worker가 **자기재귀 팬아웃을 일으키는 스킬을 열지 못하게** 한다. 차단 목록은 각 job config YAML의 `settings.deny.skills` 한 곳에서만 선언되고, 코드에는 어떤 스킬명도 하드코딩되지 않는다. 집행은 CLI별 invocation-scoped 레버로만 이뤄져 전역 설정을 오염시키지 않고 병렬 세션에 무해하다.

---

## 🔧 Changes

### `lib/generic-job.ts` — 번역 · 전송 · 집행 게이트

- `buildAugmentedCommand`가 `deny` 배열을 cliType별 차단 레버로 번역한다.
  - codex → `-c skills.config=[{name="X",enabled=false}]`
  - claude → `--settings {"skillOverrides":{"X":"off"}}`
  - opencode → `OPENCODE_CONFIG_CONTENT` 환경변수 (argv 아님)
- 번역 결과가 `splitCommand` 재토큰화를 통과하도록 따옴표를 이스케이프한다.
- `assertDenyEnforceable` 신설 — deny가 선언됐는데 집행 레버가 없는 CLI(gemini/unknown) member가 섞이면 job start에서 `exit 1`.
- `assertDenySkillsShape` / `extractDenySkills` 공용 헬퍼 — 두 스킬이 각자 구현하던 파싱·검증을 한 곳으로 모았다.

**영향 범위**
`deny`가 없거나 빈 배열이면 기존 커맨드와 **바이트 동일**하다 — 기존 `buildAugmentedCommand` 테스트 17개가 무수정 통과하는 것이 이를 보장한다. `detectCliType`은 변경 없이 재사용했다(base 대비 본문 바이트 동일). opencode 축만 argv가 아닌 env로 전달되므로 커맨드 문자열에 흔적이 남지 않는다.

### `skills/{orchestrate-review,agent-council}/scripts/job.ts` — 배관

- 병합된 settings에서 `deny.skills`를 파싱해 `cmdStart`로 전달한다.

**영향 범위**
config에 `deny` 키가 없으면 완전한 no-op다. config 파일이 아예 없는 fallback 경로도 `deny` 키 없는 기본값을 반환하므로 형식 검사와 추출 모두 무해하게 통과한다.

### config YAML — 선언 (단일 출처)

- 두 config 모두 `settings.deny.skills`에 `orchestrate-review` · `code-review` · `agent-council` 3종을 선언했다.
- `council.config.yaml` 헤더의 낡은 문장을 정정했다 — 게이트가 job 디렉터리 생성 **전에** `exit 1`하므로 "CLI 문제는 런타임에 per-member `missing_cli`로 보고된다"는 기존 약속이 이 변경으로 거짓이 됐다.

**영향 범위**
코드에 스킬명 하드코딩 0건. 차단 대상을 바꾸려면 YAML만 고치면 된다. `code-review`는 현재 codex 배포 스코프에 없어 즉시 효과가 없지만, `platforms` 설정이 바뀌는 날 자동으로 발효되도록 미리 선언해 뒀다.

### 테스트

- `codex-skill-deny-efficacy.test.ts` 신설 — 실제 config 값을 프로덕션 전송 경로(`buildAugmentedCommand` → `splitCommand`)에 태워 만든 argv로 진짜 `codex debug prompt-input`을 돌려, 선언 이름의 프롬프트 노출 카운트를 baseline/deny 쌍으로 비교한다.
- 두 스킬 `job.test.ts`에 실제 YAML 파싱 케이스와 게이트 케이스를 추가했다.

**영향 범위**
실효성 테스트는 codex 바이너리가 없으면 skip이 아니라 **실패**한다. 측정 불가를 초록으로 위장하지 않기 위한 의도적 선택이다.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 왜 설정 파일을 건드리지 않고 invocation-scoped 레버만 쓰는가

**배경 및 문제 상황:**
스킬을 끄는 가장 쉬운 방법은 `~/.codex/config.toml`을 편집하거나 gemini의 스킬 설정을 꺼두는 것이다. 그런데 이 job들은 **한 머신에서 여러 세션이 동시에** 돈다. 전역 설정을 끄면 이 job의 worker뿐 아니라 그 순간 돌고 있는 다른 세션의 CLI까지 스킬을 잃고, job이 죽으면 설정이 꺼진 채로 남는다.

**해결 방안:**
프로세스 하나에만 적용되는 레버로 한정했다. codex는 `-c` 오버라이드, claude는 `--settings` 인라인 JSON, opencode는 `OPENCODE_CONFIG_CONTENT` 환경변수. 셋 다 해당 invocation에서만 유효하고 디스크에 아무것도 쓰지 않는다.

**구현 세부사항:**
opencode 축만 argv가 아니라 env로 전달된다. 같은 목적을 세 축이 서로 다른 채널로 달성하므로, "커맨드 문자열에 deny가 있는가"라는 단일 단언으로는 세 축을 동시에 검증할 수 없다. opencode 축은 `permission.skill`에 `{"*": "allow"}`를 먼저 깔고 차단 이름만 `deny`로 덮는 형태다 — 화이트리스트가 아니라 블랙리스트여야 비선언 스킬이 살아남는다.

**선택과 트레이드오프:**
설정 파일 편집은 구현이 훨씬 단순하고 CLI 종류에 무관하게 동작했을 것이다. 그 단순함을 포기하고 CLI별로 서로 다른 세 레버를 구현한 대가로, 병렬 세션 간섭과 job 비정상 종료 시 설정 잔존이라는 두 실패 모드를 아예 없앴다. 대신 **집행 레버가 없는 CLI를 지원할 수 없다**는 제약이 생겼고, 그 제약을 조용히 넘기지 않으려고 아래 3번 게이트를 만들었다.

### 2. 번역이 맞아도 전송에서 깨진다 — `splitCommand` 왕복 항등

**배경 및 문제 상황:**
1번 커밋에서 번역을 구현한 뒤 실측해 보니, `buildAugmentedCommand`의 반환값은 정확한데 worker에 도달한 argv는 깨져 있었다. `spawnWorkers`가 커맨드를 문자열로 worker에 넘기고 worker가 `splitCommand`로 재토큰화하는데, 이 함수가 셸 유사 따옴표 의미론을 적용해 따옴표를 **소비**한다.

**관련 코드:**
```
splitCommand('codex exec -c skills.config=[{name="a",enabled=false}]')
  → ["codex","exec","-c",'skills.config=[{name=a,enabled=false}]']
                                            ^^^^^^ 따옴표 소실 → codex가 파싱 실패

splitCommand('claude -p --settings {"skillOverrides":{"a":"off"}}')
  → ["claude","-p","--settings",'{skillOverrides:{a:off}}']
                                 ^^^^^^^^^^^^^^^^^^^^^^^^ 유효한 JSON이 아님
```

**해결 방안:**
번역 시점에 따옴표를 이스케이프해 왕복이 항등이 되게 했다. 검증은 하드코딩 문자열을 `splitCommand`에 넣는 형태를 금지하고, **반드시 `buildAugmentedCommand`의 실제 반환값을 태워서** 토큰을 단언한다.

**선택과 트레이드오프:**
전송 계층(`worker-utils.ts`의 `splitCommand`)을 고치는 선택지도 있었다. 그쪽은 이 기능과 무관한 기존 호출자 전부의 동작을 바꾸므로, 훼손 축이 번역이 아니라 전송임을 인정하되 **번역 쪽에서 방어**하는 편을 택했다. 별도 커밋으로 분리한 이유도 같다 — 왕복 항등이라는 독립적으로 반증 가능한 속성이고, 이 고리를 통과해야만 실효성 측정이 의미를 갖는다.

### 3. "선언했는데 집행할 수 없음"을 조용히 통과시키지 않는다

**배경 및 문제 상황:**
gemini에는 이 세 CLI와 달리 invocation-scoped 스킬 차단 레버가 없다. 아무 조치 없이 두면 gemini member는 deny를 **무시하고** 정상 실행되고, 겉보기엔 job이 성공한다. 자기재귀 팬아웃을 막으려고 만든 장치가 특정 member에서만 조용히 무효가 되는 것이다.

**해결 방안:**
`assertDenyEnforceable`을 도입해 "deny를 선언했다면 전 member가 집행 가능한 CLI여야 한다"를 불변식으로 세웠다. 위반 시 `exit 1`이며, 에러 문자열이 configPath · 위반 member 전부와 감지된 cliType · 집행 가능 CLI 목록 · 고치는 방법 2가지를 담는다.

**구현 세부사항:**
게이트는 spawn 루프 바깥 **단일 지점**에서, `jobId`/`jobDir`/`spawnWorkers`보다 먼저 판정한다. 실행으로 확인했다 — gemini member를 주입하면 job 디렉터리가 아예 생성되지 않는다(게이트 앞의 부수효과는 jobs *루트* 생성과 1시간 초과 stale job 정리뿐이며, 둘 다 job 디렉터리를 만들지 않는다). deny가 비어 있으면 CLI 종류와 무관하게 통과하되 "차단 미선언" 한 줄을 stderr에 남긴다.

**선택과 트레이드오프:**
"gemini member만 조용히 건너뛰고 나머지는 실행"이 더 부드러운 대안이었다. 그 경우 팬아웃 위협이 남은 채로 job이 성공을 보고하므로 거부했다. 대신 **기존 config에 gemini member가 있으면 그 job은 deny를 선언하는 순간 시작조차 못 한다**는 파괴적 변화를 감수한다. 안내문이 "CLI를 교체하라 / deny 선언을 빼라" 두 갈래를 다 제시하는 이유다.

### 4. 실효성 측정이 3축 중 1축뿐이라는 점

**배경 및 문제 상황:**
"deny를 넘겼다"와 "CLI가 실제로 그 스킬을 안 연다"는 다른 명제다. 후자를 증명하려면 CLI가 인식한 스킬 집합을 읽어야 하는데, 그런 비과금 introspection 경로를 가진 것은 codex뿐이다(`codex debug prompt-input`). claude와 opencode에는 `--help` 기준으로 대응 경로가 없다.

**해결 방안:**
codex 축은 baseline(deny 미적용)/deny 적용 쌍 측정으로 실측하고, 나머지 두 축은 **측정하지 못했음을 명시**한다. 초기 AC였던 "선언된 각 이름의 노출 카운트가 0"은 폐기했다 — codex 배포 스코프에 애초에 없는 스킬(`code-review`)에 대해 deny 없이도 이미 0이라 **공허하게 통과**하기 때문이다. 지금은 baseline이 0인 이름을 사유와 함께 `[측정 불가]`로 보고하고 단언에서 제외한다.

**구현 세부사항:**
과차단 대조군을 따로 뒀다. 기존 대조군(존재하지 않는 스킬명)은 *이름 실재* 축만 바꾸고 *선언 여부* 축을 고정하므로 "시킨 것을 차단한다"만 증명하고 "시킨 것**만** 차단한다"는 어디에서도 단언되지 않았다. 새 대조군은 비선언 이름 집합을 baseline 출력에서 파생해 카운트 불변을 단언하며, 그 집합이 비면 루프가 0회 돌며 조용히 통과하므로 `surviving.size > 0` 가드를 먼저 건다.

**선택과 트레이드오프:**
미측정 두 축의 구조적 위험도는 codex보다 낮다고 본다 — codex의 `-c skills.config=[...]`는 리스트라 의미가 "이 항목들을 덮어쓴다"에서 "이것이 활성 집합이다"로 뒤집힐 여지가 있는 반면, claude의 `skillOverrides`는 이름별 맵이고 opencode는 `{"*":"allow"}`를 명시하므로 구조상 전면 차단이 나올 수 없다. 다만 이건 **논증이지 측정이 아니다.** 두 축에 과금 없는 검증 경로를 아시는 분이 있다면 알려주시면 좋겠습니다.

### 5. 리뷰에서 적발된 3건 — 1건 수정, 2건 미수정

**배경 및 문제 상황:**
독립 code-review 라운드에서 나온 PLAUSIBLE 3건이다. 기록 없이 넘기면 나중에 같은 결함을 다시 발견했을 때 "이미 알고 있었다"는 사실이 사라지므로 전부 남긴다. 이 중 첫 번째 건은 이후 Codex 리뷰가 **내가 적어둔 도달성 근거 자체를 반박**해서 `98fea011`로 수정했다.

**구현 세부사항:**

| 위치 | 내용 | 현재 도달성 |
|---|---|---|
| ~~`lib/generic-job.ts` opencode 분기~~ | `OPENCODE_CONFIG_CONTENT`를 머지 없이 덮어써 provider/model/mcp가 날아간다 | **수정됨(`98fea011`)**. 원래 근거 "전 config에 `env:` 선언 0건"은 이 변수로 합류하는 두 입력 중 하나만 센 것이었다 — spawn 시 `workerEnv`가 `process.env` 위에 마지막으로 펼쳐지므로 주변 환경 축이 실제로 열려 있었다 |
| `skills/*/scripts/job.test.ts` `afterAll` | CLI 스텁 삭제와 detached worker의 exec 사이에 happens-before 간선이 없다 | 부하 의존. 깨끗한 실행 11회 0건, 부하 상태 전체 스위트 1회에서 1건 |
| `skills/*/scripts/job.test.ts` `mock.restore()` | `mock.module`을 되돌리지 않아 스위트가 파일 순서에 의존한다 | `make test`·bare `bun test` 모두 안전한 순서. 손으로 부분집합을 지정할 때만 발현 |

**선택과 트레이드오프:**
첫 번째 건에서 배운 게 하나 있다. "도달 불가"라고 쓸 때는 **어느 축을 검사했는지까지 같이 써야** 한다. `env:` 선언 0건은 지금도 참이지만, 같은 변수에 합류하는 입력이 둘이라 그 사실만으로는 도달 불가가 증명되지 않았다. 덧붙여, 리뷰 제안대로 `permission.skill`을 단순 병합하면 결함이 하나 더 생긴다 — 기존 코드가 `"*": "allow"`를 무조건 쓰므로 상속받은 `"*": "deny"` 기본값이 넓어진다. 그래서 와일드카드는 기존 설정에 정책이 없을 때만 채우도록 했다.

두 번째 건은 이 PR 안에서 한 번 고친 것(per-test teardown → suite 수명)이 **창을 좁혔을 뿐 닫지 못했다**는 지적이다. 동기화 지점이 될 만한 `stop`이 구조적으로 못 쓰인다 — `cmdStop`은 `if (!status.pid) continue`로 건너뛰는데 그 pid는 CLI 자식의 것이라 exec 이후에야 기록되기 때문이다. 완전한 해결은 각 `start` 뒤에 `status.json`의 `pid`가 채워질 때까지 폴링하거나, `afterAll`의 삭제를 아예 없애는 것(OS가 회수하는 임시 디렉터리다). 이 PR에서 손대지 않은 이유는 검증이 끝난 diff를 재개방하지 않기 위해서이고, 세 건 모두 후속으로 다룰지는 리뷰에서 정해주시면 좋겠습니다.

---

## ✅ Checklist

### deny 번역 · 전송
- [ ] `deny`가 실제로 spawn된 worker 프로세스의 argv/env에 도달한다 (codex `-c` 토큰의 따옴표 보존, claude `--settings` 토큰이 `JSON.parse` 가능, opencode는 argv에 흔적 없이 env로 전달)
  - `lib/generic-job.ts`
  - `lib/generic-job.test.ts`
- [ ] `deny`가 없거나 빈 배열이면 커맨드가 변경 전과 바이트 동일하다
  - `lib/generic-job.test.ts`
- [ ] `__proto__` 같은 프로토타입 키 이름이 own key로 살아남는다
  - `lib/generic-job.test.ts`
- [ ] resume 경로가 읽는 `status.json`에도 deny가 유지된다 (codex/claude는 `command`, opencode는 `workerEnv`)
  - `lib/generic-job.ts`

### 집행 가능성 게이트
- [ ] `deny` 선언 + gemini/unknown member가 하나라도 있으면 job 디렉터리 생성 전에 `exit 1`한다
  - `lib/generic-job.ts`
  - `skills/agent-council/scripts/job.test.ts`
  - `skills/orchestrate-review/scripts/job.test.ts`
- [ ] 에러 문자열이 configPath · 위반 member 전부 · 집행 가능 CLI 목록 · 고치는 방법 2가지를 모두 포함한다
  - `lib/generic-job.test.ts`
- [ ] `deny`가 비어 있으면 CLI 종류와 무관하게 통과하고 stderr에 미선언 한 줄을 남긴다 (stdout은 비어 있다)
  - `lib/generic-job.test.ts`

### config 파싱 · 검증
- [ ] `[a-zA-Z0-9_-]` 밖의 문자를 담은 이름은 `exit 1`한다 (공백 · 따옴표 · 백슬래시 · 명령치환 · 경로순회 · 제어문자 · 이모지)
  - `skills/agent-council/scripts/job.test.ts`
  - `skills/orchestrate-review/scripts/job.test.ts`
- [ ] `deny.skills`가 배열이 아니거나 비문자열 원소를 담으면 `exit 1`한다
  - `skills/*/scripts/job.test.ts`
- [ ] config에 `deny` 키가 없으면 no-op이고 기존 동작이 그대로다
  - `skills/*/scripts/job.test.ts`

### 실효성 실측
- [ ] 두 config가 동일한 선언 집합을 갖고, 각자 자기 파일에서 읽어 비교한다
  - `skills/orchestrate-review/scripts/codex-skill-deny-efficacy.test.ts`
- [ ] baseline > 0인 선언 이름은 deny 적용 시 노출 카운트가 0이 된다 (baseline이 0인 이름은 측정 불가로 보고하고 단언에서 제외)
  - `skills/orchestrate-review/scripts/codex-skill-deny-efficacy.test.ts`
- [ ] 선언되지 않은 스킬의 노출 카운트는 deny 적용 후에도 불변이다 (과차단 0)
  - `skills/orchestrate-review/scripts/codex-skill-deny-efficacy.test.ts`
- [ ] 선언된 모든 이름이 `skills/<name>/SKILL.md`로 실재한다 (오타 가드)
  - `skills/orchestrate-review/scripts/codex-skill-deny-efficacy.test.ts`

