### PR TITLE
feat: rules 카테고리 배포와 codex rules supersede

### DIFF
--- a/hooks/rules-injector/codex-hook.test.ts
+++ b/hooks/rules-injector/codex-hook.test.ts
@@ -35,7 +35,7 @@ afterEach(() => {
 function makeProject(): string {
 	const projectDir = mkdtempSync(join(tmpdir(), "ri-proj-"));
 	projectDirs.push(projectDir);
-	mkdirSync(join(projectDir, ".claude", "rules"), { recursive: true });
+	mkdirSync(join(projectDir, ".codex", "rules"), { recursive: true });
 	mkdirSync(join(projectDir, "src"), { recursive: true });
 	writeFileSync(join(projectDir, "package.json"), '{"name":"ri-fixture"}\n');
 	return projectDir;
@@ -43,7 +43,7 @@ function makeProject(): string {
 
 function writeRule(projectDir: string, fileName: string, frontmatter: string, body: string): void {
 	writeFileSync(
-		join(projectDir, ".claude", "rules", fileName),
+		join(projectDir, ".codex", "rules", fileName),
 		`---\n${frontmatter}\n---\n${body}\n`,
 	);
 }

--- a/hooks/rules-injector/compaction-budget-scope.test.ts
+++ b/hooks/rules-injector/compaction-budget-scope.test.ts
@@ -58,7 +58,7 @@ function makeProjectWithStaticRule(
 ): { projectRoot: string; rulePath: string; ruleBody: string } {
 	const projectRoot = makeScratchDir("rules-injector-proj-");
 	writeFileSync(join(projectRoot, "package.json"), "{}\n");
-	const rulesDir = join(projectRoot, ".claude", "rules");
+	const rulesDir = join(projectRoot, ".codex", "rules");
 	mkdirSync(rulesDir, { recursive: true });
 	const rulePath = join(rulesDir, ruleName);
 	writeFileSync(rulePath, `---\nalwaysApply: true\n---\n${ruleBody}\n`);
@@ -310,10 +310,19 @@ test("F2: DEFAULT_AUTO_DISABLED_SOURCES excludes AGENTS.md", () => {
 	expect(DEFAULT_AUTO_DISABLED_SOURCES).toContain("AGENTS.md");
 });
 
-test("F2: DEFAULT_AUTO_DISABLED_SOURCES does NOT exclude ~/.claude/rules (Patch A: Codex injector enables it)", () => {
-	// Patch A: Codex does not natively read ~/.claude/rules, so disabling it was
-	// over-conservative. Removed from the auto-disabled set so the source is discoverable.
+test("F2: DEFAULT_AUTO_DISABLED_SOURCES does NOT exclude ~/.claude/rules (the conditional supersede lives in finder.ts, not this static list)", () => {
+	// Codex has a native rules sync category, so a de-Claude-ified counterpart
+	// USUALLY lands at ~/.codex/rules — but not always: a project that never ran
+	// OMT's sync has no ~/.codex/rules at all. Unconditionally excluding
+	// ~/.claude/rules here would lose rules entirely on such a project, so this
+	// list no longer carries that decision. findRuleCandidates (finder.ts) drops
+	// ~/.claude/rules ONLY when ~/.codex/rules is ALSO present — see F11 below,
+	// which confirms that conditional behavior end-to-end.
 	expect(DEFAULT_AUTO_DISABLED_SOURCES).not.toContain("~/.claude/rules");
+});
+
+test("F2: DEFAULT_AUTO_DISABLED_SOURCES does NOT exclude ~/.codex/rules (the codex-native replacement)", () => {
+	expect(DEFAULT_AUTO_DISABLED_SOURCES).not.toContain("~/.codex/rules");
 });
 
 test("F2: DEFAULT_AUTO_DISABLED_SOURCES excludes ~/.claude/CLAUDE.md", () => {
@@ -448,7 +457,7 @@ test("F-8: PostToolUse emits nothing under CODEX_RULES_DISABLED=1 (dynamic lane 
 	const statePath = join(tempHome, ".omt", "rules-injector", `${sessionId}.json`);
 	const projectRoot = makeScratchDir("f8-proj-");
 	writeFileSync(join(projectRoot, "package.json"), "{}\n");
-	const rulesDir = join(projectRoot, ".claude", "rules");
+	const rulesDir = join(projectRoot, ".codex", "rules");
 	mkdirSync(rulesDir, { recursive: true });
 	// A glob rule that would fire on src/x.ts if the kill-switch were absent.
 	writeFileSync(
@@ -599,27 +608,39 @@ test("P9: spawn env pins PLUGIN_DATA to the hermetic data root so external env c
 });
 
 // ===========================================================================
-// F11 — ~/.claude/rules is NO LONGER excluded by DEFAULT_AUTO_DISABLED_SOURCES (Patch A)
+// F11 — ~/.claude/rules is superseded by ~/.codex/rules when both are present
+// (finder.ts's existence-conditional supersede, not a static disabled list)
 // ===========================================================================
 
-test("F11: a rule planted under ~/.claude/rules IS injected by session-start (Patch A: source enabled)", () => {
-	// Patch A removes "~/.claude/rules" from DEFAULT_AUTO_DISABLED_SOURCES.
-	// Codex does NOT natively read ~/.claude/rules, so there is no double-inject risk.
-	// After Patch A, an alwaysApply:true rule under ~/.claude/rules MUST appear in
-	// additionalContext. Restoring "~/.claude/rules" to DEFAULT_AUTO_DISABLED_SOURCES
-	// would make this test RED.
+test("F11: a rule planted under ~/.claude/rules is NOT injected, but the same rule under ~/.codex/rules IS", () => {
+	// rules is now a supported codex sync category: the de-Claude-ified
+	// counterpart of a global rule lands at ~/.codex/rules. When BOTH
+	// ~/.claude/rules and ~/.codex/rules exist, findRuleCandidates (finder.ts)
+	// drops the raw ~/.claude/rules candidate in favor of its codex-native
+	// counterpart — reading it directly would leak unrewritten Claude
+	// vocabulary into Codex sessions. Restoring ~/.claude/rules discovery
+	// (or dropping the codex counterpart below) would make the first
+	// assertion below RED.
 	const sessionId = "f11-session";
 	const { projectRoot } = makeProjectWithStaticRule(
 		"f11-proj-rule.md",
 		"F11 PROJ BOULDER: project rule must appear.",
 	);
 
-	// Plant a rule under the hermetic HOME's ~/.claude/rules directory.
+	// Plant a rule under the hermetic HOME's ~/.claude/rules directory — must NOT surface.
 	const claudeRulesDir = join(tempHome, ".claude", "rules");
 	mkdirSync(claudeRulesDir, { recursive: true });
 	writeFileSync(
 		join(claudeRulesDir, "f11-home-rule.md"),
-		"---\nalwaysApply: true\n---\nF11 HOME BOULDER: this MUST appear in additionalContext (Patch A).\n",
+		"---\nalwaysApply: true\n---\nF11 HOME BOULDER: raw Claude source must NOT appear.\n",
+	);
+
+	// Plant the de-Claude-ified counterpart under ~/.codex/rules — must surface.
+	const codexRulesDir = join(tempHome, ".codex", "rules");
+	mkdirSync(codexRulesDir, { recursive: true });
+	writeFileSync(
+		join(codexRulesDir, "f11-home-rule.md"),
+		"---\nalwaysApply: true\n---\nF11 HOME CODEX BOULDER: this MUST appear in additionalContext.\n",
 	);
 
 	const result = runHook("session-start", sessionStartPayload(sessionId, projectRoot));
@@ -628,8 +649,10 @@ test("F11: a rule planted under ~/.claude/rules IS injected by session-start (Pa
 
 	// Project rule IS injected (positive control — confirms injection works).
 	expect(context).toContain("F11 PROJ BOULDER");
-	// Home rule is now ENABLED (Patch A: ~/.claude/rules removed from auto-disabled set).
-	expect(context).toContain("F11 HOME BOULDER");
+	// Raw Claude home source is disabled by default — no longer injected.
+	expect(context).not.toContain("F11 HOME BOULDER");
+	// Codex-native home source replaces it.
+	expect(context).toContain("F11 HOME CODEX BOULDER");
 });
 
 // ===========================================================================
@@ -834,7 +857,7 @@ test("AC1-C5: a rule dropped by budget on SessionStart is re-injected on the sub
 
 	const projectRoot = makeScratchDir("r-"); // short prefix to minimize path variance
 	writeFileSync(join(projectRoot, "package.json"), "{}\n");
-	const rulesDir = join(projectRoot, ".claude", "rules");
+	const rulesDir = join(projectRoot, ".codex", "rules");
 	mkdirSync(rulesDir, { recursive: true });
 	const ruleBody = "AC1-C5-RULE-BODY: " + "Y".repeat(1000);
 	writeFileSync(join(rulesDir, "ac1rule.md"), `---\nalwaysApply: true\n---\n${ruleBody}\n`);
@@ -884,7 +907,7 @@ test("B-5: a dynamic rule dropped by budget on PostToolUse is re-injected on the
 
 	const projectRoot = makeScratchDir("b5-");
 	writeFileSync(join(projectRoot, "package.json"), "{}\n");
-	const rulesDir = join(projectRoot, ".claude", "rules");
+	const rulesDir = join(projectRoot, ".codex", "rules");
 	mkdirSync(rulesDir, { recursive: true });
 	const ruleBody = "B5-DYNAMIC-RULE-BODY: " + "Z".repeat(1000);
 	writeFileSync(join(rulesDir, "b5rule.md"), `---\nglobs: ["**/*.ts"]\n---\n${ruleBody}\n`);
@@ -955,7 +978,7 @@ test("B-6: a dynamic rule whose marker falls past the 32K byte clamp is not mark
 
 	const projectRoot = makeScratchDir("b6-");
 	writeFileSync(join(projectRoot, "package.json"), "{}\n");
-	const rulesDir = join(projectRoot, ".claude", "rules");
+	const rulesDir = join(projectRoot, ".codex", "rules");
 	mkdirSync(rulesDir, { recursive: true });
 	mkdirSync(join(projectRoot, "src"), { recursive: true });
 	writeFileSync(join(projectRoot, "src", "y.ts"), "export const y = 2;\n");
@@ -1051,7 +1074,7 @@ test("AC3-C4: post-compact body block + directive share the budget (no double-ch
 
 	const projectRoot = makeScratchDir("ac3c4-");
 	writeFileSync(join(projectRoot, "package.json"), "{}\n");
-	const rulesDir = join(projectRoot, ".claude", "rules");
+	const rulesDir = join(projectRoot, ".codex", "rules");
 	mkdirSync(rulesDir, { recursive: true });
 
 	// hephaestus.md: never-truncated, body consumes most of the budget.
@@ -1179,7 +1202,7 @@ test("AC11-C7: dynamic recovery re-injects a rule whose path is in transcript bu
 
 	const projectRoot = makeScratchDir("ac11c7-");
 	writeFileSync(join(projectRoot, "package.json"), "{}\n");
-	const rulesDir = join(projectRoot, ".claude", "rules");
+	const rulesDir = join(projectRoot, ".codex", "rules");
 	mkdirSync(rulesDir, { recursive: true });
 
 	// Static rule: needed so SessionStart has at least one rule, triggering recovery path.
@@ -1342,7 +1365,7 @@ test("A4: dynamic recovery does NOT re-inject a rule whose frontmatter-stripped 
 
 	const projectRoot = makeScratchDir("a4-");
 	writeFileSync(join(projectRoot, "package.json"), "{}\n");
-	const rulesDir = join(projectRoot, ".claude", "rules");
+	const rulesDir = join(projectRoot, ".codex", "rules");
 	mkdirSync(rulesDir, { recursive: true });
 
 	// Static rule so SessionStart has at least one rule and runs the recovery path.

--- a/hooks/rules-injector/config.test.ts
+++ b/hooks/rules-injector/config.test.ts
@@ -45,16 +45,22 @@ test("parsePositiveInteger: ' 12 ' (whitespace-padded) is accepted", () => {
 	expect(config.maxRuleChars).toBe(12);
 });
 
-// ── C6: DISABLE_BUNDLED=1 enables ~/.claude/rules (Patch A: no longer auto-disabled) ─
+// ── C6: DISABLE_BUNDLED=1 excludes plugin-bundled; ~/.claude/rules stays listed ──
 
-test("C6: DISABLE_BUNDLED=1 with auto mode INCLUDES ~/.claude/rules (Patch A: source enabled)", () => {
-	// Patch A removes "~/.claude/rules" from DEFAULT_AUTO_DISABLED_SOURCES.
-	// sourcesWithoutBundledRules() excludes plugin-bundled + DEFAULT_AUTO_DISABLED_SOURCES,
-	// but now ~/.claude/rules is NOT in that exclusion set, so it appears in the list.
+test("C6: DISABLE_BUNDLED=1 with auto mode lists BOTH ~/.claude/rules and ~/.codex/rules (the conditional supersede is finder.ts's job, not this static list's)", () => {
+	// ~/.claude/rules is deliberately NOT in DEFAULT_AUTO_DISABLED_SOURCES anymore:
+	// unconditionally excluding it here would lose rules entirely on a project
+	// that never ran OMT's sync and so has no ~/.codex/rules at all.
+	// sourcesWithoutBundledRules() only strips plugin-bundled + the (now-shorter)
+	// DEFAULT_AUTO_DISABLED_SOURCES, so ~/.claude/rules stays in this explicit
+	// enabledSources list — the actual leak protection happens later, in
+	// findRuleCandidates (finder.ts), which drops ~/.claude/rules only when
+	// ~/.codex/rules is ALSO present in the same scope.
 	const config = configFromEnvironment({ CODEX_RULES_DISABLE_BUNDLED: "1" });
 	expect(config.enabledSources).not.toBe("auto");
 	const list = config.enabledSources as string[];
 	expect(list).toContain("~/.claude/rules");
+	expect(list).toContain("~/.codex/rules");
 });
 
 test("C6: DISABLE_BUNDLED=1 with auto mode does not include plugin-bundled", () => {

--- a/hooks/rules-injector/config.ts
+++ b/hooks/rules-injector/config.ts
@@ -152,6 +152,7 @@ function toRuleSource(value: string): RuleSource | null {
 	switch (value) {
 		case ".omo/rules":
 		case ".claude/rules":
+		case ".codex/rules":
 		case ".cursor/rules":
 		case ".github/instructions":
 		case ".github/copilot-instructions.md":
@@ -160,6 +161,7 @@ function toRuleSource(value: string): RuleSource | null {
 		case "~/.omo/rules":
 		case "~/.opencode/rules":
 		case "~/.claude/rules":
+		case "~/.codex/rules":
 			return value;
 		default:
 			return null;

--- a/hooks/rules-injector/exclude-config.test.ts
+++ b/hooks/rules-injector/exclude-config.test.ts
@@ -54,14 +54,14 @@ afterEach(() => {
 function makeProject(): string {
 	const projectDir = mkdtempSync(join(tmpdir(), "ri-exclude-proj-"));
 	projectDirs.push(projectDir);
-	mkdirSync(join(projectDir, ".claude", "rules"), { recursive: true });
+	mkdirSync(join(projectDir, ".codex", "rules"), { recursive: true });
 	writeFileSync(join(projectDir, "package.json"), '{"name":"ri-fixture"}\n');
 	return projectDir;
 }
 
 function writeRule(projectDir: string, fileName: string, frontmatter: string, body: string): void {
 	writeFileSync(
-		join(projectDir, ".claude", "rules", fileName),
+		join(projectDir, ".codex", "rules", fileName),
 		`---\n${frontmatter}\n---\n${body}\n`,
 	);
 }
@@ -151,24 +151,26 @@ test("AC1 yaml exclude removes rule end to end via absolute-anchored glob; non-m
 	expect(control).toContain("AC1_TARGET_MARKER");
 });
 
-// --- AC2: user-home ~/.claude/rules exclusion, including the .claude dot segment ---
+// --- AC2: user-home ~/.codex/rules exclusion, including the .codex dot segment ---
 
-test("AC2 yaml exclude drops a user-home ~/.claude/rules rule including the .claude dot segment", () => {
+test("AC2 yaml exclude drops a user-home ~/.codex/rules rule including the .codex dot segment", () => {
 	const projectDir = makeProject();
 	const configDir = makeConfigDir();
-	mkdirSync(join(tempHome, ".claude", "rules"), { recursive: true });
+	mkdirSync(join(tempHome, ".codex", "rules"), { recursive: true });
 	writeFileSync(
-		join(tempHome, ".claude", "rules", "personal.md"),
+		join(tempHome, ".codex", "rules", "personal.md"),
 		"---\nalwaysApply: true\n---\nAC2_USER_HOME_MARKER\n",
 	);
 
 	// Baseline: without exclude config, the user-home rule injects (auto mode
-	// does not disable ~/.claude/rules — see sources.ts DEFAULT_AUTO_DISABLED_SOURCES).
+	// does not disable ~/.codex/rules — see sources.ts DEFAULT_AUTO_DISABLED_SOURCES;
+	// the raw ~/.claude/rules counterpart IS disabled by default, superseded by this
+	// de-Claude-ified codex-native source).
 	const baseline = runSessionStart(projectDir, configDir);
 	expect(baseline).toContain("AC2_USER_HOME_MARKER");
 
-	// dot:true is required for "**/x" to match the ".claude" dot-segment path.
-	writeConfigYaml(configDir, 'exclude:\n  - "**/.claude/rules/**"\n');
+	// dot:true is required for "**/x" to match the ".codex" dot-segment path.
+	writeConfigYaml(configDir, 'exclude:\n  - "**/.codex/rules/**"\n');
 	const excluded = runSessionStart(projectDir, configDir);
 	expect(excluded).not.toContain("AC2_USER_HOME_MARKER");
 });

--- a/hooks/rules-injector/fidelity-and-lanes.test.ts
+++ b/hooks/rules-injector/fidelity-and-lanes.test.ts
@@ -54,7 +54,7 @@ afterEach(() => {
 function makeProject(): string {
 	const projectDir = mkdtempSync(join(tmpdir(), "ri-proj-"));
 	projectDirs.push(projectDir);
-	mkdirSync(join(projectDir, ".claude", "rules"), { recursive: true });
+	mkdirSync(join(projectDir, ".codex", "rules"), { recursive: true });
 	mkdirSync(join(projectDir, "src"), { recursive: true });
 	writeFileSync(join(projectDir, "package.json"), '{"name":"ri-fixture"}\n');
 	return projectDir;
@@ -62,7 +62,7 @@ function makeProject(): string {
 
 function writeRule(projectDir: string, fileName: string, frontmatter: string, body: string): void {
 	writeFileSync(
-		join(projectDir, ".claude", "rules", fileName),
+		join(projectDir, ".codex", "rules", fileName),
 		`---\n${frontmatter}\n---\n${body}\n`,
 	);
 }

--- a/hooks/rules-injector/off-file.test.ts
+++ b/hooks/rules-injector/off-file.test.ts
@@ -41,7 +41,7 @@ afterEach(() => {
 function makeProject(): string {
 	const projectDir = mkdtempSync(join(tmpdir(), "ri-off-proj-"));
 	projectDirs.push(projectDir);
-	mkdirSync(join(projectDir, ".claude", "rules"), { recursive: true });
+	mkdirSync(join(projectDir, ".codex", "rules"), { recursive: true });
 	writeFileSync(join(projectDir, "package.json"), '{"name":"ri-fixture"}\n');
 	return projectDir;
 }
@@ -81,7 +81,7 @@ function runSessionStart(projectDir: string, extraEnv?: Record<string, string>):
 test("D-22 off-file absent: session-start injects alwaysApply rule", () => {
 	const projectDir = makeProject();
 	writeFileSync(
-		join(projectDir, ".claude", "rules", "always.md"),
+		join(projectDir, ".codex", "rules", "always.md"),
 		"---\nalwaysApply: true\n---\nALWAYS_APPLY_MARKER\n",
 	);
 	const output = runSessionStart(projectDir);
@@ -93,7 +93,7 @@ test("D-22 off-file absent: session-start injects alwaysApply rule", () => {
 test("D-22 off-file present at workspace root: session-start emits nothing", () => {
 	const projectDir = makeProject();
 	writeFileSync(
-		join(projectDir, ".claude", "rules", "always.md"),
+		join(projectDir, ".codex", "rules", "always.md"),
 		"---\nalwaysApply: true\n---\nALWAYS_APPLY_MARKER\n",
 	);
 	// Place the sentinel: <workspaceRoot>/.codex/rules-injector.local.off

--- a/hooks/rules-injector/post-tool-use-static-reclaim.test.ts
+++ b/hooks/rules-injector/post-tool-use-static-reclaim.test.ts
@@ -38,7 +38,7 @@ beforeEach(() => {
 	scratchDir = mkdtempSync(join(tmpdir(), "pt-reclaim-"));
 	pluginDataRoot = join(scratchDir, "data");
 	projectDir = join(scratchDir, "project");
-	mkdirSync(join(projectDir, ".claude", "rules"), { recursive: true });
+	mkdirSync(join(projectDir, ".codex", "rules"), { recursive: true });
 	mkdirSync(join(projectDir, "src"), { recursive: true });
 	writeFileSync(join(projectDir, "package.json"), '{"name":"pt-reclaim"}\n');
 });
@@ -52,7 +52,7 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 function writeRule(fileName: string, frontmatter: string, body: string): string {
-	const rulePath = join(projectDir, ".claude", "rules", fileName);
+	const rulePath = join(projectDir, ".codex", "rules", fileName);
 	writeFileSync(rulePath, `---\n${frontmatter}\n---\n${body}\n`);
 	return rulePath;
 }
@@ -424,11 +424,11 @@ test("no reclaim when disabled", async () => {
 // ---------------------------------------------------------------------------
 
 test("dynamic rule dropped by the combined static+dynamic clamp is not marked injected", async () => {
-	// Scope rule discovery to just this project's .claude/rules so the byte math below
-	// is not perturbed by whatever global (~/.claude/rules) rules happen to exist on the
+	// Scope rule discovery to just this project's .codex/rules so the byte math below
+	// is not perturbed by whatever global (~/.codex/rules) rules happen to exist on the
 	// machine running this test.
 	const scopedEnv = {
-		CODEX_RULES_ENABLED_SOURCES: ".claude/rules",
+		CODEX_RULES_ENABLED_SOURCES: ".codex/rules",
 		CODEX_RULES_MAX_RULE_CHARS: "100000",
 		CODEX_RULES_MAX_RESULT_CHARS: "100000",
 		CODEX_RULES_DYNAMIC_MAX_RULE_CHARS: "100000",
@@ -442,7 +442,7 @@ test("dynamic rule dropped by the combined static+dynamic clamp is not marked in
 	};
 	writeRule("clamp-static.md", "alwaysApply: true", "CLAMP_STATIC_BODY_MARKER");
 	const tailPath = writeRule("z-tail.md", 'globs: ["**/*.ts"]', "TAIL_BODY_MARKER");
-	const fillerPath = join(projectDir, ".claude", "rules", "a-filler.md");
+	const fillerPath = join(projectDir, ".codex", "rules", "a-filler.md");
 	writeTarget();
 
 	// Measure the exact static-reclaim directive byte length for THIS run's absolute

--- a/hooks/rules-injector/rules/constants.ts
+++ b/hooks/rules-injector/rules/constants.ts
@@ -21,6 +21,7 @@ export const PROJECT_MARKERS: readonly string[] = [
 export const PROJECT_RULE_SUBDIRS: ReadonlyArray<readonly [string, string]> = [
 	[".omo", "rules"],
 	[".claude", "rules"],
+	[".codex", "rules"],
 	[".cursor", "rules"],
 	[".github", "instructions"],
 ];
@@ -40,6 +41,7 @@ export const USER_HOME_RULE_SUBDIRS: readonly string[] = [
 	".omo/rules",
 	".opencode/rules",
 	".claude/rules",
+	".codex/rules",
 ];
 
 /**
@@ -63,6 +65,7 @@ export const RULE_FILE_EXTENSIONS: readonly string[] = [".md", ".mdc"];
 export const SOURCE_PRIORITY: ReadonlyMap<RuleSource, number> = new Map([
 	[".omo/rules", 0],
 	[".claude/rules", 1],
+	[".codex/rules", 1],
 	[".cursor/rules", 2],
 	[".github/instructions", 3],
 	[".github/copilot-instructions.md", 4],
@@ -70,6 +73,7 @@ export const SOURCE_PRIORITY: ReadonlyMap<RuleSource, number> = new Map([
 	["~/.omo/rules", 100],
 	["~/.opencode/rules", 101],
 	["~/.claude/rules", 102],
+	["~/.codex/rules", 102],
 	["plugin-bundled", 200],
 ]);
 

--- a/hooks/rules-injector/rules/finder-sources.ts
+++ b/hooks/rules-injector/rules/finder-sources.ts
@@ -6,6 +6,7 @@ export function toProjectRuleSource(parentDirectory: string, subDirectory: strin
 	switch (source) {
 		case ".omo/rules":
 		case ".claude/rules":
+		case ".codex/rules":
 		case ".cursor/rules":
 		case ".github/instructions":
 			return source;
@@ -30,6 +31,7 @@ export function toUserHomeRuleSource(ruleSubdir: string): RuleSource {
 		case "~/.omo/rules":
 		case "~/.opencode/rules":
 		case "~/.claude/rules":
+		case "~/.codex/rules":
 			return source;
 		default:
 			throw new UnsupportedRuleSourceError(`Unsupported user-home rule source: ${source}`);

--- a/hooks/rules-injector/rules/finder.test.ts
+++ b/hooks/rules-injector/rules/finder.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { filterExcludedCandidates, findRuleCandidates } from "./finder.js";
+import { DEFAULT_AUTO_DISABLED_SOURCES } from "./sources.js";
 import type { RuleCandidate } from "./types.js";
 
 describe("findRuleCandidates — static mode distance gradient (regression: #static-distance-flatten)", () => {
@@ -176,6 +177,294 @@ describe("findRuleCandidates — excludeGlobs filter", () => {
 			excludeGlobs: ["/**/.claude/rules/**"],
 		});
 		expect(droppedByPath.find((c) => c.source === ".claude/rules")).toBeUndefined();
+	});
+});
+
+describe("findRuleCandidates — .claude/rules conditional supersede by .codex/rules", () => {
+	// Previously DEFAULT_AUTO_DISABLED_SOURCES disabled .claude/rules /
+	// ~/.claude/rules UNCONDITIONALLY, so a project with only .claude/rules
+	// deployed (no .codex/rules counterpart) lost rules entirely — []. The fix
+	// makes the supersede conditional on the codex counterpart actually being
+	// present in the SAME scope (project pairs with project, home with home).
+	let tmp: string;
+
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), "rules-supersede-test-"));
+	});
+
+	afterEach(() => {
+		rmSync(tmp, { recursive: true, force: true });
+	});
+
+	function plantClaudeRules(root: string): void {
+		const dir = join(root, ".claude", "rules");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, "probe.md"), "Ask via the AskUserQuestion tool.\n");
+	}
+
+	function plantCodexRules(root: string): void {
+		const dir = join(root, ".codex", "rules");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, "probe.md"), "Ask via the request_user_input tool.\n");
+	}
+
+	test("arm 1 — both .claude/rules and .codex/rules present: only .codex/rules is adopted (no duplicate)", () => {
+		const projectRoot = join(tmp, "repo");
+		plantClaudeRules(projectRoot);
+		plantCodexRules(projectRoot);
+
+		const candidates = findRuleCandidates({
+			projectRoot,
+			targetFile: null,
+			cwd: projectRoot,
+			skipUserHome: true,
+			pluginRoot: tmp,
+			disabledSources: new Set(DEFAULT_AUTO_DISABLED_SOURCES),
+		});
+
+		expect(candidates.map((c) => c.source)).toEqual([".codex/rules"]);
+	});
+
+	test("arm 2 — only .claude/rules present (.codex/rules NOT deployed): .claude/rules is adopted, not dropped to []", () => {
+		const projectRoot = join(tmp, "repo");
+		plantClaudeRules(projectRoot);
+
+		const candidates = findRuleCandidates({
+			projectRoot,
+			targetFile: null,
+			cwd: projectRoot,
+			skipUserHome: true,
+			pluginRoot: tmp,
+			disabledSources: new Set(DEFAULT_AUTO_DISABLED_SOURCES),
+		});
+
+		expect(candidates.map((c) => c.source)).toEqual([".claude/rules"]);
+	});
+
+	test("arm 3 — only .codex/rules present: .codex/rules is adopted", () => {
+		const projectRoot = join(tmp, "repo");
+		plantCodexRules(projectRoot);
+
+		const candidates = findRuleCandidates({
+			projectRoot,
+			targetFile: null,
+			cwd: projectRoot,
+			skipUserHome: true,
+			pluginRoot: tmp,
+			disabledSources: new Set(DEFAULT_AUTO_DISABLED_SOURCES),
+		});
+
+		expect(candidates.map((c) => c.source)).toEqual([".codex/rules"]);
+	});
+
+	test("explicit config disable of .codex/rules still unconditionally drops it, even with .claude/rules present", () => {
+		const projectRoot = join(tmp, "repo");
+		plantClaudeRules(projectRoot);
+		plantCodexRules(projectRoot);
+
+		const candidates = findRuleCandidates({
+			projectRoot,
+			targetFile: null,
+			cwd: projectRoot,
+			skipUserHome: true,
+			pluginRoot: tmp,
+			disabledSources: new Set([".codex/rules"]),
+		});
+
+		expect(candidates.map((c) => c.source)).toEqual([".claude/rules"]);
+	});
+
+	test("mixed directory (project scope): a .claude/rules file WITHOUT a .codex/rules counterpart survives, while the paired file is superseded", () => {
+		// .claude/rules/{shared.md, team-conventions.md} + .codex/rules/shared.md only.
+		// Only shared.md has a codex counterpart — team-conventions.md has none and
+		// must NOT be dropped by the scope-wide all-or-nothing gate the bug used.
+		const projectRoot = join(tmp, "repo");
+		const claudeDir = join(projectRoot, ".claude", "rules");
+		mkdirSync(claudeDir, { recursive: true });
+		writeFileSync(join(claudeDir, "shared.md"), "Ask via the AskUserQuestion tool.\n");
+		writeFileSync(join(claudeDir, "team-conventions.md"), "# Team conventions\n");
+		plantCodexRules(projectRoot); // .codex/rules/probe.md — NOT shared.md, so add shared.md directly
+		writeFileSync(join(projectRoot, ".codex", "rules", "shared.md"), "Ask via the request_user_input tool.\n");
+
+		const candidates = findRuleCandidates({
+			projectRoot,
+			targetFile: null,
+			cwd: projectRoot,
+			skipUserHome: true,
+			pluginRoot: tmp,
+			disabledSources: new Set(DEFAULT_AUTO_DISABLED_SOURCES),
+		});
+
+		const claudeCandidates = candidates.filter((c) => c.source === ".claude/rules");
+		const codexCandidates = candidates.filter((c) => c.source === ".codex/rules");
+
+		// team-conventions.md has no codex counterpart — it must survive.
+		expect(claudeCandidates.map((c) => c.relativePath)).toContain(".claude/rules/team-conventions.md");
+		// shared.md DOES have a codex counterpart — the .claude/rules copy is dropped.
+		expect(claudeCandidates.map((c) => c.relativePath)).not.toContain(".claude/rules/shared.md");
+		expect(codexCandidates.map((c) => c.relativePath)).toContain(".codex/rules/shared.md");
+	});
+
+	test("mixed directory (home scope): a ~/.claude/rules file WITHOUT a ~/.codex/rules counterpart survives", () => {
+		const projectRoot = join(tmp, "repo");
+		mkdirSync(projectRoot, { recursive: true });
+		const homeDir = join(tmp, "home");
+		const homeClaudeDir = join(homeDir, ".claude", "rules");
+		mkdirSync(homeClaudeDir, { recursive: true });
+		writeFileSync(join(homeClaudeDir, "shared.md"), "Ask via the AskUserQuestion tool.\n");
+		writeFileSync(join(homeClaudeDir, "team-conventions.md"), "# Team conventions\n");
+		const homeCodexDir = join(homeDir, ".codex", "rules");
+		mkdirSync(homeCodexDir, { recursive: true });
+		writeFileSync(join(homeCodexDir, "shared.md"), "Ask via the request_user_input tool.\n");
+
+		const candidates = findRuleCandidates({
+			projectRoot,
+			targetFile: null,
+			cwd: projectRoot,
+			homeDir,
+			pluginRoot: tmp,
+			disabledSources: new Set(DEFAULT_AUTO_DISABLED_SOURCES),
+		});
+
+		const claudeCandidates = candidates.filter((c) => c.source === "~/.claude/rules");
+		const codexCandidates = candidates.filter((c) => c.source === "~/.codex/rules");
+
+		expect(claudeCandidates.map((c) => c.relativePath)).toContain(".claude/rules/team-conventions.md");
+		expect(claudeCandidates.map((c) => c.relativePath)).not.toContain(".claude/rules/shared.md");
+		expect(codexCandidates.map((c) => c.relativePath)).toContain(".codex/rules/shared.md");
+	});
+
+	test("mixed directory (nested package, non-root walk directory): a .claude/rules file WITH a .codex/rules counterpart is superseded even when the walk directory is not projectRoot", () => {
+		// Regression: ruleStem previously derived the stem by stripping a
+		// `${source}/` prefix off `relativePath` (which is always projectRoot-
+		// relative). For a walk directory nested under projectRoot (e.g.
+		// packages/app), relativePath is "packages/app/.claude/rules/foo.md" —
+		// it never starts with ".claude/rules/", so the whole path was returned
+		// unstemmed and claude/codex candidates could never pair up. The fix
+		// derives the stem from the file's own rules-directory-relative path.
+		const projectRoot = join(tmp, "nested");
+		const appDir = join(projectRoot, "packages", "app");
+		mkdirSync(join(appDir, "src"), { recursive: true });
+		writeFileSync(join(projectRoot, "package.json"), "{}");
+		const claudeDir = join(appDir, ".claude", "rules");
+		const codexDir = join(appDir, ".codex", "rules");
+		mkdirSync(claudeDir, { recursive: true });
+		mkdirSync(codexDir, { recursive: true });
+		writeFileSync(join(claudeDir, "foo.md"), "Ask via the AskUserQuestion tool.\n");
+		writeFileSync(join(codexDir, "foo.md"), "Ask via the request_user_input tool.\n");
+
+		const candidates = findRuleCandidates({
+			projectRoot,
+			targetFile: join(appDir, "src", "index.ts"),
+			skipUserHome: true,
+			pluginRoot: tmp,
+			disabledSources: new Set(DEFAULT_AUTO_DISABLED_SOURCES),
+		});
+
+		const claudeCandidates = candidates.filter((c) => c.source === ".claude/rules");
+		const codexCandidates = candidates.filter((c) => c.source === ".codex/rules");
+
+		expect(claudeCandidates.map((c) => c.relativePath)).not.toContain(
+			"packages/app/.claude/rules/foo.md",
+		);
+		expect(codexCandidates.map((c) => c.relativePath)).toContain(
+			"packages/app/.codex/rules/foo.md",
+		);
+	});
+
+	test("scope pairing: a project-scope .codex/rules must not suppress ~/.claude/rules (home scope)", () => {
+		const projectRoot = join(tmp, "repo");
+		plantCodexRules(projectRoot);
+		const homeDir = join(tmp, "home");
+		mkdirSync(join(homeDir, ".claude", "rules"), { recursive: true });
+		writeFileSync(
+			join(homeDir, ".claude", "rules", "probe.md"),
+			"Ask via the AskUserQuestion tool.\n",
+		);
+
+		const candidates = findRuleCandidates({
+			projectRoot,
+			targetFile: null,
+			cwd: projectRoot,
+			homeDir,
+			pluginRoot: tmp,
+			disabledSources: new Set(DEFAULT_AUTO_DISABLED_SOURCES),
+		});
+
+		const sources = candidates.map((c) => c.source);
+		expect(sources).toContain(".codex/rules");
+		expect(sources).toContain("~/.claude/rules");
+	});
+
+	// Regression: supersedeClaudeRulesWithCodex previously consumed the raw candidate
+	// list before excludeGlobs and the project-boundary check ran, so a `.codex/rules`
+	// file that was about to be dropped by either filter still "won" the supersede
+	// fight and suppressed its live `.claude/rules` sibling — losing both files. The
+	// fix runs both filters before supersede; the predicates themselves are unchanged.
+	describe("ordering: exclude-glob and project-boundary filters must run BEFORE supersede", () => {
+		test("arm (i) — an excluded .codex/rules file must not suppress its .claude/rules sibling", () => {
+			const projectRoot = join(tmp, "repo");
+			plantClaudeRules(projectRoot);
+			plantCodexRules(projectRoot);
+
+			const candidates = findRuleCandidates({
+				projectRoot,
+				targetFile: null,
+				cwd: projectRoot,
+				skipUserHome: true,
+				pluginRoot: tmp,
+				disabledSources: new Set(DEFAULT_AUTO_DISABLED_SOURCES),
+				excludeGlobs: ["/**/.codex/rules/probe.md"],
+			});
+
+			// The codex file is gone (user excluded it) AND its claude sibling must
+			// survive — the old bug lost both files here.
+			expect(candidates.map((c) => c.source)).toEqual([".claude/rules"]);
+		});
+
+		test("arm (ii) — a .codex/rules candidate resolving outside the project boundary must not suppress its .claude/rules sibling", () => {
+			const projectRoot = join(tmp, "repo");
+			plantClaudeRules(projectRoot);
+
+			// .codex/rules/probe.md is a symlink to a file OUTSIDE projectRoot, so its
+			// realPath fails isCandidateWithinProjectCached — it should never have been
+			// eligible to supersede anything.
+			const outsideDir = join(tmp, "outside");
+			mkdirSync(outsideDir, { recursive: true });
+			writeFileSync(join(outsideDir, "probe.md"), "Ask via the request_user_input tool.\n");
+			const codexDir = join(projectRoot, ".codex", "rules");
+			mkdirSync(codexDir, { recursive: true });
+			symlinkSync(join(outsideDir, "probe.md"), join(codexDir, "probe.md"));
+
+			const candidates = findRuleCandidates({
+				projectRoot,
+				targetFile: null,
+				cwd: projectRoot,
+				skipUserHome: true,
+				pluginRoot: tmp,
+				disabledSources: new Set(DEFAULT_AUTO_DISABLED_SOURCES),
+			});
+
+			const claudeCandidates = candidates.filter((c) => c.source === ".claude/rules");
+			expect(claudeCandidates.map((c) => c.relativePath)).toContain(".claude/rules/probe.md");
+		});
+
+		test("arm (iii) — control: with both siblings valid and in-boundary, .codex/rules still wins as before", () => {
+			const projectRoot = join(tmp, "repo");
+			plantClaudeRules(projectRoot);
+			plantCodexRules(projectRoot);
+
+			const candidates = findRuleCandidates({
+				projectRoot,
+				targetFile: null,
+				cwd: projectRoot,
+				skipUserHome: true,
+				pluginRoot: tmp,
+				disabledSources: new Set(DEFAULT_AUTO_DISABLED_SOURCES),
+			});
+
+			expect(candidates.map((c) => c.source)).toEqual([".codex/rules"]);
+		});
 	});
 });
 

--- a/hooks/rules-injector/rules/finder.ts
+++ b/hooks/rules-injector/rules/finder.ts
@@ -16,7 +16,7 @@ import {
 	scanRuleFilesCached,
 	singleFileInfoCached,
 } from "./finder-cache.js";
-import { toPosixPath } from "./engine-paths.js";
+import { isCandidateWithinProjectCached, toPosixPath } from "./engine-paths.js";
 import { getWalkDirectories, toRelativePath } from "./finder-paths.js";
 import {
 	toProjectRuleSource,
@@ -74,6 +74,7 @@ export function findRuleCandidates(options: FinderOptions): RuleCandidate[] {
 				disabledSources,
 				options.cache,
 				options.cwd,
+				options.excludeGlobs,
 			),
 		);
 	}
@@ -87,7 +88,9 @@ export function findRuleCandidates(options: FinderOptions): RuleCandidate[] {
 	candidates.push(...findPluginBundledCandidates(pluginBundledOptions));
 
 	if (!skipUserHome) {
-		candidates.push(...findUserHomeCandidates(homeDirectory, disabledSources, options.cache));
+		candidates.push(
+			...findUserHomeCandidates(homeDirectory, disabledSources, options.cache, options.excludeGlobs),
+		);
 	}
 
 	return filterExcludedCandidates(candidates, options.excludeGlobs);
@@ -148,18 +151,65 @@ function isPluginBundledCandidateEnabled(
 	return candidate.relativePath !== WINDOWS_GIT_BASH_BUNDLED_RULE_PATH || platform === "win32";
 }
 
+/**
+ * A candidate's path within its rules directory (e.g. "foo/bar.md" for both
+ * ".claude/rules/foo/bar.md" and ".codex/rules/foo/bar.md"), used to PAIR a
+ * `.claude/rules` file with its `.codex/rules` counterpart by stem rather
+ * than by scope alone. Read directly from `ruleDirRelativePath`, which each
+ * rule-subdirectory candidate carries from creation time (computed relative
+ * to the exact rules directory it was scanned from) — NOT re-derived from
+ * `relativePath`, which is projectRoot- or homeDir-relative and therefore
+ * still carries the walk-directory prefix for a nested package (e.g.
+ * "packages/app/.claude/rules/foo.md"), where a `${source}/` prefix strip
+ * would never match.
+ */
+function ruleStem(candidate: RuleCandidate): string {
+	return candidate.ruleDirRelativePath ?? candidate.relativePath;
+}
+
+/**
+ * Drops a `.claude/rules` (project scope) / `~/.claude/rules` (home scope)
+ * candidate from `candidates` only when a `.codex/rules` / `~/.codex/rules`
+ * candidate with the SAME stem (path within the rules dir) is ALSO present
+ * in that same list — the de-Claude-ified counterpart supersedes the raw
+ * Claude source file-for-file so unrewritten Claude vocabulary
+ * (AskUserQuestion, TaskOutput, ...) is never injected into a Codex session.
+ * A `.claude/rules` file with NO codex counterpart is kept — losing a
+ * hand-written project rule that happens to sit next to OMT-deployed rules
+ * would be worse than the vocabulary leak this closes. Callers pass one
+ * scope's list at a time (a project walkDirectory, or the home-dir list) so
+ * a project-scope codex replacement can never suppress a home-scope claude
+ * source, and vice versa.
+ */
+function supersedeClaudeRulesWithCodex(candidates: RuleCandidate[]): RuleCandidate[] {
+	const codexStems = new Set(
+		candidates
+			.filter((candidate) => candidate.source === ".codex/rules" || candidate.source === "~/.codex/rules")
+			.map(ruleStem),
+	);
+	if (codexStems.size === 0) {
+		return candidates;
+	}
+	return candidates.filter((candidate) => {
+		const isClaudeRules = candidate.source === ".claude/rules" || candidate.source === "~/.claude/rules";
+		return !isClaudeRules || !codexStems.has(ruleStem(candidate));
+	});
+}
+
 function findProjectCandidates(
 	projectRoot: string,
 	targetFile: string | null,
 	disabledSources: ReadonlySet<string>,
 	cache: RuleDiscoveryCache | undefined,
 	cwd?: string,
+	excludeGlobs?: string[],
 ): RuleCandidate[] {
 	const rootDirectory = resolve(projectRoot);
 	const walkDirectories = getWalkDirectories(rootDirectory, targetFile, cwd);
 	const candidates: RuleCandidate[] = [];
 
 	for (const walkDirectory of walkDirectories) {
+		const ruleSubdirCandidates: RuleCandidate[] = [];
 		for (const [parentDirectory, subDirectory] of PROJECT_RULE_SUBDIRS) {
 			const source = toProjectRuleSource(parentDirectory, subDirectory);
 			if (disabledSources.has(source)) {
@@ -168,7 +218,7 @@ function findProjectCandidates(
 
 			const ruleDirectory = join(walkDirectory.directory, parentDirectory, subDirectory);
 			for (const scannedFile of scanRuleFilesCached(ruleDirectory, cache)) {
-				candidates.push({
+				ruleSubdirCandidates.push({
 					path: scannedFile.path,
 					realPath: scannedFile.realPath,
 					source,
@@ -176,9 +226,19 @@ function findProjectCandidates(
 					isGlobal: false,
 					isSingleFile: false,
 					relativePath: toRelativePath(rootDirectory, scannedFile.path),
+					ruleDirRelativePath: toRelativePath(ruleDirectory, scannedFile.path),
 				});
 			}
 		}
+		// exclude-glob and project-boundary filters MUST run before supersede consumes
+		// the list (see supersedeClaudeRulesWithCodex's doc comment for the predicate
+		// itself, unchanged here): an excluded or out-of-boundary `.codex/rules` file
+		// must never count as a "counterpart present" that suppresses its live
+		// `.claude/rules` sibling — it is not going to survive to be adopted itself.
+		const eligibleCandidates = filterExcludedCandidates(ruleSubdirCandidates, excludeGlobs).filter(
+			(candidate) => isCandidateWithinProjectCached(candidate, rootDirectory, undefined),
+		);
+		candidates.push(...supersedeClaudeRulesWithCodex(eligibleCandidates));
 	}
 
 	for (const walkDirectory of walkDirectories) {
@@ -213,8 +273,9 @@ function findUserHomeCandidates(
 	homeDirectory: string,
 	disabledSources: ReadonlySet<string>,
 	cache: RuleDiscoveryCache | undefined,
+	excludeGlobs?: string[],
 ): RuleCandidate[] {
-	const candidates: RuleCandidate[] = [];
+	const ruleSubdirCandidates: RuleCandidate[] = [];
 
 	for (const ruleSubdir of USER_HOME_RULE_SUBDIRS) {
 		const source = toUserHomeRuleSource(ruleSubdir);
@@ -224,7 +285,7 @@ function findUserHomeCandidates(
 
 		const ruleDirectory = join(homeDirectory, ruleSubdir);
 		for (const scannedFile of scanRuleFilesCached(ruleDirectory, cache)) {
-			candidates.push({
+			ruleSubdirCandidates.push({
 				path: scannedFile.path,
 				realPath: scannedFile.realPath,
 				source,
@@ -232,9 +293,16 @@ function findUserHomeCandidates(
 				isGlobal: true,
 				isSingleFile: false,
 				relativePath: toRelativePath(homeDirectory, scannedFile.path),
+				ruleDirRelativePath: toRelativePath(ruleDirectory, scannedFile.path),
 			});
 		}
 	}
+
+	// Exclude-glob filter before supersede — same reasoning as findProjectCandidates.
+	// No project-boundary filter here: every home-scope candidate is isGlobal, which
+	// isCandidateWithinProjectCached always accepts, so applying it would be a no-op.
+	const eligibleCandidates = filterExcludedCandidates(ruleSubdirCandidates, excludeGlobs);
+	const candidates: RuleCandidate[] = supersedeClaudeRulesWithCodex(eligibleCandidates);
 
 	for (const ruleFile of USER_HOME_SINGLE_FILES) {
 		const source = toUserHomeSingleFileSource(ruleFile);

--- a/hooks/rules-injector/rules/ordering.test.ts
+++ b/hooks/rules-injector/rules/ordering.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for sortCandidates / compareCandidates in ordering.ts.
+ *
+ * `.codex/rules` file-for-file replaces `.claude/rules` (see finder.ts's
+ * conditional supersede), so it must inherit that source's SOURCE_PRIORITY
+ * rank, not the next unused number. A project carrying `.github/instructions`
+ * (rank 3) must NOT push `.codex/rules` behind it — before the replacement,
+ * `.claude/rules` (rank 1) always sorted ahead of `.github/instructions`.
+ *
+ * The same conditional-supersede relationship holds at home scope
+ * (`~/.codex/rules` replaces `~/.claude/rules`), so it must carry the same
+ * rank there too — `~/.claude/rules` at 102 and `~/.codex/rules` left at 103
+ * was the promotion applied to project scope but not home scope.
+ */
+import { expect, test } from "bun:test";
+import { sortCandidates } from "./ordering.js";
+import { SOURCE_PRIORITY } from "./constants.js";
+import type { RuleCandidate } from "./types.js";
+
+function candidate(source: RuleCandidate["source"], relativePath: string): RuleCandidate {
+	return {
+		path: `/proj/${relativePath}`,
+		realPath: `/proj/${relativePath}`,
+		source,
+		distance: 0,
+		isGlobal: false,
+		isSingleFile: false,
+		relativePath,
+	};
+}
+
+function globalCandidate(source: RuleCandidate["source"], relativePath: string): RuleCandidate {
+	return {
+		path: `/home/user/${relativePath}`,
+		realPath: `/home/user/${relativePath}`,
+		source,
+		distance: 9999,
+		isGlobal: true,
+		isSingleFile: false,
+		relativePath,
+	};
+}
+
+test("`sortCandidates`: `.codex/rules` sorts before `.github/instructions` at equal distance", () => {
+	const candidates = [
+		candidate(".github/instructions", ".github/instructions/a.md"),
+		candidate(".codex/rules", ".codex/rules/a.md"),
+	];
+
+	const sorted = sortCandidates(candidates);
+
+	expect(sorted.map((c) => c.source)).toEqual([".codex/rules", ".github/instructions"]);
+});
+
+test("SOURCE_PRIORITY: `~/.claude/rules` and `~/.codex/rules` carry the same home-scope rank (parity with the project-scope supersede promotion)", () => {
+	expect(SOURCE_PRIORITY.get("~/.codex/rules")).toBe(SOURCE_PRIORITY.get("~/.claude/rules"));
+});
+
+test("`sortCandidates`: at equal (global) distance, `~/.claude/rules` and `~/.codex/rules` tie on rank and fall through to relativePath ordering", () => {
+	// Given out of source-priority order, a leftover rank gap (as before the
+	// fix, where `~/.codex/rules` sat one rank behind `~/.claude/rules`) would
+	// deterministically sort `~/.claude/rules` first regardless of
+	// relativePath. With equal rank, the tie-break falls through to
+	// relativePath — "a.md" sorts before "b.md" — proving the two sources are
+	// no longer distinguished by rank at home scope.
+	const candidates = [
+		globalCandidate("~/.claude/rules", "b.md"),
+		globalCandidate("~/.codex/rules", "a.md"),
+	];
+
+	const sorted = sortCandidates(candidates);
+
+	expect(sorted.map((c) => c.source)).toEqual(["~/.codex/rules", "~/.claude/rules"]);
+});

--- a/hooks/rules-injector/rules/sources.test.ts
+++ b/hooks/rules-injector/rules/sources.test.ts
@@ -1,9 +1,16 @@
 /**
  * Tests for DEFAULT_AUTO_DISABLED_SOURCES and disabledSourcesFromConfig() in sources.ts.
  *
- * Covers Patch A: ~/.claude/rules removed from DEFAULT_AUTO_DISABLED_SOURCES so that
- * in auto mode the user-home Claude rules source is discoverable (Codex does NOT read
- * ~/.claude/rules natively, so disabling it was over-conservative).
+ * `.claude/rules` / `~/.claude/rules` are deliberately NOT in this unconditional
+ * list. Codex has a native rules sync category (`SUPPORTED_CATEGORIES.codex`), so a
+ * de-Claude-ified counterpart of every rule USUALLY lands at `.codex/rules` /
+ * `~/.codex/rules` — but not always: a project that never ran OMT's sync has no
+ * `.codex/rules` at all. Unconditionally disabling `.claude/rules` here would trade
+ * the Claude-vocabulary leak for a worse outcome — losing rules entirely on every
+ * such project. Instead, `findRuleCandidates` (finder.ts) drops a `.claude/rules`
+ * (`~/.claude/rules`) candidate ONLY when a `.codex/rules` (`~/.codex/rules`)
+ * candidate is ALSO present in the same scope — see finder.test.ts's
+ * "conditional supersede by .codex/rules" suite for that behavior.
  */
 import { expect, test } from "bun:test";
 import { DEFAULT_AUTO_DISABLED_SOURCES, disabledSourcesFromConfig } from "./sources.js";
@@ -27,11 +34,23 @@ function autoConfig(): PiRulesConfig {
 	};
 }
 
-// ── Patch A: ~/.claude/rules NOT in auto-disabled set ───────────────────────
+// ── .claude/rules / ~/.claude/rules are NOT unconditionally disabled;
+// the conditional supersede is finder.ts's job, not this static list's ───────
 
-test("`DEFAULT_AUTO_DISABLED_SOURCES`: does NOT contain ~/.claude/rules (Patch A)", () => {
-	// Patch A removes this entry. Before the patch this assertion fails.
+test("`DEFAULT_AUTO_DISABLED_SOURCES`: does NOT contain .claude/rules (conditional supersede lives in finder.ts)", () => {
+	expect(DEFAULT_AUTO_DISABLED_SOURCES).not.toContain(".claude/rules");
+});
+
+test("`DEFAULT_AUTO_DISABLED_SOURCES`: does NOT contain ~/.claude/rules (conditional supersede lives in finder.ts)", () => {
 	expect(DEFAULT_AUTO_DISABLED_SOURCES).not.toContain("~/.claude/rules");
+});
+
+test("`DEFAULT_AUTO_DISABLED_SOURCES`: does NOT contain .codex/rules (the codex-native replacement stays enabled)", () => {
+	expect(DEFAULT_AUTO_DISABLED_SOURCES).not.toContain(".codex/rules");
+});
+
+test("`DEFAULT_AUTO_DISABLED_SOURCES`: does NOT contain ~/.codex/rules (the codex-native replacement stays enabled)", () => {
+	expect(DEFAULT_AUTO_DISABLED_SOURCES).not.toContain("~/.codex/rules");
 });
 
 test("`DEFAULT_AUTO_DISABLED_SOURCES`: still contains AGENTS.md (unchanged)", () => {
@@ -42,12 +61,20 @@ test("`DEFAULT_AUTO_DISABLED_SOURCES`: still contains ~/.claude/CLAUDE.md (uncha
 	expect(DEFAULT_AUTO_DISABLED_SOURCES).toContain("~/.claude/CLAUDE.md");
 });
 
-// ── 동작 검증: auto 모드에서 ~/.claude/rules가 disabled set에 없음 ────────────
+// ── 동작 검증: auto 모드에서 .claude/rules류는 static list로 disabled되지 않는다
+// (finder.ts의 존재-조건부 supersede가 대신 처리) ─────────────────────────────
 
-test("`disabledSourcesFromConfig`: auto mode does NOT disable ~/.claude/rules (Patch A)", () => {
+test("`disabledSourcesFromConfig`: auto mode does NOT disable .claude/rules or ~/.claude/rules (finder.ts supersedes conditionally instead)", () => {
 	const disabled = disabledSourcesFromConfig(autoConfig());
 	expect(disabled).toBeDefined();
+	expect(disabled!.has(".claude/rules")).toBe(false);
 	expect(disabled!.has("~/.claude/rules")).toBe(false);
+});
+
+test("`disabledSourcesFromConfig`: auto mode does NOT disable .codex/rules or ~/.codex/rules", () => {
+	const disabled = disabledSourcesFromConfig(autoConfig());
+	expect(disabled!.has(".codex/rules")).toBe(false);
+	expect(disabled!.has("~/.codex/rules")).toBe(false);
 });
 
 test("`disabledSourcesFromConfig`: auto mode still disables AGENTS.md", () => {

--- a/hooks/rules-injector/rules/sources.ts
+++ b/hooks/rules-injector/rules/sources.ts
@@ -5,6 +5,20 @@ import type { PiRulesConfig } from "./types.js";
 // this engine reads only first-party rule dirs (.claude/rules, etc.) — a dev
 // running omo's own injector would otherwise get omo's rules injected twice.
 // .cursor/rules is excluded because Codex does not use Cursor rules.
+//
+// .claude/rules and ~/.claude/rules are deliberately NOT in this list. rules
+// is a supported codex sync category (SUPPORTED_CATEGORIES.codex), so a
+// de-Claude-ified counterpart of every rule USUALLY lands at .codex/rules /
+// ~/.codex/rules (deploy-time PLATFORM_REWRITE_RULES.codex rewrite —
+// AskUserQuestion -> request_user_input, TaskOutput/TaskCreate/subagent_type,
+// .claude/ -> .codex/, etc.) — but not always: a project that never ran OMT's
+// sync has no .codex/rules at all. Unconditionally disabling .claude/rules
+// here would close the Claude-vocabulary leak at the cost of losing rules
+// entirely on every such project — a worse outcome than the leak it
+// prevents. Instead, findRuleCandidates (finder.ts) drops a .claude/rules
+// (or ~/.claude/rules) candidate ONLY when a .codex/rules (~/.codex/rules)
+// candidate is ALSO present in the same scope — existence-conditional
+// supersede, not a blanket disable.
 export const DEFAULT_AUTO_DISABLED_SOURCES: readonly string[] = [
 	"AGENTS.md",
 	"~/.claude/CLAUDE.md",

--- a/hooks/rules-injector/rules/types.ts
+++ b/hooks/rules-injector/rules/types.ts
@@ -60,6 +60,16 @@ export interface RuleCandidate {
 	 * Empty string for user-home global rules.
 	 */
 	relativePath: string;
+	/**
+	 * Path relative to the specific rules directory this candidate was scanned
+	 * from (e.g. "foo/bar.md" for both ".claude/rules/foo/bar.md" and
+	 * "packages/app/.claude/rules/foo/bar.md"), used to pair a `.claude/rules`
+	 * candidate with its `.codex/rules` counterpart by stem. Set only for
+	 * rule-subdirectory-scanned candidates (see `ruleStem` in finder.ts);
+	 * undefined for single-file and plugin-bundled candidates, which never go
+	 * through stem pairing.
+	 */
+	ruleDirRelativePath?: string;
 }
 
 /**
@@ -78,6 +88,7 @@ export interface LoadedRule extends RuleCandidate {
 export type RuleSource =
 	| ".omo/rules"
 	| ".claude/rules"
+	| ".codex/rules"
 	| ".cursor/rules"
 	| ".github/instructions"
 	| ".github/copilot-instructions.md"
@@ -85,7 +96,8 @@ export type RuleSource =
 	| "plugin-bundled"
 	| "~/.omo/rules"
 	| "~/.opencode/rules"
-	| "~/.claude/rules";
+	| "~/.claude/rules"
+	| "~/.codex/rules";
 
 /**
  * Why a candidate matched the target file. Surfaced in the injection block so

--- a/hooks/rules-injector/state-gc-sweep.test.ts
+++ b/hooks/rules-injector/state-gc-sweep.test.ts
@@ -215,10 +215,10 @@ test("SessionStart hook runs sweep and rotate", () => {
 
 	const projectDir = mkdtempSync(join(tmpdir(), "rules-injector-gc-proj-"));
 	try {
-		mkdirSync(join(projectDir, ".claude", "rules"), { recursive: true });
+		mkdirSync(join(projectDir, ".codex", "rules"), { recursive: true });
 		writeFileSync(join(projectDir, "package.json"), '{"name":"ri-gc-fixture"}\n');
 		writeFileSync(
-			join(projectDir, ".claude", "rules", "always.md"),
+			join(projectDir, ".codex", "rules", "always.md"),
 			"---\nalwaysApply: true\n---\nGC_SESSION_START_MARKER\n",
 		);
 
@@ -271,7 +271,7 @@ test("SessionStart compact-source recovery is unchanged by GC pre-step", () => {
 
 	const projectDir = mkdtempSync(join(tmpdir(), "rules-injector-gc-recovery-proj-"));
 	try {
-		const rulesDir = join(projectDir, ".claude", "rules");
+		const rulesDir = join(projectDir, ".codex", "rules");
 		mkdirSync(rulesDir, { recursive: true });
 		const rulePath = join(rulesDir, "recovery.md");
 		writeFileSync(join(projectDir, "package.json"), '{"name":"ri-gc-recovery-fixture"}\n');

--- a/hooks/rules-injector/tool-paths.ts
+++ b/hooks/rules-injector/tool-paths.ts
@@ -1,5 +1,6 @@
 import { existsSync, statSync } from "node:fs";
 import { isAbsolute, resolve } from "node:path";
+import { isFailedToolResponse } from "@lib/tool-response";
 
 export interface CodexPostToolUseLike {
 	tool_name: string;
@@ -266,23 +267,4 @@ export function tokenizeShell(command: string): string[] {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isFailedToolResponse(value: unknown): boolean {
-	if (!isRecord(value)) return false;
-	if (
-		value["isError"] === true ||
-		value["is_error"] === true ||
-		value["error"] === true ||
-		value["status"] === "error"
-	) {
-		return true;
-	}
-	if (typeof value["error"] === "string" && value["error"].length > 0) {
-		return true;
-	}
-	if (typeof value["exit_code"] === "number" && value["exit_code"] !== 0) {
-		return true;
-	}
-	return false;
 }

--- a/lib/tool-response.ts
+++ b/lib/tool-response.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared failed-tool-response predicate for Codex PostToolUse consumers.
+ *
+ * Moved out of hooks/rules-injector/tool-paths.ts (its original, still-current
+ * owner) so hooks/codex-persistent-mode/cli.ts can gate on the same signal
+ * without re-deriving the shape from scratch — see that file's runPostToolUse
+ * for the consumer that motivated the move.
+ */
+
+export function isFailedToolResponse(value: unknown): boolean {
+	if (!isRecord(value)) return false;
+	if (
+		value["isError"] === true ||
+		value["is_error"] === true ||
+		value["error"] === true ||
+		value["status"] === "error"
+	) {
+		return true;
+	}
+	if (typeof value["error"] === "string" && value["error"].length > 0) {
+		return true;
+	}
+	if (typeof value["exit_code"] === "number" && value["exit_code"] !== 0) {
+		return true;
+	}
+	return false;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## 📌 Summary

`rules/`를 codex의 **정식 배포 카테고리**로 승격하고, 그렇게 배포된 `.codex/rules`가 rules-injector의 `.claude/rules` 주입을 **덮어쓰도록**(supersede) 만든다.

문제는 이랬다 — Codex 세션에 `.claude/rules/tool-usage-policy.md`가 그대로 주입되면서 `TaskOutput`·`TaskCreate`·`subagent_type` 같은 **Codex에 존재하지 않는 도구 이름**이 모델 컨텍스트로 흘러들어갔다. 배포 시점 rewrite 파이프라인은 이 리터럴들을 정확히 제거하지만, rules-injector는 rewrite를 거치지 않은 `.claude/rules` 원본을 읽는 별개 경로였기 때문에 파이프라인을 우회하고 있었다.

---

## 🔧 Changes

### `hooks/rules-injector/rules/sources.ts` · `finder-sources.ts` — `.codex/rules` 소스 추가와 supersede

- `.codex/rules`를 rules-injector의 정식 소스로 등록.
- **stem 기반 supersede**: `.codex/rules/foo.md`가 존재하면 같은 stem의 `.claude/rules/foo.md`를 억제한다. codex 배포가 rewrite를 거친 번역본을 그 자리에 놓았으므로, 원본을 함께 주입하면 두 벌이 들어간다.
- **랭크 승계**: `.codex/rules`는 자기 스코프의 기본 랭크가 아니라 **자기가 대체하는 `.claude/rules`의 랭크**를 물려받는다. 그러지 않으면 예산 truncate 순서에서 번역본이 원본보다 뒤로 밀려, 예산이 빡빡한 세션에서 조용히 잘려나간다.

**영향 범위**
Claude 세션의 주입 결과는 **바이트 불변**이다 — supersede는 codex 하네스에서만 활성화되고, `.codex/rules` 디렉터리가 없으면(sync 이전 상태) 소스 자체가 비어 있어 기존 동작 그대로다. `SOURCE_PRIORITY` 순서표는 기존 항목의 상대 순서를 건드리지 않고 새 항목만 삽입했다.

### `hooks/rules-injector/rules/finder.ts` · `ordering.ts` · `constants.ts` · `types.ts` — 탐색·정렬 배관

- 소스 열거와 정렬 경로가 새 소스와 그 승계 랭크를 다루도록 확장.
- 상수/타입에 소스 식별자 추가.

**영향 범위**
탐색 순서는 결정론적이다(정렬 후 방출) — 캐시-안전 컨텍스트 주입 규약의 "collection은 정렬 후 방출" 조항을 그대로 따른다. 파일시스템 열거 순서가 프리픽스에 새는 경로는 없다.

### `lib/tool-response.ts` · `hooks/rules-injector/tool-paths.ts` — 실패한 도구 응답 게이트

- 도구 호출이 **실패**했을 때 주입을 건너뛰는 판정을 공유 헬퍼로 분리.
- 실패 응답에 대고 rules를 주입하면 모델이 실패 컨텍스트에 규칙 텍스트를 얹어 읽게 되어, 신호 대비 잡음만 늘어난다.

**영향 범위**
`lib/tool-response.ts`는 이 PR에서 rules-injector가, 스택 3번 PR에서 `codex-persistent-mode/cli.ts`가 임포트한다 — 두 소비자가 같은 판정을 공유하도록 `lib/`에 뒀다. 이 PR 단독으로도 임포트 그래프가 닫힌다.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 주입 시점 rewrite가 아니라 배포 카테고리 승격으로 닫은 이유

**배경 및 문제 상황:**
Codex 세션에 Claude 전용 도구 이름이 새는 문제를 막는 방법은 최소 두 가지였다.
(a) rules-injector가 주입 직전에 rewrite를 한 번 더 돌린다.
(b) `rules/`를 codex 배포 카테고리로 만들어서 `.codex/rules`에 **이미 번역된 파일**을 놓고, injector가 그걸 우선하게 한다.

**해결 방안:**
(b)를 택했다.

**선택과 트레이드오프:**
(a)는 **증상 차단**이다 — 누출 경로 하나를 막을 뿐, "codex 배포 표면에 Claude 어휘가 없다"는 불변식은 여전히 rules에 대해 성립하지 않는다. 게다가 rewrite를 런타임 훅 경로에서 매번 돌리는 비용이 붙고, 배포본과 주입본이 서로 다른 시점의 규칙 테이블로 만들어질 수 있다(드리프트).

(b)는 **하나의 파이프라인이 rules까지 덮게** 만든다. 부수 효과로 어댑터 격차(codex가 `rules` 카테고리를 지원하지 않던 문제)도 같이 닫힌다. 실제로 이 스택 전체에서 6개 축 중 5개가 "새 메커니즘"이 아니라 "이미 도는 파이프라인의 적용 범위 확대"로 닫히는데, 이건 그 대표 사례다.

대가는 **배포 의존성**이다. `.codex/rules`가 없는 머신(= sync 이전)에서는 여전히 `.claude/rules`가 주입된다. 이건 브랜치 결함이 아니라 sync 대기 상태이고, 그래서 스택 5번 PR의 세션 프로브는 `HOME` 격리로 이 교란을 제거한 뒤에야 측정이 성립한다.

### 2. supersede를 파일 대 파일(stem 매칭) 조건부로 한 이유

**배경 및 문제 상황:**
"codex 세션에서는 `.claude/rules`를 통째로 무시"가 더 단순한 규칙이다. 왜 stem 매칭인가?

**해결 방안:**
`.codex/rules/foo.md`가 **존재하는 그 stem만** `.claude/rules/foo.md`를 억제하도록 했다.

**선택과 트레이드오프:**
`.claude/rules`에는 OMT가 배포한 파일만 있는 게 아니다. 사용자가 직접 쓴 rule, 다른 도구가 놓은 rule이 섞여 있다. 통째 무시는 그것들까지 죽인다 — 배포 파이프라인이 대체본을 제공하지 않는 파일을 침묵시키는 건 명백한 회귀다.

**남는 사각도 그대로 인정한다**: `.codex/rules`에 짝이 없는 손작성 `.claude/rules` 파일은 여전히 번역 없이 주입된다. Claude 전용 어휘가 그 안에 있으면 새는 건 그대로다. 이건 "번역되지 않은 사용자 저작물"이라는 별도 클래스이고, 파이프라인이 소유하지 않은 파일을 파이프라인이 고칠 수는 없다.

### 3. 랭크를 스코프 기본값이 아니라 대체 대상에서 승계한 이유

**배경 및 문제 상황:**
rules-injector는 예산 상한이 있고, 넘치면 랭크 낮은 소스부터 잘라낸다. `.codex/rules`를 새 소스로 추가하면서 그 스코프의 기본 랭크를 주면, 번역본이 원본보다 **뒤로** 밀리는 배치가 나온다.

**해결 방안:**
`.codex/rules` 항목은 자기가 supersede하는 `.claude/rules` 항목의 랭크를 그대로 물려받는다.

**선택과 트레이드오프:**
이건 "번역은 자리를 바꾸지 않는다"는 불변식이다 — supersede는 **내용의 교체**이지 **우선순위의 변경**이 아니어야 한다. 랭크가 밀리면 예산이 빡빡한 세션에서만, 그것도 조용히 다르게 동작한다. 재현이 어렵고 원인을 짚기 힘든 클래스라 처음부터 승계로 못박았다.

---

## ✅ Checklist

### supersede 동작
- [ ] `.codex/rules/foo.md`가 있으면 `.claude/rules/foo.md`가 주입되지 않는다
  - `hooks/rules-injector/rules/sources.ts`
- [ ] `.codex/rules`에 짝이 없는 `.claude/rules/bar.md`는 계속 주입된다 (음성 대조군)
  - `hooks/rules-injector/rules/finder-sources.ts`
- [ ] `.codex/rules` 디렉터리 자체가 없으면 주입 결과가 기존과 바이트 동일하다
  - `hooks/rules-injector/rules/finder.test.ts`

### 랭크
- [ ] `.codex/rules` 항목의 랭크가 자신이 대체한 `.claude/rules` 항목과 같다
  - `hooks/rules-injector/rules/ordering.ts`
- [ ] 예산 truncate 시 번역본이 원본이 있던 위치에서 잘린다
  - `hooks/rules-injector/rules/ordering.test.ts`

### 실패 응답 게이트
- [ ] 도구 호출이 실패한 응답에는 rules가 주입되지 않는다
  - `lib/tool-response.ts`
  - `hooks/rules-injector/tool-paths.ts`

### 결정론
- [ ] 동일 파일 집합에 대해 주입 순서가 매 실행 동일하다 (정렬 후 방출)
  - `hooks/rules-injector/rules/ordering.ts`

---

## 📎 References

이 PR은 Claude↔Codex 패리티 스택의 **2/5**입니다. 각 PR은 바로 앞 PR을 base로 쌓이며, 5개 모두 `make validate` / `make test` exit 0으로 **독립 검증**되었습니다.

1. #199 — codex 배포 파이프라인 번역 충실도와 게이팅 개방
2. **#200 — rules 카테고리 배포와 codex rules supersede** ← 현재 PR
3. #201 — keyword-detector·persistent-mode codex 패리티
4. #202 — write-guard·label 게이트 codex 패리티
5. #203 — codex 세션 행동 검증 프로브 하네스

#199가 codex의 배포·번역 파이프라인을 정비하고, 이 PR이 그 파이프라인의 적용 범위를 `rules/`까지 넓힙니다 — 주입 시점 rewrite(증상 차단)를 기각한 근거가 여기 있습니다.
