### PR TITLE
fix: 신규 스킬 2종을 리뷰 워커 deny 목록에 추가

### DIFF
--- a/skills/agent-council/council.config.yaml
+++ b/skills/agent-council/council.config.yaml
@@ -53,17 +53,18 @@ council:
       # surface un-judged candidates, and `diagnose` invites verifying them instead); council members
       # fan out through the same `lib/generic-job.ts` spawn path with the same free skill loading, so
       # the shape carries over even though no council run has shown it.
-      # (3) prompt-budget guard, the remaining 24 — no skill here is relevant to a member's job of
+      # (3) prompt-budget guard, the remaining 26 — no skill here is relevant to a member's job of
       # arguing its assigned perspective, so each is dead weight; the size saved is pinned by
       # `codex-skill-deny-efficacy.test.ts`, not restated here.
       #
-      # List stops at 28 (OpenAI-bundled plugin skills use `plugin:skill` colon form, rejected by
+      # List stops at 30 (OpenAI-bundled plugin skills use `plugin:skill` colon form, rejected by
       # `lib/generic-job.ts`'s `assertDenySkillsShape`); fail-open by design (unlisted means visible,
       # the safe direction). Kept in lockstep with `orchestrate-review.config.yaml` —
       # `codex-skill-deny-efficacy.test.ts` asserts the two files declare the same set.
       skills:
         - agent-browser
         - agent-council
+        - agent-device
         - clarify
         - code-review
         - collect-jd
@@ -72,6 +73,7 @@ council:
         - deep-interview
         - design-review
         - diagnose
+        - dogfood
         - git-master
         - goal
         - hud

--- a/skills/orchestrate-review/orchestrate-review.config.yaml
+++ b/skills/orchestrate-review/orchestrate-review.config.yaml
@@ -67,17 +67,18 @@ chunk-review:
       # (2) role-boundary guard, `diagnose` alone — a finder must surface un-judged candidates,
       # not verify them (that's the upstream code-review skill's job), and `diagnose` (a
       # READ-ONLY root-cause consultant) would pull a finder across that line.
-      # (3) prompt-budget guard, the remaining 24 — none help a finder read code and surface
+      # (3) prompt-budget guard, the remaining 26 — none help a finder read code and surface
       # candidates, so each is dead prompt weight; the size this saves is pinned by
       # `codex-skill-deny-efficacy.test.ts`, not restated here.
       #
-      # List stops at 28: further items are OpenAI-bundled plugin skills outside this repo,
+      # List stops at 30: further items are OpenAI-bundled plugin skills outside this repo,
       # named in `plugin:skill` colon form, which `lib/generic-job.ts`'s `assertDenySkillsShape`
       # rejects outright. Fail-open by design: a skill added later stays loadable — unlisted
       # means visible, the safe direction.
       skills:
         - agent-browser
         - agent-council
+        - agent-device
         - clarify
         - code-review
         - collect-jd
@@ -86,6 +87,7 @@ chunk-review:
         - deep-interview
         - design-review
         - diagnose
+        - dogfood
         - git-master
         - goal
         - hud


### PR DESCRIPTION
## 문제

`main`에 `agent-device`·`dogfood` 스킬이 추가되면서, 이 두 스킬이 리뷰 워커의 `settings.deny.skills` 목록에 빠진 채 codex 배포 스코프에 들어갔다. deny 목록은 설계상 fail-open(unlisted means visible)이라 두 스킬이 그대로 프롬프트에 실렸고, `<skills_instructions>` 블록이 **10,077자**가 되어 `codex-skill-deny-efficacy.test.ts`의 AC3(deny 적용 후 10,000자 미만)가 깨졌다.

이 실패는 `make sync`의 테스트 게이트를 막아 sync 자체가 완주하지 못한다.

## 원인 실측

실제 `codex debug prompt-input`을 프로덕션 전송 경로(`buildAugmentedCommand` → `splitCommand`)로 돌려 측정했다.

| deny 목록 | 블록 크기 |
|---|---|
| 현재 (28개) | 10,077자 |
| `agent-device`+`dogfood` 추가 (30개) | 9,395자 |

두 스킬이 블록에 682자를 기여하며, 추가 시 임계 아래로 605자 여유를 두고 내려간다. 블록 내 등장은 각각 1회씩 확인.

## 변경

두 스킬 모두 파인더가 코드를 읽고 후보를 표면화하는 데 기여하지 않으므로, config가 이미 명시한 **(3) prompt-budget guard** 범주에 해당한다 — `agent-device`는 iOS/Android/TV E2E 자동화, `dogfood`는 모바일 탐색적 QA다.

- `skills/orchestrate-review/orchestrate-review.config.yaml` — deny.skills에 2종 추가 (알파벳 순 유지)
- `skills/agent-council/council.config.yaml` — 동일 집합 유지가 테스트로 강제되므로 함께 갱신
- 개수를 명시한 주석도 실제와 맞춤: "the remaining 24" → 26, "List stops at 28" → 30

## 검증

- `bun test skills/orchestrate-review/scripts/codex-skill-deny-efficacy.test.ts` — 8 pass / 0 fail (수정 전 1 fail)
- `make validate` — exit 0
- `bun test` 전체 — 4832 pass / 0 fail

https://claude.ai/code/session_01Qg4nW8wBNKMbBEugV86pCi