### PR TITLE
refactor: 모델 배정 원칙 적용과 model-map 정리

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -58,6 +58,7 @@ The details of the library's skills (42) and agents (13) live under `docs/`.
 | [Utilities & Personal Workflows](docs/skills/utilities-personal.en.md) | hud · resume · jd · mock-interview, etc. |
 | [Private Fork Management](docs/PRIVATE-FORK-MANAGEMENT.en.md) | Operating a private fork — mirroring upstream and continuous sync |
 | [Orchestration Guide](docs/ORCHESTRATION.en.md) | prometheus → sisyphus workflow and usage |
+| [Model Assignment](docs/model-assignment.en.md) | Per-agent model tier principles and `model-map` substitution rules |
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ oh-my-toong은 **에이전트 중앙 관리 프로젝트**입니다. 스킬, 에
 | [유틸·개인 워크플로우](docs/skills/utilities-personal.md) | hud · resume · jd · mock-interview 등 |
 | [프라이빗 포크 관리](docs/PRIVATE-FORK-MANAGEMENT.md) | 프라이빗 포크 운영 가이드 — 업스트림 미러링과 지속 동기화 |
 | [오케스트레이션 가이드](docs/ORCHESTRATION.md) | prometheus → sisyphus 워크플로우와 사용법 |
+| [모델 배정](docs/model-assignment.md) | 에이전트별 모델 등급 배정 원칙과 `model-map` 치환 규칙 |
 
 ## Quick Start
 

--- a/agents/hermes.md
+++ b/agents/hermes.md
@@ -1,7 +1,7 @@
 ---
 name: hermes
 description: Use when fetching content from blocked, authenticated, or bot-protected sources that resist plain HTTP. Depth-escalation peer to explore/librarian — escalates through three tiers (curl_cffi → agent-reach → Chrome stealth) until the validator confirms extraction
-model: opus
+model: sonnet
 skills: insane-browsing
 disallowedTools: Agent
 ---

--- a/codex.yaml
+++ b/codex.yaml
@@ -16,26 +16,24 @@
 config: {}
 
 model-map:
+  # Tiers set the model only. Omitting `effort` leaves `model_reasoning_effort`
+  # out of the emitted role TOML (tools/adapters/codex.ts:55), so each agent runs
+  # at whatever effort the session is configured for instead of a value frozen at
+  # sync time.
   tiers:
     opus:
       model: gpt-5.6-sol
-      effort: high
     sonnet:
       model: gpt-5.6-terra
-      effort: medium
-  agents:
-    code-reviewer:
-      model: gpt-5.6-sol
-      effort: high
-    metis:
-      model: gpt-5.6-sol
-      effort: high
-    momus:
-      model: gpt-5.6-sol
-      effort: high
-    tech-claim-examiner:
-      model: gpt-5.6-sol
-      effort: high
+  # `agents:` is for what a tier cannot express. With tiers carrying model alone,
+  # that is effort: an agent that must pin an effort rather than follow the
+  # session. It previously held code-reviewer/metis/momus/tech-claim-examiner,
+  # all four byte-identical to `tiers.opus`, so they resolved to the same TOML
+  # either way and were removed. A new entry must name what tier it could not
+  # be expressed as. Unlike `config:` above, an absent key is safe here:
+  # resolution is `modelMap.agents?.[name] ?? modelMap.tiers[tier]`
+  # (tools/adapters/codex.ts:54), and agent TOMLs are rewritten wholesale
+  # (codex.ts:431), so nothing stale survives a sync.
 hooks:
   SessionStart:
     - component: rules-injector

--- a/docs/model-assignment.en.md
+++ b/docs/model-assignment.en.md
@@ -42,8 +42,8 @@ current Sonnet value is this clause applied.
 The test: does the verdict the agent returns come from **its own model's
 reasoning**, or is it carrying another process's output through? The latter is
 delegation. `hermes` is the illustrative case — it looks like it produces its own
-verdict, but the verdict actually comes from the `ValidationVerdict` enum in
-`engine/validators.py`.
+verdict, but the verdict actually comes from the `Verdict` enum in
+`skills/insane-browsing/engine/validators.py`.
 
 ## Current assignment
 
@@ -126,8 +126,8 @@ for choosing opus.
 
 Its role is depth peer to `explore` (codebase) and `librarian` (external docs),
 taking over when they hit a wall — the search family. Both peers are sonnet. Its
-verdict comes from the `ValidationVerdict` enum in `engine/validators.py`, not
-from its own model.
+verdict comes from the `Verdict` enum in
+`skills/insane-browsing/engine/validators.py`, not from its own model.
 
 ### `explore` and `librarian` stay sonnet (2026-07-28)
 

--- a/docs/model-assignment.en.md
+++ b/docs/model-assignment.en.md
@@ -1,0 +1,172 @@
+# Agent Model Assignment
+
+Which model tier each agent gets, and how that tier is substituted into a
+concrete per-platform model.
+
+This document exists for a specific reason. The two principles below were decided
+on 2026-06-26 and 2026-07-21, but they lived **only in commit bodies** — and as a
+result `hermes` kept its initial value through 2026-07-28 without ever being
+reviewed under either one. A principle that is invisible at code-review time does
+not get applied.
+
+## The two assignment principles
+
+### Generation-versus-verification split (2026-06-26)
+
+**Generation and search run Sonnet; verification and judgment run Opus.**
+
+The reasoning is an asymmetry in where errors get caught. A generation-stage error
+is caught by downstream verification, but if verification is weak there is no net
+below it. Given equal budget, spend it on verification.
+
+### Delegation structure (2026-07-21, commit `986494ad`)
+
+**An agent that delegates to external workers and polls for results runs Sonnet;
+an agent that judges or synthesizes with its own model runs Opus.**
+
+Look at execution structure, not the role name. An agent named "reviewer" whose
+actual verdict is produced by another process — with the agent itself only
+dispatching and collecting — contributes almost nothing to output quality through
+its own model tier.
+
+### When the two conflict, delegation structure wins
+
+Some agents are verification by role but delegation by structure. In that cell,
+**delegation structure takes precedence** — Sonnet.
+
+Two agents sit there today: `oracle` and `daedalus`. Each routes through the
+delegation engine in `lib/generic-job.ts` via the `diagnose` and `design-review`
+skills respectively, and the actual analysis is done by delegated workers. Their
+current Sonnet value is this clause applied.
+
+The test: does the verdict the agent returns come from **its own model's
+reasoning**, or is it carrying another process's output through? The latter is
+delegation. `hermes` is the illustrative case — it looks like it produces its own
+verdict, but the verdict actually comes from the `ValidationVerdict` enum in
+`engine/validators.py`.
+
+## Current assignment
+
+| Agent | Tier | Rationale |
+|---|---|---|
+| `code-reviewer` | opus | Judges with its own model |
+| `issue-reviewer` | opus | Judges with its own model |
+| `metis` | opus | Judges with its own model |
+| `momus` | opus | Judges with its own model |
+| `tech-claim-examiner` | opus | Judges with its own model |
+| `chunk-reviewer` | sonnet | Delegation structure (`orchestrate-review`) |
+| `daedalus` | sonnet | Conflict cell — delegation structure wins |
+| `oracle` | sonnet | Conflict cell — delegation structure wins |
+| `explore` | sonnet | Search |
+| `librarian` | sonnet | Search |
+| `hermes` | sonnet | Search (depth peer to explore/librarian) |
+| `mnemosyne` | sonnet | Generation |
+| `sisyphus-junior` | sonnet | Generation |
+
+The single source of truth for an agent's tier is the `model:` field in
+`agents/<name>.md` frontmatter.
+
+## The tier vocabulary is two values
+
+`opus` and `sonnet`, nothing else. Adding a third requires evidence that some
+assignment can only be expressed with it — "I want this agent somewhere between
+opus and sonnet" is not enough.
+
+## Substituting a tier into a concrete model
+
+Handled by `model-map` in each `{platform}.yaml`.
+
+### `tiers:` is the normal path
+
+```yaml
+model-map:
+  tiers:
+    opus:   { model: gpt-5.6-sol }
+    sonnet: { model: gpt-5.6-terra }
+```
+
+**A tier sets the model only.** Omitting `effort` leaves `model_reasoning_effort`
+out of the emitted role TOML, so each agent runs at whatever effort the session is
+configured for rather than a value frozen at sync time.
+
+### `agents:` is only for what a tier cannot express
+
+```
+resolveCodexAgentModel: modelMap.agents?.[name] ?? modelMap.tiers[tier]
+```
+
+Since a tier fixes the model alone, the one thing that qualifies for `agents:` is
+**an agent that must pin an effort instead of following the session**. With the
+tier vocabulary fixed at two, that is effectively its only use.
+
+Pure model differentiation belongs in a tier, not here. A new entry must state
+**why it could not be expressed as a tier**.
+
+On 2026-07-28 the four `agents:` entries in `codex.yaml` (`code-reviewer`,
+`metis`, `momus`, `tech-claim-examiner`) were removed. All four matched
+`tiers.opus` exactly, so the emitted TOML was byte-identical either way — entries
+that occupied the slot without changing any deployed output.
+
+Allowed `effort` values are `low` / `medium` / `high` / `xhigh` / `max` / `ultra`,
+enforced by `make validate`. That list is the **union** of every model's
+`supported_reasoning_levels` as probed from `~/.codex/models_cache.json`, so a
+pairing a specific model does not support (say `ultra` on `gpt-5.5`) still passes.
+What it catches is the typo.
+
+## Records for individual assignments
+
+### `hermes`, opus to sonnet (2026-07-28)
+
+Its creating commit `a5bc1235` (2026-06-25) predates the generation-versus-
+verification decision by one day, and commit `986494ad`, which applied the
+delegation-structure principle, touched only `agents/daedalus.md` and
+`agents/oracle.md` — never putting `hermes` up for review. It was an initial value
+that had passed neither principle, and its creating commit body records no reason
+for choosing opus.
+
+Its role is depth peer to `explore` (codebase) and `librarian` (external docs),
+taking over when they hit a wall — the search family. Both peers are sonnet. Its
+verdict comes from the `ValidationVerdict` enum in `engine/validators.py`, not
+from its own model.
+
+### `explore` and `librarian` stay sonnet (2026-07-28)
+
+The two reference implementations point in opposite directions, so neither is a
+precedent. In `oh-my-codex`, explore's low value is a mechanical translation of a
+Claude-era `model: haiku` frontmatter (`0d2115ce`) left unadjusted since, and the
+high effort on its researcher counterpart is not a research judgment but a blanket
+rule — "standard class and not an executor implies high" — locked in by a test.
+In `lazycodex`, the low values came from `github-actions[bot]` marketplace sync
+commit `f39306f`, which lowered the whole fleet together with no human-recorded
+reason. That repo's own `model-routing.md` still says exploration should go to a
+strong reasoning model, contradicting its current values.
+
+Internal measurement points the other way. By deployed instruction size, `explore`
+(10,245 chars) and `librarian` (8,450) carry the heaviest contracts in the sonnet
+tier — 1.88x and 1.55x `sisyphus-junior` (5,449). Three structural facts matter
+more than the size:
+
+- **No automatic verification surface.** `sisyphus-junior` is caught by build,
+  typecheck, and tests; `mnemosyne` by a commit hash. Nothing re-checks these two.
+- **Under-searching is indistinguishable from exhaustion.** `ultraresearch`
+  decides convergence from the count of expansion leads workers return, so
+  shallower search terminates early and silently.
+- **They are upstream.** They feed interview questions and design, so degradation
+  propagates downstream with the trail broken.
+
+That said, no measurement exists anywhere of what actually degrades, and by how
+much, when effort is lowered on `gpt-5.6-terra`. So this decision rests on "there
+is no basis to lower them", not on "medium is correct" — and it reopens if
+measurement appears.
+
+## Per-platform notes
+
+- **claude** — does not use `model-map`. The frontmatter values `opus` and
+  `sonnet` are already valid, so no substitution is needed.
+- **codex** — the `model` key in a role TOML beats the model given by the session
+  or CLI. The deployed value is the value at run time.
+- **opencode** — no agents deploy here (`feature-platforms.agents` in
+  `config.yaml` is `[claude, codex]`). The `model-map` stays declared anyway:
+  without it the tier string survives verbatim and an unresolvable value would
+  deploy silently, whereas with it `assertMappedTier` turns that into a named
+  failure.

--- a/docs/model-assignment.md
+++ b/docs/model-assignment.md
@@ -1,0 +1,155 @@
+# 에이전트 모델 배정
+
+에이전트마다 어떤 모델 등급을 줄지, 그리고 그 등급을 플랫폼별 실제 모델로 어떻게
+치환할지에 대한 규칙이다.
+
+이 문서가 존재하는 이유는 구체적이다. 아래 두 원칙은 각각 2026-06-26과 2026-07-21에
+정해졌지만 **커밋 바디에만 적혀 있었고**, 그 결과 `hermes`가 어느 원칙의 심사도 받지
+않은 채 2026-07-28까지 초기값을 유지했다. 원칙이 코드 리뷰 시점에 보이지 않으면
+적용되지 않는다.
+
+## 두 가지 배정 원칙
+
+### 생성-검증 분리 원칙 (2026-06-26)
+
+**생성·탐색은 Sonnet, 검증·판단은 Opus.**
+
+근거는 오류가 잡히는 위치의 비대칭이다. 생성 단계의 오류는 하류 검증이 잡아주지만,
+검증이 부실하면 그 아래에 그물이 없다. 그래서 같은 예산이라면 검증 쪽에 쓴다.
+
+### 위임 구조 원칙 (2026-07-21, 커밋 `986494ad`)
+
+**외부 worker에게 위임하고 결과를 폴링하는 구조면 Sonnet, 자기 모델로 직접 판정하거나
+합성하면 Opus.**
+
+역할 이름이 아니라 실행 구조를 본다. "리뷰어"라는 이름을 달고 있어도 실제 판정을 다른
+프로세스가 내리고 자신은 배차와 취합만 한다면, 그 에이전트의 모델 등급은 결과 품질에
+거의 기여하지 않는다.
+
+### 두 원칙이 충돌할 때는 위임 구조 원칙이 이긴다
+
+역할로는 검증이지만 구조로는 위임인 에이전트가 있다. 이 셀에서는 **위임 구조 원칙이
+우선한다** — 즉 Sonnet.
+
+현재 이 셀에 있는 것은 `oracle`과 `daedalus` 둘이다. 각각 `diagnose`와 `design-review`
+스킬을 통해 `lib/generic-job.ts`의 위임 엔진을 타고, 실제 분석은 위임된 worker가
+수행한다. 둘 다 Sonnet인 현행 값이 이 조항의 적용 결과다.
+
+판별 기준: 그 에이전트가 반환하는 판정이 **자기 모델의 추론에서 나오는가**, 아니면
+다른 프로세스의 산출물을 그대로 옮기는가. 후자면 위임형이다. `hermes`가 좋은 예로,
+verdict를 자기가 만드는 것처럼 보이지만 실제로는 `engine/validators.py`의
+`ValidationVerdict` enum이 산출한다.
+
+## 현재 배정
+
+| 에이전트 | 등급 | 판단 근거 |
+|---|---|---|
+| `code-reviewer` | opus | 자기 모델로 직접 판정 |
+| `issue-reviewer` | opus | 자기 모델로 직접 판정 |
+| `metis` | opus | 자기 모델로 직접 판정 |
+| `momus` | opus | 자기 모델로 직접 판정 |
+| `tech-claim-examiner` | opus | 자기 모델로 직접 판정 |
+| `chunk-reviewer` | sonnet | 위임 구조 (`orchestrate-review`) |
+| `daedalus` | sonnet | 충돌 셀 — 위임 구조 우선 |
+| `oracle` | sonnet | 충돌 셀 — 위임 구조 우선 |
+| `explore` | sonnet | 탐색 |
+| `librarian` | sonnet | 탐색 |
+| `hermes` | sonnet | 탐색 (explore/librarian의 depth peer) |
+| `mnemosyne` | sonnet | 생성 |
+| `sisyphus-junior` | sonnet | 생성 |
+
+에이전트의 등급은 `agents/<name>.md` frontmatter의 `model:` 한 필드가 유일한 출처다.
+
+## 등급 어휘는 두 개다
+
+`opus`와 `sonnet` 둘뿐이다. 세 번째 등급을 만들려면 그것으로만 표현되는 배정이 실제로
+필요하다는 근거가 있어야 한다 — "이 에이전트를 opus와 sonnet 사이 어딘가에 두고 싶다"는
+정도로는 부족하다.
+
+## 등급을 실제 모델로 치환하는 규칙
+
+플랫폼별 `{platform}.yaml`의 `model-map`이 담당한다.
+
+### `tiers:`가 기본 경로
+
+```yaml
+model-map:
+  tiers:
+    opus:   { model: gpt-5.6-sol }
+    sonnet: { model: gpt-5.6-terra }
+```
+
+**등급은 모델만 정한다.** `effort`를 적지 않으면 배포되는 role TOML에
+`model_reasoning_effort` 키가 실리지 않고, 각 에이전트는 세션에 설정된 effort를 따른다.
+sync 시점에 값을 얼려두지 않겠다는 뜻이다.
+
+### `agents:`는 등급으로 표현 불가능한 것 전용
+
+```
+resolveCodexAgentModel: modelMap.agents?.[name] ?? modelMap.tiers[tier]
+```
+
+등급이 모델만 정하므로, `agents:`에 들어갈 자격이 있는 것은 **세션을 따르지 않고 effort를
+고정해야 하는 에이전트**다. 등급 어휘가 두 개로 고정된 이상 이것이 사실상 유일한 용도가
+된다.
+
+순수한 모델 차등은 `agents:`가 아니라 등급으로 표현한다. 새 엔트리를 추가할 때는 그것이
+**왜 등급으로 표현될 수 없는지**를 함께 적어야 한다.
+
+2026-07-28에 `codex.yaml`의 `agents:` 4건(`code-reviewer`·`metis`·`momus`·
+`tech-claim-examiner`)을 삭제했다. 넷 다 `tiers.opus`와 값이 같아 산출되는 TOML이
+바이트 단위로 동일했다 — 지워도 배포 결과가 변하지 않는, 자리만 차지하는 엔트리였다.
+
+`effort` 값은 `low` / `medium` / `high` / `xhigh` / `max` / `ultra`만 허용되며
+`make validate`가 검사한다. 이 목록은 `~/.codex/models_cache.json`의
+`supported_reasoning_levels`를 모델별로 조사한 **합집합**이라, 특정 모델이 지원하지 않는
+조합(예: `gpt-5.5`에 `ultra`)은 통과한다. 잡는 것은 오타다.
+
+## 개별 배정에 대한 기록
+
+### `hermes`를 opus에서 sonnet으로 (2026-07-28)
+
+생성 커밋 `a5bc1235`(2026-06-25)가 생성-검증 분리 원칙이 정해진 날보다 하루 이르고,
+위임 구조 원칙을 적용한 커밋 `986494ad`는 `agents/daedalus.md`와 `agents/oracle.md`
+두 파일만 변경해 `hermes`를 재검토 대상에 넣지 않았다. 어느 원칙의 심사도 받은 적 없는
+초기값이었고, 생성 커밋 본문에도 opus를 고른 근거가 없다.
+
+역할은 `explore`(코드베이스)·`librarian`(외부 문서)의 depth peer로, 두 에이전트가
+막혔을 때 이어받는 탐색 계열이다. 두 peer 모두 sonnet이다. verdict는 자기 모델이 아니라
+`engine/validators.py`의 `ValidationVerdict` enum이 만든다.
+
+### `explore`·`librarian`을 sonnet으로 유지 (2026-07-28)
+
+두 참조 구현이 정반대로 갈려 어느 쪽도 선례가 되지 못했다. `oh-my-codex`의 explore는
+Claude 시절 frontmatter `model: haiku`를 코덱스 슬러그로 기계 번역한 값이 조정 없이
+남은 것이고(`0d2115ce`), 대응 역할인 researcher의 높은 effort는 리서치 판단이 아니라
+"standard 클래스이면서 executor가 아니면 high"라는 일괄 규칙이 테스트로 잠긴 결과다.
+`lazycodex`의 낮은 값은 `github-actions[bot]`의 마켓플레이스 동기화 커밋 `f39306f`에서
+플릿 전체가 함께 내려간 것으로, 사람이 남긴 근거가 없다. 오히려 같은 레포의
+`model-routing.md`는 여전히 탐색을 강한 추론 모델에 두라고 적고 있어 현재 값과 모순이다.
+
+내부 실측은 반대 방향을 가리킨다. 배포되는 지시문 기준으로 `explore`(10,245자)와
+`librarian`(8,450자)은 sonnet 등급에서 가장 무거운 계약이며, `sisyphus-junior`(5,449자)의
+1.88배와 1.55배다. 더 결정적인 것은 셋이다.
+
+- **자동 검증면이 없다.** `sisyphus-junior`는 빌드·타입체크·테스트가, `mnemosyne`는
+  커밋 해시가 결과를 잡아준다. 이 둘의 산출물은 아무도 재검증하지 않는다.
+- **덜 찾은 것과 다 찾은 것이 구별되지 않는다.** `ultraresearch`의 수렴 판정은 워커가
+  반환한 확장 단서의 개수에 종속되므로, 탐색이 얕아지면 조용히 조기 종료된다.
+- **상류다.** 인터뷰 질문과 설계의 입력이라, 품질 저하가 하류로 전파되면서 출처 추적이
+  끊긴다.
+
+다만 `gpt-5.6-terra`에서 effort를 낮췄을 때 실제로 무엇이 얼마나 나빠지는지에 대한 측정
+데이터는 어디에도 없다. 그래서 이 결정의 근거는 "medium이 옳다"가 아니라 "내릴 근거가
+없다"이며, 측정이 생기면 다시 열릴 수 있다.
+
+## 플랫폼별 주의사항
+
+- **claude** — `model-map`을 쓰지 않는다. frontmatter의 `opus`/`sonnet`이 그대로 유효한
+  값이라 치환이 필요 없다.
+- **codex** — role TOML의 `model` 키는 세션·CLI에서 지정한 모델을 이긴다. 배포된 값이
+  실행 시점의 값이다.
+- **opencode** — 에이전트가 배포되지 않는다(`config.yaml`의 `feature-platforms.agents`가
+  `[claude, codex]`). `model-map`은 선언만 유지하는데, 없으면 등급 문자열이 그대로 남아
+  opencode가 해석하지 못하는 값이 조용히 배포되기 때문이다. 선언되어 있으면
+  `assertMappedTier`가 이름 있는 실패로 바꿔준다.

--- a/docs/model-assignment.md
+++ b/docs/model-assignment.md
@@ -37,8 +37,8 @@
 
 판별 기준: 그 에이전트가 반환하는 판정이 **자기 모델의 추론에서 나오는가**, 아니면
 다른 프로세스의 산출물을 그대로 옮기는가. 후자면 위임형이다. `hermes`가 좋은 예로,
-verdict를 자기가 만드는 것처럼 보이지만 실제로는 `engine/validators.py`의
-`ValidationVerdict` enum이 산출한다.
+verdict를 자기가 만드는 것처럼 보이지만 실제로는 `skills/insane-browsing/engine/validators.py`의
+`Verdict` enum이 산출한다.
 
 ## 현재 배정
 
@@ -116,7 +116,7 @@ resolveCodexAgentModel: modelMap.agents?.[name] ?? modelMap.tiers[tier]
 
 역할은 `explore`(코드베이스)·`librarian`(외부 문서)의 depth peer로, 두 에이전트가
 막혔을 때 이어받는 탐색 계열이다. 두 peer 모두 sonnet이다. verdict는 자기 모델이 아니라
-`engine/validators.py`의 `ValidationVerdict` enum이 만든다.
+`skills/insane-browsing/engine/validators.py`의 `Verdict` enum이 만든다.
 
 ### `explore`·`librarian`을 sonnet으로 유지 (2026-07-28)
 

--- a/opencode.yaml
+++ b/opencode.yaml
@@ -1,11 +1,24 @@
 # MCP definitions for OpenCode.
 # Note: Figma uses OpenCode remote MCP config; codex/gemini still use mcp-remote.
+# No agent reaches this map today: config.yaml's `feature-platforms.agents` is
+# [claude, codex], and no sync.yaml overrides it for opencode. It stays declared
+# anyway, because without it `translateAgentFrontmatter` leaves the frontmatter
+# tier verbatim -- an agent would deploy with `model: sonnet`, which opencode
+# cannot resolve, and nothing would say so. The map is the thing that turns that
+# silent breakage into a named sync failure via `assertMappedTier`.
+#
+# Both tiers pointing at one model is therefore untested rather than considered:
+# grading them apart only becomes a real question when agents actually deploy
+# here, and the opencode model list is unconfirmed on this host anyway (`opencode
+# models` needs a `timeout` binary macOS does not ship).
 model-map:
   tiers:
     opus:
       model: openai/gpt-5.5
     sonnet:
       model: openai/gpt-5.5
+  # Empty by rule, not by accident -- see codex.yaml: `agents:` is for what a
+  # tier cannot express (effort differentiation), and nothing here needs it.
   agents: {}
 mcps:
   context7:

--- a/skills/prometheus/interview.md
+++ b/skills/prometheus/interview.md
@@ -76,8 +76,6 @@ Agent(subagent_type="explore", prompt="I'm planning auth feature and need existi
 Agent(subagent_type="librarian", prompt="I'm planning OAuth 2.0 implementation and need authoritative guidance. Find: setup, flow types (PKCE), security considerations. Skip tutorials — production patterns only.")
 ```
 
-**Research depth (opus escalation)**: For complex research beyond simple library lookups, dispatch librarian with opus — `Agent(subagent_type="librarian", model="opus", prompt=...)`.
-
 ### Oracle dispatch — feasibility / risk / alternative / dependency
 
 | Type | Question to Oracle |

--- a/skills/sisyphus/delegation.md
+++ b/skills/sisyphus/delegation.md
@@ -98,10 +98,6 @@ Rate limit: 100 requests per minute per IP. Return 429 Too Many Requests when ex
 
 When delegating to sisyphus-junior, refer to the Load Skills table in the `<skill-catalog>` block and include situation-matching skills in Section 7.
 
-### Model: Junior always runs Sonnet
-
-sisyphus-junior runs on Sonnet — always. Do NOT pass `model="opus"` to junior. Junior is the generation agent; its output is checked by junior's own mandatory tests, and re-checked by the orchestrator's inline verify only when the orchestrator creates an explicit verify task — implement tasks get no automatic verify pass. If an implementation seems to need more capability, tighten junior's required tests or add an explicit verify task — never escalate the generator to Opus.
-
 ---
 
 ## Mnemosyne Delegation Template
@@ -157,10 +153,6 @@ Agent(subagent_type="explore", prompt="I'm implementing JWT auth for the REST AP
 // External docs
 Agent(subagent_type="librarian", prompt="I'm implementing JWT auth and need current security best practices for token storage and expiration. Find: OWASP auth guidelines, recommended token lifetimes, refresh rotation. Skip tutorials — production security guidance only.")
 ```
-
-### Research Depth (opus escalation)
-
-For complex research beyond simple library lookups, delegate to librarian with opus: `Agent(subagent_type="librarian", model="opus", prompt=...)`. The inline `model` argument overrides the agent's sonnet default.
 
 ---
 

--- a/tools/adapters/opencode.test.ts
+++ b/tools/adapters/opencode.test.ts
@@ -815,6 +815,23 @@ Body content.`,
 			await fs.rm(targetDir, { recursive: true, force: true });
 		}
 	});
+
+	it("rejects and leaves no file containing the raw tier when the tier is unmapped via `syncAgentsDirect`", async () => {
+		const targetDir = await mkTempDir();
+		try {
+			// Fixture agentFile declares `model: opus`, but this map has no `opus` tier.
+			const modelMap: ModelMap = { tiers: { sonnet: { model: "openai/gpt-4o" } } };
+			await expect(
+				opencodeAdapter.syncAgentsDirect(targetDir, "oracle", agentFile, [], [], false, modelMap),
+			).rejects.toThrow(/oracle\.md.*opus|opus.*oracle\.md/);
+
+			const target = path.join(targetDir, ".opencode", "agents", "oracle.md");
+			const content = await fs.readFile(target, "utf-8").catch(() => "");
+			expect(content).not.toContain("model: opus");
+		} finally {
+			await fs.rm(targetDir, { recursive: true, force: true });
+		}
+	});
 });
 
 // =============================================================================

--- a/tools/adapters/opencode.test.ts
+++ b/tools/adapters/opencode.test.ts
@@ -188,6 +188,23 @@ Body.`;
 		expect(result).not.toContain("model: opus\n");
 	});
 
+	it("applies a per-agent override, not just the tier default, via `translateAgentFrontmatter`", () => {
+		const content = `---
+name: oracle
+model: opus
+---
+
+Body.`;
+
+		const modelMap: ModelMap = {
+			tiers: { opus: { model: "openai/o3" } },
+			agents: { oracle: { model: "openai/o3-special" } },
+		};
+		const result = translateAgentFrontmatter(content, modelMap, "agents/oracle.md", "oracle");
+
+		expect(result).toContain("model: openai/o3-special");
+	});
+
 	it("throws when the frontmatter model tier is not in model map (P2-5) via `translateAgentFrontmatter`", () => {
 		const content = `---
 name: oracle

--- a/tools/adapters/opencode.ts
+++ b/tools/adapters/opencode.ts
@@ -45,6 +45,7 @@ export function translateAgentFrontmatter(
 	content: string,
 	modelMap?: ModelMap,
 	agentFile?: string,
+	agentName?: string,
 ): string {
 	const { frontmatter, body, hasFrontmatter } = parseFrontmatter(content);
 
@@ -63,7 +64,7 @@ export function translateAgentFrontmatter(
 
 	// P2-5: Apply model map to model field if provided
 	if (modelMap && typeof frontmatter["model"] === "string") {
-		frontmatter["model"] = applyModelMap(modelMap, frontmatter["model"], agentFile ?? "");
+		frontmatter["model"] = applyModelMap(modelMap, frontmatter["model"], agentFile ?? "", agentName);
 	}
 
 	return serializeFrontmatter(frontmatter, body);
@@ -114,7 +115,7 @@ export const opencodeAdapter: PlatformAdapter = {
 		// Translate frontmatter for OpenCode compatibility (P2-5: pass modelMap)
 		try {
 			const content = await fs.readFile(targetFile, "utf-8");
-			const translated = translateAgentFrontmatter(content, modelMap, displayName);
+			const translated = translateAgentFrontmatter(content, modelMap, sourcePath, displayName);
 			await fs.writeFile(targetFile, translated, "utf-8");
 		} catch {
 			logWarn(`Failed to translate frontmatter for: ${sourcePath}. Copying as-is.`);

--- a/tools/adapters/opencode.ts
+++ b/tools/adapters/opencode.ts
@@ -8,7 +8,7 @@ import { syncDirectory, copyFile } from "../lib/sync-directory.ts";
 import type { PlatformAdapter } from "./types.ts";
 import { deepMerge } from "../lib/deep-merge.ts";
 import { readJsonFile, writeJsonFile } from "../lib/json.ts";
-import { assertMappedTier } from "../lib/model-map.ts";
+import { assertMappedTier, ModelMapError } from "../lib/model-map.ts";
 
 // =============================================================================
 // Model Map Helper
@@ -117,7 +117,14 @@ export const opencodeAdapter: PlatformAdapter = {
 			const content = await fs.readFile(targetFile, "utf-8");
 			const translated = translateAgentFrontmatter(content, modelMap, sourcePath, displayName);
 			await fs.writeFile(targetFile, translated, "utf-8");
-		} catch {
+		} catch (err) {
+			if (err instanceof ModelMapError) {
+				// The initial copy (line 112) already wrote the raw, untranslated
+				// frontmatter — remove it so no file is left containing the
+				// unmapped tier string before propagating the hard-fail.
+				await fs.rm(targetFile, { force: true });
+				throw err;
+			}
 			logWarn(`Failed to translate frontmatter for: ${sourcePath}. Copying as-is.`);
 			await fs.copyFile(sourcePath, targetFile);
 		}

--- a/tools/lib/model-map.ts
+++ b/tools/lib/model-map.ts
@@ -1,6 +1,13 @@
 import type { ModelMap, Platform } from "./types.ts";
 
 /**
+ * Distinguishes the model-map hard-fail from unrelated errors (e.g. malformed
+ * YAML frontmatter) so a catch block can re-throw this one instead of
+ * swallowing it into a copy-as-is fallback.
+ */
+export class ModelMapError extends Error {}
+
+/**
  * Hard-fail guard shared by every platform adapter that applies a model-map:
  * a deployed agent's tier must be present in `modelMap.tiers`, or sync aborts
  * naming the offending agent file and tier. A per-agent override in
@@ -13,7 +20,7 @@ export function assertMappedTier(
 	ctx: { platform: Platform; agentFile: string; agentName?: string },
 ): void {
 	if (tier in modelMap.tiers) return;
-	throw new Error(
+	throw new ModelMapError(
 		`model-map: agent '${ctx.agentFile}' declares tier '${tier}' not mapped in ${ctx.platform} model-map.tiers`,
 	);
 }

--- a/tools/validators/schema.test.ts
+++ b/tools/validators/schema.test.ts
@@ -1184,6 +1184,40 @@ model-map:
 		expect(result.errors).toHaveLength(0);
 	});
 
+	it("returns error when a codex model-map effort is misspelled", () => {
+		const path = writeYaml(
+			dir,
+			"codex.yaml",
+			`
+model-map:
+  tiers:
+    opus:
+      model: gpt-5.6-sol
+      effort: hgih
+`,
+		);
+		const result = validatePlatformYaml(path, "codex");
+		expect(result.errors.some((e) => e.includes("effort"))).toBe(true);
+	});
+
+	it("accepts every probe-verified codex effort level", () => {
+		for (const effort of ["low", "medium", "high", "xhigh", "max", "ultra"]) {
+			const path = writeYaml(
+				dir,
+				"codex.yaml",
+				`
+model-map:
+  tiers:
+    opus:
+      model: gpt-5.6-sol
+      effort: ${effort}
+`,
+			);
+			const result = validatePlatformYaml(path, "codex");
+			expect(result.errors).toHaveLength(0);
+		}
+	});
+
 	it("returns error when opencode model-map tier declares effort", () => {
 		const path = writeYaml(
 			dir,

--- a/tools/validators/schema.ts
+++ b/tools/validators/schema.ts
@@ -684,6 +684,23 @@ const VALID_MODEL_MAP_TOP_FIELDS = new Set(["tiers", "agents"]);
 const VALID_MODEL_MAP_ENTRY_FIELDS = new Set(["model", "effort"]);
 
 /**
+ * Reasoning-effort levels accepted in a codex model-map entry.
+ *
+ * This is the UNION of every model's `supported_reasoning_levels` as probed from
+ * `~/.codex/models_cache.json`, not a per-model list: `ultra` exists only on
+ * gpt-5.6-sol/terra and `max` only on those plus gpt-5.6-luna, while
+ * low/medium/high/xhigh are universal. Validating per model would mean reading
+ * that cache, which is a machine-local file — `make validate` must not depend on
+ * one host's cache, so the union is hardcoded here the same way `codex-versions`
+ * in config.yaml hardcodes a probe-verified set.
+ *
+ * Consequence to keep in mind: a real-but-unsupported pairing (say `ultra` on
+ * gpt-5.5) still passes. The failure this catches is the typo — `hgih`,
+ * `higher`, `Medium` — which previously reached the deployed TOML untouched.
+ */
+const VALID_CODEX_EFFORTS = new Set(["low", "medium", "high", "xhigh", "max", "ultra"]);
+
+/**
  * Validates a model-map.tiers or model-map.agents entry map: each entry needs
  * a string `model`, and `effort` (if present) must be a string — except for
  * opencode, where `effort` is forbidden outright (opencode's ModelMapEntry has
@@ -725,8 +742,14 @@ function validateModelMapEntries(
 			if (entry.effort !== undefined) {
 				result.errors.push(`${entryCtx}.effort: opencode model-map은 effort를 지원하지 않습니다`);
 			}
-		} else if (entry.effort !== undefined && typeof entry.effort !== "string") {
-			result.errors.push(`${entryCtx}.effort: string이어야 합니다 (got ${typeof entry.effort})`);
+		} else if (entry.effort !== undefined) {
+			if (typeof entry.effort !== "string") {
+				result.errors.push(`${entryCtx}.effort: string이어야 합니다 (got ${typeof entry.effort})`);
+			} else if (!VALID_CODEX_EFFORTS.has(entry.effort)) {
+				result.errors.push(
+					`${entryCtx}.effort: 알 수 없는 값 '${entry.effort}' (지원: ${[...VALID_CODEX_EFFORTS].join(", ")})`,
+				);
+			}
 		}
 	}
 }


### PR DESCRIPTION
## 📌 Summary

에이전트별 모델 등급 배정을 두 원칙에 맞게 정리하고, 그 원칙을 `docs/`에 문서로 세웠다. codex `model-map`의 티어에서 `effort`를 제거해 세션 설정을 따르게 했고, 작업 중 발견한 opencode 어댑터의 결함 2건을 함께 고쳤다.

---

## 🔧 Changes

### 에이전트 모델 등급

- `hermes`를 `opus` → `sonnet`으로 하향

`hermes`는 두 배정 원칙 어느 쪽의 심사도 받은 적이 없다. 생성 커밋 `a5bc1235`(2026-06-25)가 생성-검증 분리 원칙이 정해진 날보다 하루 이르고, 위임 구조 원칙을 적용한 `986494ad`는 `daedalus`와 `oracle` 두 파일만 변경했다. 생성 커밋 본문에도 `opus`를 고른 근거가 없다.

**영향 범위**: 배포되는 `hermes` role TOML의 model이 `gpt-5.6-sol` → `gpt-5.6-terra`. `insane-browsing` 3단 에스컬레이션이 sonnet에서 끝까지 도는 것을 실제 실행으로 확인(curl_cffi 403 → Jina Reader CAPTCHA → CloakBrowser 추출 성공). 나머지 12개 에이전트 등급은 불변.

### codex model-map

- `tiers`에서 `effort` 키 제거 (`opus: high`, `sonnet: medium` 삭제)
- `agents`의 4개 엔트리 삭제 (`code-reviewer`, `metis`, `momus`, `tech-claim-examiner`)

**영향 범위**: role TOML에 `model_reasoning_effort` 키가 실리지 않으므로 각 에이전트가 세션 설정을 따른다. 지금까지 `medium`으로 고정돼 있던 sonnet 티어 8개가 세션 값을 따라가게 되는 동작 변경이다. 삭제한 `agents` 4건은 전부 `tiers.opus`와 값이 같아 산출 TOML이 바이트 단위로 동일했으므로 배포 결과는 불변.

### opencode 어댑터

- `translateAgentFrontmatter`에 `agentName` 인자를 전달 — `model-map.agents` 조회가 항상 `undefined`로 떨어지던 결함 수정
- `ModelMapError` 타입 도입 — `assertMappedTier`의 하드 실패가 catch-all에 흡수되던 fail-open 차단

**영향 범위**: opencode는 현재 에이전트가 0개 배포된다(`config.yaml`의 `feature-platforms.agents`가 `[claude, codex]`). 두 결함 모두 잠복 상태였으나 `model-map.agents`가 effort 차등의 지정 창구가 되면서 밟힐 확률이 오른다. `ModelMapError`는 `tools/lib/model-map.ts`에 있어 codex 어댑터도 공유하지만, codex에는 이를 감싸는 try/catch가 없어 거동 변화가 없다.

### 스키마 검증

- `model-map` 엔트리의 `effort` 값에 허용 목록 검증 추가

**영향 범위**: `make validate`가 오타를 막는다. 허용값은 모델별 `supported_reasoning_levels`의 합집합이라 실재하지만 특정 모델이 미지원인 조합은 통과한다.

### 스킬 본문

- `skills/sisyphus/delegation.md`와 `skills/prometheus/interview.md`에서 인라인 `model` 지정 3개소 삭제

**영향 범위**: 이 문자열들은 codex 배포 시 번역되지 않고 남는데 codex spawn은 미지 model에 하드 에러를 낸다. 모델 등급의 단일 출처는 `agents/*.md` frontmatter이므로 본문이 되풀이할 이유가 없다.

### 문서

- `docs/model-assignment.md` / `.en.md` 신설, README 양쪽 카탈로그 행 추가

**영향 범위**: 문서만. 두 원칙이 커밋 바디에만 있어 `hermes`가 심사를 빠져나간 것이 이 문서를 만든 이유다.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.

### 1. 티어에서 effort를 빼고 세션에 위임한 결정

**배경 및 문제 상황:** `model-map`의 티어 엔트리가 `{ model, effort }`를 함께 정하는 구조라, sync 시점의 effort가 배포본에 얼어붙었다. 세션을 다른 effort로 띄워도 에이전트는 배포 당시 값으로 돈다.

**해결 방안:** 티어에서 `effort`를 제거해 모델만 정하게 했다. `codex.ts`가 `entry.effort === undefined`면 `model_reasoning_effort` 키 자체를 안 싣기 때문에, 키 부재가 곧 세션 상속이 된다.

**구현 세부사항:** 티어 어휘를 늘려 해결하는 안(`sonnet-low` 같은 등급 신설)은 기각했다. 등급 어휘가 늘면 에이전트 배정 판단이 모델 축과 effort 축 두 개로 쪼개지는데, 두 배정 원칙은 모델 축에 대해서만 쓰여 있어 판단 기준이 없는 축이 생긴다.

**선택과 트레이드오프:** 실제 결과로 sonnet 티어 8개가 지금까지의 `medium`이 아니라 세션 값을 따르게 된다. 세션이 `high`면 8개가 다 `high`로 돈다 — 비용이 오르는 방향이다. 반대로 얻는 것은 "이 에이전트만 낮게 돌리고 싶다"가 세션 레벨에서 가능해진다는 것. 여기가 갈리는 지점이라 의견을 듣고 싶다: 등급별로 effort를 고정해두는 편이 예측 가능성 면에서 나은지, 아니면 세션 위임이 맞는지.

### 2. `agents:`의 용도를 재규정하고 기존 4건을 지운 것

**배경 및 문제 상황:** `model-map.agents`에 4개 엔트리가 있었는데 전부 `tiers.opus`와 값이 동일했다. 해석식이 `modelMap.agents?.[name] ?? modelMap.tiers[tier]`이므로 지워도 같은 TOML이 나온다 — 자리만 차지하고 배포 결과를 바꾸지 않는 상태였다.

**해결 방안:** 4건을 지우고 `agents:`를 "티어로 표현 불가능한 것 전용"으로 규정했다. 티어가 모델만 정하게 됐으므로 실질적으로 effort 차등 전용이 된다.

**구현 세부사항:** 지워도 안전한 근거를 실행으로 확인했다 — 실제 `codex.yaml`로 13개 role TOML을 생성해 `model_reasoning_effort` 키 0건, 5개는 `gpt-5.6-sol`, 8개는 `gpt-5.6-terra`임을 대조했다. 같은 파일의 `config: {}`는 정반대 성질이라 주석으로 구분해뒀다 — 그쪽은 키를 지우면 배포된 `.codex/config.toml`의 관리 블록이 영구 스테일로 고착하는데, `agents:`는 role TOML이 매 sync마다 통째로 다시 쓰이므로 잔존이 없다.

**선택과 트레이드오프:** 4건을 남기면 "나중에 티어 값이 바뀌어도 이 넷은 sol에 고정"이라는 기능은 있다. 다만 그 고정이 왜 이 4개에만 필요하고 나머지 opus 에이전트(`hermes`, `issue-reviewer`)에는 불필요한지 설명이 없어서, 규칙이 아니라 잔여물로 판단했다.

### 3. opencode의 fail-open을 타입으로 닫은 것

**배경 및 문제 상황:** `syncAgentsDirect`가 `translateAgentFrontmatter`를 blanket `catch {}`로 감싸고 실패 시 원본을 그대로 복사한다. `assertMappedTier`는 미매핑 티어에 대해 sync를 중단시키려고 throw하는데, 그 throw가 이 catch에 흡수됐다. 재현하면 미매핑 티어가 WARN 한 줄만 남기고 `model: sonnet`을 그대로 배포하며 exit 0이 된다.

**해결 방안:** `ModelMapError` 타입을 만들어 `assertMappedTier`가 그것을 던지게 하고, catch에서 그 타입만 재throw했다. 나머지 실패(YAML 파싱 등)는 기존 copy-as-is 폴백을 그대로 유지한다.

**관련 코드:**
```ts
// Before
} catch {
    logWarn(`Failed to translate frontmatter for: ${sourcePath}. Copying as-is.`);
    await fs.copyFile(sourcePath, targetFile);
}

// After
} catch (err) {
    if (err instanceof ModelMapError) {
        await fs.rm(targetFile, { force: true });
        throw err;
    }
    logWarn(`Failed to translate frontmatter for: ${sourcePath}. Copying as-is.`);
    await fs.copyFile(sourcePath, targetFile);
}
```

**선택과 트레이드오프:** 메시지 문자열 매칭 대신 타입으로 가른 이유는 기존 테스트들이 에러 메시지 문구에 정규식을 걸고 있어서, 문구를 건드리지 않고 분기 축만 추가하는 편이 안전했기 때문이다. `fs.rm`이 붙은 이유는 catch보다 먼저 실행되는 무조건 복사가 이미 원본을 써놓기 때문 — 지우지 않으면 throw가 전파돼도 미번역 티어 문자열이 디스크에 남는다. 대가로 sync가 중단되면 해당 에이전트 파일이 배포면에서 사라진 상태가 된다. 잘못된 값이 남는 것보다는 낫다고 봤지만, 이 판단은 이견이 있을 수 있다.

### 4. `explore`·`librarian`을 내리지 않은 판단

**배경 및 문제 상황:** 탐색 계열을 더 낮은 등급/effort로 내릴지 검토했다. 참조 구현 두 곳을 조사했는데 정반대로 갈렸다 — 한쪽은 탐색을 최저 등급에 두고, 다른 한쪽은 문서 리서치 역할의 effort를 오히려 올려 잡는다.

**해결 방안:** 유지하기로 했다. 다만 근거는 "현재 값이 옳다"가 아니라 "내릴 근거가 없다"이다.

**구현 세부사항:** 양쪽 값 모두 판단의 산물이 아니었다. 한쪽은 이전 플랫폼의 프론트매터 값을 기계 번역한 뒤 조정하지 않은 잔여물이고, 다른 한쪽은 봇의 마켓플레이스 동기화 커밋에서 플릿 전체가 함께 내려간 것으로 사람이 남긴 근거가 없다. 후자의 레포는 자체 라우팅 문서가 여전히 탐색을 강한 모델에 두라고 적고 있어 현재 값과 모순이다.

반면 내부 실측은 반대 방향을 가리킨다. 배포되는 지시문 길이로 `explore`와 `librarian`이 sonnet 등급에서 가장 무거운 계약이고(`sisyphus-junior` 대비 1.85배·1.52배), 더 결정적으로 (a) 두 에이전트만 자동 검증면이 없으며, (b) `ultraresearch`의 수렴 판정이 워커가 반환한 확장 단서 개수에 종속돼 탐색이 얕아지면 조용히 조기 종료되고, (c) 인터뷰·설계의 입력이라 품질 저하가 하류로 전파되면서 출처 추적이 끊긴다.

**선택과 트레이드오프:** `gpt-5.6-terra`에서 effort를 낮췄을 때 실제로 무엇이 얼마나 나빠지는지 측정 데이터가 어디에도 없다. 그래서 이 결정은 비대칭에 기대고 있다 — 내렸다가 나빠지면 조용히 나빠지고, 유지했다가 손해면 비용으로 드러난다. 측정이 생기면 다시 열릴 결정이다.

---

## ✅ Checklist

### 모델 배정
- [ ] 배포되는 role TOML 13개 전부에 `model_reasoning_effort` 키가 없다
  - `codex.yaml`
- [ ] `hermes`의 배포 model이 `gpt-5.6-terra`다
  - `agents/hermes.md`
- [ ] `agents:` 4건 삭제 전후로 산출되는 role TOML이 동일하다
  - `codex.yaml`
- [ ] `hermes`가 sonnet에서 `insane-browsing` 3단 에스컬레이션을 완주한다
  - `agents/hermes.md`

### model-map 검증
- [ ] `effort`에 허용 목록 밖의 값을 쓰면 `make validate`가 실패한다
  - `tools/validators/schema.ts`
- [ ] `low`/`medium`/`high`/`xhigh`/`max`/`ultra` 6개는 전부 통과한다
  - `tools/validators/schema.ts`
- [ ] `effort`가 문자열이 아닌 타입(숫자·불리언·배열·null)이면 거부된다
  - `tools/validators/schema.ts`

### opencode 어댑터
- [ ] `syncAgentsDirect`에서 `model-map.agents`의 per-agent 오버라이드가 티어 기본값을 이긴다
  - `tools/adapters/opencode.ts`
- [ ] 미매핑 티어로 sync하면 예외가 전파되고, 원문 티어 문자열을 담은 파일이 남지 않는다
  - `tools/adapters/opencode.ts`
  - `tools/lib/model-map.ts`
- [ ] 프론트매터가 깨진 파일은 기존대로 copy-as-is 폴백을 탄다
  - `tools/adapters/opencode.ts`

### 문서
- [ ] `docs/model-assignment.md`가 인용하는 심볼과 경로가 실존한다
  - `docs/model-assignment.md`
- [ ] README 양쪽 카탈로그의 `docs/` 링크가 모두 해석된다
  - `README.md`
  - `README.en.md`