### PR TITLE
feat: write-guard·label 게이트 codex 패리티

### DIFF
--- a/codex.yaml
+++ b/codex.yaml
@@ -51,6 +51,12 @@ hooks:
     - component: codex-write-guard.sh
       type: command
       matcher: "Bash|bash|apply_patch|exec_command|shell_command|Edit|Write|edit|write|multiedit|multi_edit"
+    # Claude<->Codex hook-parity: root claude.yaml registers label-commit-gate.sh
+    # globally (PreToolUse, matcher "Bash"), so its Codex analog is global too --
+    # see hooks/codex-label-commit-gate.sh + shared hooks/label-commit-gate-core.sh.
+    - component: codex-label-commit-gate.sh
+      type: command
+      matcher: "Bash|bash|exec_command|shell_command"
   PostToolUse:
     - component: rules-injector
       type: command
@@ -63,6 +69,13 @@ hooks:
       # are read via a shell command, not a dedicated file-read tool — see cli.ts's header).
       matcher: "^update_plan$|Bash|bash|exec_command|shell_command"
       command: "bun run .codex/hooks/codex-persistent-mode/cli.ts hook post-tool-use"
+    # Claude<->Codex hook-parity: root claude.yaml registers label-edit-warn.sh
+    # globally (PostToolUse, matcher "Write|Edit|MultiEdit"), so its Codex analog
+    # is global too -- see hooks/codex-label-edit-warn.sh + shared hooks/label-
+    # edit-warn-core.sh.
+    - component: codex-label-edit-warn.sh
+      type: command
+      matcher: "apply_patch|Edit|Write|edit|write|multiedit|multi_edit"
   PostCompact:
     - component: rules-injector
       type: command

--- a/hooks/codex-label-commit-gate.sh
+++ b/hooks/codex-label-commit-gate.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# =============================================================================
+# codex-label-commit-gate.sh
+# Codex PreToolUse shim for the "hard-block a git commit whose MESSAGE
+# contains a clean-economics invented label" gate (Claude<->Codex hook-
+# parity plan). Thin shim over the shared judgment core (hooks/label-commit-
+# gate-core.sh) -- the SAME git-commit-shape detector, message extraction,
+# and label check hooks/label-commit-gate.sh (Claude) uses.
+#
+# tool_name is normalized to lowercase before routing (mirroring hooks/
+# codex-write-guard.sh's toLowerCase treatment), covering Codex's native
+# bash/exec_command/shell_command tool names. The raw shell command text is
+# read from tool_input.command, falling back to tool_input.cmd (mirroring
+# hooks/codex-write-guard.sh's command/cmd fallback for exec_command/
+# shell_command payloads). Before delegating to the core, the process cwd
+# is switched to the command's own working directory (tool_input.workdir ??
+# tool_input.cwd, resolved against the top-level cwd) so the core's -F/
+# --file relative-path lookup resolves against the SAME directory the
+# actual command would run in (mirroring tool-paths.ts:44-47).
+#
+# Deny envelope is Codex's PreToolUse contract (hookSpecificOutput +
+# permissionDecision:"deny" on stdout, exit 0) -- NOT the Claude shim's
+# stderr + exit 2 contract, since that pre-existing Claude behavior must not
+# change (see label-commit-gate-core.sh's header for the full rationale).
+#
+# Fail-open throughout: missing lib/core, missing jq, or a non-commit-shaped
+# command all fall through to a plain exit 0 (allow) -- this is a style
+# gate, not a security gate.
+#
+# omt-hook-dep: label-commit-gate-core.sh
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "$SCRIPT_DIR/lib/label-patterns.sh" 2>/dev/null || exit 0
+source "$SCRIPT_DIR/label-commit-gate-core.sh" 2>/dev/null || exit 0
+
+if ! command -v jq > /dev/null 2>&1; then
+    exit 0
+fi
+
+input=$(cat)
+
+tool_name_raw=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null) || tool_name_raw=""
+tool_name=$(printf '%s' "$tool_name_raw" | tr '[:upper:]' '[:lower:]')
+
+case "$tool_name" in
+    bash | exec_command | shell_command) ;;
+    *) exit 0 ;;
+esac
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) || cmd=""
+if [ -z "$cmd" ]; then
+    cmd=$(printf '%s' "$input" | jq -r '.tool_input.cmd // empty' 2>/dev/null) || cmd=""
+fi
+
+# Resolve the command's own working directory -- tool_input.workdir ??
+# tool_input.cwd -- against the hook's top-level cwd, mirroring the sibling
+# extractor hooks/rules-injector/tool-paths.ts:44-47 (workdir ?? cwd) and
+# hooks/codex-write-guard.sh:505-538's shell-route carve-out ("Scope: this
+# shell route only"). Without this, a payload whose command actually runs
+# in a different workdir than the top-level cwd resolves a relative
+# `-F <file>` message path against the wrong directory -- the core's -f
+# test finds nothing and the label check silently misses it (allow).
+# Scope: this shell route only -- the whole script has exactly one route.
+top_cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null) || top_cwd=""
+[ -n "$top_cwd" ] || top_cwd="$PWD"
+workdir=$(printf '%s' "$input" | jq -r '.tool_input.workdir // .tool_input.cwd // empty' 2>/dev/null) || workdir=""
+if [ -n "$workdir" ]; then
+    case "$workdir" in
+        /*) top_cwd="$workdir" ;;
+        *) top_cwd="$top_cwd/$workdir" ;;
+    esac
+fi
+cd "$top_cwd" 2>/dev/null || true
+
+matched_token=$(label_commit_gate_core_check "$cmd") || exit 0
+
+reason="Invented label in commit message (see rules/communication-style.md). Reword to name the thing, not '${matched_token}'."
+jq -n --arg reason "$reason" '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$reason}}'
+exit 0

--- a/hooks/codex-label-commit-gate_test.sh
+++ b/hooks/codex-label-commit-gate_test.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+# =============================================================================
+# Codex Label Commit Gate Hook Tests (Claude<->Codex hook-parity plan)
+#
+# Covers hooks/codex-label-commit-gate.sh: the Codex PreToolUse shim over
+# the shared judgment core (hooks/label-commit-gate-core.sh) that hooks/
+# label-commit-gate.sh (Claude) also uses. Asserts:
+#   - the shared core is actually referenced (zero duplicated judgment logic)
+#   - a hard-tier label in the commit message -> Codex-shaped deny envelope
+#     (hookSpecificOutput.permissionDecision:"deny", stdout, exit 0 --
+#     NOT Claude's stderr+exit2 contract)
+#   - a clean commit message -> allow (no stdout, exit 0)
+#   - a non-commit Bash command -> passthrough
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/codex-label-commit-gate.sh"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# -----------------------------------------------------------------------------
+# mktemp -d + cleanup trap (OMT shell-test convention)
+# -----------------------------------------------------------------------------
+TEST_TMP_DIR=$(mktemp -d)
+cleanup() {
+    rm -rf "$TEST_TMP_DIR"
+}
+trap cleanup EXIT
+
+run_test() {
+    local test_name="$1"
+    if "$test_name"; then
+        echo "[PASS] $test_name"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "[FAIL] $test_name"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+run_hook() {
+    local tool_name="$1" cmd="$2"
+    jq -n --arg t "$tool_name" --arg c "$cmd" '{tool_name:$t,tool_input:{command:$c}}' | bash "$HOOK"
+}
+
+test_shim_sources_shared_core() {
+    grep -qF 'source "$SCRIPT_DIR/label-commit-gate-core.sh"' "$HOOK" \
+        || { echo "ASSERTION FAILED: must source label-commit-gate-core.sh"; return 1; }
+    return 0
+}
+
+test_hard_label_denies_codex_shape() {
+    local output exit_code=0
+    output=$(run_hook "bash" "git commit -m 'fix D-36'") || exit_code=$?
+    [ "$exit_code" -eq 0 ] || { echo "ASSERTION FAILED: exit should be 0 (Codex deny is stdout-based), got $exit_code"; return 1; }
+    echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' > /dev/null \
+        || { echo "ASSERTION FAILED: expected permissionDecision:deny. Got: $output"; return 1; }
+    echo "$output" | grep -qF "D-36" \
+        || { echo "ASSERTION FAILED: reason should name D-36. Got: $output"; return 1; }
+    return 0
+}
+
+test_clean_message_allows() {
+    local output exit_code=0
+    output=$(run_hook "bash" "git commit -m 'add enrich flag'") || exit_code=$?
+    [ "$exit_code" -eq 0 ] || { echo "ASSERTION FAILED: expected exit 0, got $exit_code"; return 1; }
+    [ -z "$output" ] || { echo "ASSERTION FAILED: expected empty stdout for a clean message. Got: $output"; return 1; }
+    return 0
+}
+
+test_non_commit_passthrough() {
+    local output exit_code=0
+    output=$(run_hook "bash" "ls") || exit_code=$?
+    [ "$exit_code" -eq 0 ] || { echo "ASSERTION FAILED: expected exit 0, got $exit_code"; return 1; }
+    [ -z "$output" ] || { echo "ASSERTION FAILED: expected empty stdout for non-commit. Got: $output"; return 1; }
+    return 0
+}
+
+test_exec_command_tool_name_routes() {
+    # exec_command (a Codex-native tool name distinct from bash) must also route.
+    local output exit_code=0
+    output=$(run_hook "exec_command" "git commit -m 'fix D-36'") || exit_code=$?
+    [ "$exit_code" -eq 0 ] || { echo "ASSERTION FAILED: expected exit 0, got $exit_code"; return 1; }
+    echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' > /dev/null \
+        || { echo "ASSERTION FAILED: exec_command routed command should also deny. Got: $output"; return 1; }
+    return 0
+}
+
+test_cmd_key_fallback() {
+    # shell_command payloads carry the text under .tool_input.cmd, not .command.
+    local output exit_code=0
+    output=$(jq -n '{tool_name:"shell_command",tool_input:{cmd:"git commit -m '"'"'fix D-36'"'"'"}}' | bash "$HOOK") || exit_code=$?
+    [ "$exit_code" -eq 0 ] || { echo "ASSERTION FAILED: expected exit 0, got $exit_code"; return 1; }
+    echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' > /dev/null \
+        || { echo "ASSERTION FAILED: .tool_input.cmd fallback should deny. Got: $output"; return 1; }
+    return 0
+}
+
+test_body_only_label_allows_codex_shape() {
+    # Cross-lane parity proof: the shared core's title-only judgment (fixed
+    # for label-commit-gate-core.sh's body-scanning false positive) must
+    # reach the Codex lane too, not just Claude's label-commit-gate.sh.
+    local output exit_code=0
+    output=$(run_hook "bash" "git commit -m 'clean subject' -m 'fix D-36'") || exit_code=$?
+    [ "$exit_code" -eq 0 ] || { echo "ASSERTION FAILED: expected exit 0, got $exit_code"; return 1; }
+    [ -z "$output" ] || { echo "ASSERTION FAILED: label only in body (2nd -m) should allow. Got: $output"; return 1; }
+    return 0
+}
+
+test_unrelated_tool_name_passthrough() {
+    local output exit_code=0
+    output=$(jq -n '{tool_name:"read",tool_input:{}}' | bash "$HOOK") || exit_code=$?
+    [ "$exit_code" -eq 0 ] || { echo "ASSERTION FAILED: expected exit 0, got $exit_code"; return 1; }
+    [ -z "$output" ] || { echo "ASSERTION FAILED: expected empty stdout for unrelated tool. Got: $output"; return 1; }
+    return 0
+}
+
+# =============================================================================
+# tool_input.workdir fallback (mirrors hooks/rules-injector/tool-paths.ts:
+# 44-47's `workdir ?? cwd` and hooks/codex-write-guard.sh:505-538's shell-
+# route carve-out). A `-F <relative file>` message is resolved against the
+# COMMAND's own workdir, not wherever this hook process happens to run.
+# =============================================================================
+test_workdir_resolves_relative_dash_capital_f_denies() {
+    local base_dir="$TEST_TMP_DIR/wd_base"
+    local sub_dir="$base_dir/sub"
+    mkdir -p "$sub_dir"
+    printf 'fix D-36\n' > "$sub_dir/relfile.txt"
+
+    local output exit_code=0
+    output=$(jq -n --arg cwd "$base_dir" '{cwd:$cwd,tool_name:"bash",tool_input:{command:"git commit -F relfile.txt",workdir:"sub"}}' \
+        | bash "$HOOK") || exit_code=$?
+
+    [ "$exit_code" -eq 0 ] || { echo "ASSERTION FAILED: expected exit 0 (Codex deny is stdout-based), got $exit_code"; return 1; }
+    echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' > /dev/null \
+        || { echo "ASSERTION FAILED: relative -F file under tool_input.workdir should deny. Got: $output"; return 1; }
+    echo "$output" | grep -qF "D-36" \
+        || { echo "ASSERTION FAILED: reason should name D-36. Got: $output"; return 1; }
+    return 0
+}
+
+test_workdir_absolute_form_resolves_dash_capital_f_denies() {
+    local base_dir="$TEST_TMP_DIR/wd_base_abs"
+    local sub_dir="$base_dir/sub_abs"
+    mkdir -p "$sub_dir"
+    printf 'fix D-36\n' > "$sub_dir/relfile.txt"
+
+    local output exit_code=0
+    output=$(jq -n --arg wd "$sub_dir" '{tool_name:"bash",tool_input:{command:"git commit -F relfile.txt",workdir:$wd}}' \
+        | bash "$HOOK") || exit_code=$?
+
+    [ "$exit_code" -eq 0 ] || { echo "ASSERTION FAILED: expected exit 0 (Codex deny is stdout-based), got $exit_code"; return 1; }
+    echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' > /dev/null \
+        || { echo "ASSERTION FAILED: absolute tool_input.workdir should deny. Got: $output"; return 1; }
+    return 0
+}
+
+# Negative control: the SAME relative -F command WITHOUT a workdir field
+# behaves identically before and after the fix -- the relative path never
+# resolves against this hook process's own cwd, so it allows either way.
+test_no_workdir_field_relative_dash_capital_f_still_allows() {
+    local output exit_code=0
+    output=$(jq -n '{tool_name:"bash",tool_input:{command:"git commit -F relfile_does_not_resolve_here.txt"}}' \
+        | bash "$HOOK") || exit_code=$?
+
+    [ "$exit_code" -eq 0 ] || { echo "ASSERTION FAILED: expected exit 0, got $exit_code"; return 1; }
+    [ -z "$output" ] || { echo "ASSERTION FAILED: expected empty stdout (allow) when no workdir field is present. Got: $output"; return 1; }
+    return 0
+}
+
+main() {
+    echo "=========================================="
+    echo "Codex Label Commit Gate Tests"
+    echo "=========================================="
+
+    run_test test_shim_sources_shared_core
+    run_test test_hard_label_denies_codex_shape
+    run_test test_clean_message_allows
+    run_test test_non_commit_passthrough
+    run_test test_exec_command_tool_name_routes
+    run_test test_cmd_key_fallback
+    run_test test_body_only_label_allows_codex_shape
+    run_test test_unrelated_tool_name_passthrough
+    run_test test_workdir_resolves_relative_dash_capital_f_denies
+    run_test test_workdir_absolute_form_resolves_dash_capital_f_denies
+    run_test test_no_workdir_field_relative_dash_capital_f_still_allows
+
+    echo "=========================================="
+    echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"
+    echo "=========================================="
+
+    if [[ $TESTS_FAILED -gt 0 ]]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/hooks/codex-label-edit-warn.sh
+++ b/hooks/codex-label-edit-warn.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# =============================================================================
+# codex-label-edit-warn.sh
+# Codex PostToolUse shim for the "soft-warn on a bare invented/opaque label
+# in just-written content" nudge (Claude<->Codex hook-parity plan). Thin
+# shim over the shared judgment core (hooks/label-edit-warn-core.sh) -- the
+# SAME label check + defined-in-place exemption + warning text hooks/label-
+# edit-warn.sh (Claude) uses.
+#
+# tool_name is normalized to lowercase before routing (mirroring hooks/
+# codex-write-guard.sh's toLowerCase treatment), covering Codex's native
+# write/edit/multiedit/multi_edit tool names plus apply_patch. Content is
+# extracted per tool shape:
+#   - write: tool_input.content
+#   - edit: tool_input.new_string
+#   - multiedit/multi_edit: tool_input.edits[]?.new_string
+#   - apply_patch: only lines starting with `+` (the added content), across
+#     all 4 payload keys Codex has been observed sending the patch text
+#     under (command/input/patch/cmd -- mirrors hooks/codex-write-guard.sh's
+#     _cwg_extract_patch_headers keys). The leading `+` is stripped and the
+#     `*** ` envelope lines / removed (`-`) lines are excluded, so this
+#     carries the SAME meaning as the write/edit/multiedit routes above:
+#     added content only. Scanning the whole patch text (envelope + removed
+#     lines too) let a removal-only edit or a `+### D-1: <name>` defining
+#     heading warn/miss-exempt differently than the identical Write/Edit
+#     content would on Claude -- this keeps the two platforms in parity.
+#
+# This hook never blocks on either platform (PostToolUse, additionalContext
+# only) -- always exits 0.
+#
+# omt-hook-dep: label-edit-warn-core.sh
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "$SCRIPT_DIR/lib/label-patterns.sh" 2>/dev/null || exit 0
+source "$SCRIPT_DIR/label-edit-warn-core.sh" 2>/dev/null || exit 0
+
+if ! command -v jq > /dev/null 2>&1; then
+    exit 0
+fi
+
+INPUT="$(cat)"
+
+tool_name_raw="$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)" || tool_name_raw=""
+tool_name="$(printf '%s' "$tool_name_raw" | tr '[:upper:]' '[:lower:]')"
+
+CONTENT=""
+case "$tool_name" in
+    write)
+        CONTENT="$(printf '%s' "$INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null)"
+        ;;
+    edit)
+        CONTENT="$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null)"
+        ;;
+    multiedit | multi_edit)
+        CONTENT="$(printf '%s' "$INPUT" | jq -r '.tool_input.edits[]?.new_string // empty' 2>/dev/null)"
+        ;;
+    apply_patch)
+        for _clw_key in command input patch cmd; do
+            v="$(printf '%s' "$INPUT" | jq -r --arg k "$_clw_key" '.tool_input[$k] // empty' 2>/dev/null)"
+            if [ -n "$v" ]; then
+                added="$(printf '%s\n' "$v" | tr -d '\r' | grep -E '^\+' | sed -E 's/^\+//')"
+                [ -n "$added" ] && CONTENT="${CONTENT}${added}"$'\n'
+            fi
+        done
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+
+WARNING_TEXT=$(label_edit_warn_core_check "$CONTENT") || exit 0
+
+jq -n --arg ctx "$WARNING_TEXT" '{hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: $ctx}}'
+exit 0

--- a/hooks/codex-label-edit-warn_test.sh
+++ b/hooks/codex-label-edit-warn_test.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# =============================================================================
+# Codex Label Edit Warn Hook Tests (Claude<->Codex hook-parity plan)
+#
+# Covers hooks/codex-label-edit-warn.sh: the Codex PostToolUse shim over the
+# shared judgment core (hooks/label-edit-warn-core.sh) that hooks/label-
+# edit-warn.sh (Claude) also uses. Asserts:
+#   - the shared core is actually referenced (zero duplicated judgment logic)
+#   - write/edit/multiedit/multi_edit/apply_patch each route to a warn
+#   - a defined-in-place heading is exempt (no warn)
+#   - an unrelated tool name never warns
+#   - this hook never blocks (always exit 0)
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/codex-label-edit-warn.sh"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+run_test() {
+    local test_name="$1"
+    if "$test_name"; then
+        echo "[PASS] $test_name"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "[FAIL] $test_name"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+test_shim_sources_shared_core() {
+    grep -qF 'source "$SCRIPT_DIR/label-edit-warn-core.sh"' "$HOOK" \
+        || { echo "ASSERTION FAILED: must source label-edit-warn-core.sh"; return 1; }
+    return 0
+}
+
+test_write_bare_label_warns() {
+    local output exit_code=0
+    output=$(jq -n '{tool_name:"write",tool_input:{content:"see D-1"}}' | bash "$HOOK") || exit_code=$?
+    [ "$exit_code" -eq 0 ] || { echo "ASSERTION FAILED: expected exit 0, got $exit_code"; return 1; }
+    echo "$output" | grep -qF "hookSpecificOutput" || { echo "ASSERTION FAILED: expected a warn. Got: $output"; return 1; }
+    return 0
+}
+
+test_write_defined_in_place_no_warn() {
+    local output exit_code=0
+    output=$(jq -n '{tool_name:"write",tool_input:{content:"### D-1: Add flag"}}' | bash "$HOOK") || exit_code=$?
+    [ "$exit_code" -eq 0 ] || { echo "ASSERTION FAILED: expected exit 0, got $exit_code"; return 1; }
+    [ -z "$output" ] || { echo "ASSERTION FAILED: heading-defined label must be exempt. Got: $output"; return 1; }
+    return 0
+}
+
+test_edit_bare_label_warns() {
+    local output exit_code=0
+    output=$(jq -n '{tool_name:"edit",tool_input:{new_string:"see D-1"}}' | bash "$HOOK") || exit_code=$?
+    [ "$exit_code" -eq 0 ] || { echo "ASSERTION FAILED: expected exit 0, got $exit_code"; return 1; }
+    echo "$output" | grep -qF "additionalContext" || { echo "ASSERTION FAILED: expected a warn. Got: $output"; return 1; }
+    return 0
+}
+
+test_multiedit_bare_label_warns() {
+    local output exit_code=0
+    output=$(jq -n '{tool_name:"multiedit",tool_input:{edits:[{new_string:"see D-1"}]}}' | bash "$HOOK") || exit_code=$?
+    [ "$exit_code" -eq 0 ] || { echo "ASSERTION FAILED: expected exit 0, got $exit_code"; return 1; }
+    echo "$output" | grep -qF "additionalContext" || { echo "ASSERTION FAILED: expected a warn. Got: $output"; return 1; }
+    return 0
+}
+
+test_multi_edit_underscore_variant_routes() {
+    local output exit_code=0
+    output=$(jq -n '{tool_name:"multi_edit",tool_input:{edits:[{new_string:"see D-1"}]}}' | bash "$HOOK") || exit_code=$?
+    [ "$exit_code" -eq 0 ] || { echo "ASSERTION FAILED: expected exit 0, got $exit_code"; return 1; }
+    echo "$output" | grep -qF "additionalContext" || { echo "ASSERTION FAILED: multi_edit variant should also warn. Got: $output"; return 1; }
+    return 0
+}
+
+test_apply_patch_bare_label_warns() {
+    local output exit_code=0
+    output=$(jq -n '{tool_name:"apply_patch",tool_input:{command:"*** Update File: foo.md\n+see D-1\n"}}' | bash "$HOOK") || exit_code=$?
+    [ "$exit_code" -eq 0 ] || { echo "ASSERTION FAILED: expected exit 0, got $exit_code"; return 1; }
+    echo "$output" | grep -qF "additionalContext" || { echo "ASSERTION FAILED: apply_patch payload should warn. Got: $output"; return 1; }
+    return 0
+}
+
+# =============================================================================
+# Regression -- apply_patch must extract ADDED (+) content only, mirroring
+# the write/edit/multiedit routes above (Claude parity: hooks/label-edit-
+# warn.sh only ever sees content/new_string, never the surrounding patch
+# envelope or removed lines). Before the fix, the raw patch text (envelope
+# + hunks, unfiltered) was scanned, so a `+### D-1: Add flag` defining
+# heading never matched the core's heading-exemption regex (which expects
+# a bare `### D-1: ...` line, not one prefixed with a diff `+`) and warned
+# where the identical Write content would not.
+# =============================================================================
+test_apply_patch_added_defining_heading_no_warn() {
+    local output exit_code=0
+    output=$(jq -n '{tool_name:"apply_patch",tool_input:{command:"*** Update File: foo.md\n+### D-1: Add flag\n"}}' | bash "$HOOK") || exit_code=$?
+    [ "$exit_code" -eq 0 ] || { echo "ASSERTION FAILED: expected exit 0, got $exit_code"; return 1; }
+    [ -z "$output" ] || { echo "ASSERTION FAILED: an ADDED defining heading must be exempt, same as Write. Got: $output"; return 1; }
+    return 0
+}
+
+# =============================================================================
+# Regression -- a patch that only REMOVES a line carrying a label must not
+# warn (this edit does not ADD a bare label; it deletes one). Before the
+# fix, the removed (`-`) line was scanned as part of the unfiltered patch
+# text and warned.
+# =============================================================================
+test_apply_patch_removal_only_no_warn() {
+    local output exit_code=0
+    output=$(jq -n '{tool_name:"apply_patch",tool_input:{command:"*** Update File: foo.md\n-see D-1 for details\n"}}' | bash "$HOOK") || exit_code=$?
+    [ "$exit_code" -eq 0 ] || { echo "ASSERTION FAILED: expected exit 0, got $exit_code"; return 1; }
+    [ -z "$output" ] || { echo "ASSERTION FAILED: a removal-only patch must not warn. Got: $output"; return 1; }
+    return 0
+}
+
+test_unrelated_tool_never_warns() {
+    local output exit_code=0
+    output=$(jq -n '{tool_name:"read",tool_input:{}}' | bash "$HOOK") || exit_code=$?
+    [ "$exit_code" -eq 0 ] || { echo "ASSERTION FAILED: expected exit 0, got $exit_code"; return 1; }
+    [ -z "$output" ] || { echo "ASSERTION FAILED: unrelated tool must not warn. Got: $output"; return 1; }
+    return 0
+}
+
+main() {
+    echo "=========================================="
+    echo "Codex Label Edit Warn Tests"
+    echo "=========================================="
+
+    run_test test_shim_sources_shared_core
+    run_test test_write_bare_label_warns
+    run_test test_write_defined_in_place_no_warn
+    run_test test_edit_bare_label_warns
+    run_test test_multiedit_bare_label_warns
+    run_test test_multi_edit_underscore_variant_routes
+    run_test test_apply_patch_bare_label_warns
+    run_test test_apply_patch_added_defining_heading_no_warn
+    run_test test_apply_patch_removal_only_no_warn
+    run_test test_unrelated_tool_never_warns
+
+    echo "=========================================="
+    echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"
+    echo "=========================================="
+
+    if [[ $TESTS_FAILED -gt 0 ]]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/hooks/codex-write-guard.sh
+++ b/hooks/codex-write-guard.sh
@@ -165,6 +165,8 @@ _cwg_mask_quoted() {
             insq = 0
             indq = 0
             dpdepth = 0
+            subsq = 0
+            subdq = 0
             btactive = 0
             out = ""
             for (i = 1; i <= n; i++) {
@@ -190,13 +192,45 @@ _cwg_mask_quoted() {
                 }
 
                 # Inside a live $( ... ) command-substitution span: pass
-                # every character through untouched (no masking, no quote
-                # toggling) while tracking paren depth so a nested $( ... )
-                # or a plain ( ) inside the substitution body is matched
-                # correctly.
+                # every character through untouched (no masking, no OUTER
+                # quote toggling) while tracking paren depth so a nested
+                # $( ... ) or a plain ( ) inside the substitution body is
+                # matched correctly.
+                #
+                # Quote state INSIDE the span is tracked separately (subsq/
+                # subdq) for one reason: a QUOTED right-paren -- as in a
+                # printf whose sole argument is that character -- is
+                # ordinary text to the shell and does NOT close the
+                # substitution. Without tracking it, such a right-paren
+                # dropped dpdepth to 0, every separator after it was then
+                # read as sitting inside the OUTER double quotes and masked
+                # away, and a command chained behind it became invisible to
+                # the scan. A backslash escapes the next character except
+                # inside single quotes, same asymmetry as the outer scan.
                 if (dpdepth > 0) {
-                    if (c == lp) { dpdepth++ }
-                    else if (c == rp) { dpdepth-- }
+                    if (subsq) {
+                        if (c == sq) { subsq = 0 }
+                    } else if (subdq) {
+                        if (c == bs && i < n) { out = out c; i++; c = substr($0, i, 1) }
+                        else if (c == dq) { subdq = 0 }
+                    } else if (c == bs && i < n) {
+                        out = out c; i++; c = substr($0, i, 1)
+                    } else if (c == sq) {
+                        subsq = 1
+                    } else if (c == dq) {
+                        subdq = 1
+                    } else if (c == lp) {
+                        dpdepth++
+                    } else if (c == rp) {
+                        dpdepth--
+                        # The right-paren that ENDS the span is a token
+                        # boundary at execution time, not part of the last
+                        # word inside it. Emit it as a space so a path
+                        # sitting immediately before it stays its own token
+                        # -- glued on, it made the guarded-path comparison,
+                        # which matches whole path tokens, miss.
+                        if (dpdepth == 0) { out = out " "; continue }
+                    }
                     out = out c
                     continue
                 }
@@ -215,6 +249,8 @@ _cwg_mask_quoted() {
                 # backticks are inert text and must stay masked as-is.
                 if (indq && c == dl && i < n && substr($0, i + 1, 1) == lp) {
                     dpdepth = 1
+                    subsq = 0
+                    subdq = 0
                     out = out c lp
                     i++
                     continue

--- a/hooks/codex-write-guard.sh
+++ b/hooks/codex-write-guard.sh
@@ -275,12 +275,25 @@ _cwg_mask_quoted() {
 #
 # Best-effort, matching this file's "not a shell interpreter" posture: only
 # the FIRST heredoc marker on a given line is recognized (multiple heredocs
-# on one line, e.g. `cmd <<A <<B`, is a rare construct left unhandled), and
-# a `<<DELIM` token appearing inside an already-quoted string on the same
-# line is not specially excluded.
+# on one line, e.g. `cmd <<A <<B`, is a rare construct left unhandled).
+#
+# CONFIRMED BYPASS FIX (quoted heredoc marker): marker detection runs on a
+# QUOTE-MASKED copy of the line, never the raw line. `echo "<<EOF"` opens no
+# heredoc at real execution time -- the token is literal text inside a string
+# -- but a raw-text scan read it as an opener and then dropped every
+# following line through `EOF`, swallowing a live `rm -rf` on the next line
+# and bypassing the dangerous-command guard entirely. _cwg_mask_quoted is
+# exactly the right masker here because it neutralizes `<` INSIDE quoted
+# spans while PRESERVING a genuinely quoted delimiter as a bare word
+# (`cat <<'EOF'` -> `cat <<EOF`), so real quoted heredocs keep stripping.
+#
+# Residual, unclosed by design (same class as this file's other static-scan
+# limits): masking is per-line, so a quote opened on one line and closed on a
+# later one is not tracked across the boundary, and a `<<DELIM` inside a live
+# `$( )`/backtick span is passed through unmasked by _cwg_mask_quoted itself.
 _cwg_strip_heredoc_bodies() {
     local text="$1"
-    local out="" line delim="" striptabs=0 inhd=0 cmp marker
+    local out="" line delim="" striptabs=0 inhd=0 cmp marker masked
     while IFS= read -r line || [ -n "$line" ]; do
         if [ "$inhd" -eq 1 ]; then
             cmp="$line"
@@ -292,7 +305,8 @@ _cwg_strip_heredoc_bodies() {
             fi
             continue
         fi
-        marker=$(printf '%s\n' "$line" | grep -oE "<<-?[[:space:]]*['\"]?[A-Za-z_][A-Za-z0-9_]*['\"]?" | head -1) || marker=""
+        masked=$(_cwg_mask_quoted "$line")
+        marker=$(printf '%s\n' "$masked" | grep -oE "<<-?[[:space:]]*['\"]?[A-Za-z_][A-Za-z0-9_]*['\"]?" | head -1) || marker=""
         if [ -n "$marker" ]; then
             striptabs=0
             case "$marker" in "<<-"*) striptabs=1 ;; esac

--- a/hooks/codex-write-guard.sh
+++ b/hooks/codex-write-guard.sh
@@ -49,13 +49,304 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/write-guard-core.sh"
 
-# jq is required for JSON extraction; fail-open (allow, no guard) if absent --
-# this hook is best-effort, not a hard security boundary.
+# stdin is read unconditionally, BEFORE the jq-presence check below -- the
+# jq-absent fallback path (further down) still needs the raw payload text to
+# run a best-effort dangerous-command scan.
+input=$(cat)
+
+# _cwg_mask_quoted <shell_command_text>
+# Quote-aware normalizer, originally re-derived from the Claude twin's
+# _wg_scan (hooks/pre-tool-enforcer.sh:160-179) but now WIDER than it: masks
+# shell-active metacharacters (`> < | ; &`) that appear INSIDE a
+# single-quoted OR double-quoted span by replacing them with a space, and
+# drops the quote CHARACTERS themselves while preserving the quoted CONTENT
+# -- so prose like `printf 'see foo > <ledger> here' | omt-ledger.sh append`
+# is never misread by the redirect/segment-splitter logic below as a live
+# redirect or a live `|`/`;`/`&` chain separator. Without single-quote
+# masking, ANY `>`/`;`/etc in the raw shell text -- quoted or not -- was
+# read as live; without double-quote masking (CONFIRMED bypass, independent
+# code review + directly reproduced), a DOUBLE-quoted separator such as
+# `echo "note; rm -rf /tmp/x"` was split the same as a real `;` chain,
+# denying an entirely harmless command with no bypass/ask escape hatch on
+# this deny-only gate.
+#
+# Why double-quote masking belongs here, not just single: the dangerous-
+# command guard further below exists to emulate claude.yaml's own
+# `permissions.deny` glob evaluation (`Bash(rm -rf *)` etc.), which Claude
+# Code evaluates with its own shell-aware parser -- and that parser reads
+# `echo "note; rm -rf /tmp/x"` as ONE `echo` invocation with one argument,
+# never as a chain, so Claude ALLOWS it natively. A single-quote-only masker
+# here disagreed with that real Claude behavior and denied it -- the
+# widened masker below is what makes this shim's verdict match Claude's
+# actual behavior, not a departure from it. The Claude-side _wg_scan used by
+# the ledger-guard route now masks double-quoted spans too (hooks/pre-tool-
+# enforcer.sh) -- it was single-quote-only until the parity fix, which is why
+# `echo "note; rm <ledger>"` was DENIED there while ALLOWED here. Measured
+# after the fix: both sides allow it, and both still DENY the unquoted
+# `echo hi; rm <ledger>`.
+#
+# Nested-quote and escape handling (kept minimal, NOT a shell parser): a
+# single quote appearing literally inside a double-quoted span (and vice
+# versa) does not toggle the wrong quote state -- each toggle check is
+# gated on the OTHER quote type being inactive.
+#
+# CONFIRMED false-deny fix (both-platform measurement): an escaped `\;`/
+# `\|`/`\&`/`\>`/`\<` outside single-quote mode is DEAD text at real
+# execution time -- outside any quotes it is a literal escaped character,
+# never a chain separator or redirect; inside double quotes the backslash
+# has no escaping power over these characters at all (bash keeps both chars
+# literal there), but they are ALREADY dead text because they sit inside a
+# quoted span. Either way the metachar must never reach the chain-splitter
+# or redirect/rm extractor below as if it were live. The prior version
+# preserved the backslash-escaped pair completely untouched (`out = out c
+# substr($0, i+1, 1)`), leaving the raw metachar character sitting in `out`
+# -- so `echo safe \; rm -rf /tmp/x` (real shell: ECHO prints the whole
+# literal string, rm never runs) was misread as a real `;`-separated chain
+# by the sed-based splitter downstream, denying an entirely harmless
+# command with no bypass/ask escape hatch on this deny-only gate. Fix: when
+# the escaped character is one of the metachars this masker tracks, mask it
+# (two spaces, dropping both the backslash and the metachar) exactly like a
+# quoted occurrence; any OTHER escaped character is still preserved
+# literally as before (this masker's job is metachar liveness, not general
+# backslash removal).
+#
+# Comment truncation (CONFIRMED false-deny fix): outside any quote/
+# command-substitution/backtick span, a `#` that starts a shell WORD (the
+# very first character of the line, or immediately preceded by whitespace)
+# begins a comment that runs to end of line at real execution time -- text
+# after it is never parsed as shell code. `echo safe # note; rm -rf /tmp/x`
+# never runs `rm -rf`; only `safe` is printed. The prior version had no
+# comment awareness at all, so the dangerous-command pattern behind the `#`
+# was still visible to the chain-splitter and denied a harmless command.
+# Only a WORD-LEADING `#` is treated as a comment (mirroring real shell
+# tokenizing) -- `foo#bar` (no leading whitespace) is NOT a comment start
+# and is left untouched. A backslash-escaped `#` is consumed whole by the
+# escape branch above and never reaches this check, so `\#` is not
+# mistaken for a comment leader either. Scoped to the same "live" context as
+# every other check here (not inside single/double quotes, not inside a
+# live $()/backtick span) -- a `#` nested inside a live command
+# substitution is left for that substitution's own (unmodeled) grammar, per
+# this file's "not a shell interpreter" posture.
+#
+# Process substitution, ANSI-C `$'...'` quoting, and other exotic shell
+# grammar are still out of scope, per this file's header "not a shell
+# interpreter" list. This is independently re-derived bash+awk, not sourced
+# from the sibling file (Claude/Codex parsing intentionally never shares
+# code, see the file header) -- so the two guards can still diverge if one
+# is edited without the other.
+#
+# CONFIRMED REGRESSION FIX (double-quote masking widened too far): a
+# `$( ... )` or `` ` ... ` `` command substitution nested INSIDE a
+# double-quoted span is live shell code the outer shell actually executes --
+# `echo "$(true; rm -rf /tmp/x)"` really runs `rm -rf /tmp/x` -- unlike
+# ordinary dq prose, which is dead text. The masking above (correctly) drops
+# a `;`/`|`/etc that sits directly inside dq prose, but was ALSO dropping one
+# that sits inside a nested `$( ... )`/backtick span, hiding a real chain
+# separator from the dangerous-command scan and the redirect/rm extractor
+# below -- a silent allow of a live destructive command. Fix: while indq is
+# active, entering a literal `$(` or a backtick suspends masking (and quote
+# toggling) for that span -- metacharacters pass through untouched, exactly
+# as they would outside any quotes -- until the matching `)` (paren-depth
+# counted, so `$( $( ) )` nests correctly) or the closing backtick is seen,
+# at which point normal dq masking resumes. Single-quoted spans are NOT
+# given this treatment: `$( )`/backticks inside single quotes are inert
+# shell literals (never expand), so masking them stays correct as-is.
+#
+# Defined here (ahead of both the jq-presence check and the "Extraction
+# helpers" section further below, which also calls it) because the
+# dangerous-command guard -- reachable from BOTH the jq-present route below
+# AND the jq-absent fallback further up in file order -- is a caller and
+# must never see this function undefined.
+_cwg_mask_quoted() {
+    printf '%s' "$1" | awk '
+        BEGIN { sq = sprintf("%c", 39); dq = sprintf("%c", 34); bs = sprintf("%c", 92); dl = sprintf("%c", 36); lp = sprintf("%c", 40); rp = sprintf("%c", 41); bt = sprintf("%c", 96); hs = sprintf("%c", 35) }
+        {
+            n = length($0)
+            insq = 0
+            indq = 0
+            dpdepth = 0
+            btactive = 0
+            out = ""
+            for (i = 1; i <= n; i++) {
+                c = substr($0, i, 1)
+
+                # Backslash: special everywhere EXCEPT single-quote mode
+                # (real shells give backslash no escaping power there). If
+                # the escaped char is one of the metachars this masker
+                # tracks, mask the PAIR (it is dead text / never a live
+                # separator at real execution time, see docstring above);
+                # any other escaped char is preserved literally so it
+                # cannot toggle quote state or be read as a metachar -- an
+                # escaped `\"` must not desync in-quote tracking.
+                if (c == bs && !insq && i < n) {
+                    nc = substr($0, i + 1, 1)
+                    if (nc == ">" || nc == "<" || nc == "|" || nc == ";" || nc == "&") {
+                        out = out "  "
+                    } else {
+                        out = out c nc
+                    }
+                    i++
+                    continue
+                }
+
+                # Inside a live $( ... ) command-substitution span: pass
+                # every character through untouched (no masking, no quote
+                # toggling) while tracking paren depth so a nested $( ... )
+                # or a plain ( ) inside the substitution body is matched
+                # correctly.
+                if (dpdepth > 0) {
+                    if (c == lp) { dpdepth++ }
+                    else if (c == rp) { dpdepth-- }
+                    out = out c
+                    continue
+                }
+                # Inside a live backtick `...` span: pass through untouched
+                # until the closing backtick.
+                if (btactive) {
+                    if (c == bt) { btactive = 0 }
+                    out = out c
+                    continue
+                }
+
+                # Entering a live span only matters while indq is active --
+                # outside any quotes, metacharacters are already unmasked
+                # (the final condition below never fires), so no special
+                # handling is needed there. Inside single quotes, $( )/
+                # backticks are inert text and must stay masked as-is.
+                if (indq && c == dl && i < n && substr($0, i + 1, 1) == lp) {
+                    dpdepth = 1
+                    out = out c lp
+                    i++
+                    continue
+                }
+                if (indq && c == bt) {
+                    btactive = 1
+                    out = out c
+                    continue
+                }
+
+                if (!indq && c == sq) {
+                    insq = 1 - insq
+                    continue
+                }
+                if (!insq && c == dq) {
+                    indq = 1 - indq
+                    continue
+                }
+                if ((insq || indq) && (c == ">" || c == "<" || c == "|" || c == ";" || c == "&")) {
+                    out = out " "
+                    continue
+                }
+                # Comment truncation: a live (unquoted, not inside a $()/
+                # backtick span) '#' that starts a shell WORD -- start of
+                # line, or immediately preceded by whitespace -- begins a
+                # comment that runs to end of line at real execution time.
+                # Everything from here on is dropped (not masked to spaces:
+                # comment text carries no position-preservation need).
+                if (!insq && !indq && dpdepth == 0 && !btactive && c == hs && (out == "" || substr(out, length(out), 1) ~ /[ \t]/)) {
+                    break
+                }
+                out = out c
+            }
+            print out
+        }'
+}
+
+# _cwg_strip_heredoc_bodies <shell_command_text>
+# Removes the BODY of every here-document embedded in the text (operator
+# `<<` or `<<-`, delimiter optionally single- or double-quoted) before the
+# dangerous-command guard scans it -- heredoc body lines are literal data
+# fed to the command's stdin, never parsed/executed as shell code, so a
+# destructive-looking string sitting inside one (e.g. `cat <<'EOF'` /
+# `rm -rf /tmp/x` / `EOF`) must not be read as a live command. The heredoc
+# START line itself (up to and including the `<<DELIM` token) is KEPT --
+# real shell/chain content can precede or follow the marker on that same
+# line (`cmd <<'EOF' && next`) -- only the BODY lines, up to and including
+# the terminator line, are dropped.
+#
+# Scope note: this is called ONLY from the dangerous-command guard's own
+# command text, NOT from the ledger/code-review-artifact candidate
+# extraction route (_cwg_process_shell_text further below) -- that route's
+# OWN apply_patch-heredoc handling (_cwg_extract_heredoc_body) depends on
+# reading INTO a heredoc body to find `*** Update File:` headers, which
+# this general stripper would blank out. The two heredoc handlers serve
+# opposite needs (one must see inside; one must not) and are intentionally
+# separate.
+#
+# Best-effort, matching this file's "not a shell interpreter" posture: only
+# the FIRST heredoc marker on a given line is recognized (multiple heredocs
+# on one line, e.g. `cmd <<A <<B`, is a rare construct left unhandled), and
+# a `<<DELIM` token appearing inside an already-quoted string on the same
+# line is not specially excluded.
+_cwg_strip_heredoc_bodies() {
+    local text="$1"
+    local out="" line delim="" striptabs=0 inhd=0 cmp marker
+    while IFS= read -r line || [ -n "$line" ]; do
+        if [ "$inhd" -eq 1 ]; then
+            cmp="$line"
+            if [ "$striptabs" -eq 1 ]; then
+                cmp="${cmp#"${cmp%%[!$'\t']*}"}"
+            fi
+            if [ "$cmp" = "$delim" ]; then
+                inhd=0
+            fi
+            continue
+        fi
+        marker=$(printf '%s\n' "$line" | grep -oE "<<-?[[:space:]]*['\"]?[A-Za-z_][A-Za-z0-9_]*['\"]?" | head -1) || marker=""
+        if [ -n "$marker" ]; then
+            striptabs=0
+            case "$marker" in "<<-"*) striptabs=1 ;; esac
+            delim=$(printf '%s' "$marker" | sed -E "s/^<<-?[[:space:]]*//; s/^['\"]//; s/['\"]\$//")
+            inhd=1
+        fi
+        out="${out}${line}"$'\n'
+    done <<< "$text"
+    printf '%s' "$out"
+}
+
+# jq is required for full JSON-shaped extraction (tool_name routing,
+# apply_patch multi-key payloads, Edit/Write path-key scanning, session-id/
+# OMT_DIR resolution, candidate absolutization). When jq is ABSENT, this
+# hook used to fail open UNCONDITIONALLY (exit 0) before even the
+# dangerous-command guard ran -- but that guard exists specifically to
+# emulate Claude's OWN native, jq-independent `permissions.deny` glob
+# enforcement (claude.yaml), so the two platforms' verdicts on the exact
+# same `rm -rf`/`git push --force` diverged whenever jq happened to be
+# missing from PATH, even though Claude's deny has nothing to do with jq.
+# Below: a raw-text (no JSON parsing) best-effort extraction of
+# tool_input.command/.cmd sufficient to still run the dangerous-command
+# guard, same best-effort grep class as pre-tool-enforcer.sh's
+# extract_json_field (stops at the first unescaped-looking '"', so an
+# embedded escaped quote in the value is not handled). Everything else this
+# hook does (ledger guard, code-review artifact guard, apply_patch/Edit/
+# Write routes) still requires jq and stays fail-open on this path,
+# unchanged -- this is a floor under the one deny Codex has no other
+# mechanism for, not a full jq-free reimplementation of the hook.
 if ! command -v jq > /dev/null 2>&1; then
+    _cwg_nojq_extract_str_field() {
+        printf '%s' "$input" \
+            | grep -o "\"$1\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" \
+            | head -1 \
+            | sed -E "s/^\"$1\"[[:space:]]*:[[:space:]]*\"//; s/\"\$//"
+    }
+    _cwg_nojq_cmd=$(_cwg_nojq_extract_str_field command) || _cwg_nojq_cmd=""
+    if [ -z "$_cwg_nojq_cmd" ]; then
+        _cwg_nojq_cmd=$(_cwg_nojq_extract_str_field cmd) || _cwg_nojq_cmd=""
+    fi
+    if [ -n "$_cwg_nojq_cmd" ]; then
+        _cwg_nojq_stripped=$(_cwg_strip_heredoc_bodies "$_cwg_nojq_cmd")
+        _cwg_nojq_masked=$(_cwg_mask_quoted "$_cwg_nojq_stripped")
+        while IFS= read -r _cwg_nojq_seg; do
+            [ -n "$_cwg_nojq_seg" ] || continue
+            _cwg_nojq_out=$(write_guard_core_check_dangerous_command "$_cwg_nojq_seg")
+            if [ -n "$_cwg_nojq_out" ]; then
+                printf '%s\n' "$_cwg_nojq_out"
+                exit 0
+            fi
+        done < <(printf '%s\n' "$_cwg_nojq_masked" | sed -E 's/(&&|\|\||;|\||&)/\n/g')
+    fi
     exit 0
 fi
-
-input=$(cat)
 
 # Normalize tool_name to lowercase before routing, mirroring the sibling
 # extractor hooks/rules-injector/tool-paths.ts:29 (toLowerCase()) -- Codex
@@ -69,6 +360,63 @@ tool_name=$(printf '%s' "$tool_name_raw" | tr '[:upper:]' '[:lower:]')
 case "$tool_name" in
     apply_patch | bash | exec_command | shell_command | edit | write | multiedit | multi_edit) ;;
     *) exit 0 ;;
+esac
+
+# Claude<->Codex parity story 9/9, AC2/AC4: dangerous-command guard (rm -rf,
+# git push --force) runs FIRST, independent of the ledger session-id/OMT_DIR
+# resolution below -- it needs neither. Deliberately placed before that
+# resolution block: a resolution failure there fail-OPENs via _cwg_halt
+# (exit 0, allow) because the LEDGER guard cannot do its job without a
+# resolved session id -- but this dangerous-command guard has no such
+# dependency, and must not silently inherit that unrelated fail-open.
+#
+# Heredoc-body stripping (_cwg_strip_heredoc_bodies) runs BEFORE quote-aware
+# masking (CONFIRMED false-deny fix, both-platform measurement): a
+# destructive-looking string sitting inside a heredoc BODY (e.g.
+# `cat <<'EOF'` / `rm -rf /tmp/x` / `EOF`) is literal stdin data, never
+# parsed as shell code, so it must never reach the chain-splitter below.
+#
+# Quote-aware masking (_cwg_mask_quoted, same function the shell-target route
+# below uses) is applied BEFORE chain-splitting, mirroring that sibling route
+# exactly (code-review CONFIRMED fix, both single- and double-quoted spans):
+# without it, a `;`/`|` inside a quoted string (e.g. `echo 'note; rm -rf
+# /tmp/x'` OR `echo "note; rm -rf /tmp/x"`) was read the same as a live
+# chain separator, splitting the segment so its second half
+# (`rm -rf /tmp/x'` / `rm -rf /tmp/x"`) matched the dangerous-command
+# pattern and denied an otherwise-harmless command -- with no bypass/ask
+# escape hatch on this deny-only gate, that false deny was unrecoverable for
+# the user. Masking finds correct split points; write_guard_core_check_
+# dangerous_command is then called per split segment exactly as before --
+# see _cwg_mask_quoted's own docstring for why double-quote coverage is
+# required for actual parity with Claude's native shell-aware permission-deny
+# evaluation, not an optional widening.
+#
+# Chain-separator set includes a single `&` (background operator) alongside
+# `&&`/`||`/`;`/`|` (CONFIRMED bypass, both-platform measurement):
+# `echo safe & rm -rf /tmp/x` backgrounds the echo and runs `rm -rf` as its
+# own command at real execution time, but the prior separator set did not
+# include a lone `&`, so the whole string was scanned as ONE segment that
+# never matched any dangerous-command pattern -- silently ALLOWING it, while
+# Claude's own shell-aware parser (which does recognize `&`) denies it
+# natively. `&&` is listed before the lone `&` in the alternation so a real
+# `&&` is not mis-split into two `&` matches.
+case "$tool_name" in
+    bash | exec_command | shell_command)
+        for _cwg_dc_key in command cmd; do
+            _cwg_dc_cmd=$(printf '%s' "$input" | jq -r --arg k "$_cwg_dc_key" '.tool_input[$k] // empty' 2>/dev/null) || _cwg_dc_cmd=""
+            [ -n "$_cwg_dc_cmd" ] || continue
+            _cwg_dc_stripped=$(_cwg_strip_heredoc_bodies "$_cwg_dc_cmd")
+            _cwg_dc_masked=$(_cwg_mask_quoted "$_cwg_dc_stripped")
+            while IFS= read -r _cwg_dc_seg; do
+                [ -n "$_cwg_dc_seg" ] || continue
+                _cwg_dc_out=$(write_guard_core_check_dangerous_command "$_cwg_dc_seg")
+                if [ -n "$_cwg_dc_out" ]; then
+                    printf '%s\n' "$_cwg_dc_out"
+                    exit 0
+                fi
+            done < <(printf '%s\n' "$_cwg_dc_masked" | sed -E 's/(&&|\|\||;|\||&)/\n/g')
+        done
+        ;;
 esac
 
 cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null) || cwd=""
@@ -249,46 +597,9 @@ _cwg_extract_shell_targets() {
     esac
 }
 
-# _cwg_mask_quoted <shell_command_text>
-# Quote-aware normalizer, re-derived from the same algorithm as the Claude
-# twin's _wg_scan (hooks/pre-tool-enforcer.sh:160-179): masks shell-active
-# metacharacters (`> < | ; &`) that appear INSIDE a single-quoted span by
-# replacing them with a space, and drops the quote CHARACTERS themselves
-# while preserving the quoted CONTENT -- so prose like
-# `printf 'see foo > <ledger> here' | omt-ledger.sh append` is never
-# misread by the redirect/segment-splitter logic below as a live redirect
-# or a live `|`/`;`/`&` chain separator. Without this, ANY `>` in the raw
-# shell text -- quoted or not -- was read as a live redirect, so a
-# legitimate ledger-append command whose prose happened to contain
-# `> <ledger>` inside quotes was denied (a false-positive over-block).
-# Double-quoted spans (`> "$f"`) and metacharacters OUTSIDE any quote (real
-# redirects/splitters) pass through unchanged -- same single-quote-only
-# scope as the Claude twin. This is independently re-derived bash+awk, not
-# sourced from the sibling file (Claude/Codex parsing intentionally never
-# shares code, see the file header) -- so the two guards can still diverge
-# if one is edited without the other.
-_cwg_mask_quoted() {
-    printf '%s' "$1" | awk '
-        BEGIN { sq = sprintf("%c", 39) }
-        {
-            n = length($0)
-            inq = 0
-            out = ""
-            for (i = 1; i <= n; i++) {
-                c = substr($0, i, 1)
-                if (c == sq) {
-                    inq = 1 - inq
-                    continue
-                }
-                if (inq && (c == ">" || c == "<" || c == "|" || c == ";" || c == "&")) {
-                    out = out " "
-                    continue
-                }
-                out = out c
-            }
-            print out
-        }'
-}
+# _cwg_mask_quoted is defined earlier in this file (before the
+# dangerous-command guard, its first use in file order) -- see there for the
+# full docstring. Reused here unmodified by _cwg_process_shell_text below.
 
 # _cwg_strip_quotes <token> -- removes EVERY double-quote and single-quote
 # character in the token (not just one outermost pair each way), mirroring
@@ -336,7 +647,7 @@ _cwg_strip_quotes() {
 # envsubst. FIVE variables/forms are expanded (three more than the Claude
 # twin): $OMT_DIR -> $omt_dir; BOTH $OMT_SESSION_ID and $CODEX_THREAD_ID ->
 # $sid, because Codex's resolved session id is OMT_SESSION_ID ?? CODEX_
-# THREAD_ID (resolved above at :74-89) -- either env-var spelling composes
+# THREAD_ID (the cli_sid resolution above) -- either env-var spelling composes
 # the same real ledger path; and $HOME/${HOME}/a leading `~` -> env $HOME,
 # because the resolved omt_dir is ALWAYS $HOME/.omt/<proj> (lib/omt-dir.sh),
 # so a home-relative spelling of the ledger (`rm "$HOME/.omt/<proj>/

--- a/hooks/codex-write-guard_test.sh
+++ b/hooks/codex-write-guard_test.sh
@@ -1488,6 +1488,42 @@ EOF"
     return 0
 }
 
+# Regression -- a QUOTED right-paren inside a LIVE command substitution is
+# ordinary text to the shell and does not close the substitution, but
+# _cwg_mask_quoted counted it as a closer. Depth fell to 0 early, the
+# separator behind it was then treated as sitting inside the OUTER double
+# quotes and masked away, and the chained destructive command was never
+# seen as its own segment. Verified against a real shell first: the payload
+# below genuinely executes its second command.
+test_regression_quoted_paren_in_substitution_does_not_hide_rm_rf_denies() {
+    new_sandbox
+    local out cmd sq
+    sq="'"
+    cmd="echo \"\$(printf ${sq})${sq}; rm -rf /tmp/x)\""
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        rm -rf "$SBX"
+        echo "ASSERTION FAILED quoted-paren-substitution-bypass: expected deny, got '$out'"
+        return 1
+    fi
+    rm -rf "$SBX"
+    return 0
+}
+
+# Negative control for the arm above -- without it, "deny when a quoted
+# right-paren appears in a substitution" would be satisfiable by denying
+# every such command outright. A substitution carrying the same quoted
+# right-paren but no destructive command must still pass.
+test_regression_quoted_paren_without_danger_still_allows() {
+    new_sandbox
+    local out rc=0 cmd sq
+    sq="'"
+    cmd="echo \"\$(printf ${sq})${sq}; echo hello)\""
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook) || rc=$?
+    rm -rf "$SBX"
+    assert_allow "$out" "$rc" "quoted-paren-substitution-false-deny"
+}
+
 test_ac4_negative_plain_rm_allows() {
     new_sandbox
     local out rc=0
@@ -2583,6 +2619,8 @@ main() {
     run_test test_ledger_shell_command_mv_source_denies
     run_test test_regression_quoted_heredoc_marker_does_not_hide_rm_rf_denies
     run_test test_regression_genuine_heredoc_body_still_stripped_allows
+    run_test test_regression_quoted_paren_in_substitution_does_not_hide_rm_rf_denies
+    run_test test_regression_quoted_paren_without_danger_still_allows
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/codex-write-guard_test.sh
+++ b/hooks/codex-write-guard_test.sh
@@ -1439,6 +1439,55 @@ test_ac_dangerous_exec_command_rm_rf_denies() {
     fi
 }
 
+# CONFIRMED BYPASS regression: a `<<EOF` token sitting inside a quoted string
+# opens no heredoc at real execution time, but the heredoc stripper used to
+# read it as an opener and drop every following line through `EOF` -- which
+# swallowed the live destructive command on the next line and let it through.
+# Both quote flavors are covered: the masker treats them differently
+# (single-quoted spans never expand, double-quoted ones can host $( )).
+test_regression_quoted_heredoc_marker_does_not_hide_rm_rf_denies() {
+    new_sandbox
+    local out flavor cmd
+    for flavor in '"' "'"; do
+        cmd="echo ${flavor}<<EOF${flavor}
+rm -rf /tmp/x
+EOF"
+        out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+        if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+            rm -rf "$SBX"
+            echo "ASSERTION FAILED quoted-heredoc-marker-bypass (${flavor}): expected deny, got '$out'"
+            return 1
+        fi
+    done
+    rm -rf "$SBX"
+    return 0
+}
+
+# Negative control for the fix above -- without it, "deny on quoted marker"
+# would be satisfiable by simply never stripping heredoc bodies at all. A
+# GENUINE heredoc body is literal stdin data, never executed, so a
+# destructive-looking line inside one must still NOT deny. All three opener
+# forms the stripper recognizes are exercised: bare, quoted delimiter, and
+# the `<<-` tab-stripping variant.
+test_regression_genuine_heredoc_body_still_stripped_allows() {
+    new_sandbox
+    local out opener cmd rc
+    for opener in 'cat <<EOF' "cat <<'EOF'" 'cat <<-EOF'; do
+        cmd="${opener}
+rm -rf /tmp/x
+EOF"
+        rc=0
+        out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook) || rc=$?
+        if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+            rm -rf "$SBX"
+            echo "ASSERTION FAILED genuine-heredoc-false-deny (${opener}): expected no deny, got '$out'"
+            return 1
+        fi
+    done
+    rm -rf "$SBX"
+    return 0
+}
+
 test_ac4_negative_plain_rm_allows() {
     new_sandbox
     local out rc=0
@@ -2532,6 +2581,8 @@ main() {
     run_test test_codereview_shell_command_mv_source_denies
     run_test test_codereview_shell_command_cp_source_allows
     run_test test_ledger_shell_command_mv_source_denies
+    run_test test_regression_quoted_heredoc_marker_does_not_hide_rm_rf_denies
+    run_test test_regression_genuine_heredoc_body_still_stripped_allows
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/codex-write-guard_test.sh
+++ b/hooks/codex-write-guard_test.sh
@@ -1390,6 +1390,690 @@ test_own_file_paths_key_non_ledger_allows() {
 }
 
 # =============================================================================
+# Claude<->Codex parity story 9/9, AC2/AC4 -- Codex has no native declarative
+# permission-deny primitive equivalent to claude.yaml's permissions.deny
+# (Bash(rm -rf *) / Bash(git push --force*) etc.), so codex-write-guard.sh
+# enforces the same verdict via a PreToolUse hook deny
+# (write_guard_core_check_dangerous_command, hooks/write-guard-core.sh).
+# new_sandbox/run_hook are reused purely for a valid cwd/session environment
+# (this guard itself needs neither ledger path nor session id). The negative
+# controls (plain rm, rm -r, non-force git push) are AC4: without them this
+# guard would be indistinguishable from "deny everything".
+# =============================================================================
+test_ac_dangerous_rm_rf_denies() {
+    new_sandbox
+    local out
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/x"},"session_id":"cx","cwd":"%s"}' "$GITDIR" | run_hook)
+    rm -rf "$SBX"
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED dangerous-rm-rf: expected deny for 'rm -rf /tmp/x', got '$out'"
+        return 1
+    fi
+}
+
+test_ac_dangerous_git_push_force_denies() {
+    new_sandbox
+    local out
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"git push --force"},"session_id":"cx","cwd":"%s"}' "$GITDIR" | run_hook)
+    rm -rf "$SBX"
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED dangerous-git-push-force: expected deny for 'git push --force', got '$out'"
+        return 1
+    fi
+}
+
+test_ac_dangerous_exec_command_rm_rf_denies() {
+    new_sandbox
+    local out
+    out=$(printf '{"tool_name":"exec_command","tool_input":{"cmd":"rm -rf /tmp/x"},"session_id":"cx","cwd":"%s"}' "$GITDIR" | run_hook)
+    rm -rf "$SBX"
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED dangerous-exec-command-rm-rf: expected deny for 'rm -rf /tmp/x' via .cmd, got '$out'"
+        return 1
+    fi
+}
+
+test_ac4_negative_plain_rm_allows() {
+    new_sandbox
+    local out rc=0
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"rm /tmp/x"},"session_id":"cx","cwd":"%s"}' "$GITDIR" | run_hook) || rc=$?
+    rm -rf "$SBX"
+    assert_allow "$out" "$rc" "AC4-negative-plain-rm"
+}
+
+test_ac4_negative_rm_r_allows() {
+    new_sandbox
+    local out rc=0
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"rm -r /tmp/x"},"session_id":"cx","cwd":"%s"}' "$GITDIR" | run_hook) || rc=$?
+    rm -rf "$SBX"
+    assert_allow "$out" "$rc" "AC4-negative-rm-r"
+}
+
+test_ac4_negative_git_push_no_force_allows() {
+    new_sandbox
+    local out rc=0
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"git push origin main"},"session_id":"cx","cwd":"%s"}' "$GITDIR" | run_hook) || rc=$?
+    rm -rf "$SBX"
+    assert_allow "$out" "$rc" "AC4-negative-git-push-no-force"
+}
+
+# =============================================================================
+# Defect 1 (both-platform measurement) -- jq absence used to fail the WHOLE
+# hook open (exit 0, `command -v jq` check at file top ran BEFORE even the
+# dangerous-command guard), even though that guard exists to emulate
+# Claude's OWN native, jq-independent claude.yaml `permissions.deny`
+# enforcement -- so the same `rm -rf`/`git push --force` DENIED on Claude but
+# silently ALLOWED on Codex whenever jq happened to be missing from PATH.
+# Fix: a raw-text (no jq) best-effort extraction of tool_input.command/.cmd
+# still runs the dangerous-command guard when jq is absent.
+#
+# jq_less_bin mirrors hooks/codex-ledger_test.sh's own jq_less_bin pattern:
+# a PATH containing ONLY the externals this jq-absent path legitimately
+# needs (dirname/cat/sed/grep/head/awk/tr -- dirname/cat needed by
+# SCRIPT_DIR resolution and `input=$(cat)`, sed/grep/head/awk/tr by the
+# heredoc-strip/mask/split pipeline), deliberately excluding jq. Absolute
+# /bin/bash sidesteps a bare `bash` lookup failing against the restricted
+# PATH (same rationale as hooks/codex-ledger_test.sh:181-183).
+# =============================================================================
+new_jq_less_bin() {
+    JQLESS=$(mktemp -d)
+    ln -s /usr/bin/dirname "$JQLESS/dirname"
+    ln -s /bin/cat "$JQLESS/cat"
+    ln -s /usr/bin/sed "$JQLESS/sed"
+    ln -s /usr/bin/grep "$JQLESS/grep"
+    ln -s /usr/bin/head "$JQLESS/head"
+    ln -s /usr/bin/awk "$JQLESS/awk"
+    ln -s /usr/bin/tr "$JQLESS/tr"
+}
+
+run_hook_nojq() {
+    env -u OMT_DIR -u OMT_SESSION_ID HOME="$SBX" CODEX_THREAD_ID=cx PATH="$JQLESS" /bin/bash "$HOOK"
+}
+
+test_defect1_nojq_dangerous_rm_rf_denies() {
+    new_sandbox
+    new_jq_less_bin
+    local out result=0
+
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/x"},"session_id":"cx","cwd":"%s"}' "$GITDIR" | run_hook_nojq)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED defect1-nojq-dangerous-rm-rf: expected deny for 'rm -rf /tmp/x' with jq absent from PATH (Claude denies this natively regardless of jq), got '$out'"
+        result=1
+    fi
+
+    rm -rf "$JQLESS" "$SBX"
+    return "$result"
+}
+
+test_defect1_nojq_dangerous_git_push_force_denies() {
+    new_sandbox
+    new_jq_less_bin
+    local out result=0
+
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"git push --force"},"session_id":"cx","cwd":"%s"}' "$GITDIR" | run_hook_nojq)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED defect1-nojq-dangerous-git-push-force: expected deny for 'git push --force' with jq absent from PATH, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$JQLESS" "$SBX"
+    return "$result"
+}
+
+test_defect1_nojq_cmd_key_dangerous_denies() {
+    new_sandbox
+    new_jq_less_bin
+    local out result=0
+
+    out=$(printf '{"tool_name":"exec_command","tool_input":{"cmd":"rm -rf /tmp/x"},"session_id":"cx","cwd":"%s"}' "$GITDIR" | run_hook_nojq)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED defect1-nojq-cmd-key-dangerous: expected deny for exec_command tool_input.cmd 'rm -rf /tmp/x' with jq absent from PATH, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$JQLESS" "$SBX"
+    return "$result"
+}
+
+# Negative control (AC4-equivalent for the jq-absent path) -- a harmless
+# command must still ALLOW with jq absent, proving the raw-text fallback is
+# not "deny everything".
+test_defect1_nojq_negative_control_allows() {
+    new_sandbox
+    new_jq_less_bin
+    local out rc=0 result=0
+
+    out=$(printf '{"tool_name":"Bash","tool_input":{"command":"ls -la"},"session_id":"cx","cwd":"%s"}' "$GITDIR" | run_hook_nojq) || rc=$?
+    if ! assert_allow "$out" "$rc" "defect1-nojq-negative-control"; then
+        result=1
+    fi
+
+    rm -rf "$JQLESS" "$SBX"
+    return "$result"
+}
+
+# =============================================================================
+# Defect 3 (both-platform measurement) -- the chain-separator set the
+# dangerous-command guard splits on (&&/||/;/|) did not include a lone `&`
+# (background operator): `echo safe & rm -rf /tmp/x` backgrounds the echo and
+# runs `rm -rf` as its own command at real execution time, but the whole
+# string was scanned as ONE segment that never matched any dangerous-command
+# pattern -- silently ALLOWING it, while Claude's own shell-aware parser
+# (which recognizes `&`) denies it natively. Fix: add a lone `&` to the
+# separator set, with `&&` ordered first so a real `&&` is not mis-split
+# into two `&` matches (already covered unchanged by
+# test_regression_dc_real_chain_and_rm_rf_denies above).
+# =============================================================================
+test_defect3_single_ampersand_background_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg cmd 'echo safe & rm -rf /tmp/x' --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED defect3-single-ampersand: expected deny for 'echo safe & rm -rf /tmp/x' (real shell backgrounds echo, runs rm -rf as its own command), got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# Negative control -- a harmless `&`-backgrounded chain must still ALLOW,
+# proving the new separator does not turn ordinary background usage into an
+# over-broad denier.
+test_defect3_ampersand_negative_control_allows() {
+    new_sandbox
+    local out rc=0 result=0
+
+    out=$(jq -n --arg cmd 'echo safe & echo also-safe' --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook) || rc=$?
+    if ! assert_allow "$out" "$rc" "defect3-ampersand-negative-control"; then
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
+# Defect 4 (both-platform measurement) -- three false-positive shapes on the
+# dangerous-command guard, all denied before this fix even though the real
+# shell never executes `rm -rf` in any of them:
+#   1. backslash-escaped `\;` outside quotes is dead text (an escaped
+#      literal, not a chain separator) -- `echo safe \; rm -rf /tmp/x`
+#      prints the whole literal string; rm never runs.
+#   2. a word-leading `#` starts a comment that runs to end of line --
+#      `echo safe # note; rm -rf /tmp/x` only ever prints "safe".
+#   3. a heredoc BODY is literal stdin data, never parsed as shell code --
+#      `cat <<'EOF'` / `rm -rf /tmp/x` / `EOF` only ever prints text.
+# Each must ALLOW. No-bypass proofs (the guard must not have gone blind to a
+# REAL dangerous command sitting elsewhere in the same string) are grouped
+# immediately after.
+# =============================================================================
+test_defect4_escaped_semicolon_allows() {
+    new_sandbox
+    local out rc=0 result=0
+
+    out=$(jq -n --arg cmd 'echo safe \; rm -rf /tmp/x' --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook) || rc=$?
+    if ! assert_allow "$out" "$rc" "defect4-escaped-semicolon"; then
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_defect4_escaped_pipe_allows() {
+    new_sandbox
+    local out rc=0 result=0
+
+    out=$(jq -n --arg cmd 'echo safe \| rm -rf /tmp/x' --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook) || rc=$?
+    if ! assert_allow "$out" "$rc" "defect4-escaped-pipe"; then
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_defect4_comment_allows() {
+    new_sandbox
+    local out rc=0 result=0
+
+    out=$(jq -n --arg cmd 'echo safe # note; rm -rf /tmp/x' --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook) || rc=$?
+    if ! assert_allow "$out" "$rc" "defect4-comment"; then
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_defect4_heredoc_body_allows() {
+    new_sandbox
+    local cmd out rc=0 result=0
+
+    cmd=$(printf "cat <<'EOF'\nrm -rf /tmp/x\nEOF\n")
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook) || rc=$?
+    if ! assert_allow "$out" "$rc" "defect4-heredoc-body"; then
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# No-bypass proof 1 -- a REAL dangerous command sitting BEFORE a comment
+# marker on the same line must still be caught: comment truncation only
+# drops what comes AFTER the `#`, never what precedes it.
+test_defect4_real_command_before_comment_still_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg cmd 'rm -rf /tmp/x # this text is just a comment' --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED defect4-real-command-before-comment: expected deny for 'rm -rf /tmp/x # comment' (dangerous command precedes the comment marker), got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# No-bypass proof 2 -- a `#` that does NOT lead a shell word (no preceding
+# whitespace/start-of-line, e.g. glued mid-token as `foo#bar`) must NOT be
+# treated as a comment start, so a REAL chain separator later on the same
+# line stays live and the trailing dangerous command is still caught.
+test_defect4_midword_hash_not_comment_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg cmd 'grep foo#bar file && rm -rf /tmp/x' --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED defect4-midword-hash-not-comment: expected deny for 'grep foo#bar file && rm -rf /tmp/x' (mid-word '#' must not swallow the real '&&' chain), got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# No-bypass proof 3 -- the heredoc START line (everything up to and
+# including the `<<DELIM` token) is KEPT, not stripped: a real dangerous
+# command chained BEFORE the heredoc marker on that same line must still be
+# caught, even though the heredoc BODY that follows is correctly ignored.
+test_defect4_heredoc_startline_chain_before_marker_denies() {
+    new_sandbox
+    local cmd out result=0
+
+    cmd=$(printf "rm -rf /tmp/x && cat <<'EOF'\nharmless body text\nEOF\n")
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED defect4-heredoc-startline-chain: expected deny for 'rm -rf /tmp/x && cat <<EOF ...' (real chain precedes the heredoc marker), got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
+# Regression (CONFIRMED bypass, independent code review) -- the
+# dangerous-command guard split its command text on chain separators
+# (&&/||/;/|) WITHOUT the quote-aware masking (_cwg_mask_quoted) the sibling
+# shell-target route a few lines below it in the same file already applies
+# before splitting. A `;`/`|` INSIDE a single-quoted string was read the
+# same as a live chain separator, so the back half of the split (e.g.
+# `rm -rf /tmp/x'` out of `echo 'note; rm -rf /tmp/x'`) matched one of
+# write_guard_core_check_dangerous_command's 9 patterns and denied an
+# entirely harmless command -- with no bypass/ask escape hatch on this
+# deny-only gate, an unrecoverable false block for the user.
+#
+# Four arms, each proving a different thing:
+#   1. quoted-separator false positive: DENY before the fix, ALLOW after
+#      (`;` and `|`, the two live-inside-quotes forms this guard can mask).
+#   2. real chain hazard: DENY both before and after (masking must not
+#      blind the guard to a genuine unquoted `&&`/`;`/`|` chain).
+#   3. standalone dangerous command, no quoting involved: already covered
+#      unchanged by test_ac_dangerous_rm_rf_denies /
+#      test_ac_dangerous_git_push_force_denies above (masking is a no-op on
+#      unquoted text) -- not duplicated here.
+#   4. negative control: an ordinary safe chain (no quotes, no dangerous
+#      command) ALLOWs both before and after, proving the masking fix does
+#      not turn correct splitting into an over-broad denier.
+# =============================================================================
+test_regression_dc_quoted_semicolon_false_positive_allows() {
+    new_sandbox
+    local cmd out rc=0 result=0
+
+    cmd="echo 'note; rm -rf /tmp/x'"
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook) || rc=$?
+    if ! assert_allow "$out" "$rc" "regression-dc-quoted-semicolon"; then
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_regression_dc_quoted_pipe_false_positive_allows() {
+    new_sandbox
+    local cmd out rc=0 result=0
+
+    cmd="printf 'safe|rm -rf /tmp/x'"
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook) || rc=$?
+    if ! assert_allow "$out" "$rc" "regression-dc-quoted-pipe"; then
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_regression_dc_real_chain_and_rm_rf_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg cmd 'echo hi && rm -rf /tmp/x' --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED regression-dc-real-chain-and: expected deny for 'echo hi && rm -rf /tmp/x', got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_regression_dc_real_chain_semicolon_rm_rf_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg cmd 'git status ; rm -rf /tmp/x' --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED regression-dc-real-chain-semicolon: expected deny for 'git status ; rm -rf /tmp/x', got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_regression_dc_real_chain_pipe_rm_rf_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg cmd 'ls | rm -rf /tmp/x' --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED regression-dc-real-chain-pipe: expected deny for 'ls | rm -rf /tmp/x', got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_regression_dc_negative_control_safe_chain_allows() {
+    new_sandbox
+    local out rc=0 result=0
+
+    out=$(jq -n --arg cmd 'echo safe && echo also-safe' --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook) || rc=$?
+    if ! assert_allow "$out" "$rc" "regression-dc-negative-control-safe-chain"; then
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
+# Regression (CONFIRMED bypass, double-quote masking gap in _cwg_mask_quoted)
+# -- _cwg_mask_quoted used to mask shell-active metacharacters only inside
+# SINGLE-quoted spans; a `;`/`|` inside a DOUBLE-quoted string was still read
+# as a live chain separator, splitting the segment so its second half matched
+# a dangerous-command pattern and denied an entirely harmless command -- with
+# no bypass/ask escape hatch on this deny-only gate, an unrecoverable false
+# block for the user. Reproduces, verbatim, the 5-row discriminating-power
+# probe this fix was verified against: each row proves something DIFFERENT
+# (positive control, negative control, single-quote already-fixed, the
+# double-quote defect itself, and a real unquoted chain that must stay
+# denied). Rows 1/3/5 already have equivalent coverage elsewhere in this
+# suite (test_ac_dangerous_rm_rf_denies, test_regression_dc_quoted_
+# semicolon_false_positive_allows, test_regression_dc_real_chain_and_rm_rf_
+# denies) -- reproduced here anyway, as its own self-contained block, per the
+# "copy the whole sibling pattern, not half" principle: the two rows that
+# differ by exactly ONE quote character (single vs double) are meaningless
+# apart from each other.
+# =============================================================================
+test_probe_row1_positive_control_rm_rf_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg cmd 'rm -rf /tmp/x' --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED probe-row1-positive-control: expected deny for 'rm -rf /tmp/x' (probe discriminating-power positive control), got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_probe_row2_negative_control_echo_allows() {
+    new_sandbox
+    local out rc=0 result=0
+
+    out=$(jq -n --arg cmd 'echo hello' --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook) || rc=$?
+    if ! assert_allow "$out" "$rc" "probe-row2-negative-control"; then
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_probe_row3_single_quoted_semicolon_allows() {
+    new_sandbox
+    local out rc=0 result=0
+
+    out=$(jq -n --arg cmd "echo 'note; rm -rf /tmp/x'" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook) || rc=$?
+    if ! assert_allow "$out" "$rc" "probe-row3-single-quoted-semicolon"; then
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# Row 4 -- the defect itself, differing from row 3 by exactly ONE quote
+# character. Before the fix this DENIED (false positive); after, ALLOWS.
+test_probe_row4_double_quoted_semicolon_allows() {
+    new_sandbox
+    local out rc=0 result=0
+
+    out=$(jq -n --arg cmd 'echo "note; rm -rf /tmp/x"' --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook) || rc=$?
+    if ! assert_allow "$out" "$rc" "probe-row4-double-quoted-semicolon-DEFECT-FIX"; then
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_probe_row5_real_chain_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg cmd 'echo hi && rm -rf /tmp/x' --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED probe-row5-real-chain: expected deny for 'echo hi && rm -rf /tmp/x', got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# Sibling of test_regression_dc_quoted_pipe_false_positive_allows (single
+# quote) -- same defect class via `|` instead of `;`, double-quoted.
+test_regression_dc_double_quoted_pipe_false_positive_allows() {
+    new_sandbox
+    local cmd out rc=0 result=0
+
+    cmd='printf "safe|rm -rf /tmp/x"'
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook) || rc=$?
+    if ! assert_allow "$out" "$rc" "regression-dc-double-quoted-pipe"; then
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
+# No-bypass proof (this fix's most dangerous possible side effect): widening
+# _cwg_mask_quoted to also mask INSIDE double quotes must not blind the
+# ledger-guard or code-review-artifact-guard extraction routes to a REAL,
+# unquoted separator/redirect that sits next to (but outside) a double-quoted
+# span. Each case below targets a guarded path via an UNQUOTED redirect that
+# follows a double-quoted segment containing its own (now-masked) `;` -- the
+# masking of the quoted segment's internal separator must not swallow or
+# desync tracking for the later, genuinely live separator/redirect.
+# =============================================================================
+test_regression_doublequote_mask_does_not_hide_ledger_redirect_denies() {
+    new_sandbox
+    local cmd out result=0
+
+    cmd="echo \"hello; world\" ; echo x > $LED"
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED regression-doublequote-mask-ledger: a real unquoted ';' after a double-quoted span with its own masked ';' must still split and the trailing redirect must still deny, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_regression_doublequote_mask_does_not_hide_codereview_redirect_denies() {
+    new_sandbox
+    cr_paths
+    local cmd out result=0
+
+    cmd="echo \"hello; world\" ; echo x > $CR_GOAL"
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED regression-doublequote-mask-codereview: a real unquoted ';' after a double-quoted span with its own masked ';' must still split and the trailing redirect to the (agent_type-absent) code-review artifact must still deny, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
+# Regression (CONFIRMED, this fix) -- the double-quote masking widening
+# (commit d59f35ed) fixed the double-quoted-prose false positive but went too
+# far: it also masks a `;`/`|`/etc that sits INSIDE a live `$( ... )` (or
+# `` ` ... ` ``) command substitution nested within a double-quoted string --
+# even though that substitution's body is REAL shell code the outer shell
+# executes, not dead text. `echo "$(true; rm -rf /tmp/x)"` actually runs
+# `rm -rf /tmp/x` at real execution time, but pre-fix the masker replaced the
+# `;` inside the substitution with a space (same as any other in-dq `;`), so
+# the chain-splitter never saw a second segment and the dangerous-command scan
+# never evaluated `rm -rf /tmp/x` -- a silent allow of a live destructive
+# command.
+#
+# Three arms, reproducing the exact regression table this fix was verified
+# against (each row proves something different; fixing only one would leave
+# the other two unverified):
+#   1. cmd-sub semicolon regression: DENY pre-fix would have been allow (the
+#      bug); must DENY after the fix -- the `;` inside `$( ... )` is live code.
+#   2. dq-prose semicolon (the ORIGINAL commit d59f35ed intended fix): must
+#      stay ALLOW -- a `;` in ordinary double-quoted prose (no `$( )`) is
+#      still dead text and must not trip the dangerous-command scan. Do not
+#      regress this by reverting double-quote masking wholesale.
+#   3. unquoted semicolon chain: must stay DENY both before and after -- a
+#      real top-level `;` chain separator was never masked in the first
+#      place and must keep splitting normally.
+# =============================================================================
+test_regression_cmdsub_semicolon_in_dq_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg cmd 'echo "$(true; rm -rf /tmp/x)"' --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED regression-cmdsub-semicolon-in-dq: 'echo \"\$(true; rm -rf /tmp/x)\"' actually executes rm -rf at runtime via the live command substitution -- expected deny, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_regression_dq_prose_semicolon_no_cmdsub_allows() {
+    new_sandbox
+    local out rc=0 result=0
+
+    out=$(jq -n --arg cmd 'echo "note; rm -rf /tmp/x"' --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook) || rc=$?
+    if ! assert_allow "$out" "$rc" "regression-dq-prose-semicolon-no-cmdsub"; then
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_regression_unquoted_semicolon_chain_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg cmd 'echo safe; rm -rf /tmp/x' --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED regression-unquoted-semicolon-chain: 'echo safe; rm -rf /tmp/x' is a real unquoted chain -- expected deny, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# Nested $($()) and backtick coverage (per the fix's own "consider nesting"
+# note): a nested command substitution inside a double-quoted string, and a
+# backtick-form substitution, must each keep their live `;` visible too.
+test_regression_nested_cmdsub_semicolon_in_dq_denies() {
+    new_sandbox
+    local out result=0
+
+    out=$(jq -n --arg cmd 'echo "$(echo $(true; rm -rf /tmp/x))"' --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED regression-nested-cmdsub-semicolon: nested \$(\$()) inside dq must still deny on the live inner ';', got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_regression_backtick_semicolon_in_dq_denies() {
+    new_sandbox
+    local cmd out result=0
+
+    cmd='echo "`true; rm -rf /tmp/x`"'
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED regression-backtick-semicolon-in-dq: backtick-form command substitution inside dq must still deny on the live inner ';', got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
 # Code-review artifact identity guard (agent_type wiring task): covers the
 # codereview_guard_core_run wiring (see codereview_guard_core_run in
 # hooks/write-guard-core.sh) added at the tail of hooks/codex-write-guard.sh,
@@ -1797,6 +2481,44 @@ main() {
     run_test test_own_file_paths_key_ledger_denies
     run_test test_own_file_paths_key_mid_array_ledger_denies
     run_test test_own_file_paths_key_non_ledger_allows
+    run_test test_ac_dangerous_rm_rf_denies
+    run_test test_ac_dangerous_git_push_force_denies
+    run_test test_ac_dangerous_exec_command_rm_rf_denies
+    run_test test_ac4_negative_plain_rm_allows
+    run_test test_ac4_negative_rm_r_allows
+    run_test test_ac4_negative_git_push_no_force_allows
+    run_test test_defect1_nojq_dangerous_rm_rf_denies
+    run_test test_defect1_nojq_dangerous_git_push_force_denies
+    run_test test_defect1_nojq_cmd_key_dangerous_denies
+    run_test test_defect1_nojq_negative_control_allows
+    run_test test_defect3_single_ampersand_background_denies
+    run_test test_defect3_ampersand_negative_control_allows
+    run_test test_defect4_escaped_semicolon_allows
+    run_test test_defect4_escaped_pipe_allows
+    run_test test_defect4_comment_allows
+    run_test test_defect4_heredoc_body_allows
+    run_test test_defect4_real_command_before_comment_still_denies
+    run_test test_defect4_midword_hash_not_comment_denies
+    run_test test_defect4_heredoc_startline_chain_before_marker_denies
+    run_test test_regression_dc_quoted_semicolon_false_positive_allows
+    run_test test_regression_dc_quoted_pipe_false_positive_allows
+    run_test test_regression_dc_real_chain_and_rm_rf_denies
+    run_test test_regression_dc_real_chain_semicolon_rm_rf_denies
+    run_test test_regression_dc_real_chain_pipe_rm_rf_denies
+    run_test test_regression_dc_negative_control_safe_chain_allows
+    run_test test_probe_row1_positive_control_rm_rf_denies
+    run_test test_probe_row2_negative_control_echo_allows
+    run_test test_probe_row3_single_quoted_semicolon_allows
+    run_test test_probe_row4_double_quoted_semicolon_allows
+    run_test test_probe_row5_real_chain_denies
+    run_test test_regression_dc_double_quoted_pipe_false_positive_allows
+    run_test test_regression_doublequote_mask_does_not_hide_ledger_redirect_denies
+    run_test test_regression_doublequote_mask_does_not_hide_codereview_redirect_denies
+    run_test test_regression_cmdsub_semicolon_in_dq_denies
+    run_test test_regression_dq_prose_semicolon_no_cmdsub_allows
+    run_test test_regression_unquoted_semicolon_chain_denies
+    run_test test_regression_nested_cmdsub_semicolon_in_dq_denies
+    run_test test_regression_backtick_semicolon_in_dq_denies
     run_test test_codereview_apply_patch_agent_type_absent_denies
     run_test test_codereview_apply_patch_agent_type_code_reviewer_allows
     run_test test_codereview_apply_patch_agent_type_sisyphus_junior_denies

--- a/hooks/label-commit-gate-core.sh
+++ b/hooks/label-commit-gate-core.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# =============================================================================
+# label-commit-gate-core.sh
+# Shared judgment core for the "hard-block a git commit whose SUBJECT
+# contains a clean-economics invented label" gate, sourced by both
+# hooks/label-commit-gate.sh (Claude) and hooks/codex-label-commit-gate.sh
+# (Codex). Owns ALL platform-agnostic text logic: the git-commit-shape
+# detector, subject extraction across every documented `git commit` form
+# (-m/-am/--message[=]/-F/--file[=]), and the label_match_hard check +
+# offending-token extraction.
+#
+# Subject-only, never body: git's documented convention is that the FIRST
+# -m (or --message) is the commit SUBJECT and any repeated -m are separate
+# BODY paragraphs; a -F/--file source's subject is that file's first line.
+# Only the subject is judged -- a label mentioned in body prose (e.g. an ADR
+# heading two paragraphs in) must not deny.
+#
+# Low recognition altitude, deliberately: rather than growing an
+# ever-larger set of quote-shape branches to mimic git/bash's full argument
+# grammar, the value alternation below stays shallow (single/double/ANSI-C
+# `$'...'`-quoted, or a bare unquoted token bounded by whitespace) and just
+# exposes whatever raw text follows the flag to label_match_hard -- the
+# perl substring search underneath does the recognition, not this regex.
+# See reference_parser_guard_lower_recognition_altitude: don't imitate
+# grammar, raise the visibility of the target text instead.
+#
+# The per-platform shim owns ONLY: extracting the raw shell command text from
+# its own tool_input shape (Claude: .tool_input.command; Codex: .tool_input.
+# command // .tool_input.cmd, mirroring hooks/codex-write-guard.sh's routing)
+# and building its own deny envelope. The two envelopes are deliberately NOT
+# unified here (unlike hooks/write-guard-core.sh's single shared deny JSON):
+# label-commit-gate.sh's existing stderr + `{"decision":"deny","reason":...}`
+# + exit 2 contract is pre-existing, tested Claude behavior that must not
+# change, while Codex's PreToolUse deny contract is `{"hookSpecificOutput":
+# {"permissionDecision":"deny",...}}` on stdout with exit 0 (codex-write-
+# guard.sh's established shape for this repo).
+#
+# Requires label_match_hard and $_LABEL_PATTERN_HARD (hooks/lib/label-
+# patterns.sh) to already be sourced by the caller before
+# label_commit_gate_core_check is invoked.
+#
+# label_commit_gate_core_check <cmd_text>
+# Prints the offending token to stdout and returns 0 iff <cmd_text> is a
+# `git commit` invocation whose extracted SUBJECT contains a hard-tier
+# invented label. Prints nothing and returns 1 for every other case
+# (non-commit command, commit with no subject text, or a clean subject).
+# =============================================================================
+
+label_commit_gate_core_check() {
+    local cmd="$1"
+
+    # Fast path: not a git commit -> allow. Tolerates git GLOBAL options
+    # between `git` and `commit` (e.g. `git -C <path> commit`), bounded to a
+    # single line -- see hooks/label-commit-gate.sh's original header comment
+    # for the full rationale (unchanged here, just relocated).
+    local _lcg_nl=$'\n\r'
+    local _lcg_re='git[[:blank:]]([^\&\|\;'"$_lcg_nl"']*[[:blank:]])?commit([[:space:]]|$)'
+    if [[ ! "$cmd" =~ $_lcg_re ]]; then
+        return 1
+    fi
+
+    # Scope every extraction below to the segment AFTER the matched
+    # `git ... commit` invocation, never the raw $cmd. Matching against the
+    # whole command string let an unrelated, earlier -m elsewhere on the
+    # same line (e.g. `printf '%s' -m clean; git commit -m "fix <label>"`)
+    # be mistaken for the commit subject while the real, later -m went
+    # unchecked. Literal (quoted) substring removal, not a glob match --
+    # same idiom already used below for the heredoc body (was: raw $cmd).
+    local _lcg_commit_match="${BASH_REMATCH[0]}"
+    local _lcg_seg="${cmd#*"$_lcg_commit_match"}"
+
+    # The FIRST NON-EMPTY -m / -am / --message occurrence (space or = form,
+    # ANSI-C $'...', single/double quoted, or a bare unquoted token) -- this
+    # IS the subject; a second, third, ... -m is body and is intentionally
+    # never reached once a non-empty one is found. Not just the literal
+    # first -m: git's own cleanup=strip mode drops an empty leading message
+    # paragraph and promotes the next -m to the subject line (verified via
+    # `git commit --allow-empty -m '' -m 'fix D-36'` -> subject `fix D-36`),
+    # so a first -m with an empty value must be skipped over, not treated as
+    # a title-less commit. The separator group requires at least one space
+    # or a literal '=' (never both optional-empty) so the flag-alternation
+    # can't false-match a `m`-ending prefix sitting inside an unrelated long
+    # flag (e.g. "-am" inside "--amend") immediately followed by ordinary
+    # flag text -- with an empty-separator allowance the broadened unquoted
+    # branch below would swallow that text as a bogus "value" and stop
+    # searching before ever reaching a real -m further down the command.
+    local title=""
+    local _lcg_msg_re="(^|[[:space:]])(-[a-zA-Z]*m|--message)([[:space:]]+=?[[:space:]]*|=[[:space:]]*)(\\\$'[^']*'|'[^']*'|\"[^\"]*\"|[^[:space:]]+)"
+    local _lcg_msg_found=0
+    local _lcg_msg_search="$_lcg_seg"
+    while [[ "$_lcg_msg_search" =~ $_lcg_msg_re ]]; do
+        _lcg_msg_found=1
+        local _lcg_raw="${BASH_REMATCH[4]}"
+        local _lcg_full_match="${BASH_REMATCH[0]}"
+        # Unquote (single matching wrapper only) just to test for emptiness
+        # -- title itself stays in its raw, still-quoted form below, same as
+        # before, since label_match_hard's substring search doesn't care.
+        local _lcg_val="$_lcg_raw"
+        case "$_lcg_val" in
+            \$\'*\') _lcg_val="${_lcg_val#\$\'}" _lcg_val="${_lcg_val%\'}" ;;
+            \'*\') _lcg_val="${_lcg_val#\'}" _lcg_val="${_lcg_val%\'}" ;;
+            \"*\") _lcg_val="${_lcg_val#\"}" _lcg_val="${_lcg_val%\"}" ;;
+        esac
+        if [[ -n "$_lcg_val" ]]; then
+            title="$_lcg_raw"
+            title="${title%%$'\n'*}"
+            break
+        fi
+        # This -m's value is empty -- advance past it and keep looking for
+        # the next -m, same literal-substring idiom as the commit-match
+        # scoping strip above (safe against $/quote metacharacters).
+        _lcg_msg_search="${_lcg_msg_search#*"$_lcg_full_match"}"
+    done
+
+    if [[ "$_lcg_msg_found" -eq 0 ]]; then
+        # -F/--file message file: space form (-F <path>, --file <path>) or
+        # --file=<path>.
+        local _lcg_file_path=""
+        if [[ "$_lcg_seg" =~ (^|[[:space:]])(-F|--file)[[:space:]]+([^[:space:]]+) ]]; then
+            _lcg_file_path="${BASH_REMATCH[3]}"
+        elif [[ "$_lcg_seg" =~ (^|[[:space:]])--file=([^[:space:]]+) ]]; then
+            _lcg_file_path="${BASH_REMATCH[2]}"
+        fi
+
+        if [[ "$_lcg_file_path" == "-" ]]; then
+            # `-F -` reads the message from real stdin -- a genuine
+            # interactive human path with nothing to introspect, left
+            # unread (same as before). But when a heredoc supplies that
+            # stdin inline, its body IS fully known static text; extract
+            # the heredoc body's first line as the subject.
+            local _lcg_heredoc_re="<<-?[[:space:]]*'?\"?([A-Za-z_][A-Za-z0-9_]*)\"?'?"
+            if [[ "$_lcg_seg" =~ $_lcg_heredoc_re ]]; then
+                local _lcg_delim="${BASH_REMATCH[1]}"
+                local _lcg_body="${_lcg_seg#*"${BASH_REMATCH[0]}"}"
+                _lcg_body="${_lcg_body#*$'\n'}"
+                _lcg_body="${_lcg_body%%$'\n'"$_lcg_delim"*}"
+                title="${_lcg_body%%$'\n'*}"
+            fi
+        elif [[ -n "$_lcg_file_path" && -f "$_lcg_file_path" ]]; then
+            title=$(head -n 1 -- "$_lcg_file_path" 2> /dev/null) || title=""
+        fi
+    fi
+
+    if [[ -z "$title" ]]; then
+        return 1
+    fi
+
+    if label_match_hard "$title"; then
+        printf '%s\n' "$title" \
+            | LABEL_RE="$_LABEL_PATTERN_HARD" perl -ne 'if (/($ENV{LABEL_RE})/) { print $1; exit }'
+        return 0
+    fi
+
+    return 1
+}

--- a/hooks/label-commit-gate-core.sh
+++ b/hooks/label-commit-gate-core.sh
@@ -77,20 +77,43 @@ label_commit_gate_core_check() {
     # paragraph and promotes the next -m to the subject line (verified via
     # `git commit --allow-empty -m '' -m 'fix D-36'` -> subject `fix D-36`),
     # so a first -m with an empty value must be skipped over, not treated as
-    # a title-less commit. The separator group requires at least one space
-    # or a literal '=' (never both optional-empty) so the flag-alternation
-    # can't false-match a `m`-ending prefix sitting inside an unrelated long
-    # flag (e.g. "-am" inside "--amend") immediately followed by ordinary
-    # flag text -- with an empty-separator allowance the broadened unquoted
-    # branch below would swallow that text as a bogus "value" and stop
-    # searching before ever reaching a real -m further down the command.
+    # a title-less commit.
+    #
+    # The value is reached through TWO alternatives, because the separator
+    # and the value form are independent axes:
+    #
+    #   (a) SEPARATED -- at least one space or a literal '=', then any value
+    #       form (ANSI-C $'...', single/double quoted, or a bare unquoted
+    #       token). The separator is never optional-empty HERE so the
+    #       flag-alternation can't false-match a `m`-ending prefix sitting
+    #       inside an unrelated long flag (e.g. "-am" inside "--amend")
+    #       immediately followed by ordinary flag text -- with an
+    #       empty-separator allowance the bare-token branch would swallow
+    #       that text as a bogus "value" and stop searching before ever
+    #       reaching a real -m further down the command.
+    #   (b) ATTACHED -- no separator at all, QUOTED value only. Shell quote
+    #       concatenation makes `-m'fix <label>'` a single word, and git
+    #       reads it exactly like the separated form, so it must be
+    #       extracted too. Restricting this branch to quoted values is what
+    #       keeps (a)'s guarantee intact: a bare token can never attach, so
+    #       unrelated flag text is still unreachable as a value.
+    #
+    # Splitting the axes this way, rather than making the separator
+    # optional again, is deliberate -- an optional separator would let the
+    # bare-token branch attach and reintroduce the false-match above.
     local title=""
-    local _lcg_msg_re="(^|[[:space:]])(-[a-zA-Z]*m|--message)([[:space:]]+=?[[:space:]]*|=[[:space:]]*)(\\\$'[^']*'|'[^']*'|\"[^\"]*\"|[^[:space:]]+)"
+    local _lcg_quoted_val="\\\$'[^']*'|'[^']*'|\"[^\"]*\""
+    local _lcg_msg_re="(^|[[:space:]])(-[a-zA-Z]*m|--message)((([[:space:]]+=?[[:space:]]*|=[[:space:]]*)($_lcg_quoted_val|[^[:space:]]+))|($_lcg_quoted_val))"
     local _lcg_msg_found=0
     local _lcg_msg_search="$_lcg_seg"
     while [[ "$_lcg_msg_search" =~ $_lcg_msg_re ]]; do
         _lcg_msg_found=1
-        local _lcg_raw="${BASH_REMATCH[4]}"
+        # Separated form captures into group 6, attached form into group 7;
+        # exactly one of the two alternatives matched, so the other is empty.
+        local _lcg_raw="${BASH_REMATCH[6]}"
+        if [[ -z "$_lcg_raw" ]]; then
+            _lcg_raw="${BASH_REMATCH[7]}"
+        fi
         local _lcg_full_match="${BASH_REMATCH[0]}"
         # Unquote (single matching wrapper only) just to test for emptiness
         # -- title itself stays in its raw, still-quoted form below, same as

--- a/hooks/label-commit-gate-core_test.sh
+++ b/hooks/label-commit-gate-core_test.sh
@@ -201,6 +201,66 @@ test_dash_capital_f_scoped_to_segment_after_commit() {
 }
 
 # =============================================================================
+# Regression (attached short option) -- shell quote concatenation makes
+# `git commit -m'fix D-1'` a SINGLE word, and git reads it exactly like the
+# separated `-m 'fix D-1'` form. A separator group that demanded at least
+# one space or `=` never matched these, so the subject was never extracted
+# and the hard gate allowed a labelled commit -- for both the -m and -am
+# flags, and for either quote style. Measured against the pre-change gate,
+# which blocked all four, so this was a live regression, not a pre-existing
+# gap.
+# =============================================================================
+test_regression_attached_quoted_short_option_denies() {
+    local form cmd out rc
+    for form in "-m'fix D-1'" "-am'fix D-1'" '-m"fix D-1"' '-am"fix D-1"'; do
+        rc=0
+        cmd="git commit $form"
+        out=$(label_commit_gate_core_check "$cmd") || rc=$?
+        if [[ "$rc" -ne 0 || "$out" != "D-1" ]]; then
+            echo "ASSERTION FAILED attached-quoted-short-option ($form): expected rc=0 out='D-1', got rc=$rc out='$out'"
+            return 1
+        fi
+    done
+    return 0
+}
+
+# Negative control for the arm above -- without it, "deny on the attached
+# form" would be satisfiable by a matcher that denies every attached form
+# regardless of content. A clean subject in the same attached shape must
+# still pass.
+test_attached_quoted_short_option_clean_subject_allows() {
+    local form cmd out rc
+    for form in "-m'fix retry timeout'" '-am"fix retry timeout"'; do
+        rc=0
+        cmd="git commit $form"
+        out=$(label_commit_gate_core_check "$cmd") || rc=$?
+        if [[ "$rc" -eq 0 ]]; then
+            echo "ASSERTION FAILED attached-clean-subject ($form): expected allow, got rc=$rc out='$out'"
+            return 1
+        fi
+    done
+    return 0
+}
+
+# The property the separator requirement was protecting, pinned so the
+# attached branch cannot quietly undo it: the attached alternative accepts
+# QUOTED values only, so a bare token can never attach to the flag. If it
+# could, the tail text of an unrelated long flag would be swallowed as a
+# bogus subject and the search would stop before reaching the real -m
+# further down the command line.
+test_amend_does_not_shadow_the_real_dash_m_denies() {
+    local cmd out rc=0
+    cmd="git commit --amend --no-edit -m 'fix D-1'"
+    out=$(label_commit_gate_core_check "$cmd") || rc=$?
+    if [[ "$rc" -eq 0 && "$out" == "D-1" ]]; then
+        return 0
+    else
+        echo "ASSERTION FAILED amend-does-not-shadow: expected rc=0 out='D-1', got rc=$rc out='$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 main() {
@@ -216,6 +276,9 @@ main() {
     run_test test_empty_first_dash_m_promotes_second_to_subject_denies
     run_test test_nonempty_first_dash_m_label_only_in_second_still_allows
     run_test test_dash_capital_f_scoped_to_segment_after_commit
+    run_test test_regression_attached_quoted_short_option_denies
+    run_test test_attached_quoted_short_option_clean_subject_allows
+    run_test test_amend_does_not_shadow_the_real_dash_m_denies
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/hooks/label-commit-gate-core_test.sh
+++ b/hooks/label-commit-gate-core_test.sh
@@ -1,0 +1,229 @@
+#!/bin/bash
+# =============================================================================
+# label-commit-gate-core.sh tests
+# Covers label_commit_gate_core_check <cmd_text> directly (bypassing both
+# platform shims) -- the git-commit-shape detector, subject scoping and
+# extraction across the documented -m/-am/--message/-F/--file forms, and the
+# label_match_hard check. Colocated sibling to hooks/write-guard-core_test.sh,
+# hooks/keyword-detector-core_test.sh -- both platform shims
+# (hooks/label-commit-gate.sh, hooks/codex-label-commit-gate.sh) already have
+# their own _test.sh, but the core itself did not until now: a shim-only test
+# suite exercises the core only through each shim's own fixed set of sample
+# commands, and never proved the core's subject-scoping was correct against
+# an unrelated -m sitting earlier in the same shell command line -- which is
+# exactly the regression this suite's first arm pins.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=./lib/label-patterns.sh
+source "$SCRIPT_DIR/lib/label-patterns.sh"
+# shellcheck source=./label-commit-gate-core.sh
+source "$SCRIPT_DIR/label-commit-gate-core.sh"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# -----------------------------------------------------------------------------
+# mktemp -d + cleanup trap (OMT shell-test convention)
+# -----------------------------------------------------------------------------
+TEST_TMP_DIR=$(mktemp -d)
+cleanup() {
+    rm -rf "$TEST_TMP_DIR"
+}
+trap cleanup EXIT
+
+run_test() {
+    local test_name="$1"
+    if "$test_name"; then
+        echo "[PASS] $test_name"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "[FAIL] $test_name"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+# =============================================================================
+# Regression (scoping fix) -- an unrelated -m sitting BEFORE the real
+# `git commit` on the same command line must not be mistaken for the
+# subject. label_commit_gate_core_check must scope its -m/-F search to the
+# segment AFTER the matched `git ... commit` invocation, not the whole raw
+# command string. Before the fix, the first (unrelated) -m short-circuited
+# the search and the real, later -m carrying the hard-tier label went
+# unscanned -> false ALLOW.
+# =============================================================================
+test_regression_unrelated_earlier_dash_m_still_denies() {
+    local cmd out rc=0
+    cmd="printf '%s' -m clean; git commit -m \"fix D-1\""
+    out=$(label_commit_gate_core_check "$cmd") || rc=$?
+    if [[ "$rc" -eq 0 && "$out" == "D-1" ]]; then
+        return 0
+    else
+        echo "ASSERTION FAILED regression-unrelated-earlier-dash-m: expected rc=0 out='D-1', got rc=$rc out='$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
+# Intended reduction (must NOT change) -- git's own convention treats the
+# FIRST -m as the SUBJECT and any repeated -m as BODY paragraphs; the core
+# deliberately never scans body. A label living only in a second -m must
+# keep allowing. Pinned here as a fixed arm so a future over-broadening of
+# the scoping fix (e.g. looping over every -m instead of stopping at the
+# first) cannot silently regress this documented behavior.
+# =============================================================================
+test_intended_reduction_label_only_in_second_dash_m_allows() {
+    local cmd out rc=0
+    cmd="git commit -m 'clean' -m 'D-1 apply'"
+    out=$(label_commit_gate_core_check "$cmd") || rc=$?
+    if [[ "$rc" -eq 1 && -z "$out" ]]; then
+        return 0
+    else
+        echo "ASSERTION FAILED intended-reduction-second-dash-m: expected rc=1 out='', got rc=$rc out='$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
+# Positive control -- an ordinary `git commit -m '<label>'` with nothing
+# preceding it on the line must still deny. Without this, the scoping fix
+# above could regress into never matching anything.
+# =============================================================================
+test_plain_hard_label_denies() {
+    local cmd out rc=0
+    cmd="git commit -m 'fix D-36'"
+    out=$(label_commit_gate_core_check "$cmd") || rc=$?
+    if [[ "$rc" -eq 0 && "$out" == "D-36" ]]; then
+        return 0
+    else
+        echo "ASSERTION FAILED plain-hard-label: expected rc=0 out='D-36', got rc=$rc out='$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
+# Negative control -- a clean subject with no invented label must allow.
+# =============================================================================
+test_clean_subject_allows() {
+    local cmd out rc=0
+    cmd="git commit -m 'add enrich flag'"
+    out=$(label_commit_gate_core_check "$cmd") || rc=$?
+    if [[ "$rc" -eq 1 && -z "$out" ]]; then
+        return 0
+    else
+        echo "ASSERTION FAILED clean-subject: expected rc=1 out='', got rc=$rc out='$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
+# Non-commit command -> allow, unconditionally (fast path).
+# =============================================================================
+test_non_commit_command_allows() {
+    local cmd out rc=0
+    cmd="ls -la"
+    out=$(label_commit_gate_core_check "$cmd") || rc=$?
+    if [[ "$rc" -eq 1 && -z "$out" ]]; then
+        return 0
+    else
+        echo "ASSERTION FAILED non-commit-command: expected rc=1 out='', got rc=$rc out='$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
+# Regression (empty-first-subject fix) -- `git commit -m '' -m '<label>'`.
+# git's own cleanup=strip mode drops the empty first message paragraph and
+# promotes the second -m to the SUBJECT (verified with a real
+# `git commit --allow-empty -m '' -m 'fix D-36'` -> subject `fix D-36`).
+# Before the fix, the core confirmed the first -m as the subject even though
+# its raw captured text was the quoted-empty token `''` (never actually
+# `-z`, since the quote characters themselves are non-empty), so it fell
+# through the `[[ -z "$title" ]]` allow-path and let a subject git itself
+# resolves to `fix D-36` pass unchecked -> false ALLOW.
+# =============================================================================
+test_empty_first_dash_m_promotes_second_to_subject_denies() {
+    local cmd out rc=0
+    cmd="git commit -m '' -m 'fix D-36'"
+    out=$(label_commit_gate_core_check "$cmd") || rc=$?
+    if [[ "$rc" -eq 0 && "$out" == "D-36" ]]; then
+        return 0
+    else
+        echo "ASSERTION FAILED empty-first-dash-m-promotes-second: expected rc=0 out='D-36', got rc=$rc out='$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
+# Negative control for the fix above (must NOT change) -- when the FIRST -m
+# is itself non-empty (e.g. 'clean'), it stays the subject and a label
+# living only in a later -m must keep allowing. This is the SAME documented
+# design exception as test_intended_reduction_label_only_in_second_dash_m_
+# allows above, pinned again with an explicit non-empty first value so a
+# future broadening of the empty-skip fix (e.g. skipping ANY -m whose value
+# doesn't itself carry a label, not just an empty one) cannot silently
+# regress this "subject-only, never body" policy.
+# =============================================================================
+test_nonempty_first_dash_m_label_only_in_second_still_allows() {
+    local cmd out rc=0
+    cmd="git commit -m 'clean' -m 'fix D-1'"
+    out=$(label_commit_gate_core_check "$cmd") || rc=$?
+    if [[ "$rc" -eq 1 && -z "$out" ]]; then
+        return 0
+    else
+        echo "ASSERTION FAILED nonempty-first-dash-m-second-allows: expected rc=1 out='', got rc=$rc out='$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
+# -F/--file scoping (same root cause as the -m regression) -- a -F file path
+# sitting BEFORE the real `git commit` on the line must not be picked up in
+# place of the file path that follows the real commit invocation.
+# =============================================================================
+test_dash_capital_f_scoped_to_segment_after_commit() {
+    local decoy_file real_file cmd out rc=0
+    decoy_file="$TEST_TMP_DIR/decoy.txt"
+    real_file="$TEST_TMP_DIR/real.txt"
+    printf 'clean decoy subject\n' > "$decoy_file"
+    printf 'fix D-1\n' > "$real_file"
+
+    cmd="cat -F $decoy_file > /dev/null; git commit -F $real_file"
+    out=$(label_commit_gate_core_check "$cmd") || rc=$?
+    if [[ "$rc" -eq 0 && "$out" == "D-1" ]]; then
+        return 0
+    else
+        echo "ASSERTION FAILED dash-capital-f-scoped: expected rc=0 out='D-1', got rc=$rc out='$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+main() {
+    echo "=========================================="
+    echo "label-commit-gate-core Tests"
+    echo "=========================================="
+
+    run_test test_regression_unrelated_earlier_dash_m_still_denies
+    run_test test_intended_reduction_label_only_in_second_dash_m_allows
+    run_test test_plain_hard_label_denies
+    run_test test_clean_subject_allows
+    run_test test_non_commit_command_allows
+    run_test test_empty_first_dash_m_promotes_second_to_subject_denies
+    run_test test_nonempty_first_dash_m_label_only_in_second_still_allows
+    run_test test_dash_capital_f_scoped_to_segment_after_commit
+
+    echo "=========================================="
+    echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"
+    echo "=========================================="
+
+    if [[ $TESTS_FAILED -gt 0 ]]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/hooks/label-commit-gate.sh
+++ b/hooks/label-commit-gate.sh
@@ -6,6 +6,15 @@
 # by design: scanning staged content would collide with legitimate
 # `### D-1:` ADR headings.
 # matcher: "Bash"
+#
+# Claude PreToolUse shim over the shared judgment core (hooks/label-commit-
+# gate-core.sh) -- the core owns the git-commit-shape detector, message
+# extraction, and label check (label_commit_gate_core_check), shared
+# verbatim with hooks/codex-label-commit-gate.sh (Codex). This file owns
+# ONLY Claude's tool_input shape and Claude's existing deny envelope
+# (stderr `{"decision":"deny","reason":...}` + exit 2).
+#
+# omt-hook-dep: label-commit-gate-core.sh
 # =============================================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -16,70 +25,16 @@ source "$SCRIPT_DIR/lib/label-patterns.sh" 2>/dev/null || {
     echo "WARNING: label-patterns.sh missing — commit-gate disabled" >&2
     exit 0
 }
+source "$SCRIPT_DIR/label-commit-gate-core.sh" 2>/dev/null || {
+    echo "WARNING: label-commit-gate-core.sh missing — commit-gate disabled" >&2
+    exit 0
+}
 
 input=$(cat)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
 
-# Fast path: not a git commit → passthrough. Tolerates git GLOBAL options
-# between `git` and `commit` (e.g. `git -C <path> commit`), bounded to a
-# single line: the between-run excludes shell operators (&/|/;) AND
-# newline/CR — a newline is also a command separator, so a `git <x>` on
-# one line must never bleed into an unrelated `commit` token on a later
-# line. The two inter-token gaps use [[:blank:]] (space/tab only, never
-# newline) so `git` and `commit` must share one line. Still guards
-# against `git commit-graph`/`commit-tree` by requiring a space or
-# end-of-string after "commit".
-_commit_gate_nl=$'\n\r'
-_commit_gate_re='git[[:blank:]]([^\&\|\;'"$_commit_gate_nl"']*[[:blank:]])?commit([[:space:]]|$)'
-if [[ ! "$cmd" =~ $_commit_gate_re ]]; then
-    exit 0
-fi
+matched_token=$(label_commit_gate_core_check "$cmd") || exit 0
 
-# Extract the commit MESSAGE across ALL documented forms, then scan their
-# union. Human paths (editor-driven commit, bare --amend, -F -) leave the
-# message empty → passthrough. First-match-only extraction previously let
-# documented forms (--message, repeated -m as subject/body, --file <path>)
-# bypass the hard block (Codex PR #161 P2).
-message=""
-
-# Every -m / -am / --message value (space or = form, single or double
-# quoted). git treats repeated -m as subject/body paragraphs, so all values
-# are collected. Iterated because bash =~ captures only the leftmost match
-# per call; each pass strips through the matched value and re-scans the rest.
-# The leading (^|[[:space:]]) pins the flag to a token boundary so
-# -[a-zA-Z]*m never mis-binds to the "-m" substring inside "--message".
-_msg_re='(^|[[:space:]])(-[a-zA-Z]*m|--message)[[:space:]]*=?[[:space:]]*('\''[^'\'']*'\''|"[^"]*")'
-_rest="$cmd"
-while [[ "$_rest" =~ $_msg_re ]]; do
-    _val="${BASH_REMATCH[3]}"
-    _val="${_val#[\'\"]}"; _val="${_val%[\'\"]}"   # strip the surrounding quotes
-    message="$message$_val"$'\n'
-    _rest="${_rest#*"${BASH_REMATCH[0]}"}"          # advance past this match
-done
-
-# -F/--file message file: space form (-F <path>, --file <path>) or
-# --file=<path>. -F - (stdin) is a human path → left unread.
-file_path=""
-if [[ "$cmd" =~ (^|[[:space:]])(-F|--file)[[:space:]]+([^[:space:]]+) ]]; then
-    file_path="${BASH_REMATCH[3]}"
-elif [[ "$cmd" =~ (^|[[:space:]])--file=([^[:space:]]+) ]]; then
-    file_path="${BASH_REMATCH[2]}"
-fi
-if [[ -n "$file_path" && "$file_path" != "-" && -f "$file_path" ]]; then
-    message="$message$(cat "$file_path")"$'\n'
-fi
-
-if [[ -z "$message" ]]; then
-    exit 0
-fi
-
-if label_match_hard "$message"; then
-    # Best-effort extraction of the offending token so the reason names it.
-    matched_token=$(printf '%s\n' "$message" \
-        | LABEL_RE="$_LABEL_PATTERN_HARD" perl -ne 'if (/($ENV{LABEL_RE})/) { print $1; exit }')
-    reason="Invented label in commit message (see rules/communication-style.md). Reword to name the thing, not '${matched_token}'."
-    jq -n --arg reason "$reason" '{decision:"deny",reason:$reason}' >&2
-    exit 2
-fi
-
-exit 0
+reason="Invented label in commit message (see rules/communication-style.md). Reword to name the thing, not '${matched_token}'."
+jq -n --arg reason "$reason" '{decision:"deny",reason:$reason}' >&2
+exit 2

--- a/hooks/label-commit-gate_test.sh
+++ b/hooks/label-commit-gate_test.sh
@@ -299,16 +299,31 @@ test_dash_dash_message_equals_denies() {
         || { echo "ASSERTION FAILED: stderr should name 'D-36'. Got: '$stderr_out'"; return 1; }
 }
 
-# Repeated -m (subject + body): git accepts multiple -m as paragraphs; the
-# label lives in the SECOND value, which the first-match-only extractor missed.
-test_repeated_dash_m_label_in_body_denies() {
-    local exit_code=0 stderr_out
+# Repeated -m (subject + body): git treats the FIRST -m as the commit
+# SUBJECT and any later -m as separate BODY paragraphs. The gate judges the
+# subject only -- a label that lives solely in a later (body) -m must
+# allow, matching rules/communication-style.md's own "### D-1: <name>"
+# carve-out for a body heading that defines itself in place.
+test_repeated_dash_m_label_only_in_body_allows() {
+    local exit_code=0
     local cmd="git commit -m 'clean subject' -m 'fix D-36'"
+    jq -n --arg c "$cmd" '{tool_input:{command:$c}}' \
+        | bash "$HOOK" >/dev/null 2>&1 || exit_code=$?
+
+    [[ "$exit_code" -eq 0 ]] \
+        || { echo "ASSERTION FAILED: label only in 2nd (body) -m should allow (exit=$exit_code)"; return 1; }
+}
+
+# Guard-preserving positive: a label in the FIRST -m (the subject) must
+# still deny even when a later, clean -m (body) follows it.
+test_label_in_first_dash_m_subject_still_denies() {
+    local exit_code=0 stderr_out
+    local cmd="git commit -m 'fix D-36' -m 'clean body paragraph'"
     stderr_out=$(jq -n --arg c "$cmd" '{tool_input:{command:$c}}' \
         | bash "$HOOK" 2>&1 >/dev/null) || exit_code=$?
 
     [[ "$exit_code" -eq 2 ]] \
-        || { echo "ASSERTION FAILED: repeated -m (label in 2nd) should deny (exit=$exit_code)"; return 1; }
+        || { echo "ASSERTION FAILED: label in 1st (subject) -m should deny (exit=$exit_code)"; return 1; }
     echo "$stderr_out" | grep -q "D-36" \
         || { echo "ASSERTION FAILED: stderr should name 'D-36'. Got: '$stderr_out'"; return 1; }
 }
@@ -340,6 +355,77 @@ test_repeated_dash_m_all_clean_passthrough() {
 
     [[ "$exit_code" -eq 0 ]] \
         || { echo "ASSERTION FAILED: repeated -m all-clean should passthrough (exit=$exit_code)"; return 1; }
+}
+
+# =============================================================================
+# `-m=<value>` equals form, UNQUOTED (a bare short-option-concatenated
+# value, e.g. `git commit -m=D-36` -> message "=D-36") -> exit 2. The old
+# quote-only value alternation never captured an unquoted value at all.
+# =============================================================================
+test_dash_m_equals_unquoted_denies() {
+    local exit_code=0 stderr_out
+    local cmd="git commit -m=D-36"
+    stderr_out=$(jq -n --arg c "$cmd" '{tool_input:{command:$c}}' \
+        | bash "$HOOK" 2>&1 >/dev/null) || exit_code=$?
+
+    [[ "$exit_code" -eq 2 ]] \
+        || { echo "ASSERTION FAILED: -m=<unquoted value> should deny (exit=$exit_code)"; return 1; }
+    echo "$stderr_out" | grep -q "D-36" \
+        || { echo "ASSERTION FAILED: stderr should name 'D-36'. Got: '$stderr_out'"; return 1; }
+}
+
+# =============================================================================
+# ANSI-C quoted value (`-m $'...'`) -- a legitimate multi-word quoting form
+# the old regex's single/double-quote-only alternation never recognized as
+# a quote at all -> exit 2.
+# =============================================================================
+test_dash_m_ansi_c_quoted_denies() {
+    local exit_code=0 stderr_out
+    local cmd
+    cmd=$(printf "git commit -m \$'fix D-36 issue'")
+    stderr_out=$(jq -n --arg c "$cmd" '{tool_input:{command:$c}}' \
+        | bash "$HOOK" 2>&1 >/dev/null) || exit_code=$?
+
+    [[ "$exit_code" -eq 2 ]] \
+        || { echo "ASSERTION FAILED: ANSI-C \$'...' quoted -m should deny (exit=$exit_code)"; return 1; }
+    echo "$stderr_out" | grep -q "D-36" \
+        || { echo "ASSERTION FAILED: stderr should name 'D-36'. Got: '$stderr_out'"; return 1; }
+}
+
+# =============================================================================
+# Heredoc body piped into `-F -`: unlike genuine interactive stdin (left
+# unread, see test_stdin_message_dash_f_dash_passthrough), a heredoc
+# attached to that same stdin IS fully known static text in the command
+# string -> its body's first line is the subject -> exit 2.
+# =============================================================================
+test_heredoc_into_dash_capital_f_dash_denies() {
+    local exit_code=0 stderr_out
+    local cmd
+    cmd=$(printf 'git commit -F - <<EOF\nfix D-36\nEOF')
+    stderr_out=$(jq -n --arg c "$cmd" '{tool_input:{command:$c}}' \
+        | bash "$HOOK" 2>&1 >/dev/null) || exit_code=$?
+
+    [[ "$exit_code" -eq 2 ]] \
+        || { echo "ASSERTION FAILED: heredoc body into -F - should deny (exit=$exit_code)"; return 1; }
+    echo "$stderr_out" | grep -q "D-36" \
+        || { echo "ASSERTION FAILED: stderr should name 'D-36'. Got: '$stderr_out'"; return 1; }
+}
+
+# =============================================================================
+# Regression guard: the broadened unquoted-value branch must not let a
+# `m`-ending prefix inside an unrelated long flag (e.g. "-am" inside
+# "--amend") swallow the rest of the line and hide a REAL -m further on.
+# =============================================================================
+test_amend_then_real_dash_m_denies() {
+    local exit_code=0 stderr_out
+    local cmd="git commit --amend -m 'fix D-36'"
+    stderr_out=$(jq -n --arg c "$cmd" '{tool_input:{command:$c}}' \
+        | bash "$HOOK" 2>&1 >/dev/null) || exit_code=$?
+
+    [[ "$exit_code" -eq 2 ]] \
+        || { echo "ASSERTION FAILED: --amend followed by a real -m should still deny (exit=$exit_code)"; return 1; }
+    echo "$stderr_out" | grep -q "D-36" \
+        || { echo "ASSERTION FAILED: stderr should name 'D-36'. Got: '$stderr_out'"; return 1; }
 }
 
 # =============================================================================
@@ -383,9 +469,14 @@ main() {
     run_test test_dash_dash_file_equals_shape_denies
     run_test test_dash_dash_message_space_denies
     run_test test_dash_dash_message_equals_denies
-    run_test test_repeated_dash_m_label_in_body_denies
+    run_test test_repeated_dash_m_label_only_in_body_allows
+    run_test test_label_in_first_dash_m_subject_still_denies
     run_test test_dash_dash_file_space_denies
     run_test test_repeated_dash_m_all_clean_passthrough
+    run_test test_dash_m_equals_unquoted_denies
+    run_test test_dash_m_ansi_c_quoted_denies
+    run_test test_heredoc_into_dash_capital_f_dash_denies
+    run_test test_amend_then_real_dash_m_denies
     run_test test_combined_short_flag_am_denies
     run_test test_git_global_option_before_commit_denies
     run_test test_commit_graph_still_passthrough

--- a/hooks/label-edit-warn-core.sh
+++ b/hooks/label-edit-warn-core.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# =============================================================================
+# label-edit-warn-core.sh
+# Shared judgment core for the "soft-warn on a bare invented/opaque label in
+# just-written content" nudge, sourced by both hooks/label-edit-warn.sh
+# (Claude) and hooks/codex-label-edit-warn.sh (Codex). Owns the full-tier
+# label check (label_match_full) plus the defined-in-place exemption (a
+# label that itself defines a markdown heading, e.g. "### D-1: <name>", is
+# exempt) and the shared warning text.
+#
+# The per-platform shim owns ONLY: extracting the just-written text from its
+# own tool_input shape (Claude: Write/Edit/MultiEdit's content/new_string/
+# edits[].new_string; Codex: the lowercase write|edit|multiedit|multi_edit|
+# apply_patch tool names, mirroring hooks/codex-write-guard.sh's routing) and
+# building its own PostToolUse additionalContext envelope. This hook never
+# blocks on either platform, so there is no deny-envelope divergence to
+# manage (unlike label-commit-gate-core.sh) -- the shim's envelope shape is
+# the same {"hookSpecificOutput": {"hookEventName": "PostToolUse",
+# "additionalContext": ...}} for both.
+#
+# Requires label_match_full and $_LABEL_PATTERN_FULL (hooks/lib/label-
+# patterns.sh) to already be sourced by the caller before
+# label_edit_warn_core_check is invoked.
+#
+# label_edit_warn_core_check <content>
+# Prints the shared warning text and returns 0 iff <content> contains a bare
+# invented/opaque label not defined in place. Prints nothing and returns 1
+# otherwise (including empty content).
+# =============================================================================
+
+_LABEL_EDIT_WARN_CORE_TEXT='Detected a bare invented/opaque label (e.g. D-1, AC M1, Step 3, Phase 2) in the content just written. Per rules/communication-style.md: name the thing instead of coining a label. A label is fine when it defines itself in place (e.g. a heading like "### D-1: <name>") — but a bare reference elsewhere should spell out what it means. This is a soft reminder; nothing was blocked.'
+
+label_edit_warn_core_check() {
+    local content="$1"
+
+    if [ -z "$content" ]; then
+        return 1
+    fi
+
+    if ! label_match_full "$content"; then
+        return 1
+    fi
+
+    # defined-in-place exemption: drop lines that themselves DEFINE a label
+    # as a markdown heading (e.g. "### D-1: Add flag"), then re-check what's
+    # left. Reuses label-patterns.sh's own _LABEL_PATTERN_FULL (the single
+    # source of truth for the label set) so heading recognition never drifts
+    # from bare recognition.
+    local non_define_text
+    non_define_text="$(printf '%s\n' "$content" | LABEL_RE="$_LABEL_PATTERN_FULL" perl -ne 'print unless /^\s*#{1,6}\s+(?:$ENV{LABEL_RE}):/' 2>/dev/null)"
+
+    if ! label_match_full "$non_define_text"; then
+        return 1
+    fi
+
+    printf '%s' "$_LABEL_EDIT_WARN_CORE_TEXT"
+    return 0
+}

--- a/hooks/label-edit-warn-core_test.sh
+++ b/hooks/label-edit-warn-core_test.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# =============================================================================
+# label-edit-warn-core.sh tests
+# Covers label_edit_warn_core_check <content> directly (bypassing both
+# platform shims) -- the full-tier label check (label_match_full) plus the
+# defined-in-place heading exemption. Colocated sibling to
+# hooks/keyword-detector-core_test.sh (no filesystem interaction needed here,
+# same as that core -- unlike hooks/write-guard-core_test.sh, which needs
+# mktemp -d isolation because its core resolves real OMT_DIR paths on disk).
+# Both platform shims (hooks/label-edit-warn.sh, hooks/codex-label-edit-
+# warn.sh) already have their own _test.sh, but the core itself did not.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=./lib/label-patterns.sh
+source "$SCRIPT_DIR/lib/label-patterns.sh"
+# shellcheck source=./label-edit-warn-core.sh
+source "$SCRIPT_DIR/label-edit-warn-core.sh"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+run_test() {
+    local test_name="$1"
+    if "$test_name"; then
+        echo "[PASS] $test_name"
+        ((TESTS_PASSED++)) || true
+    else
+        echo "[FAIL] $test_name"
+        ((TESTS_FAILED++)) || true
+    fi
+}
+
+# =============================================================================
+# Bare label -> warn: prints the shared warning text verbatim, returns 0.
+# =============================================================================
+test_bare_label_warns() {
+    local out rc=0
+    out=$(label_edit_warn_core_check "see D-1") || rc=$?
+    if [[ "$rc" -eq 0 && "$out" == "$_LABEL_EDIT_WARN_CORE_TEXT" ]]; then
+        return 0
+    else
+        echo "ASSERTION FAILED bare-label-warns: expected rc=0 out='\$_LABEL_EDIT_WARN_CORE_TEXT', got rc=$rc out='$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
+# Defined-in-place heading -> exempt: a label that itself defines a markdown
+# heading (e.g. "### D-1: Add flag") must not warn.
+# =============================================================================
+test_defined_in_place_heading_exempt() {
+    local out rc=0
+    out=$(label_edit_warn_core_check '### D-1: Add flag') || rc=$?
+    if [[ "$rc" -eq 1 && -z "$out" ]]; then
+        return 0
+    else
+        echo "ASSERTION FAILED defined-in-place-exempt: expected rc=1 out='', got rc=$rc out='$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
+# Mixed heading + separate bare reference -> still warns. The heading
+# exempts only its own defining line; a bare occurrence elsewhere in the
+# same content remains subject to the check.
+# =============================================================================
+test_mixed_heading_plus_bare_still_warns() {
+    local content out rc=0
+    content=$'### D-1: Add flag\nsee D-1 above'
+    out=$(label_edit_warn_core_check "$content") || rc=$?
+    if [[ "$rc" -eq 0 && "$out" == "$_LABEL_EDIT_WARN_CORE_TEXT" ]]; then
+        return 0
+    else
+        echo "ASSERTION FAILED mixed-heading-plus-bare: expected rc=0 out='\$_LABEL_EDIT_WARN_CORE_TEXT', got rc=$rc out='$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
+# FULL-tier-only pattern ("Phase 2") -> warns. Unlike label-commit-gate-
+# core.sh (label_match_hard only), this core uses label_match_full -- the
+# broader FULL tier is exactly the reason the two cores are NOT merged.
+# =============================================================================
+test_full_tier_only_pattern_warns() {
+    local out rc=0
+    out=$(label_edit_warn_core_check "Phase 2 rollout notes") || rc=$?
+    if [[ "$rc" -eq 0 && "$out" == "$_LABEL_EDIT_WARN_CORE_TEXT" ]]; then
+        return 0
+    else
+        echo "ASSERTION FAILED full-tier-only-pattern: expected rc=0 out='\$_LABEL_EDIT_WARN_CORE_TEXT', got rc=$rc out='$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
+# Plain prose, no label -> allow (no warn).
+# =============================================================================
+test_plain_prose_no_warn() {
+    local out rc=0
+    out=$(label_edit_warn_core_check "just a normal sentence") || rc=$?
+    if [[ "$rc" -eq 1 && -z "$out" ]]; then
+        return 0
+    else
+        echo "ASSERTION FAILED plain-prose-no-warn: expected rc=1 out='', got rc=$rc out='$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
+# Empty content -> allow (no warn), no error.
+# =============================================================================
+test_empty_content_no_warn() {
+    local out rc=0
+    out=$(label_edit_warn_core_check "") || rc=$?
+    if [[ "$rc" -eq 1 && -z "$out" ]]; then
+        return 0
+    else
+        echo "ASSERTION FAILED empty-content-no-warn: expected rc=1 out='', got rc=$rc out='$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+main() {
+    echo "=========================================="
+    echo "label-edit-warn-core Tests"
+    echo "=========================================="
+
+    run_test test_bare_label_warns
+    run_test test_defined_in_place_heading_exempt
+    run_test test_mixed_heading_plus_bare_still_warns
+    run_test test_full_tier_only_pattern_warns
+    run_test test_plain_prose_no_warn
+    run_test test_empty_content_no_warn
+
+    echo "=========================================="
+    echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"
+    echo "=========================================="
+
+    if [[ $TESTS_FAILED -gt 0 ]]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/hooks/label-edit-warn.sh
+++ b/hooks/label-edit-warn.sh
@@ -12,10 +12,18 @@
 # missing-lib fail-open path. It only ever adds additionalContext; it never
 # emits a deny/block decision.
 #
+# Claude PostToolUse shim over the shared judgment core (hooks/label-edit-
+# warn-core.sh) -- the core owns the label check + defined-in-place
+# exemption + warning text (label_edit_warn_core_check), shared verbatim
+# with hooks/codex-label-edit-warn.sh (Codex). This file owns ONLY Claude's
+# tool_input shape (Write/Edit/MultiEdit) and the additionalContext envelope.
+#
 # NOTE: deliberately no `set -euo pipefail` here (mirrors label-commit-gate.sh)
 # — `source`/`.` is a POSIX special builtin, and bash treats its "file not
 # found" error as fatal to the whole shell even inside a `||` when errexit is
 # active, which would defeat the fail-open guard below.
+#
+# omt-hook-dep: label-edit-warn-core.sh
 # =============================================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -24,6 +32,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # deploy drift must never wedge a write/edit.
 source "$SCRIPT_DIR/lib/label-patterns.sh" 2>/dev/null || {
     echo "WARNING: label-patterns.sh missing — label-edit-warn disabled" >&2
+    exit 0
+}
+source "$SCRIPT_DIR/label-edit-warn-core.sh" 2>/dev/null || {
+    echo "WARNING: label-edit-warn-core.sh missing — label-edit-warn disabled" >&2
     exit 0
 }
 
@@ -47,26 +59,7 @@ case "$TOOL_NAME" in
         ;;
 esac
 
-if [ -z "$CONTENT" ]; then
-    exit 0
-fi
-
-if ! label_match_full "$CONTENT"; then
-    exit 0
-fi
-
-# defined-in-place exemption: drop lines that themselves DEFINE a label as a
-# markdown heading (e.g. "### D-1: Add flag"), then re-check what's left.
-# Reuses label-patterns.sh's own _LABEL_PATTERN_FULL (the single source of
-# truth for the label set) so heading recognition never drifts from bare
-# recognition.
-NON_DEFINE_TEXT="$(printf '%s\n' "$CONTENT" | LABEL_RE="$_LABEL_PATTERN_FULL" perl -ne 'print unless /^\s*#{1,6}\s+(?:$ENV{LABEL_RE}):/' 2>/dev/null)"
-
-if ! label_match_full "$NON_DEFINE_TEXT"; then
-    exit 0
-fi
-
-WARNING_TEXT='Detected a bare invented/opaque label (e.g. D-1, AC M1, Step 3, Phase 2) in the content just written. Per rules/communication-style.md: name the thing instead of coining a label. A label is fine when it defines itself in place (e.g. a heading like "### D-1: <name>") — but a bare reference elsewhere should spell out what it means. This is a soft reminder; nothing was blocked.'
+WARNING_TEXT=$(label_edit_warn_core_check "$CONTENT") || exit 0
 
 jq -n --arg ctx "$WARNING_TEXT" '{hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: $ctx}}'
 exit 0

--- a/hooks/pre-tool-enforcer.sh
+++ b/hooks/pre-tool-enforcer.sh
@@ -229,22 +229,80 @@ if [[ -n "$_wg_sid" && -n "$_wg_omt_dir" ]]; then
             # drop the quote CHARACTERS but keep the quoted CONTENT visible, while
             # masking shell-active metachars (`> < | ; &`) that appear INSIDE quotes
             # -- so an in-quote `>` never reads as a live redirect (grep below) and
-            # an in-quote `|`/`;`/`&` never spuriously splits a segment. Metachars
-            # OUTSIDE quotes (real redirects/splitters) and DOUBLE-quoted paths
-            # (`> "$f"`) pass through unchanged, exactly as before.
+            # an in-quote `|`/`;`/`&` never spuriously splits a segment.
+            #
+            # DOUBLE-quoted spans are masked too (CONFIRMED parity fix, both-
+            # platform measurement): this file used to mask single quotes only,
+            # so `echo "note; rm <ledger>"` was read as a live `;`-chain and
+            # DENIED here, while the Codex twin's _cwg_mask_quoted
+            # (hooks/codex-write-guard.sh) already masked double-quoted spans
+            # too and ALLOWED the identical command -- a same-command,
+            # different-verdict divergence against this repo's parity
+            # invariant ("same verdict for the same command", not "identical
+            # code path" -- see hooks/codex-write-guard.sh's own header). This
+            # block is widened to match: quote-toggle logic, the backslash
+            # pass-through that keeps an escaped `\"` from desyncing in-quote
+            # tracking, and the `$( ... )`/backtick-span suspension (a `;`/
+            # `rm` sitting inside a LIVE command substitution nested in double
+            # quotes -- e.g. `echo "$(true; rm <ledger>)"` -- is real shell
+            # code the outer shell actually executes, so masking must not hide
+            # it) are ported verbatim from _cwg_mask_quoted's pre-existing
+            # logic. Independently re-derived here, not sourced from that
+            # file, per this repo's own established Claude/Codex
+            # parsing-independence convention (hooks/codex-write-guard.sh's
+            # file header) -- the two guards can still diverge if one is
+            # edited without the other.
             _wg_scan=$(printf '%s' "$_wg_cmd" | awk '
-                BEGIN { sq = sprintf("%c", 39) }
+                BEGIN { sq = sprintf("%c", 39); dq = sprintf("%c", 34); bs = sprintf("%c", 92); dl = sprintf("%c", 36); lp = sprintf("%c", 40); rp = sprintf("%c", 41); bt = sprintf("%c", 96) }
                 {
                     n = length($0)
-                    inq = 0
+                    insq = 0
+                    indq = 0
+                    dpdepth = 0
+                    btactive = 0
                     out = ""
                     for (i = 1; i <= n; i++) {
                         c = substr($0, i, 1)
-                        if (c == sq) {
-                            inq = 1 - inq
+
+                        if (c == bs && !insq && i < n) {
+                            out = out c substr($0, i + 1, 1)
+                            i++
                             continue
                         }
-                        if (inq && (c == ">" || c == "<" || c == "|" || c == ";" || c == "&")) {
+
+                        if (dpdepth > 0) {
+                            if (c == lp) { dpdepth++ }
+                            else if (c == rp) { dpdepth-- }
+                            out = out c
+                            continue
+                        }
+                        if (btactive) {
+                            if (c == bt) { btactive = 0 }
+                            out = out c
+                            continue
+                        }
+
+                        if (indq && c == dl && i < n && substr($0, i + 1, 1) == lp) {
+                            dpdepth = 1
+                            out = out c lp
+                            i++
+                            continue
+                        }
+                        if (indq && c == bt) {
+                            btactive = 1
+                            out = out c
+                            continue
+                        }
+
+                        if (!indq && c == sq) {
+                            insq = 1 - insq
+                            continue
+                        }
+                        if (!insq && c == dq) {
+                            indq = 1 - indq
+                            continue
+                        }
+                        if ((insq || indq) && (c == ">" || c == "<" || c == "|" || c == ";" || c == "&")) {
                             out = out " "
                             continue
                         }

--- a/hooks/pre-tool-enforcer.sh
+++ b/hooks/pre-tool-enforcer.sh
@@ -259,6 +259,8 @@ if [[ -n "$_wg_sid" && -n "$_wg_omt_dir" ]]; then
                     insq = 0
                     indq = 0
                     dpdepth = 0
+                    subsq = 0
+                    subdq = 0
                     btactive = 0
                     out = ""
                     for (i = 1; i <= n; i++) {
@@ -270,9 +272,36 @@ if [[ -n "$_wg_sid" && -n "$_wg_omt_dir" ]]; then
                             continue
                         }
 
+                        # Quote state INSIDE the substitution is tracked
+                        # separately (subsq/subdq): a QUOTED right-paren --
+                        # as in a printf whose sole argument is that
+                        # character -- is ordinary text to the shell and does
+                        # NOT close the substitution. Untracked, it dropped
+                        # dpdepth to 0, every separator behind it was then
+                        # read as inside the OUTER double quotes and masked
+                        # away, and a chained `rm <ledger>` went unseen. The
+                        # closing right-paren is emitted as a space because
+                        # it is a token boundary at execution time, not part
+                        # of the last word: glued on, it broke the whole-token
+                        # guarded-path comparison downstream.
                         if (dpdepth > 0) {
-                            if (c == lp) { dpdepth++ }
-                            else if (c == rp) { dpdepth-- }
+                            if (subsq) {
+                                if (c == sq) { subsq = 0 }
+                            } else if (subdq) {
+                                if (c == bs && i < n) { out = out c; i++; c = substr($0, i, 1) }
+                                else if (c == dq) { subdq = 0 }
+                            } else if (c == bs && i < n) {
+                                out = out c; i++; c = substr($0, i, 1)
+                            } else if (c == sq) {
+                                subsq = 1
+                            } else if (c == dq) {
+                                subdq = 1
+                            } else if (c == lp) {
+                                dpdepth++
+                            } else if (c == rp) {
+                                dpdepth--
+                                if (dpdepth == 0) { out = out " "; continue }
+                            }
                             out = out c
                             continue
                         }
@@ -284,6 +313,8 @@ if [[ -n "$_wg_sid" && -n "$_wg_omt_dir" ]]; then
 
                         if (indq && c == dl && i < n && substr($0, i + 1, 1) == lp) {
                             dpdepth = 1
+                            subsq = 0
+                            subdq = 0
                             out = out c lp
                             i++
                             continue

--- a/hooks/pre-tool-enforcer_test.sh
+++ b/hooks/pre-tool-enforcer_test.sh
@@ -1333,6 +1333,43 @@ test_wg_r1_unset_home_no_fail_open_denied() {
         || { echo "ASSERTION FAILED WG-R1: \$OMT_DIR-spelled ledger delete must still DENY when HOME is unset. Got: $out"; return 1; }
 }
 
+# (s1) Regression -- a QUOTED right-paren inside a LIVE command substitution
+# does not close the substitution in a real shell, but _wg_scan counted it as
+# a closer. Depth fell to 0 early, the separator behind it was then read as
+# sitting inside the OUTER double quotes and masked away, and the chained
+# ledger delete stopped being its own segment -> false ALLOW. Measured
+# against the pre-change hook, which denied this, so it was a live
+# regression. Same defect and same fix as the Codex twin
+# (hooks/codex-write-guard_test.sh), independently pinned per this repo's
+# Claude/Codex parsing-independence convention.
+test_wg_s1_quoted_paren_in_substitution_ledger_rm_denied() {
+    local ledger sq
+    ledger=$(wg_ledger_path)
+    sq="'"
+    wg_assert_deny "echo \"\$(printf ${sq})${sq}; rm $ledger; true)\"" "WG-S1"
+}
+
+# (s2) The right-paren that CLOSES a substitution is a token boundary at
+# execution time, not part of the preceding word. Glued on, it turned the
+# guarded path into `<ledger>)`, which the whole-token comparison never
+# matched -> false ALLOW. Emitting that closer as a space fixes it.
+test_wg_s2_substitution_closing_paren_adjacent_ledger_rm_denied() {
+    local ledger
+    ledger=$(wg_ledger_path)
+    wg_assert_deny "echo \"\$(true; rm $ledger)\"" "WG-S2"
+}
+
+# (s3) Negative control for s1/s2 -- without it, both arms above would be
+# satisfiable by denying every command that contains a substitution. A
+# substitution carrying the same shapes but touching a NON-ledger path must
+# still pass.
+test_wg_s3_substitution_nonledger_allows() {
+    local out sq
+    sq="'"
+    out=$(printf '%s' "$(hg_bash_json "echo \"\$(printf ${sq})${sq}; rm /tmp/y)\"")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_allow "$out" || { echo "ASSERTION FAILED WG-S3: non-ledger path inside a substitution should pass. Got: $out"; return 1; }
+}
+
 # =============================================================================
 # Defect 5 (Claude<->Codex parity, both-platform measurement) -- this file's
 # quote-aware normalizer (_wg_scan) used to mask single-quoted spans only,
@@ -1688,6 +1725,9 @@ main() {
     run_test test_wg_q3_home_dquoted_var_nonledger_allows
     run_test test_wg_q4_home_toplevel_nonledger_allows
     run_test test_wg_r1_unset_home_no_fail_open_denied
+    run_test test_wg_s1_quoted_paren_in_substitution_ledger_rm_denied
+    run_test test_wg_s2_substitution_closing_paren_adjacent_ledger_rm_denied
+    run_test test_wg_s3_substitution_nonledger_allows
 
     # Defect 5 -- Claude<->Codex ledger-guard parity (double-quote masking)
     run_test test_defect5_row1_plain_redirect_denies

--- a/hooks/pre-tool-enforcer_test.sh
+++ b/hooks/pre-tool-enforcer_test.sh
@@ -1334,6 +1334,75 @@ test_wg_r1_unset_home_no_fail_open_denied() {
 }
 
 # =============================================================================
+# Defect 5 (Claude<->Codex parity, both-platform measurement) -- this file's
+# quote-aware normalizer (_wg_scan) used to mask single-quoted spans only,
+# unlike the Codex twin's _cwg_mask_quoted (hooks/codex-write-guard.sh),
+# which already masked double-quoted spans too. Same command, different
+# verdict: `echo "note; rm <ledger>"` was read here as a live `;`-chain and
+# DENIED, while Codex's wider masker correctly read it as inert double-
+# quoted prose and ALLOWED -- a parity violation against this repo's own
+# invariant ("same verdict for the same command", not "identical code
+# path"). Fixed by widening _wg_scan to mask double-quoted spans too
+# (option (a) from the divergence report: restore equivalence by porting
+# Codex's wider masking here, rather than documenting the gap as accepted).
+# Four rows pin the exact table the fix was verified against; row 2 is the
+# actual defect (DENY before the fix, ALLOW after); rows 1/3/4 are controls
+# proving the fix does not touch what already agreed.
+# =============================================================================
+test_defect5_row1_plain_redirect_denies() {
+    local ledger out
+    ledger=$(wg_ledger_path)
+    out=$(printf '%s' "$(hg_bash_json "echo x > $ledger")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" || { echo "ASSERTION FAILED defect5-row1(plain redirect): expected deny. Got: $out"; return 1; }
+}
+
+# Row 2 -- the defect itself. Before the fix this DENIED (parity violation
+# against Codex's allow); after, ALLOWS.
+test_defect5_row2_dquoted_semicolon_now_allows() {
+    local ledger out
+    ledger=$(wg_ledger_path)
+    out=$(printf '%s' "$(hg_bash_json "echo \"note; rm $ledger\"")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_allow "$out" || { echo "ASSERTION FAILED defect5-row2(dquoted semicolon, THE FIX): expected allow (parity with Codex's _cwg_mask_quoted, which already masks double quotes). Got: $out"; return 1; }
+}
+
+test_defect5_row3_squoted_semicolon_still_allows() {
+    local ledger out
+    ledger=$(wg_ledger_path)
+    out=$(printf '%s' "$(hg_bash_json "echo 'note; rm $ledger'")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_allow "$out" || { echo "ASSERTION FAILED defect5-row3(squoted semicolon control): expected allow (unchanged by the fix). Got: $out"; return 1; }
+}
+
+test_defect5_row4_real_chain_semicolon_still_denies() {
+    local ledger out
+    ledger=$(wg_ledger_path)
+    out=$(printf '%s' "$(hg_bash_json "echo hi; rm $ledger")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" || { echo "ASSERTION FAILED defect5-row4(real chain control): expected deny (a real unquoted ';' must stay live). Got: $out"; return 1; }
+}
+
+# Cross-platform proof: runs BOTH real hooks (not a read of either file's own
+# masking logic, which would be tautological) against the row-2 command under
+# the SAME OMT_DIR/session, then compares verdicts -- the actual parity claim
+# this fix makes, not just "Claude alone now allows it".
+test_defect5_codex_claude_verdict_parity() {
+    local ledger claude_out codex_out result=0
+    ledger=$(wg_ledger_path)
+
+    claude_out=$(printf '%s' "$(hg_bash_json "echo \"note; rm $ledger\"")" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+
+    codex_out=$(jq -n --arg cmd "echo \"note; rm $ledger\"" --arg cwd "$OMT_DIR" \
+        '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"test-sid", cwd:$cwd}' \
+        | env -u CODEX_THREAD_ID OMT_DIR="$OMT_DIR" OMT_SESSION_ID="test-sid" bash "$SCRIPT_DIR/codex-write-guard.sh")
+
+    hg_is_allow "$claude_out" || { echo "ASSERTION FAILED defect5-parity: claude leg did not allow. Got: $claude_out"; result=1; }
+    if printf '%s' "$codex_out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED defect5-parity: codex leg unexpectedly denied. Got: $codex_out"
+        result=1
+    fi
+
+    return "$result"
+}
+
+# =============================================================================
 # Code-review artifact identity guard (code-review-artifact-guard-core plan)
 # -- wires codereview_guard_core_run (hooks/write-guard-core.sh) into this
 # adapter. Distinct guard from the ledger write-guard above: the ledger guard
@@ -1619,6 +1688,13 @@ main() {
     run_test test_wg_q3_home_dquoted_var_nonledger_allows
     run_test test_wg_q4_home_toplevel_nonledger_allows
     run_test test_wg_r1_unset_home_no_fail_open_denied
+
+    # Defect 5 -- Claude<->Codex ledger-guard parity (double-quote masking)
+    run_test test_defect5_row1_plain_redirect_denies
+    run_test test_defect5_row2_dquoted_semicolon_now_allows
+    run_test test_defect5_row3_squoted_semicolon_still_allows
+    run_test test_defect5_row4_real_chain_semicolon_still_denies
+    run_test test_defect5_codex_claude_verdict_parity
 
     # Code-review artifact identity guard (code-review-artifact-guard-core plan)
     run_test test_cr1_write_ultragoal_codereview_no_agent_type_denied

--- a/hooks/write-guard-core.sh
+++ b/hooks/write-guard-core.sh
@@ -134,6 +134,64 @@ _wg_core_pathwise_glob_match() {
 # ledger path (e.g. `rm "$OMT_DIR"/session-ledger-*.md` never EXACT-matches
 # but would still destroy the current-session ledger); else emits nothing
 # (allow).
+# Claude<->Codex parity story 9/9: the second deny reason this core owns,
+# alongside the ledger deny above. Claude enforces this same policy natively
+# via claude.yaml's declarative `permissions.deny` glob list (own product-UI
+# deny text, not authored by OMT and not mechanically reproducible here) --
+# Codex has no equivalent declarative primitive, so hooks/codex-write-guard.sh
+# calls write_guard_core_check_dangerous_command below to emulate the same
+# verdict via a PreToolUse hook deny. hooks/pre-tool-enforcer.sh (Claude) does
+# NOT call this function: Claude already denies these commands natively, so
+# wiring a second hook-level deny on top would only add risk (ordering
+# against the native deny, a different message than users already see) for a
+# case that is not broken. The invariant this repo's parity is built on is
+# "same verdict for the same command", not "identical code path" (see
+# reference_parity_is_shared_invariant_not_symmetric_copy) -- Codex closes
+# the actual gap; Claude's existing behavior is left untouched.
+_wg_core_dangerous_deny_json='{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Blocked: destructive command (rm -rf/-fr/-Rf/-r -f/-f -r, or git push --force/-f in any position) is denied -- Codex-side enforcement of the same policy Claude applies natively via claude.yaml permissions.deny."}}'
+
+# write_guard_core_check_dangerous_command <command-segment>
+# Tests ONE already-split shell chain segment (caller owns splitting on
+# &&/||/;/| and any quote-masking -- same division of labor as
+# write_guard_core_run above) against claude.yaml's declarative
+# permissions.deny glob set for rm -rf and git push --force, mirrored 1:1:
+#   Bash(rm -rf *) / Bash(rm -fr *) / Bash(rm -Rf *) / Bash(rm -r -f *) / Bash(rm -f -r *)
+#   Bash(git push --force*) / Bash(git push * --force*) / Bash(git push -f*) / Bash(git push * -f*)
+# Emits the deny JSON iff the (leading-whitespace-trimmed) segment matches one
+# of those patterns; else emits nothing (allow). Plain `rm <path>` / `rm -r
+# <path>` / `git push <remote> <branch>` (no force flag) do NOT match any
+# pattern -- the negative control this guard needs to be distinguishable from
+# "deny everything" (AC4).
+write_guard_core_check_dangerous_command() {
+    local seg="$1"
+    # Trim leading whitespace only (a chain segment split off after `&&`/`;`
+    # carries the separator's trailing space) -- patterns below are anchored
+    # to the start of the command, so a stray leading space would silently
+    # miss every case.
+    seg="${seg#"${seg%%[![:space:]]*}"}"
+    # Collapse internal whitespace runs (spaces AND tabs) to a single space
+    # (CONFIRMED bypass, both-platform measurement): the patterns below are
+    # literal-token globs requiring EXACTLY one space between words
+    # ("rm -rf "*), but a real shell treats any run of spaces/tabs between
+    # tokens as an equivalent single word separator -- `rm  -rf x` (two
+    # spaces) or `rm<TAB>-rf x` still runs `rm -rf x` at real execution time,
+    # yet the literal-space pattern silently failed to match either variant,
+    # ALLOWing a destructive command that Claude denies natively (its own
+    # shell-aware parser is whitespace-run-tolerant). Collapsing here only
+    # normalizes the CLASSIFICATION input to this function, not any candidate
+    # path text elsewhere, so it carries no over-block risk beyond making the
+    # 9 literal patterns below whitespace-run-tolerant like a real shell.
+    seg="$(printf '%s' "$seg" | tr -s '[:space:]' ' ')"
+    case "$seg" in
+        "rm -rf "* | "rm -fr "* | "rm -Rf "* | "rm -r -f "* | "rm -f -r "* | \
+        "git push --force"* | "git push "*" --force"* | "git push -f"* | "git push "*" -f"*)
+            printf '%s\n' "$_wg_core_dangerous_deny_json"
+            return 0
+            ;;
+    esac
+    return 0
+}
+
 write_guard_core_run() {
     local omt_dir="$1"
     local session_id="$2"

--- a/hooks/write-guard-core_test.sh
+++ b/hooks/write-guard-core_test.sh
@@ -366,6 +366,180 @@ test_glob_dotfile_basename_star_denies() {
 }
 
 # =============================================================================
+# Claude<->Codex parity story 9/9, AC2/AC4 -- write_guard_core_check_dangerous_
+# command <command-segment> mirrors claude.yaml's declarative permissions.deny
+# glob set (rm -rf/-fr/-Rf/-r -f/-f -r, git push --force/-f in either
+# position) for the platform (Codex) that has no native declarative permission
+# engine. DENY cases below are the positive set; ALLOW cases (plain rm, rm -r,
+# non-force git push) are the negative control -- without them a deny guard
+# cannot be told apart from "deny everything".
+# =============================================================================
+test_dangerous_rm_rf_denies() {
+    local out
+    out=$(bash -c "source '$CORE'; write_guard_core_check_dangerous_command 'rm -rf /tmp/x'")
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED dangerous-rm-rf: expected deny for 'rm -rf /tmp/x', got '$out'"
+        return 1
+    fi
+}
+
+test_dangerous_rm_fr_denies() {
+    local out
+    out=$(bash -c "source '$CORE'; write_guard_core_check_dangerous_command 'rm -fr /tmp/x'")
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED dangerous-rm-fr: expected deny for 'rm -fr /tmp/x', got '$out'"
+        return 1
+    fi
+}
+
+test_dangerous_rm_r_dash_f_denies() {
+    local out
+    out=$(bash -c "source '$CORE'; write_guard_core_check_dangerous_command 'rm -r -f /tmp/x'")
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED dangerous-rm-r-dash-f: expected deny for 'rm -r -f /tmp/x', got '$out'"
+        return 1
+    fi
+}
+
+test_dangerous_git_push_force_denies() {
+    local out
+    out=$(bash -c "source '$CORE'; write_guard_core_check_dangerous_command 'git push --force'")
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED dangerous-git-push-force: expected deny for 'git push --force', got '$out'"
+        return 1
+    fi
+}
+
+test_dangerous_git_push_origin_force_denies() {
+    local out
+    out=$(bash -c "source '$CORE'; write_guard_core_check_dangerous_command 'git push origin --force'")
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED dangerous-git-push-origin-force: expected deny for 'git push origin --force', got '$out'"
+        return 1
+    fi
+}
+
+test_dangerous_git_push_dash_f_denies() {
+    local out
+    out=$(bash -c "source '$CORE'; write_guard_core_check_dangerous_command 'git push origin -f'")
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED dangerous-git-push-dash-f: expected deny for 'git push origin -f', got '$out'"
+        return 1
+    fi
+}
+
+# Negative control (AC4) -- a plain rm / rm -r / non-force git push must NOT
+# be denied. Without this, a deny guard is indistinguishable from "deny
+# everything".
+test_negative_plain_rm_allows() {
+    local out
+    out=$(bash -c "source '$CORE'; write_guard_core_check_dangerous_command 'rm /tmp/x'")
+    if [ -z "$out" ]; then
+        return 0
+    else
+        echo "ASSERTION FAILED negative-plain-rm: expected empty (ALLOW), got '$out'"
+        return 1
+    fi
+}
+
+test_negative_rm_r_allows() {
+    local out
+    out=$(bash -c "source '$CORE'; write_guard_core_check_dangerous_command 'rm -r /tmp/x'")
+    if [ -z "$out" ]; then
+        return 0
+    else
+        echo "ASSERTION FAILED negative-rm-r: expected empty (ALLOW), got '$out'"
+        return 1
+    fi
+}
+
+test_negative_git_push_no_force_allows() {
+    local out
+    out=$(bash -c "source '$CORE'; write_guard_core_check_dangerous_command 'git push origin main'")
+    if [ -z "$out" ]; then
+        return 0
+    else
+        echo "ASSERTION FAILED negative-git-push-no-force: expected empty (ALLOW), got '$out'"
+        return 1
+    fi
+}
+
+# =============================================================================
+# Regression (CONFIRMED bypass, both-platform measurement) -- the 9 dangerous-
+# command patterns are literal-token globs requiring EXACTLY one ASCII space
+# between words ("rm -rf "*), but a real shell treats any run of spaces/tabs
+# between tokens as an equivalent single separator: `rm  -rf x` (two spaces)
+# and `rm<TAB>-rf x` both run `rm -rf x` at real execution time, yet neither
+# literally matched the single-space pattern, silently ALLOWING a command
+# Claude denies natively (its own shell-aware parser is whitespace-run-
+# tolerant). Fix: collapse internal whitespace runs to a single space before
+# the case match. Each DENY case below reproduces one whitespace-run variant;
+# the ALLOW controls prove the collapse does not turn ordinary whitespace
+# into an over-broad denier.
+# =============================================================================
+test_dangerous_rm_rf_double_space_denies() {
+    local out
+    out=$(bash -c "source '$CORE'; write_guard_core_check_dangerous_command 'rm  -rf /tmp/x'")
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED dangerous-rm-rf-double-space: expected deny for 'rm  -rf /tmp/x' (two spaces), got '$out'"
+        return 1
+    fi
+}
+
+test_dangerous_rm_rf_tab_denies() {
+    local out cmd
+    cmd=$(printf 'rm\t-rf /tmp/x')
+    out=$(bash -c "source '$CORE'; write_guard_core_check_dangerous_command \"\$1\"" _ "$cmd")
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED dangerous-rm-rf-tab: expected deny for 'rm<TAB>-rf /tmp/x', got '$out'"
+        return 1
+    fi
+}
+
+test_dangerous_git_push_force_multispace_denies() {
+    local out
+    out=$(bash -c "source '$CORE'; write_guard_core_check_dangerous_command 'git  push  --force'")
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED dangerous-git-push-force-multispace: expected deny for 'git  push  --force', got '$out'"
+        return 1
+    fi
+}
+
+# Negative controls -- ordinary single-space commands must be unaffected by
+# the whitespace collapse (already covered by test_negative_plain_rm_allows /
+# test_negative_git_push_no_force_allows above); this control additionally
+# proves a harmless command that itself contains a double-space in a
+# non-leading position stays allowed (the collapse does not turn benign
+# multi-space text into a denier).
+test_negative_double_space_nondangerous_allows() {
+    local out
+    out=$(bash -c "source '$CORE'; write_guard_core_check_dangerous_command 'echo  hello  world'")
+    if [ -z "$out" ]; then
+        return 0
+    else
+        echo "ASSERTION FAILED negative-double-space-nondangerous: expected empty (ALLOW), got '$out'"
+        return 1
+    fi
+}
+
 # codereview_guard_core_run <OMT_DIR> <session_id> <agent_type> tests
 # (code-review-artifact-guard-core plan) -- identity-conditional guard: unlike
 # write_guard_core_run's unconditional deny, this one allows the SAME guarded
@@ -610,6 +784,19 @@ main() {
     run_test test_glob_dotfile_literal_project_star_denies
     run_test test_glob_dotfile_basename_partial_star_denies
     run_test test_glob_dotfile_basename_star_denies
+    run_test test_dangerous_rm_rf_denies
+    run_test test_dangerous_rm_fr_denies
+    run_test test_dangerous_rm_r_dash_f_denies
+    run_test test_dangerous_git_push_force_denies
+    run_test test_dangerous_git_push_origin_force_denies
+    run_test test_dangerous_git_push_dash_f_denies
+    run_test test_negative_plain_rm_allows
+    run_test test_negative_rm_r_allows
+    run_test test_negative_git_push_no_force_allows
+    run_test test_dangerous_rm_rf_double_space_denies
+    run_test test_dangerous_rm_rf_tab_denies
+    run_test test_dangerous_git_push_force_multispace_denies
+    run_test test_negative_double_space_nondangerous_allows
     run_test test_ac_codereview_byte_identical_deny
     run_test test_codereview_guard_ultragoal_empty_agent_type_denies
     run_test test_codereview_guard_ultragoal_missing_agent_type_denies


### PR DESCRIPTION
## 📌 Summary

쓰기·커밋을 막는 **PreToolUse/PostToolUse 가드 3종**의 Codex 패리티를 맞춘다 — write-guard(위험 명령·세션 렛저), label-commit-gate(커밋 제목의 임의 라벨 하드 블록), label-edit-warn(작성 내용의 임의 라벨 소프트 경고).

핵심 판단은 **패리티의 기준을 "같은 코드 경로"가 아니라 "같은 명령에 같은 판정"으로 잡은 것**이다. Claude는 `rm -rf`·`git push --force`를 `claude.yaml`의 `permissions.deny` 글롭으로 **네이티브하게** 막는다. Codex에는 선언적 deny 프리미티브 자체가 없어서, `codex-write-guard.sh`가 같은 글롭 집합을 bash `case`로 에뮬레이션한다. 훅 레이어만 비교하면 Claude가 "허용"하는 것처럼 보이지만, 두 플랫폼은 구조가 다른 경로로 **같은 판정에 도달한다.**

---

## 🔧 Changes

### `hooks/write-guard-core.sh` — 공유 판정 코어

- `write_guard_core_run` — 세션 렛저 쓰기 가드 (양 플랫폼 공유).
- `codereview_guard_core_run` — code-review 아티팩트 신원 가드 (양 플랫폼 공유).
- `write_guard_core_check_dangerous_command` — 위험 명령 deny. **의도적으로 Codex 전용**이며 미러가 아니다. `claude.yaml`의 `permissions.deny` 글롭 집합을 bash `case` 형태로 1:1 대응시켰다.
- deny 사유 문구의 단일 출처. 어댑터는 페이로드 필드를 추출해 전달할 뿐, 판정을 다시 유도하지 않는다.

**영향 범위**
`hooks/pre-tool-enforcer.sh`(Claude)는 위험 명령 검사를 **갖지 않는다** — 가지면 `permissions.deny`와 이중 판정이 된다. 이 비대칭은 CLAUDE.md 훅 목록에 명시했다.

### `hooks/pre-tool-enforcer.sh` — 따옴표 마스킹 폭 확장

- 명령 스캔이 작은따옴표 구간만 마스킹하던 것을 **큰따옴표 구간까지** 확장.
- 명령 치환(`$(...)`) 회귀 케이스 보강.

**영향 범위**
Claude 실제 동작과 맞추는 방향의 수정이다 — `echo "note; rm x"`를 Claude는 한 개 명령으로 본다. 마스킹이 좁으면 가드가 문자열 리터럴 안의 구분자를 진짜 구분자로 오인해 **오탐(false deny)** 을 낸다. 이 가드에는 bypass나 `ask` 탈출구가 없어 오탐이 사용자에게 회복 불가능하다.

### `hooks/label-commit-gate-core.sh` + `label-commit-gate.sh` + `codex-label-commit-gate.sh`

- 커밋 **제목(subject)** 에 임의/불투명 라벨(`D-1`, `T1`, `WI-4` 류)이 있으면 하드 블록.
- git commit 형태 인식: 문서화된 모든 `-m`/`-am`/`--message`/`-F`/`--file` 형태.
- **제목만** 검사하고 본문은 보지 않는다.
- Codex의 `apply_patch` 형태 처리와 빈 `-m` 스코핑 수정.

**영향 범위**
deny envelope은 **플랫폼별로 다르다** — Claude는 기존 계약대로 stderr + exit 2, Codex는 `hookSpecificOutput` + `permissionDecision:"deny"`. Claude의 선행 계약을 바꾸지 않기 위한 의도적 분기다.

### `hooks/label-edit-warn-core.sh` + `label-edit-warn.sh` + `codex-label-edit-warn.sh`

- 방금 쓴 내용에 **그 자리에서 정의되지 않은** 임의 라벨이 있으면 소프트 경고. **절대 차단하지 않는다.**
- 정의됨 예외: 라벨 자신이 제목을 만들면(`### D-1: <이름>`) 면제.
- Codex 어댑터는 `write`/`edit`/`multiedit`/`multi_edit`/`apply_patch`를 커버하며, patch에서는 **추가된 줄만** 검사한다.

**영향 범위**
commit gate와 달리 여기서는 양 플랫폼이 **동일한 `PostToolUse`/`additionalContext` envelope**을 낸다 — deny가 아니라 nudge라서 관리할 분기가 없다.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 위험 명령 deny를 Codex에만 넣은 것은 격차가 아니라 정석 매핑

**배경 및 문제 상황:**
`rm -rf`·`git push --force` 차단은 Claude에서 `claude.yaml`의 `permissions.deny` 글롭으로 이미 걸려 있다. Codex에는 대응하는 **선언적 deny 프리미티브가 없다.**

작업 중 이걸 실제로 잘못 측정했다. `rm -rf /tmp/zz`를 두 훅에 던져 Claude=allow / Codex=DENY가 나오자 "불일치"로 보고했는데, 틀렸다 — Claude 훅이 allow를 낸 건 그 정책을 **훅이 아닌 곳에서** 집행하기 때문이고, 최종 판정은 양쪽 다 deny다. 측정 고도가 틀린 것이었다.

**해결 방안:**
`write_guard_core_check_dangerous_command`를 만들되 **Codex 어댑터에서만** 호출한다. `claude.yaml` 글롭 집합과 bash `case` 패턴을 1:1로 대응시켜, 한쪽이 바뀌면 다른 쪽도 바꿔야 함이 눈에 보이게 했다.

**선택과 트레이드오프:**
패리티 기준은 **"같은 명령에 같은 판정"** 이다. "같은 코드 경로"를 기준으로 삼으면, 플랫폼이 제공하는 네이티브 프리미티브를 버리고 훅으로 재구현해야 한다 — Claude에서 `permissions.deny`를 떼고 훅으로 옮기는 건 더 약하고(선언적 집행 → 훅 집행) 더 복잡한 방향이다.

**대가는 두 곳을 동기화해야 한다는 것이다.** 글롭 집합이 `claude.yaml`과 `write-guard-core.sh` 두 파일에 살아 있고, 자동 검증이 없다. 한쪽만 늘면 조용히 갈라진다. 현재는 주석과 CLAUDE.md 문서화로만 묶여 있다 — 여기가 이 PR에서 가장 리뷰가 필요한 지점이다.

### 2. 따옴표 마스킹 — 좁으면 오탐, 넓으면 미탐, 오탐 쪽이 훨씬 비싸다

**배경 및 문제 상황:**
가드가 `;`·`&&`·`|` 같은 구분자로 명령을 쪼개 각 조각을 검사하는데, 그 구분자가 **문자열 리터럴 안에** 있을 수 있다. `echo "note; rm x"`는 한 개 명령이다.

**해결 방안:**
마스킹 폭을 작은따옴표에서 큰따옴표 구간까지 넓혀, 셸이 실제로 하는 토큰화에 근접시켰다.

**선택과 트레이드오프:**
두 방향의 오류가 대칭이 아니다.
- **미탐(놓침)**: 위험 명령이 통과한다. 나쁘지만, 다른 층(`permissions.deny`, 사용자 확인)이 남아 있다.
- **오탐(오차단)**: 평범한 명령이 막힌다. **이 가드에는 bypass도 `ask` 탈출구도 없어서, 사용자가 회복할 방법이 없다.**

그래서 애매하면 통과시키는 쪽으로 기울였다. 같은 이유로 `verify-entrypoint-gate`도 "deny 아니면 무개입"만 하고 절대 `allow`를 발급하지 않는다.

**남는 사각은 명시적으로 인정한다**: 셸 변수/파라미터 확장(`pnpm${IFS}test`)이나 명령 치환을 통과한 경로는 리터럴 argv 텍스트만 보는 이 파일에 **원리적으로 보이지 않는다.** 유한한 정적 규칙으로는 평범한 명령을 오차단하지 않으면서 이걸 닫을 수 없다.

### 3. 라벨 게이트는 제목만 본다 — git이 본문을 다루는 방식과 맞추기 위해

**배경 및 문제 상황:**
임의 라벨 금지 규칙(`D-1`, `T1` 같은 사적 축약어를 독자가 이미 안다는 듯 던지지 말 것)을 커밋 메시지에 강제할 때, 검사 범위를 제목까지로 할지 본문까지로 할지가 문제였다.

**해결 방안:**
**제목만** 검사한다. 본문의 라벨은 통과시킨다.

**선택과 트레이드오프:**
제목은 `git log --oneline`·PR 목록·blame 등 **맥락이 잘려나간 자리에 단독으로 나타난다** — 거기서 `D-1`은 해독 불가능하다. 본문은 항상 자기 문맥과 함께 읽히고, 그 안에서 라벨을 정의할 수도 있다.

같은 논리를 edit-warn에도 적용했다: 라벨이 **그 자리에서 자기를 정의하면**(`### D-1: 재시도 타임아웃 수정`) 면제한다. 규칙이 금지하는 건 라벨의 존재가 아니라 **정의 없는 라벨**이다.

commit gate는 하드 블록, edit-warn은 절대 차단하지 않는 nudge로 나눈 것도 같은 축이다. 커밋은 되돌리기 비싼 영구 기록이고, 편집 중인 파일은 아직 아무 데도 안 갔다.

---

## ✅ Checklist

### 위험 명령
- [ ] Codex에서 `rm -rf`·`git push --force`가 deny된다
  - `hooks/codex-write-guard.sh`
- [ ] `write-guard-core.sh`의 `case` 패턴 집합이 `claude.yaml` `permissions.deny` 글롭 집합과 1:1 대응한다
  - `hooks/write-guard-core.sh`
- [ ] Claude 훅은 위험 명령 검사를 하지 않는다 (네이티브 집행과 이중 판정 방지)
  - `hooks/pre-tool-enforcer.sh`

### 따옴표 마스킹
- [ ] `echo "note; rm x"`가 오차단되지 않는다 (오탐 회귀)
  - `hooks/pre-tool-enforcer.sh`
- [ ] 명령 치환을 포함한 형태에서 기존 판정이 유지된다
  - `hooks/pre-tool-enforcer_test.sh`

### 커밋 라벨 게이트
- [ ] 제목에 정의 없는 라벨이 있는 `git commit`이 차단된다
  - `hooks/label-commit-gate-core.sh`
- [ ] 본문에만 라벨이 있는 커밋은 통과한다 (음성 대조군)
  - `hooks/label-commit-gate-core_test.sh`
- [ ] `-m`/`-am`/`--message`/`-F`/`--file` 전 형태에서 제목이 올바르게 추출된다
  - `hooks/label-commit-gate-core.sh`
- [ ] Claude는 stderr + exit 2, Codex는 `permissionDecision:"deny"`로 각자의 계약을 유지한다
  - `hooks/label-commit-gate.sh`
  - `hooks/codex-label-commit-gate.sh`

### 편집 라벨 경고
- [ ] 정의 없는 라벨에 경고가 나오되 **차단되지 않는다**
  - `hooks/label-edit-warn-core.sh`
- [ ] `### D-1: <이름>` 형태로 그 자리에서 정의된 라벨은 경고하지 않는다
  - `hooks/label-edit-warn-core_test.sh`
- [ ] Codex `apply_patch`에서 **추가된 줄만** 검사한다 (기존 줄 오탐 방지)
  - `hooks/codex-label-edit-warn.sh`

---

## 📎 References

이 PR은 Claude↔Codex 패리티 스택의 **4/5**입니다. 각 PR은 바로 앞 PR을 base로 쌓이며, 5개 모두 `make validate` / `make test` exit 0으로 **독립 검증**되었습니다.

1. #199 — codex 배포 파이프라인 번역 충실도와 게이팅 개방
2. #200 — rules 카테고리 배포와 codex rules supersede
3. #201 — keyword-detector·persistent-mode codex 패리티
4. **#202 — write-guard·label 게이트 codex 패리티** ← 현재 PR
5. #203 — codex 세션 행동 검증 프로브 하네스

#201과 같은 패턴(공유 판정 코어 + 플랫폼 어댑터)을 씁니다. 다만 이 PR에서는 deny envelope이 플랫폼별로 갈라지는데, #201에서 설명한 "패리티는 같은 JSON 모양이 아니라 같은 판정"의 두 번째 사례입니다.
