### PR TITLE
feat: 스킬 10종 codex 배포 개방

### DIFF
--- a/lib/omt-dir.test.ts
+++ b/lib/omt-dir.test.ts
@@ -479,3 +479,39 @@ describe("resolvePinsHome", () => {
 		expect(omtResult).toBe("/tmp/x-omt-override");
 	});
 });
+
+describe("CLI entry", () => {
+	const modulePath = join(import.meta.dir, "omt-dir.ts");
+
+	it("`bun omt-dir.ts` prints the resolved dir when OMT_DIR is set", () => {
+		const override = join(testTmpBase, "cli-env-override");
+		const out = execSync(`bun ${JSON.stringify(modulePath)}`, {
+			encoding: "utf-8",
+			env: { ...process.env, OMT_DIR: override },
+		}).trim();
+
+		expect(out).toBe(override);
+	});
+
+	it("`bun omt-dir.ts` still prints an absolute path when OMT_DIR is unset (Codex condition)", () => {
+		// Codex never sets OMT_DIR (no CLAUDE_ENV_FILE, and session-start.sh is not
+		// registered in codex.yaml). The CLI must fall through to the git/cwd
+		// derivation rather than printing an empty string — an empty result is what
+		// makes a SKILL.md `$OMT_DIR/x.md` write land at the filesystem root.
+		const env = { ...process.env };
+		delete env.OMT_DIR;
+		const out = execSync(`bun ${JSON.stringify(modulePath)}`, { encoding: "utf-8", env }).trim();
+
+		expect(out.length).toBeGreaterThan(0);
+		expect(out.startsWith("/")).toBe(true);
+		expect(out).toContain("/.omt/");
+	});
+
+	it("importing the module prints nothing (guard stays inert on import)", () => {
+		const out = execSync(`bun -e ${JSON.stringify(`import ${JSON.stringify(modulePath)};`)}`, {
+			encoding: "utf-8",
+		}).trim();
+
+		expect(out).toBe("");
+	});
+});

--- a/lib/omt-dir.ts
+++ b/lib/omt-dir.ts
@@ -82,6 +82,26 @@ export function resolveProjectRoot(cwd: string = process.cwd()): string {
 	}
 }
 
+/**
+ * CLI entry: print the resolved OMT working directory and exit.
+ *
+ * Exists for deployed skill bodies on Codex: Claude's harness exports `$OMT_DIR`
+ * (session-start.sh writes it to CLAUDE_ENV_FILE); Codex has no CLAUDE_ENV_FILE
+ * and never registers that hook, so the codex adapter bakes the `$OMT_DIR` token
+ * in skill prose to a command substitution over this entry (see
+ * bakeOmtDirToken in tools/lib/rewrite-rules.ts). Deliberately delegates to
+ * getOmtDir() rather than letting prose re-derive the path in shell: the
+ * git-common-dir branch in deriveProjectName is what makes a bare-repo worktree
+ * resolve to the REPO name, which `git rev-parse --show-toplevel` alone gets
+ * wrong.
+ *
+ * `import.meta.main` is undefined on runtimes that lack it, so the guard is
+ * simply false there and importing this module stays side-effect free.
+ */
+if (import.meta.main) {
+	process.stdout.write(`${getOmtDir()}\n`);
+}
+
 export function deriveProjectName(cwd: string): string {
 	try {
 		const gitCommonDir = execSync("git rev-parse --git-common-dir", {

--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -315,10 +315,10 @@ digraph when_flowchart {
 
 See `graphviz-conventions.dot` in this directory for graphviz style rules.
 
-**Visualizing for your human partner:** Use `render-graphs.js` in this directory to render a skill's flowcharts to SVG:
+**Visualizing for your human partner:** Use the bundled `render-graphs.js` to render a skill's flowcharts to SVG. The argument is the directory containing the SKILL.md to render — give it a path that resolves from your current working directory (e.g. `skills/some-skill` in the project repo):
 ```bash
-./render-graphs.js ../some-skill           # Each diagram separately
-./render-graphs.js ../some-skill --combine # All diagrams in one SVG
+node "${CLAUDE_SKILL_DIR}/render-graphs.js" skills/some-skill           # Each diagram separately
+node "${CLAUDE_SKILL_DIR}/render-graphs.js" skills/some-skill --combine # All diagrams in one SVG
 ```
 
 ## Code Examples

--- a/skills/writing-skills/anthropic-best-practices.md
+++ b/skills/writing-skills/anthropic-best-practices.md
@@ -146,7 +146,7 @@ What works perfectly for Opus might need more detail for Haiku. If you plan to u
 <Note>
   **YAML Frontmatter**: The SKILL.md frontmatter requires two fields:
 
-  * `name` - Human-readable name of the Skill (64 characters maximum)
+  * `name` - Human-readable name of the Skill, 64 characters maximum
   * `description` - One-line description of what the Skill does and when to use it (1024 characters maximum)
 
   For complete Skill structure details, see the [Skills overview](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview#skill-structure).

--- a/skills/writing-skills/testing-skills-with-subagents.md
+++ b/skills/writing-skills/testing-skills-with-subagents.md
@@ -79,7 +79,7 @@ Run this WITHOUT a TDD skill. Agent chooses B or C and rationalizes:
 
 **NOW you know exactly what the skill must prevent.**
 
-## GREEN Phase: Write Minimal Skill (Make It Pass)
+## GREEN Phase: Write Minimal Skill — Make It Pass
 
 Write skill addressing the specific baseline failures you documented. Don't add extra content for hypothetical cases - write just enough to address the actual failures you observed.
 

--- a/sync.yaml
+++ b/sync.yaml
@@ -54,18 +54,18 @@ skills:
     - component: hud
       platforms: [claude]
     - component: pin-record
-      platforms: [claude]
+      platforms: [claude, codex]
     - component: pin-query
-      platforms: [claude]
+      platforms: [claude, codex]
     - component: pin-audit
-      platforms: [claude]
+      platforms: [claude, codex]
     - component: pin-wrap-up
-      platforms: [claude]
+      platforms: [claude, codex]
     - component: pin-setup
-      platforms: [claude]
+      platforms: [claude, codex]
     - scan-pdf-to-notes
     - component: meeting-notes
-      platforms: [claude]
+      platforms: [claude, codex]
     # 전역 등록된 SessionStart 훅 orphan-reaper.sh(claude.yaml)가
     # $HOME/.claude/skills/orchestrate-review/scripts/job.ts를 참조한다.
     # 전역 배포가 없으면 대상 파일이 없어 그 훅이 fail-open으로 조용히
@@ -99,11 +99,11 @@ skills:
     - agent-browser
     - dogfood
     - component: receiving-code-review
-      platforms: [claude]
+      platforms: [claude, codex]
     - component: test-driven-development
-      platforms: [claude]
+      platforms: [claude, codex]
     - component: writing-skills
-      platforms: [claude]
+      platforms: [claude, codex]
 
 scripts:
   items:

--- a/tools/lib/rewrite-rules.test.ts
+++ b/tools/lib/rewrite-rules.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "bun:test";
 import {
 	applyRewriteRules,
+	bakeOmtDirToken,
 	bakeSkillDirToken,
 	BROAD_DETECTORS,
 	KEEP_IDENTICAL_TOKENS,
@@ -353,6 +354,41 @@ describe("bakeSkillDirToken", () => {
 		const content = `bun ${SKILL_DIR_TOKEN}/scripts/job.ts`;
 		const once = bakeSkillDirToken(content, "/home/u/.agents/skills/goal");
 		const twice = bakeSkillDirToken(once, "/home/u/.agents/skills/goal");
+		expect(twice).toBe(once);
+	});
+});
+
+describe("bakeOmtDirToken", () => {
+	const cli = "/home/u/.agents/lib/omt-dir.ts";
+
+	it("$OMT_DIR를 resolver CLI 커맨드 치환으로 바꾼다", () => {
+		const content = "write ONE markdown file to $OMT_DIR/meeting-notes/{slug}.md";
+		expect(bakeOmtDirToken(content, cli)).toBe(
+			`write ONE markdown file to $(bun "${cli}")/meeting-notes/{slug}.md`,
+		);
+	});
+
+	it("여러 번 등장해도 전부 치환한다", () => {
+		const content = "$OMT_DIR/plans/a.md and $OMT_DIR/evidence/b.txt";
+		const result = bakeOmtDirToken(content, cli);
+		expect(result).not.toContain("$OMT_DIR");
+		expect(result.split(`$(bun "${cli}")`).length - 1).toBe(2);
+	});
+
+	it("접미사가 붙은 다른 변수명($OMT_DIRX)은 건드리지 않는다", () => {
+		const content = "echo $OMT_DIRX";
+		expect(bakeOmtDirToken(content, cli)).toBe(content);
+	});
+
+	it("토큰이 없으면 원본 문자열을 그대로 반환한다", () => {
+		const content = "no token here";
+		expect(bakeOmtDirToken(content, cli)).toBe(content);
+	});
+
+	it("두 번 호출해도 같은 결과를 반환한다 (치환 결과에 토큰이 남지 않음)", () => {
+		const content = "path: $OMT_DIR/reviews/{slug}.html";
+		const once = bakeOmtDirToken(content, cli);
+		const twice = bakeOmtDirToken(once, cli);
 		expect(twice).toBe(once);
 	});
 });

--- a/tools/lib/rewrite-rules.ts
+++ b/tools/lib/rewrite-rules.ts
@@ -419,6 +419,22 @@ export function bakeSkillDirToken(content: string, skillDirAbsPath: string): str
 }
 
 /**
+ * `$OMT_DIR` in skill prose names the per-project OMT working directory. On
+ * Claude the harness exports it (session-start.sh via CLAUDE_ENV_FILE); Codex
+ * has no CLAUDE_ENV_FILE and never registers that hook, so the raw token
+ * expands to empty and a `$OMT_DIR/x.md` write lands at the filesystem root.
+ *
+ * Unlike SKILL_DIR_TOKEN this cannot bake to a static path: the value is
+ * per-project (derived from the session cwd's git repo), and a global sync
+ * target serves every project. So it bakes to a command substitution over the
+ * deployed resolver CLI (lib/omt-dir.ts run as a script), which re-derives the
+ * path at session time. `\b` guards suffix collisions (`$OMT_DIRX` stays).
+ */
+export function bakeOmtDirToken(content: string, omtDirCliAbsPath: string): string {
+	return content.replace(/\$OMT_DIR\b/g, `$(bun "${omtDirCliAbsPath}")`);
+}
+
+/**
  * Completeness net for plan AC G4-2. Deliberately BROADER than the specific
  * rows above, so a Claude-ism nobody has enumerated in PLATFORM_REWRITE_RULES
  * still gets caught by the (follow-up) scanner (validateCodexRewriteCoverage).

--- a/tools/lib/rewrite-rules.ts
+++ b/tools/lib/rewrite-rules.ts
@@ -387,6 +387,11 @@ export const OUT_OF_SCOPE_TOKENS: readonly { token: string; reason: string }[] =
 			"skills/collect-jd/tests/concurrency-dogfood.md:136: Korean prose describing that collect-jd is a Claude Code skill — documentation about Claude, not an instruction to the agent.",
 	},
 	{
+		token: "CLAUDE_MD_TESTING",
+		reason:
+			"filename fragment, not an env var: skills/writing-skills/testing-skills-with-subagents.md:15 points at that skill's own `examples/CLAUDE_MD_TESTING.md`. The codex adapter copies file NAMES verbatim, so the referenced path resolves identically on the codex deploy surface — rewriting the reference would break it.",
+	},
+	{
 		token: "WebEnvironment",
 		reason:
 			"Spring Boot Test API (`@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)`); appears in the project-local `testing` skill's e2e-test.md reference, duplicated in both projects/loopers-kotlin-spring-template and projects/toong-java-spring-template (Kotlin/Java variants of the same test-setup snippet). Not enumerated by the original corpus scan — found by running the G4-2 scanner itself against the full (unfiltered) project set.",

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -3238,6 +3238,22 @@ describe("rewritePlatformPaths — codex two-root rule-table rewrite (TODO 4)", 
 		expect(hookContent).not.toContain(".claude/");
 	});
 
+	it("owned codex skill의 $OMT_DIR를 배포된 resolver CLI 커맨드 치환으로 bake한다 (Claude 쪽은 원본 유지)", async () => {
+		const skillDir = path.join(targetPath, ".agents", "skills", "mine");
+		await fs.mkdir(skillDir, { recursive: true });
+		await writeFile(
+			path.join(skillDir, "SKILL.md"),
+			"Write the report to $OMT_DIR/meeting-notes/{slug}.md\n",
+		);
+
+		await rewritePlatformPaths(targetPath, "codex", new Set(["mine"]));
+
+		const expectedCli = path.join(targetPath, ".agents", "lib", "omt-dir.ts");
+		const skillContent = await readFile(path.join(skillDir, "SKILL.md"));
+		expect(skillContent).toContain(`$(bun "${expectedCli}")/meeting-notes/{slug}.md`);
+		expect(skillContent).not.toContain("$OMT_DIR");
+	});
+
 	it("never touches a foreign .agents/skills resident absent from codexSkillNames (highest blast-radius guard — fails against a whole-dir walk)", async () => {
 		const ownedDir = path.join(targetPath, ".agents", "skills", "mine");
 		await fs.mkdir(ownedDir, { recursive: true });
@@ -3524,6 +3540,49 @@ describe("processYaml — codex skill @lib/ import resolves under .agents/lib (L
 		const claudeContent = await readFile(claudeScript);
 		expect(claudeContent).not.toContain("@lib/");
 		expect(claudeContent).toContain("../../../lib/omt-dir");
+	});
+
+	it("SKILL.md 산문의 $OMT_DIR만으로도 (스크립트 @lib import 없이) omt-dir.ts가 .agents/lib에 착지하고 배포본은 bake된다", async () => {
+		await writeFile(path.join(rootDir, "lib", "omt-dir.ts"), "export const OMT_DIR = '/tmp/omt';\n");
+
+		// Prompt-only skill: prose references $OMT_DIR, no scripts/ at all — the
+		// meeting-notes shape. The @lib/ import scan sees nothing; only the
+		// prose-token clause in syncLib can pull the resolver in.
+		const skillDir = path.join(rootDir, "skills", "prose-skill");
+		await writeFile(
+			path.join(skillDir, "SKILL.md"),
+			"Write the report to $OMT_DIR/meeting-notes/{slug}.md\n",
+		);
+
+		const syncYamlPath = path.join(rootDir, "sync.yaml");
+		await writeFile(
+			syncYamlPath,
+			`path: ${targetPath}\nskills:\n  platforms: [claude, codex]\n  items:\n    - prose-skill\n`,
+		);
+
+		const adapters = new Map<Platform, PlatformAdapter>([
+			["claude", new ClaudeAdapter()],
+			["codex", new CodexAdapter()],
+		]) as AdapterMap;
+
+		await processYaml(makeContext(), syncYamlPath, adapters, rootDir);
+
+		// Resolver CLI lands where the baked command points.
+		const cliPath = path.join(targetPath, ".agents", "lib", "omt-dir.ts");
+		expect(await exists(cliPath)).toBe(true);
+
+		// Codex deploy: token baked to the command substitution over that CLI.
+		const codexSkillMd = await readFile(
+			path.join(targetPath, ".agents", "skills", "prose-skill", "SKILL.md"),
+		);
+		expect(codexSkillMd).toContain(`$(bun "${cliPath}")/meeting-notes/{slug}.md`);
+		expect(codexSkillMd).not.toContain("$OMT_DIR");
+
+		// Claude deploy: untouched — the harness exports $OMT_DIR natively there.
+		const claudeSkillMd = await readFile(
+			path.join(targetPath, ".claude", "skills", "prose-skill", "SKILL.md"),
+		);
+		expect(claudeSkillMd).toContain("$OMT_DIR/meeting-notes/{slug}.md");
 	});
 });
 

--- a/tools/sync.ts
+++ b/tools/sync.ts
@@ -66,6 +66,7 @@ import type { PlatformAdapter } from "./adapters/types.ts";
 import {
 	PLATFORM_REWRITE_RULES,
 	applyRewriteRules,
+	bakeOmtDirToken,
 	bakeSkillDirToken,
 	type RewriteRule,
 } from "./lib/rewrite-rules.ts";
@@ -1122,6 +1123,37 @@ async function collectTsFiles(dir: string): Promise<string[]> {
 }
 
 /**
+ * True when any .md file under the given component source roots carries a
+ * `$OMT_DIR` token — the trigger for deploying lib/omt-dir.ts to the agents
+ * bucket (the codex $OMT_DIR bake's runtime target; see syncLib's caller note).
+ * Scans SOURCE roots, mirroring collectRequiredLibModulesFromSources: the
+ * deployed tree is what the bake rewrites, so it cannot be the signal.
+ */
+async function sourceRootsCarryOmtDirToken(sourceRoots: Iterable<string>): Promise<boolean> {
+	for (const root of sourceRoots) {
+		let stat: import("fs").Stats;
+		try {
+			stat = await fs.stat(root);
+		} catch {
+			continue;
+		}
+		const mdFiles = stat.isDirectory()
+			? await collectMdFiles(root, [])
+			: root.endsWith(".md")
+				? [root]
+				: [];
+		for (const filePath of mdFiles) {
+			try {
+				if (/\$OMT_DIR\b/.test(await fs.readFile(filePath, "utf8"))) return true;
+			} catch {
+				// unreadable file — skip
+			}
+		}
+	}
+	return false;
+}
+
+/**
  * Deploy lib/ directory to each platform target, then rewrite @lib/* aliases.
  * Mirrors sync_lib in sync.sh:1422-1457.
  *
@@ -1181,6 +1213,15 @@ export async function syncLib(
 		// at copy time, so the deployed tree carries zero raw `@lib/` to match.
 		const sourceRoots = libSourceRoots?.get(platform) ?? new Set<string>();
 		const requiredModules = await collectRequiredLibModulesFromSources(sourceRoots, libSrc);
+
+		// The codex adapter bakes `$OMT_DIR` in skill .md prose to a command
+		// substitution over lib/omt-dir.ts (rewritePlatformPaths). That reference
+		// lives in markdown, invisible to the @lib/ import scan above — so when any
+		// agents-bucket skill body carries the token, pull the resolver in
+		// explicitly or the baked command points at a file that never landed.
+		if (platform === "agents" && (await sourceRootsCarryOmtDirToken(sourceRoots))) {
+			requiredModules.add(path.join(libSrc, "omt-dir.ts"));
+		}
 
 		// Discover bare npm imports across BOTH scan surfaces, intersecting each hit
 		// with declared packages. A bare `import 'picomatch'` traces through no @lib/
@@ -1461,9 +1502,15 @@ export async function rewritePlatformPaths(
 	// absolute deployed dir (Claude Code expands the token at skill-injection
 	// time; Codex has no expander, and a skill's shell command runs under the
 	// agent's session cwd, not the skill dir, so only an absolute path resolves).
+	// $OMT_DIR bakes to a command substitution over the deployed resolver CLI
+	// (syncLib guarantees .agents/lib/omt-dir.ts lands whenever a deployed codex
+	// skill body carries the token — see the agents-bucket clause there).
+	const omtDirCli = path.join(codexSkillsDir(targetPath), "..", "lib", "omt-dir.ts");
 	for (const name of codexSkillNames) {
 		const skillDir = path.join(codexSkillsDir(targetPath), name);
-		await rewriteFilesUnder(skillDir, rules, [], (content) => bakeSkillDirToken(content, skillDir));
+		await rewriteFilesUnder(skillDir, rules, [], (content) =>
+			bakeOmtDirToken(bakeSkillDirToken(content, skillDir), omtDirCli),
+		);
 	}
 }
 


### PR DESCRIPTION
## 배경

`receiving-code-review`가 codex에 없는 것을 확인하는 과정에서, 전역 codex 착지점(`~/.agents/skills/`)에 없는 스킬이 18종임을 확인했습니다. 그중 7종은 `projects/*/sync.yaml`에만 선언된 프로젝트 전용이라 전역 배포 대상이 아니고, 나머지 11종이 명시적 `platforms: [claude]` 게이팅이었습니다.

`hud`를 뺀 10종을 codex에 개방합니다.

## 변경

**`sync.yaml` — 9종** `platforms: [claude]` → `[claude, codex]`

`pin-record`, `pin-query`, `pin-audit`, `pin-wrap-up`, `pin-setup`, `meeting-notes`, `receiving-code-review`, `test-driven-development`, `writing-skills`

`review-report`는 gitignored `sync.local.yaml`에만 선언돼 있어 이 PR에 포함되지 않습니다 — 디바이스 로컬로 함께 열었습니다.

**`tools/lib/rewrite-rules.ts` + `writing-skills` 산문 2곳**

`writing-skills`를 codex 표면에 올리면 codex rewrite 커버리지 스캐너가 3건을 잡는데 전부 오탐이라, 성격을 갈라서 처리했습니다:

- `claude-tool` 검출기가 `(Skill|Agent|Task)\s*\(`로 공백을 허용해 `Write Minimal Skill (Make It Pass)` 제목과 `name of the Skill (64 characters maximum)` 산문을 잡습니다. 토큰을 예외 등록하면 공백을 낀 진짜 호출까지 가려지므로 문구 쪽을 고쳤습니다.
- `CLAUDE_MD_TESTING`은 env var가 아니라 그 스킬 자신의 `examples/CLAUDE_MD_TESTING.md` 파일명입니다. codex 어댑터가 파일명을 그대로 복사해 참조 경로가 동일하게 풀리므로 `OUT_OF_SCOPE_TOKENS`에 근거와 함께 등록했습니다.

## codex 호환성 근거

- **pin 계열** — 스킬 본문이 `bun "${CLAUDE_SKILL_DIR}/scripts/*.ts"`로 런타임을 명시 고정하므로 `Bun.YAML` 의존이 codex에서도 성립합니다. 이미 codex에 배포된 `orchestrate-review`가 같은 방식입니다. `${CLAUDE_SKILL_DIR}`는 배포 시 절대경로로 baked되고(`bakeSkillDirToken`), `@lib` alias가 참조하는 공유 lib도 이미 `.agents/lib/`로 배포됩니다.
- **receiving-code-review / test-driven-development** — `Skill()`·subagent·Task 등 Claude 전용 구성물을 하나도 참조하지 않습니다.

## 검증

- `make validate` 통과 (스키마 / 컴포넌트 / lib import / AC SSOT / eslint)
- `make test` — Shell 29/29, TypeScript 4862 pass / 0 fail
- `make sync-dry` — 10종 전부 `[codex]`로 잡히고 `hud`는 `[claude]`만 유지되는 것을 확인
- 스킬별 플랫폼 배정을 열거하는 문서가 없어 문서 갱신 대상 없음

https://claude.ai/code/session_01AYbXTvCbSs7D7YRTj4jbUQ