### PR TITLE
feat: verify-entrypoint-gate Codex 세션 확장

### DIFF
--- a/projects/algocare-home/codex.yaml
+++ b/projects/algocare-home/codex.yaml
@@ -1,0 +1,41 @@
+# Claude<->Codex parity for verify-entrypoint-gate — see claude.yaml's own
+# PreToolUse hook comment for the Claude half. Same policy, same scope
+# (algocare-home only — see root codex.yaml's own hooks: header for why global
+# hooks live there instead), enforced by the SAME index.ts (processHookInput
+# accepts both platforms' payload shapes — see scripts/verify-entrypoint-gate/
+# index.ts's PreToolUse IO contract comment).
+#
+# command references the GLOBAL single copy ($HOME/.codex/scripts/
+# verify-entrypoint-gate/index.ts — root sync.yaml's scripts section), not a
+# per-worktree deploy: this project's own scripts/ overlay only ships the
+# .local.yaml policy override (see sync.yaml's own comment), not index.ts
+# itself, so a relative ".codex/..." reference here would resolve to a path
+# with no script at all.
+#
+# Command form is NOT `bun run "$HOME/.codex/scripts/..."` (one quoted span) —
+# tools/adapters/codex.ts:832 unconditionally rewrites every literal
+# ".codex/" substring in a hook's command (even a raw `command:`, unlike the
+# Claude adapter, which leaves a raw `command:` untouched) into
+# `<this project's own deploy root>/.codex/`, which would silently redirect
+# this to the WRONG (per-worktree) .codex instead of the global one — measured
+# directly: `"bun run $HOME/.codex/scripts/.../index.ts"` run through that
+# exact rewrite came back as `bun run $HOME/<worktree-path>/.codex/scripts/
+# .../index.ts`. Splitting the quotes as `"$HOME/.codex"/scripts/...` breaks
+# up the literal 7-character substring `.codex/` (a `"` sits between `x` and
+# `/`), so the rewrite's `.replaceAll(".codex/", ...)` no longer matches, while
+# bash still concatenates the two adjacent tokens into the same one-word path
+# at actual execution time. Confirmed end-to-end against a real `codex exec`
+# (isolated CODEX_HOME, hooks.json registering exactly this command string
+# pointed at a marker-writing script under `<isolated CODEX_HOME>/scripts/
+# verify-entrypoint-gate/index.ts`): the marker was written from that exact
+# resolved path, proving both (a) Codex's hook runner shell-expands `$HOME` in
+# a bare `command:` string — no explicit `bash -c`/`sh -c` wrapper needed —
+# and (b) the quote-split form survives real execution unchanged. The four
+# `projects/*/codex.yaml` files existing before this one carry no raw
+# `command:` precedent (all `{}` or component-only), so this is the first of
+# its kind — the measurement above stands in for missing precedent.
+hooks:
+  PreToolUse:
+    - command: 'bun run "$HOME/.codex"/scripts/verify-entrypoint-gate/index.ts'
+      matcher: "Bash|bash|exec_command|shell_command"
+      timeout: 10

--- a/projects/algocare-home/sync.yaml
+++ b/projects/algocare-home/sync.yaml
@@ -13,7 +13,9 @@ scripts:
     # verify-entrypoint-gate 프로젝트 오버레이. component 미스코프 참조라 own-project
     # 우선(projects/algocare-home/scripts/verify-entrypoint-gate/)으로 해석되어 그
     # 디렉터리(=.local.yaml만 담은) 전체가 각 워크트리의
-    # .claude/scripts/verify-entrypoint-gate/에 배포된다 — index.ts가 그 경로에서
-    # 프로젝트 오버레이를 읽는 위치와 정확히 일치.
+    # .claude/scripts/verify-entrypoint-gate/ + .codex/scripts/verify-entrypoint-gate/에
+    # 배포된다 — index.ts의 resolveLocalDir()가 그 두 경로에서(.claude 우선) 프로젝트
+    # 오버레이를 읽는 위치와 정확히 일치. 훅 등록 자체는 claude.yaml/codex.yaml이 담당하고
+    # (전역 단일본 index.ts를 raw command로 참조), 여기서는 오버레이 정책만 배포한다.
     - component: verify-entrypoint-gate
-      platforms: [claude]
+      platforms: [claude, codex]

--- a/scripts/verify-entrypoint-gate/index.ts
+++ b/scripts/verify-entrypoint-gate/index.ts
@@ -607,6 +607,19 @@ export function readPackageScripts(workspaceRoot: string): string[] {
 // workspace root resolved from `cwd`, so callers pass it explicitly (or omit
 // it to get base-only, e.g. when no workspace root was found at all).
 // -----------------------------------------------------------------------------
+// Resolves which project-overlay directory to read `verify-entrypoint-gate.
+// local.yaml` from, for a given workspace root. Both platforms sync the SAME
+// overlay source to two different deploy roots (`.claude/scripts/...` and
+// `.codex/scripts/...` — see deployLocationForManifest in tools/sync.ts), so
+// their content is identical; this order only decides which copy's presence
+// to trust first when both COULD exist (`.claude` wins), never a policy
+// difference between the two.
+function resolveLocalDir(workspaceRoot: string): string {
+	const claudeDir = join(workspaceRoot, ".claude", "scripts", "verify-entrypoint-gate");
+	if (existsSync(join(claudeDir, "verify-entrypoint-gate.local.yaml"))) return claudeDir;
+	return join(workspaceRoot, ".codex", "scripts", "verify-entrypoint-gate");
+}
+
 export function loadConfig(
 	baseDir: string = fileURLToPath(new URL(".", import.meta.url)),
 	localDir?: string,
@@ -651,19 +664,37 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 // -----------------------------------------------------------------------------
-// PreToolUse IO contract — parses the hook's stdin JSON (which includes
-// `cwd`, the Bash tool's working directory — see docs.claude.com/en/docs/
-// claude-code/hooks), resolves the workspace root + package.json scripts for
-// that cwd, calls decide(), and formats the output envelope. There is no
+// PreToolUse IO contract — parses the hook's stdin JSON, resolves the
+// workspace root + package.json scripts for the command's own working
+// directory, calls decide(), and formats the output envelope. There is no
 // "allow" envelope anywhere in this file: a deny produces a permissionDecision
 // deny envelope, everything else produces "" (no hook output at all, i.e. the
 // tool call proceeds through the harness's normal permission flow untouched).
+//
+// Two payload shapes land here, both routed through the SAME decide() core:
+//   - Claude: tool_name "Bash", command in tool_input.command, cwd at the
+//     top level (docs.claude.com/en/docs/claude-code/hooks).
+//   - Codex: tool_name "bash"/"exec_command"/"shell_command" (any case —
+//     compared lowercased), command in tool_input.command falling back to
+//     tool_input.cmd, and the command's OWN execution directory in
+//     tool_input.workdir falling back to tool_input.cwd (resolved against
+//     the top-level cwd) — mirroring hooks/codex-write-guard.sh and
+//     hooks/codex-label-commit-gate.sh's identical fallback/precedence.
+// Claude's payload never carries tool_input.cmd/workdir/cwd, so the fallback
+// logic below is a no-op for it and its resolved command/cwd stay byte-
+// identical to before this dual-payload support was added.
 // -----------------------------------------------------------------------------
 type PreToolUseInput = {
 	tool_name?: unknown;
-	tool_input?: { command?: unknown };
+	tool_input?: { command?: unknown; cmd?: unknown; workdir?: unknown; cwd?: unknown };
 	cwd?: unknown;
 };
+
+const SUPPORTED_TOOL_NAMES = new Set(["bash", "exec_command", "shell_command"]);
+
+function pickNonEmptyString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
 
 export function processHookInput(
 	raw: string,
@@ -671,15 +702,18 @@ export function processHookInput(
 ): string {
 	try {
 		const input: PreToolUseInput = JSON.parse(raw);
-		if (input.tool_name !== "Bash") return "";
+		const toolName = typeof input.tool_name === "string" ? input.tool_name.toLowerCase() : "";
+		if (!SUPPORTED_TOOL_NAMES.has(toolName)) return "";
 
-		const command = input.tool_input?.command;
-		if (typeof command !== "string" || command.trim().length === 0) return "";
+		const command = pickNonEmptyString(input.tool_input?.command) ?? pickNonEmptyString(input.tool_input?.cmd);
+		if (command === undefined) return "";
 
-		const cwd = typeof input.cwd === "string" && input.cwd.length > 0 ? resolve(input.cwd) : resolve(process.cwd());
+		const topCwd = typeof input.cwd === "string" && input.cwd.length > 0 ? input.cwd : process.cwd();
+		const workdir = pickNonEmptyString(input.tool_input?.workdir) ?? pickNonEmptyString(input.tool_input?.cwd);
+		const cwd = workdir === undefined ? resolve(topCwd) : resolve(topCwd, workdir);
 
 		const workspaceRoot = findWorkspaceRoot(cwd);
-		const localDir = workspaceRoot === null ? undefined : join(workspaceRoot, ".claude", "scripts", "verify-entrypoint-gate");
+		const localDir = workspaceRoot === null ? undefined : resolveLocalDir(workspaceRoot);
 		const policy = loadConfig(baseDir, localDir);
 		const scripts = workspaceRoot === null ? [] : readPackageScripts(workspaceRoot);
 

--- a/scripts/verify-entrypoint-gate/verify-entrypoint-gate.test.ts
+++ b/scripts/verify-entrypoint-gate/verify-entrypoint-gate.test.ts
@@ -691,6 +691,154 @@ describe("processHookInput", () => {
 });
 
 // -----------------------------------------------------------------------------
+// processHookInput — Codex payload support. Field-set provenance: cmd/workdir
+// are drawn from a real rollout capture (see this file's own PROVENANCE note
+// below) and from hooks/codex-write-guard_test.sh:2171-2180's FIXTURE
+// PROVENANCE footnote — a codex-binary `strings` scan is the only source for
+// these field names, which is why this remains marked provisional there and
+// here alike.
+//
+// FIXTURE PROVENANCE (provisional, inherited from hooks/codex-write-
+// guard_test.sh:2171-2180): the exec_command/shell_command field set (tool_name
+// lowercase, tool_input.cmd, tool_input.workdir) is grounded in a real rollout
+// capture (~/.codex/sessions/2026/07/30/rollout-2026-07-30T10-45-36-*.jsonl:
+// `{"cmd":"pnpm verify backend --force ...","workdir":"/Users/toong/repos/
+// algocare-home/dolomite-awe"}`), not an official schema doc — Codex ships no
+// public payload reference for these hook fields.
+// -----------------------------------------------------------------------------
+describe("processHookInput — Codex payload support", () => {
+	const moduleDir = fileURLToPath(new URL(".", import.meta.url));
+
+	function makeWorkspace(): string {
+		const root = mkdtempSync(join(tmpdir(), "verify-entrypoint-gate-codex-e2e-"));
+		writeFileSync(join(root, "pnpm-workspace.yaml"), "packages: []\n");
+		writeFileSync(join(root, "package.json"), JSON.stringify({ scripts: { verify: "echo verify" } }));
+		return root;
+	}
+
+	test("exec_command + cmd + workdir: `pnpm verify backend --force` denies — the real dolomite-awe incident shape", () => {
+		const root = makeWorkspace();
+		try {
+			const output = processHookInput(
+				JSON.stringify({
+					tool_name: "exec_command",
+					tool_input: { cmd: "pnpm verify backend --force", workdir: root },
+					cwd: "/tmp/unrelated",
+				}),
+				moduleDir,
+			);
+			const parsed = JSON.parse(output);
+			expect(parsed.hookSpecificOutput.permissionDecision).toBe("deny");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("exec_command + cmd + workdir: `pnpm verify backend` (no --force) passes through with empty output", () => {
+		const root = makeWorkspace();
+		try {
+			const output = processHookInput(
+				JSON.stringify({
+					tool_name: "exec_command",
+					tool_input: { cmd: "pnpm verify backend", workdir: root },
+					cwd: "/tmp/unrelated",
+				}),
+				moduleDir,
+			);
+			expect(output).toBe("");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("shell_command tool_name is also recognized (three-way whitelist)", () => {
+		const root = makeWorkspace();
+		try {
+			const output = processHookInput(
+				JSON.stringify({
+					tool_name: "shell_command",
+					tool_input: { cmd: "pnpm verify backend --force", cwd: root },
+				}),
+				moduleDir,
+			);
+			expect(JSON.parse(output).hookSpecificOutput.permissionDecision).toBe("deny");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("a tool_name not in the whitelist (e.g. read_file) passes through silently regardless of cmd content", () => {
+		const output = processHookInput(
+			JSON.stringify({ tool_name: "read_file", tool_input: { cmd: "pnpm verify --all" } }),
+			moduleDir,
+		);
+		expect(output).toBe("");
+	});
+
+	test("neither tool_input.command nor tool_input.cmd present passes through silently", () => {
+		const output = processHookInput(
+			JSON.stringify({ tool_name: "exec_command", tool_input: { workdir: "/tmp" } }),
+			moduleDir,
+		);
+		expect(output).toBe("");
+	});
+
+	test("local overlay resolution prefers .claude/scripts/... over .codex/scripts/... when both exist", () => {
+		const root = mkdtempSync(join(tmpdir(), "verify-entrypoint-gate-overlay-order-"));
+		try {
+			writeFileSync(join(root, "pnpm-workspace.yaml"), "packages: []\n");
+			writeFileSync(join(root, "package.json"), JSON.stringify({ scripts: { verify: "echo verify" } }));
+
+			// .claude overlay empties the entrypoints whitelist entirely, so
+			// "pnpm verify --force" is no longer even recognized as a
+			// verification attempt (passthrough). .codex overlay keeps
+			// "verify" — if it were picked instead, the same command would
+			// deny (--force isn't in allowed_turbo_opts). The two overlays'
+			// diverging outcomes are what makes this test discriminate which
+			// one actually won, not just that loading didn't throw.
+			const claudeLocalDir = join(root, ".claude", "scripts", "verify-entrypoint-gate");
+			mkdirSync(claudeLocalDir, { recursive: true });
+			writeFileSync(join(claudeLocalDir, "verify-entrypoint-gate.local.yaml"), "entrypoints: []\n");
+
+			const codexLocalDir = join(root, ".codex", "scripts", "verify-entrypoint-gate");
+			mkdirSync(codexLocalDir, { recursive: true });
+			writeFileSync(join(codexLocalDir, "verify-entrypoint-gate.local.yaml"), "entrypoints: [verify]\n");
+
+			const output = processHookInput(
+				JSON.stringify({ tool_name: "exec_command", tool_input: { cmd: "pnpm verify --force", workdir: root } }),
+				moduleDir,
+			);
+			expect(output).toBe("");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("tool_input.workdir takes precedence over tool_input.cwd when both are present", () => {
+		const root = makeWorkspace();
+		const decoy = mkdtempSync(join(tmpdir(), "verify-entrypoint-gate-codex-decoy-"));
+		try {
+			// decoy has no pnpm-workspace.yaml — if the gate wrongly preferred
+			// tool_input.cwd over tool_input.workdir it would fail-closed deny
+			// for the WRONG reason (workspace root not found) instead of the
+			// shape-mismatch deny this test actually asserts.
+			const output = processHookInput(
+				JSON.stringify({
+					tool_name: "exec_command",
+					tool_input: { cmd: "pnpm verify backend --force", workdir: root, cwd: decoy },
+				}),
+				moduleDir,
+			);
+			const parsed = JSON.parse(output);
+			expect(parsed.hookSpecificOutput.permissionDecisionReason).toContain("verify");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+			rmSync(decoy, { recursive: true, force: true });
+		}
+	});
+});
+
+// -----------------------------------------------------------------------------
 // Drift pin — every table test above runs decide() against POLICY, a
 // hand-copied snapshot of verify-entrypoint-gate.yaml's shipped values. If
 // the real yaml drifts (an entrypoint renamed, a runner removed), the table

--- a/sync.yaml
+++ b/sync.yaml
@@ -85,15 +85,19 @@ scripts:
   items:
     # verify-entrypoint-gate: entrypoint 화이트리스트를
     # package.json scripts와 실시간 교집합해 존재하지 않는 스크립트를 안내하지 않는다.
-    # scripts로 배포(등록 없음)하여 $HOME/.claude/scripts/verify-entrypoint-gate/에 단일본으로 두고,
-    # 실제 hook 등록은 projects/algocare-home/claude.yaml이 raw command로 이 경로를 참조한다.
+    # scripts로 배포(등록 없음)하여 $HOME/.claude/scripts/verify-entrypoint-gate/ +
+    # $HOME/.codex/scripts/verify-entrypoint-gate/ 두 단일본으로 두고, 실제 hook 등록은
+    # projects/algocare-home/claude.yaml(Bash matcher)과 projects/algocare-home/
+    # codex.yaml(Bash|bash|exec_command|shell_command matcher)이 각각 raw command로
+    # 이 경로를 참조한다 — processHookInput이 두 플랫폼의 payload 모양(tool_name 대소문자,
+    # command/cmd, cwd/workdir)을 모두 받아 같은 decide() 코어로 판정한다.
     # base 정책 verify-entrypoint-gate.yaml은 index.ts가 import.meta.url 기준(자기 옆)으로
     # 로드하지만, 프로젝트 오버레이 .local.yaml은 대상 워크스페이스 루트 기준으로 로드한다
     # — 이 2층 분리가 구 게이트의 구조적 버그를 고친 지점. 구 loadConfig는 base·local을
     # 둘 다 스크립트 자기 디렉터리에서 해석해서, 전역 단일본 배포 하에선 "프로젝트별
     # 오버라이드"마저 전역 단일본이었다(어느 프로젝트에서 실행해도 같은 파일을 봤다).
     - component: verify-entrypoint-gate
-      platforms: [claude]
+      platforms: [claude, codex]
 
 rules:
   items:


### PR DESCRIPTION
## 📌 Summary
verify-entrypoint-gate(algocare-home 검증 명령 게이트)가 Claude 세션에만 배선돼 있어, Codex 세션의 `pnpm verify backend --force`가 게이트를 거치지 않고 무차단 실행된 실사례가 있었습니다. 같은 엔진·같은 정책이 Codex `exec_command`에도 강제되도록 페이로드 지원과 훅 배선을 추가합니다.

---

## 🔧 Changes

### 게이트 엔진 (`scripts/verify-entrypoint-gate/`)

- `processHookInput`이 Codex 페이로드를 수용: `tool_name` 소문자화 후 `{bash, exec_command, shell_command}` 집합 판정(Claude의 `"Bash"`도 같은 집합에 흡수), 명령 문자열은 `tool_input.command` → `cmd` 폴백, 실행 디렉터리는 `tool_input.workdir` → `cwd` 폴백
- 프로젝트 오버레이(`.local.yaml`) 탐색을 `.claude/scripts/` → `.codex/scripts/` 존재-확인 순서로 확장
- Codex 페이로드 회귀 테스트 7건 추가(실사건 페이로드 shape 포함) — 총 126 테스트

판정 코어 `decide()`와 deny 봉투는 이미 플랫폼 중립이라 IO 계층만 확장했습니다.

**영향 범위**
Claude 경로 기존 동작 불변(기존 테스트 전건 유지). 정책 규칙(`entrypoints`/`allowed_turbo_opts`)은 한 글자도 바뀌지 않음.

### 배선 (`sync.yaml`, `projects/algocare-home/`)

- 전역·프로젝트 scripts 항목 platforms `[claude]` → `[claude, codex]` — 전역 단일본이 `~/.codex/scripts/`에도 배포
- `projects/algocare-home/codex.yaml` 신규: PreToolUse 훅 등록(matcher는 기존 codex twin들과 동일한 `"Bash|bash|exec_command|shell_command"`, timeout 10)

**영향 범위**
algocare-home 프로젝트 스코프 한정(전역 codex.yaml 무변경). 실배포는 main 머지 후 `make sync` 시점.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 어댑터의 `.codex/` 무조건 재작성과 인용부-분할 우회

**배경 및 문제 상황:**
codex 어댑터(`tools/adapters/codex.ts:832`)는 훅 command 문자열의 `.codex/` 리터럴을 배포 타깃 기준 절대경로로 무조건 재작성합니다(Claude 어댑터는 raw command를 그대로 둠). 이 게이트의 command는 전역 단일본(`$HOME/.codex/scripts/...`)을 가리켜야 하는데 — 워크트리 사본에는 index.ts가 없고 오버레이 `.local.yaml`만 배포됨 — 그대로 쓰면 재작성이 워크트리 경로로 오염시킵니다.

**해결 방안:**
`bun run "$HOME/.codex"/scripts/...`로 인용부를 쪼개 `.codex/` 7글자 리터럴 매치를 끊었습니다. 셸은 인접 토큰을 한 단어로 이어붙이므로 실행 시 동일 경로입니다.

**구현 세부사항:**
격리 `CODEX_HOME`의 실제 `codex exec`로 (a) bare command에서 `$HOME` 셸 확장이 동작하고 (b) 인용부-분할 형태가 실행에서 보존됨을 end-to-end 실증했습니다. QA에서 어댑터 재작성 식을 그대로 적용해 무변형을 재확인했습니다.

**선택과 트레이드오프:**
어댑터를 고쳐 raw command를 재작성 대상에서 빼는 대안(Claude 어댑터와 대칭)이 근본 해결이지만, 기존 전역 codex 훅 전부의 배포 산출물이 바뀌는 블라스트를 이 PR에 싣지 않으려 로컬 우회를 택했습니다. 우회가 트릭성이라는 점은 인정하며 codex.yaml에 근거 주석을 상세히 남겼습니다. 어댑터 수정을 별도 PR로 다룰지 의견 환영합니다.

### 2. bash shim twin 선례 대신 단일 TS 모듈 분기

**배경 및 문제 상황:**
기존 codex twin들(`codex-label-commit-gate.sh` 등)은 "공유 코어 + 플랫폼별 얇은 shim" 구조입니다. 선례를 따르면 게이트도 codex 전용 엔트리 파일을 신설해야 합니다.

**해결 방안:**
엔진이 이미 TS 단일 모듈이고 deny 봉투(`hookSpecificOutput`)가 양 플랫폼 계약과 동일해, `processHookInput`에 분기를 추가하는 것이 최소 변경입니다.

**구현 세부사항:**
shim이 Claude 엔트리 대비 추가하던 축 4개(tool_name 화이트리스트·cmd 폴백·workdir 전환·deny 봉투) 중 봉투는 이미 동일했고, 나머지 3개만 이식해 각각 테스트로 커버했습니다.

**선택과 트레이드오프:**
"모든 twin은 shim 패턴"이라는 파일 구조 대칭성을 포기하고 변경 최소화를 택했습니다. Codex 페이로드 계약이 Claude와 갈라지는 시점이 오면 그때 분리하면 됩니다.

### 3. 오버레이 `.claude`-first 순서와 sync 경로 재작성의 상호작용

**배경 및 문제 상황:**
sync는 `.codex` 트리에 `.claude/` → `.codex/` 경로 재작성 패스를 돌립니다. 배포된 codex 사본의 `resolveLocalDir`가 재작성되면 탐색 순서의 의미가 바뀔 수 있습니다.

**해결 방안:**
`resolveLocalDir`는 `".claude"`(슬래시 없음)를 join 인자로 쓰므로 재작성 규칙(전부 `.claude/` 슬래시 포함 매치)에 걸리지 않습니다.

**구현 세부사항:**
실제 재작성 규칙 전체(`tools/lib/rewrite-rules.ts`의 codex 테이블)를 적용한 시뮬레이션으로 배포본에서도 `.claude`-first가 보존됨을 확인했습니다. 두 사본은 같은 소스에서 sync되므로 이 순서는 존재-확인용일 뿐 정책 차이가 아닙니다(코드 주석에 명시).

**선택과 트레이드오프:**
플랫폼을 명시 인자로 주입하는 대안은 배선 명령 계약을 바꿔야 해 기각했습니다. 존재-확인 순서는 "두 사본 내용 동일" 전제에 기대며, 그 전제는 sync가 보장합니다.

---

## ✅ Checklist

### Codex 페이로드 판정
- [ ] 실사건 shape(`exec_command` + `cmd`의 파이프 조합 + `workdir`)가 deny된다
  - `scripts/verify-entrypoint-gate/verify-entrypoint-gate.test.ts`
- [ ] tool_name 대소문자 변형(`EXEC_COMMAND` 등)이 게이트를 비껴가지 않는다
  - `scripts/verify-entrypoint-gate/index.ts`
- [ ] Claude 경로(`tool_name:"Bash"`) 기존 테스트가 전건 그대로 통과한다
  - `scripts/verify-entrypoint-gate/verify-entrypoint-gate.test.ts`

### 배선/배포
- [ ] `make sync-dry`에서 algocare-home 워크트리에 hooks.json 갱신과 `[codex] scripts` 배포가 계획된다
  - `projects/algocare-home/sync.yaml`
- [ ] codex.yaml의 command 문자열이 어댑터 `.codex/` 재작성 후에도 불변이다
  - `projects/algocare-home/codex.yaml`

---

## 📎 References
- [#193 검증 진입점 게이트를 교집합 화이트리스트로 재설계](https://github.com/toongri/oh-my-toong-playground/pull/193)
- [#202 write-guard·label 게이트 codex 패리티](https://github.com/toongri/oh-my-toong-playground/pull/202)

https://claude.ai/code/session_01TYhBf1UkBa3qkmwhq2k7FJ