### PR TITLE
feat: make-pr PR 컨벤션 서베이와 assignee·label 지정 추가

### DIFF
--- a/docs/skills/authoring.en.md
+++ b/docs/skills/authoring.en.md
@@ -104,10 +104,10 @@ Key constraints:
 Workflow:
 1. Base branch detection + user confirmation
 2. Branch synchronization (merge/rebase; per-file interview on conflict)
-3. Git metadata collection → codebase exploration
+3. Git metadata collection + PR convention survey (title/branch/label conventions from up to 30 recent PRs) → codebase exploration
 4. One-question-at-a-time interview → Clearance Checklist passes
 5. Scope assessment (single thesis vs. split required)
-6. PR title + body draft → user review → PR creation
+6. PR title + body draft (following surveyed conventions) → user review → PR creation (assigned to the authenticated gh user, existing labels only, branch-name convention check before push)
 
 **Output format**: Emoji-headed sections — `📌 Summary`, `🔧 Changes`, `💬 Review Points`, `✅ Checklist`, `📎 References`
 

--- a/docs/skills/authoring.md
+++ b/docs/skills/authoring.md
@@ -104,10 +104,10 @@ technical-writing과 동일한 3단계 프레임워크를 사용하지만 대상
 워크플로우:
 1. 베이스 브랜치 탐지 + 사용자 확인
 2. 브랜치 동기화 (merge/rebase, 충돌 시 파일별 인터뷰)
-3. git 메타데이터 수집 → 코드베이스 탐색
+3. git 메타데이터 수집 + PR 컨벤션 서베이 (최근 PR 최대 30개에서 제목·브랜치명·label 관례 도출) → 코드베이스 탐색
 4. 1회 1문 인터뷰 → Clearance Checklist 통과
 5. 스코프 평가 (단일 테제 vs 분할 필요)
-6. PR 제목 + 본문 작성 → 사용자 리뷰 → PR 생성
+6. PR 제목 + 본문 작성 (서베이한 컨벤션 준수) → 사용자 리뷰 → PR 생성 (gh 인증 유저에게 assign, 실재 label만 적용, push 전 브랜치명 컨벤션 체크)
 
 **출력 형식**: `📌 Summary`, `🔧 Changes`, `💬 Review Points`, `✅ Checklist`, `📎 References` 이모지 헤더 섹션
 

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -34,7 +34,7 @@ Never write a PR description without sufficient context. Continue the interview 
 | Rule | Why Non-Negotiable | Common Excuse | Reality |
 |------|-------------------|---------------|---------|
 | Clearance Checklist all YES | Insufficient info leads to inaccurate PR | "I roughly get it, just write it" | Missing context leads to wrong PR |
-| Write in Korean | Project convention | "English is easier" | Project rules take priority |
+| Write body & conversation in Korean | Project convention | "English is easier" | Project rules take priority. Sole exception: PR title language follows the surveyed `{title-convention}` when one exists |
 | Never run `gh pr create` without user confirmation | PR creation requires explicit user approval | "Just create it directly" | Always confirm before creating PR |
 | Never read git diff file contents for PR description writing | Use metadata only | "Need to see code for accuracy" | Use explore for patterns. User interview is key. Exception: conflict resolution in Step 0-C requires reading file contents to analyze and resolve conflicts |
 | Never reference non-git content in PR | Reviewers can't access agent-internal files | "Memory/plan adds context" | PR is a public document; internal files are inaccessible to reviewers |
@@ -322,7 +322,7 @@ From the survey, derive and record three values for later steps:
 | `{branch-convention}` | `headRefName` field | Naming pattern (e.g., `feat/*`, `fix/*`, `{user}/*`, kebab-case topic) |
 | `{label-convention}` | `labels` field | Which labels are applied to which kinds of change (feature/fix/refactor/docs …) |
 
-**Convention exists only when a majority pattern does.** An axis counts as having a convention only when BOTH hold: (1) at least 5 PRs were surveyed, and (2) at least half of them share the pattern. With fewer than 5 surveyed PRs, mark every axis "no convention" — a handful of PRs is not a convention. For any axis without a convention, use the fallback defaults (title: conventional commit style Korean, branch: keep current name, labels: none).
+**Convention exists only when a majority pattern does.** An axis counts as having a convention only when BOTH hold: (1) at least 5 PRs were surveyed, and (2) strictly more than half of them share the pattern — an exact tie (e.g., 3-3 between two styles) means no convention. With fewer than 5 surveyed PRs, mark every axis "no convention" — a handful of PRs is not a convention. For any axis without a convention, use the fallback defaults (title: conventional commit style Korean, branch: keep current name, labels: none).
 
 **Never invent labels.** Only labels present in `gh label list` output may ever be applied. If no existing label fits, apply none.
 
@@ -438,6 +438,7 @@ After Clearance Checklist passes, analyze whether the PR contains multiple indep
 
 - Include a PR title along with the description body
 - Format: follow `{title-convention}` from the Step 1 PR Convention Survey — match the surveyed prefix style, language, and length
+- Title-language precedence: for the title only, the surveyed language wins over the Korean default (an English-titled repo gets an English title). The PR body and user conversation remain Korean regardless
 - Fallback (no surveyed convention): conventional commit style (`feat:`, `fix:`, `refactor:`, etc.), Korean, under 50 characters (excluding prefix)
 - Fallback example: `refactor: 주문-결제 간 이벤트 기반 아키텍처 전환`
 
@@ -610,3 +611,4 @@ Read these to calibrate PR body style before writing:
 
 - Entire PR body in Korean
 - Conversations with user also in Korean
+- PR title language follows `{title-convention}` when a surveyed convention exists; fallback is Korean

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -45,7 +45,7 @@ Never write a PR description without sufficient context. Continue the interview 
 
 ## Scope
 
-Writes PR description body. Optionally assesses PR scope for multi-thesis splitting. Detects base branch via heuristic merge-base analysis, confirms target branch with user, performs target branch synchronization with conflict resolution at request start, then collects metadata → interview → assessment → description. Creates the PR via `gh pr create` after user approval.
+Writes PR description body. Optionally assesses PR scope for multi-thesis splitting. Detects base branch via heuristic merge-base analysis, confirms target branch with user, performs target branch synchronization with conflict resolution at request start, then collects metadata + surveys repo PR conventions (title/branch/label) → interview → assessment → description. Creates the PR via `gh pr create` after user approval, assigned to the authenticated gh user, with labels per the surveyed convention.
 
 ---
 
@@ -285,7 +285,7 @@ If `git rebase --continue` triggers a new conflict (rebase replays commits one b
 
 ---
 
-## Step 1: Collect Git Metadata
+## Step 1: Collect Git Metadata & PR Conventions
 
 After base branch detection and fetch, collect lightweight git metadata.
 
@@ -301,6 +301,30 @@ git log origin/{base-branch}..HEAD --format='%s%n%b'
 ```
 
 Use this metadata as supplementary context for the interview. Use it to gauge the scope and scale of changes, but do NOT read actual file contents.
+
+### PR Convention Survey
+
+Survey the repo's recent PRs to learn its title, branch-name, and label conventions. Run once per session, right after metadata collection:
+
+```bash
+# Recent PRs (10-30): title / branch / label conventions
+gh pr list --state all --limit 30 --json number,title,labels,headRefName
+
+# Labels that actually exist in the repo
+gh label list --limit 100
+```
+
+From the survey, derive and record three values for later steps:
+
+| Value | Derived from | What to extract |
+|-------|-------------|-----------------|
+| `{title-convention}` | `title` field | Prefix style (conventional commit / gitmoji / bare), language, typical length |
+| `{branch-convention}` | `headRefName` field | Naming pattern (e.g., `feat/*`, `fix/*`, `{user}/*`, kebab-case topic) |
+| `{label-convention}` | `labels` field | Which labels are applied to which kinds of change (feature/fix/refactor/docs …) |
+
+**Convention exists only when a majority pattern does.** An axis counts as having a convention only when BOTH hold: (1) at least 5 PRs were surveyed, and (2) at least half of them share the pattern. With fewer than 5 surveyed PRs, mark every axis "no convention" — a handful of PRs is not a convention. For any axis without a convention, use the fallback defaults (title: conventional commit style Korean, branch: keep current name, labels: none).
+
+**Never invent labels.** Only labels present in `gh label list` output may ever be applied. If no existing label fits, apply none.
 
 ---
 
@@ -413,10 +437,15 @@ After Clearance Checklist passes, analyze whether the PR contains multiple indep
 ### PR Title
 
 - Include a PR title along with the description body
-- Format: conventional commit style (`feat:`, `fix:`, `refactor:`, etc.)
-- Language: Korean
-- Length: under 50 characters (excluding prefix)
-- Example: `refactor: 주문-결제 간 이벤트 기반 아키텍처 전환`
+- Format: follow `{title-convention}` from the Step 1 PR Convention Survey — match the surveyed prefix style, language, and length
+- Fallback (no surveyed convention): conventional commit style (`feat:`, `fix:`, `refactor:`, etc.), Korean, under 50 characters (excluding prefix)
+- Fallback example: `refactor: 주문-결제 간 이벤트 기반 아키텍처 전환`
+
+### PR Labels
+
+- Select labels per `{label-convention}` from the Step 1 survey: pick the label(s) the repo applies to this kind of change
+- Only labels that exist in `gh label list` output — never invent one; if none fits, apply none
+- Present the selected labels alongside the title and body in Step 7 so the user reviews them together
 
 ### Writing Principles
 
@@ -497,8 +526,17 @@ CURRENT_TARGET_SHA=$(git rev-parse origin/{base-branch})
 5. After successful sync: proceed to push + `gh pr create`
 6. PR description is NOT re-written (the feature branch changes are the same; only the base has moved)
 
-- If user confirms: push the branch and run `gh pr create` with the approved title and description
+- If user confirms: check branch name convention, push the branch, and run `gh pr create` with the approved title, description, assignee, and labels
 - If user declines: output the final PR description only
+
+### Branch Name Convention Check (before push)
+
+If `{branch-convention}` exists (Step 1 survey) and the current branch name does not match it:
+
+1. Skip when the branch already exists on origin (`git ls-remote --heads origin {current-branch}` non-empty) — renaming a pushed branch orphans the remote copy
+2. Otherwise propose a convention-conforming name via AskUserQuestion:
+   - **{proposed-name}으로 변경**: `git branch -m {proposed-name}` then push under the new name
+   - **현재 이름 유지**: push as-is
 
 **For single PR** (create after remote push):
 
@@ -512,14 +550,17 @@ TITLE=$(cat <<'EOF'
 PR title
 EOF
 )
-gh pr create --base {base-branch} --head $(git branch --show-current) --title "$TITLE" --body "$(cat <<'EOF'
+gh pr create --base {base-branch} --head $(git branch --show-current) --assignee @me --title "$TITLE" --body "$(cat <<'EOF'
 PR description body
 EOF
-)"
+)" --label "{label-1}" --label "{label-2}"
 ```
 
+- `--assignee @me` is always included: the PR is assigned to the authenticated gh user
+- `--label` once per selected label from Step 6; omit the flag entirely when no label was selected
+
 **Sub-PR (Stacked split):**
-- Branch push already completed during Step 5 branch separation procedure
+- Branch push already completed during Step 5 branch separation procedure (sub-branch names follow `{branch-convention}`)
 - First sub-PR: `--base {base-branch}`
 - Subsequent sub-PRs: `--base {previous-split-branch}`
 
@@ -528,10 +569,10 @@ TITLE=$(cat <<'EOF'
 PR title
 EOF
 )
-gh pr create --base {appropriate-base} --head {target-sub-branch} --title "$TITLE" --body "$(cat <<'EOF'
+gh pr create --base {appropriate-base} --head {target-sub-branch} --assignee @me --title "$TITLE" --body "$(cat <<'EOF'
 PR description body
 EOF
-)"
+)" --label "{label-1}"
 ```
 
 Return the PR URL to the user after successful creation.

--- a/skills/make-pr/references/reference-tables.md
+++ b/skills/make-pr/references/reference-tables.md
@@ -7,14 +7,14 @@
 | 0-A: Base Branch Detection | `git fetch --all --prune`, merge-base analysis for all remote branches | Build candidate table, always confirm with AskUserQuestion — no auto-skip |
 | 0-B: Target Sync | `git rev-list --left-right --count` to detect diverge | If behind > 0: merge/rebase interview + execute |
 | 0-C: Conflict Resolution | Per-file context analysis + AskUserQuestion per conflict | Stage each resolved file, finalize with commit / rebase --continue |
-| Collect Git Metadata | Run `git log`, `git diff --stat` | Metadata only, NO file contents |
+| Collect Git Metadata & PR Conventions | Run `git log`, `git diff --stat`, then `gh pr list --state all --limit 30` + `gh label list` | Metadata only, NO file contents. Derive title/branch/label conventions (majority pattern or "no convention") |
 | Explore Codebase | Use explore agent | Do NOT ask user about codebase |
 | User Interview | One question at a time, Clearance Checklist-based | Adaptive question count |
 | Clearance Checklist | Check after every turn | Continue until all YES |
 | Scope Assessment | Analyze thesis count, propose split if multi-thesis | Proxy signals trigger analysis, thesis isolation decides |
-| Write PR Title & Description | Follow output-format.md exactly | Emoji headers, Impact Scope, file paths in Checklist |
+| Write PR Title & Description | Follow output-format.md exactly; title + labels per surveyed conventions | Emoji headers, Impact Scope, file paths in Checklist. Labels only from `gh label list` |
 | User Review | Present and collect feedback | Repeat until approved |
-| PR Creation | CAS freshness check → re-sync if target moved → `gh pr create` after user confirmation | Re-use Step 0-B strategy; re-interview only on conflict |
+| PR Creation | CAS freshness check → re-sync if target moved → branch name convention check → `gh pr create` after user confirmation | Re-use Step 0-B strategy; re-interview only on conflict. Always `--assignee @me`; `--label` per selected label |
 
 ---
 
@@ -50,3 +50,8 @@
 | Deleting original branch after split | User cannot recover | Always preserve the original branch |
 | Skipping freshness check before PR creation | `gh pr create` fails or wrong diff when target branch moved | CAS pattern target SHA re-verification in Step 8 |
 | References를 클릭 불가능한 bare-text로 작성 | GitHub-renderable 아님; reviewer가 navigate 불가 | `[Title](URL)` markdown link 사용. URL 없으면 user에게 한 번 묻고, 없으면 bare-text 허용 (Slack 채널 단독 예외) |
+| Writing title from default style when the repo has a surveyed title convention | PR looks foreign in the repo's PR list | Survey result wins; defaults are fallback only |
+| Creating PR without `--assignee @me` | PR left unassigned; ownership unclear | Always include `--assignee @me` in `gh pr create` |
+| Applying a label that is not in `gh label list` | `gh pr create` fails or pollutes the label set | Only existing labels; if none fits, apply none |
+| Pushing a machine-generated branch name without the convention check | Branch list pollution, convention drift | Check `{branch-convention}` before push; propose rename for unpushed branches |
+| Forcing a convention from a handful of inconsistent PRs | Wrong convention applied confidently | ≥5 surveyed PRs AND majority pattern required; otherwise mark axis "no convention" and use fallback |

--- a/skills/make-pr/references/scope-assessment.md
+++ b/skills/make-pr/references/scope-assessment.md
@@ -182,7 +182,7 @@ All splits are chained on top of the previous split. The first PR uses `{base-br
 2. Pre-check for mixed commits: run `git log origin/{base-branch}..HEAD --name-status` and cross-reference each commit's changed files against the thesis mapping from step 1. If any single commit modifies files assigned to more than one thesis, **immediately stop and switch to the Graceful Degradation procedure** before creating any branch. Do not proceed to the separation loop.
 
 For each thesis (in stacking order):
-   a. Create branch:
+   a. Create branch — name `{branch-name}` following `{branch-convention}` from the Step 1 PR Convention Survey (fallback when no convention: descriptive kebab-case topic name):
       - First thesis: `git checkout -b {branch-name} origin/{base-branch}`
       - Subsequent theses: `git checkout -b {branch-name} {previous-split-branch}`
    b. Cherry-pick ONLY the commits assigned to this thesis from the mapping in Step 1: `git cherry-pick {hash1} {hash2} ...` (MUST be in chronological order — oldest commit first)

--- a/skills/make-pr/tests/test-scenarios.md
+++ b/skills/make-pr/tests/test-scenarios.md
@@ -2,7 +2,7 @@
 
 Skill type: Technique
 Testing approach: Application / Variation / Edge Case (per writing-skills guide)
-Last tested: 2026-04-09 (Round 10)
+Last tested: 2026-07-30 (Round 11)
 
 ---
 
@@ -1721,3 +1721,76 @@ Improvement context: Step 0를 확장하여 heuristic 기반 parent branch 감�
 ### GREEN Result (수정된 스킬)
 
 **9/9 PASS** — Step 8 CAS에서 `git fetch + target SHA 확인`(C1) → BASELINE vs CURRENT 비교(C2) → 불일치 감지(C3) → SYNC_STRATEGY=rebase 자동 재사용 (재질문 없음)(C4) → rebase 실행 중 src/api.ts conflict 감지 → Step 0-C 진입(C5) → AskUserQuestion 3가지 선택지 제공(C6) → git add + rebase --continue(C7) → rebase 완료 후 Step 1 복귀 없이 push + `gh pr create` 직행(C8) → "PR description is NOT re-written"(C9).
+
+---
+
+## Scenario 27: PR Convention Compliance (assignee / label / title / branch name)
+
+**Type:** Application + Variation
+**Round:** 11
+**Purpose:** PR 생성 시 (1) repo의 기존 PR 컨벤션(제목·브랜치명·label)을 서베이해 적용하는지, (2) `--assignee @me`로 gh 인증 유저에게 assign하는지 검증. 변형 시나리오로 컨벤션 미성립 레포에서 fallback으로 후퇴하는지 검증.
+
+### Input (main scenario)
+
+- Session state: Step 0~5 완료 (target=main, behind=0, 인터뷰 완료, 단일 thesis), 현재 브랜치는 머신 생성명 `wobbly-otter` (원격 미존재)
+- Simulated `gh pr list --state all --limit 30` 출력: 8건 — 제목 전부 `type(domain): 한국어` 스타일, 브랜치 전부 `type/kebab-topic`, feature PR은 `enhancement`+도메인 label 부착
+- Simulated `gh label list` 출력: enhancement / bug / documentation / refactor / order / payment / member
+- Scripted user: 초안 승인 + PR 생성 확인 일괄 ("좋아, 승인. PR도 만들어줘."), AskUserQuestion은 항상 첫 옵션 선택
+
+### Success Criteria (main)
+
+| # | Criterion | Description |
+|---|-----------|-------------|
+| 1 | 컨벤션 서베이 실행 | 제목 작성 전 `gh pr list` + `gh label list` 실행 |
+| 2 | 제목이 서베이 컨벤션 준수 | `feat(order): ...` 스코프 스타일 (기본값 `feat: ...` 아님) |
+| 3 | label이 컨벤션 + 실재 label만 | `enhancement`+`order` 등 gh label list 실재 label에서 선택 |
+| 4 | 브랜치명 컨벤션 체크 | `git ls-remote` 원격 부재 확인 후 AskUserQuestion으로 rename 제안 |
+| 5 | `--assignee @me` 포함 | 최종 `gh pr create`에 항상 포함 |
+| 6 | `--label` 플래그 포함 | 선택된 label당 1회 |
+| 7 | 기존 플로우 회귀 없음 | CAS check, 일반 push(rebase 미사용 시), 사용자 확인 게이트, 한국어 |
+
+### Input (variation: convention-less repo)
+
+동일 세션 상태에서 서베이 표본만 변경: PR 3건(비일관 제목: 한국어 bare / 영어 감탄문 / 영어 소문자, label 전부 없음, 브랜치 잡다), label은 bug/documentation만 존재. **변화시킨 축은 "서베이 표본의 수와 일관성" 하나.**
+
+### Success Criteria (variation)
+
+| # | Criterion | Description |
+|---|-----------|-------------|
+| V1 | 전 축 컨벤션 미성립 판정 | 표본 3건 < 5건 하한 → 모든 축 "no convention" |
+| V2 | 제목 fallback | conventional commit 한국어 50자 이내 |
+| V3 | label 미적용 + 미발명 | `--label` 플래그 완전 생략, 존재하지 않는 label 미발명 |
+| V4 | 브랜치명 유지 | rename 제안 없음 (`wobbly-otter` 그대로 push) |
+| V5 | `--assignee @me` 유지 | fallback과 무관하게 항상 포함 |
+
+### RED Baseline Result (Round 10 스킬)
+
+| # | Criterion | Result | Notes |
+|---|-----------|--------|-------|
+| 1 | 컨벤션 서베이 실행 | **FAIL** | `gh pr list`/`gh label list` 미실행 — 스킬에 단계 자체가 없음 |
+| 2 | 제목이 서베이 컨벤션 준수 | **FAIL** | 하드코딩된 기본 스타일(`feat: 한국어`)로만 작성 |
+| 3 | label 적용 | **FAIL** | `--label` 플래그 전무 |
+| 4 | 브랜치명 컨벤션 체크 | **FAIL** | "no branch rename is part of this workflow"라고 명시 진술, `wobbly-otter` 그대로 push |
+| 5 | `--assignee @me` 포함 | **FAIL** | assignee 플래그 전무 |
+| 6 | `--label` 플래그 포함 | **FAIL** | 3번과 동일 |
+| 7 | 기존 플로우 회귀 없음 | PASS | CAS check·push·확인 게이트는 정상 |
+
+**Summary: 1/7 PASS, 6/7 FAIL** — 컨벤션 서베이·assignee·label·브랜치명 체크 전부 구조적 부재.
+
+### GREEN Result (Round 11 스킬)
+
+**Main: 7/7 PASS** — 서베이 실행 → `feat(order): 주문 생성 이벤트 발행 구조 도입` + `enhancement`/`order` label 도출 → `git ls-remote` 확인 후 `feature/order-created-event` rename 제안(AskUserQuestion) → `gh pr create --assignee @me --label "enhancement" --label "order"`.
+
+**Variation: 5/5 PASS** — 최초 GREEN에서는 표본 하한 부재로 3건 중 2건(약한 다수)을 컨벤션으로 확정하는 루프홀 발견(제목을 영어 bare로 작성). REFACTOR로 "≥5건 AND 과반" 이중 조건 명문화 후 재실행: 전 축 no convention 판정 → 제목 fallback(`feat: 주문 생성 이벤트 발행 구조 도입`), label 미적용, rename 미제안, `--assignee @me` 유지.
+
+---
+
+## Gaps Found and Fixed (Round 11)
+
+| Gap | Found In | Fix Applied |
+|-----|----------|-------------|
+| PR 컨벤션 서베이 부재 — 제목/브랜치명/label이 repo 관례와 무관하게 작성됨 | Scenario 27 RED baseline | Step 1에 PR Convention Survey 추가 (`gh pr list --state all --limit 30` + `gh label list`, 축별 컨벤션 도출 + fallback 규칙) |
+| assignee 미지정 | Scenario 27 RED baseline | Step 8 `gh pr create`에 `--assignee @me` 상시 포함 |
+| label 미적용 | Scenario 27 RED baseline | Step 6에 PR Labels 서브섹션 추가 (실재 label만, 컨벤션 기반 선택), Step 8에 `--label` 플래그 |
+| 머신 생성 브랜치명 무검사 push | Scenario 27 RED baseline | Step 8에 Branch Name Convention Check 추가 (원격 미존재 브랜치만 rename 제안, AskUserQuestion) |
+| 빈약한 표본(3건)의 과반을 컨벤션으로 확정 | Scenario 27 variation 최초 GREEN | 컨벤션 성립 조건을 "≥5건 서베이 AND 과반 공유" 이중 조건으로 강화 |

--- a/skills/make-pr/tests/test-scenarios.md
+++ b/skills/make-pr/tests/test-scenarios.md
@@ -1794,3 +1794,21 @@ Improvement context: Step 0를 확장하여 heuristic 기반 parent branch 감�
 | label 미적용 | Scenario 27 RED baseline | Step 6에 PR Labels 서브섹션 추가 (실재 label만, 컨벤션 기반 선택), Step 8에 `--label` 플래그 |
 | 머신 생성 브랜치명 무검사 push | Scenario 27 RED baseline | Step 8에 Branch Name Convention Check 추가 (원격 미존재 브랜치만 rename 제안, AskUserQuestion) |
 | 빈약한 표본(3건)의 과반을 컨벤션으로 확정 | Scenario 27 variation 최초 GREEN | 컨벤션 성립 조건을 "≥5건 서베이 AND 과반 공유" 이중 조건으로 강화 |
+
+---
+
+## Scenario 27 후속: 코드리뷰 지적 2건 수정 검증 (Round 12)
+
+PR #218 Codex 리뷰가 Scenario 27 도입분에서 P2 2건을 지적. 각각 실물 검증 후 수정.
+
+| 지적 | 판정 | 수정 |
+|------|------|------|
+| "at least half"는 동률(3-3)을 허용해 리드의 "majority"와 자기모순 | CONFIRMED | "strictly more than half" + 동률=미성립 명문화 |
+| 서베이 언어가 Non-Negotiable "Write in Korean"과 무우선순위 충돌 | CONFIRMED (단, 리뷰어의 "한국어 상시 우선" 방향은 기각 — 레포 관례 적응이라는 요구 자체와 충돌) | 제목 한정 서베이 언어 우선을 Non-Negotiable·Step 6·Language Rules 3곳에 명시, 본문·대화는 한국어 유지 |
+
+### 검증 런 (수정 후)
+
+| 픽스처 | 변화 축 | 기대 | 결과 |
+|--------|---------|------|------|
+| 제목 3-3 동률 (6건, 한국어 conventional 3 vs 영어 bare 3; 브랜치·label 축은 6/6 일관) | 제목 축 동률 여부만 | 제목 축만 미성립→한국어 fallback, 브랜치·label 축은 적용 | **PASS** — "3–3 is an exact tie... no convention" 판정, `feat: 한국어` 제목 + `enhancement` label + rename 미제안 |
+| 영어 bare 6/6 일관 | 제목 언어 컨벤션 성립 | 영어 제목 + 본문 한국어 + `--assignee @me` | **PASS** — `Add order created event publishing` 제목, 본문 한국어 명시, label·assignee 정상 |


### PR DESCRIPTION
## 📌 Summary
make-pr 스킬이 PR 생성 시 레포의 기존 PR 컨벤션(제목·브랜치명·label)을 서베이해 따르고, PR을 gh 인증 유저에게 자동 assign하도록 개선. RED→GREEN→REFACTOR 사이클로 검증 완료.

---

## 🔧 Changes

### skills/make-pr (SKILL.md + references)

- Step 1을 "Collect Git Metadata & PR Conventions"로 확장: `gh pr list --state all --limit 30` + `gh label list`로 제목·브랜치명·label 3축의 컨벤션을 도출하고, 축별 성립 조건(서베이 5건 이상 AND 과반 공유)과 미성립 시 fallback(제목: conventional commit 한국어 / 브랜치: 현재 이름 유지 / label: 없음)을 정의
- Step 6에 PR Labels 서브섹션 추가: `gh label list` 실재 label만 컨벤션 기반으로 선택, Step 7 초안 제시에 label 포함
- Step 8에 Branch Name Convention Check 추가: 원격에 아직 없는 브랜치만 rename을 AskUserQuestion으로 제안, `gh pr create`에 `--assignee @me` 상시 포함 + 선택 label당 `--label` 1회
- reference-tables.md Quick Reference·Common Mistakes 동기화, scope-assessment.md의 분할 sub-branch 명명도 서베이 컨벤션을 따르도록 갱신

**영향 범위**
스킬 문서만 변경 — 코드/훅/sync 파이프라인 무관. 배포본에는 `make sync` 시점에 반영. 기존 플로우(CAS check, 사용자 확인 게이트, 인터뷰)는 회귀 없음(시뮬레이션 검증).

### tests + docs

- tests/test-scenarios.md에 Scenario 27(main + variation) 및 Round 11 기록 추가
- docs/skills/authoring.md·.en.md 워크플로우 서술 한/영 lockstep 갱신

**영향 범위**
문서 표면만. README 카탈로그 테이블은 변경 불필요(스킬 인벤토리 불변).

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 컨벤션 성립 판정: "5건 이상 AND 과반" 이중 조건

**배경 및 문제 상황:**
최초 구현은 "서베이된 PR의 과반이 패턴 공유"만을 성립 조건으로 뒀다. 변형 시나리오(비일관 PR 3건 레포)에서 에이전트가 3건 중 2건이라는 빈약한 표본의 영어 bare 제목을 컨벤션으로 확정하는 루프홀이 실측됐다.

**해결 방안:**
표본 하한을 추가해 "5건 이상 서베이 AND 과반 공유"의 이중 조건으로 강화. 하한 미달이면 전 축을 컨벤션 미성립으로 판정하고 fallback을 쓴다.

**구현 세부사항:**
하한 5는 요구사항의 "기존 PR 10~30개 파악"에서 의미 있는 표본의 최소선으로 잡은 값. 재검증에서 동일 3건 표본이 전 축 fallback으로 후퇴함을 확인.

**선택과 트레이드오프:**
젊은 레포가 일관된 PR 3~4건을 갖고 있어도 그 관례를 무시하게 되는 비용이 있다. 그 대가로 빈약한 표본에서 오판을 확신하는 실패 모드를 제거했다. 하한값 5의 적정성은 열린 질문.

### 2. 브랜치 rename 제안을 원격 미존재 브랜치로 한정

**배경 및 문제 상황:**
워크트리 코드네임 브랜치(`wobbly-otter` 류)가 컨벤션 없이 그대로 push되는 문제를 잡되, 이미 push된 브랜치를 rename하면 원격에 옛 이름 사본이 고아로 남는다.

**해결 방안:**
`git ls-remote --heads origin {branch}` 결과가 비었을 때만 rename을 제안. 이미 원격에 있으면 검사 자체를 스킵. rename은 항상 AskUserQuestion으로 사용자 확인을 거친다.

**선택과 트레이드오프:**
"항상 제안 + 원격 정리까지 수행" 대안은 원격 브랜치 삭제라는 파괴적 동작이 끼어들어 기각. 이미 push된 비컨벤션 브랜치는 그대로 두는 보수적 선택.

### 3. assignee를 git config가 아닌 gh 인증 유저(@me)로

**배경 및 문제 상황:**
"그 git 유저"를 assignee로 붙이려면 git config user → GitHub 계정 매핑이 필요한데, 이 매핑은 보장되지 않는다(듀얼 계정 환경 등).

**해결 방안:**
`gh pr create --assignee @me` — PR을 생성하는 gh 인증 계정에 assign. 매핑 추론 없이 항상 유효한 값.

**선택과 트레이드오프:**
git config의 user와 gh 인증 계정이 다른 환경에선 gh 쪽이 이긴다. PR 생성 주체 = assignee라는 의미론이 실제 의도와 일치한다고 판단.

---

## ✅ Checklist

### make-pr 스킬
- [ ] 컨벤션 서베이 명령과 축별 성립 조건(5건 이상 AND 과반)이 정의되어 있다
  - `skills/make-pr/SKILL.md`
- [ ] 단일 PR·서브 PR 두 `gh pr create` 블록 모두 `--assignee @me`를 포함한다
  - `skills/make-pr/SKILL.md`
- [ ] label은 실재 label만 선택하고 미선택 시 `--label` 생략이 명시되어 있다
  - `skills/make-pr/SKILL.md`
- [ ] 원격에 이미 존재하는 브랜치는 rename 제안에서 제외된다
  - `skills/make-pr/SKILL.md`

### 검증·문서
- [ ] Scenario 27에 RED(6/7 FAIL)·GREEN(main 7/7, variation 5/5) 결과가 기록되어 있다
  - `skills/make-pr/tests/test-scenarios.md`
- [ ] authoring 문서 한/영 쌍이 동일 내용으로 갱신되어 있다
  - `docs/skills/authoring.md`, `docs/skills/authoring.en.md`

---

## 📎 References
- 해당 없음 (세션 내 요구로 진행, 연결된 이슈/외부 문서 없음)

---
https://claude.ai/code/session_01EWM3Y5MJsWsrWwxK1EFStp