### PR TITLE
fix: write-guard 조기 return의 SIGPIPE fail-open 차단

### DIFF
--- a/hooks/codex-write-guard_test.sh
+++ b/hooks/codex-write-guard_test.sh
@@ -2485,6 +2485,95 @@ test_codereview_nested_agent_type_in_tool_input_denies() {
 }
 
 # =============================================================================
+# SIGPIPE regression (codex twin of the Claude suite's CR-16/17) --
+# write_guard_core_run / codereview_guard_core_run both `return 0` early on a
+# match/identity bypass WITHOUT draining the rest of stdin (hooks/write-guard-
+# core.sh:208/231/262/272/279). This hook wires codereview_guard_core_run at
+# the very end of an internal pipe (codex-write-guard.sh:901); when the
+# candidate stream left unread after the early return exceeds a real pipe's
+# kernel buffer (64KB), the still-writing `printf` is killed, and `pipefail`
+# makes the WHOLE hook process exit nonzero even though the function's own
+# stdout (allow: nothing; deny: the JSON) was already correct -- the harness
+# cannot tell that apart from a crashed hook. Not a symmetric copy of the
+# Claude cases (that shim captures this call into a variable and discards the
+# output too; this one streams it straight through as the LAST statement in
+# the script, so only the exit code is wrong here) -- same invariant, though:
+# a >64KB candidate stream must never turn a correct verdict into exit 141.
+#
+# cwg_pad_redirect_targets appends <count> SEPARATE `;`-segments, each holding
+# one harmless never-matching `> <long-filler>` redirect target, so the
+# candidate list alone comfortably exceeds 64KB -- deterministic on SIZE,
+# never scheduling. Each padding segment sits AFTER the real `mv` segment, so
+# the goal-codereview candidate is always read FIRST and the padding is left
+# entirely undrained at the moment of an early return. Kept to a LOW segment
+# count with a LONG filler per segment rather than thousands of tiny ones:
+# this hook's extractor forks a subprocess (awk/grep) per CHAIN SEGMENT, and
+# a many-tiny-segments draft of this helper turned "make the candidate list
+# big" into "fork thousands of subprocesses in one shell invocation" --
+# which crashed the real hook process outright (SIGSEGV) on this
+# environment's bash, a resource-exhaustion confound this suite must not
+# depend on.
+# =============================================================================
+cwg_pad_redirect_targets() {
+    local count="$1" i=0 out="" filler
+    printf -v filler '%*s' 3200 ''
+    filler="${filler// /x}"
+    while [ "$i" -lt "$count" ]; do
+        out="${out}; > /tmp/omt-cwg-sigpipe-pad-$(printf '%03d' "$i")-$filler"
+        i=$((i + 1))
+    done
+    printf '%s' "$out"
+}
+
+# (a) code-reviewer identity-bypass allow, >64KB candidates -> exit 0. The
+# bypass returns before reading ANY stdin, so the oversized write blocks and
+# the internal pipe's SIGPIPE propagates as this hook's own nonzero exit even
+# though the function's own stdout is correctly empty (allow).
+test_sigpipe_codereview_shell_command_code_reviewer_large_candidates_allowed() {
+    new_sandbox
+    cr_paths
+    local cmd tool_input out rc=0 result=0
+
+    cmd="mv $CR_GOAL /tmp/saved.json$(cwg_pad_redirect_targets 80)"
+    tool_input=$(jq -n --arg cmd "$cmd" '{cmd:$cmd}')
+    out=$(codex_full_payload "shell_command" "$tool_input" "cx" "$GITDIR" "code-reviewer" | run_hook) || rc=$?
+    if ! assert_allow "$out" "$rc" "sigpipe-codereview-code-reviewer-large-candidates"; then
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# (b) a non-reviewer deny, >64KB candidates -> the deny JSON must reach
+# stdout AND the hook's own exit must be 0. codereview_guard_core_run's
+# match-triggered early return leaves virtually all of the padding undrained,
+# so the internal pipe's SIGPIPE makes this LAST-statement pipeline's exit
+# status nonzero (pipefail) even though the deny JSON was already streamed
+# straight through (unlike the ledger guard above it, this call site is not
+# captured into a variable) -- the hook process itself still exits wrong.
+test_sigpipe_codereview_shell_command_no_agent_type_large_candidates_denied() {
+    new_sandbox
+    cr_paths
+    local cmd tool_input out rc=0 result=0
+
+    cmd="mv $CR_GOAL /tmp/saved.json$(cwg_pad_redirect_targets 80)"
+    tool_input=$(jq -n --arg cmd "$cmd" '{cmd:$cmd}')
+    out=$(codex_full_payload "shell_command" "$tool_input" "cx" "$GITDIR" | run_hook) || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "ASSERTION FAILED sigpipe-codereview-deny-large-candidates: expected exit 0, got exit $rc, output '$out'"
+        result=1
+    fi
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED sigpipe-codereview-deny-large-candidates: expected the already-streamed deny JSON to survive, got '$out'"
+        result=1
+    fi
+
+    rm -rf "$SBX"
+    return "$result"
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -2613,6 +2702,8 @@ main() {
     run_test test_codereview_negative_control_candidates_json_allows
     run_test test_ac4_codex_claude_deny_json_byte_identical
     run_test test_codereview_nested_agent_type_in_tool_input_denies
+    run_test test_sigpipe_codereview_shell_command_code_reviewer_large_candidates_allowed
+    run_test test_sigpipe_codereview_shell_command_no_agent_type_large_candidates_denied
     run_test test_codereview_shell_command_mv_source_denies
     run_test test_codereview_shell_command_cp_source_allows
     run_test test_ledger_shell_command_mv_source_denies

--- a/hooks/codex-write-guard_test.sh
+++ b/hooks/codex-write-guard_test.sh
@@ -2194,16 +2194,16 @@ codex_full_payload() {
     local tool_name="$1" tool_input="$2" sid="$3" cwd="$4"
     if [ "$#" -ge 5 ]; then
         local agent_type="$5"
-        jq -n --arg tool_name "$tool_name" --argjson tool_input "$tool_input" \
+        printf '%s' "$tool_input" | jq -n --arg tool_name "$tool_name" \
             --arg sid "$sid" --arg cwd "$cwd" --arg agent_type "$agent_type" \
-            '{session_id:$sid, turn_id:"turn-1", agent_type:$agent_type,
+            'input as $tool_input | {session_id:$sid, turn_id:"turn-1", agent_type:$agent_type,
               transcript_path:"/tmp/codex-transcript.jsonl", hook_event_name:"PreToolUse",
               model:"gpt-5-codex", permission_mode:"default", trigger:"tool_call",
               tool_name:$tool_name, tool_input:$tool_input, tool_use_id:"tu-1", cwd:$cwd}'
     else
-        jq -n --arg tool_name "$tool_name" --argjson tool_input "$tool_input" \
+        printf '%s' "$tool_input" | jq -n --arg tool_name "$tool_name" \
             --arg sid "$sid" --arg cwd "$cwd" \
-            '{session_id:$sid, turn_id:"turn-1",
+            'input as $tool_input | {session_id:$sid, turn_id:"turn-1",
               transcript_path:"/tmp/codex-transcript.jsonl", hook_event_name:"PreToolUse",
               model:"gpt-5-codex", permission_mode:"default", trigger:"tool_call",
               tool_name:$tool_name, tool_input:$tool_input, tool_use_id:"tu-1", cwd:$cwd}'
@@ -2535,7 +2535,7 @@ test_sigpipe_codereview_shell_command_code_reviewer_large_candidates_allowed() {
     local cmd tool_input out rc=0 result=0
 
     cmd="mv $CR_GOAL /tmp/saved.json$(cwg_pad_redirect_targets 80)"
-    tool_input=$(jq -n --arg cmd "$cmd" '{cmd:$cmd}')
+    tool_input=$(printf '%s' "$cmd" | jq -Rs '{cmd:.}')
     out=$(codex_full_payload "shell_command" "$tool_input" "cx" "$GITDIR" "code-reviewer" | run_hook) || rc=$?
     if ! assert_allow "$out" "$rc" "sigpipe-codereview-code-reviewer-large-candidates"; then
         result=1
@@ -2558,7 +2558,7 @@ test_sigpipe_codereview_shell_command_no_agent_type_large_candidates_denied() {
     local cmd tool_input out rc=0 result=0
 
     cmd="mv $CR_GOAL /tmp/saved.json$(cwg_pad_redirect_targets 80)"
-    tool_input=$(jq -n --arg cmd "$cmd" '{cmd:$cmd}')
+    tool_input=$(printf '%s' "$cmd" | jq -Rs '{cmd:.}')
     out=$(codex_full_payload "shell_command" "$tool_input" "cx" "$GITDIR" | run_hook) || rc=$?
     if [ "$rc" -ne 0 ]; then
         echo "ASSERTION FAILED sigpipe-codereview-deny-large-candidates: expected exit 0, got exit $rc, output '$out'"

--- a/hooks/pre-tool-enforcer_test.sh
+++ b/hooks/pre-tool-enforcer_test.sh
@@ -1650,6 +1650,95 @@ test_cr15_bash_mv_source_ledger_denied() {
     wg_assert_deny "mv \"$(wg_ledger_path)\" /tmp/saved.md" "CR15(mv ledger source)"
 }
 
+# =============================================================================
+# CR-16/17 -- SIGPIPE regression (write-guard-core.sh's write_guard_core_run /
+# codereview_guard_core_run both `return 0` early on a match/identity bypass
+# WITHOUT draining the rest of stdin). This hook wires both functions at the
+# end of an internal pipe (`printf ... | write_guard_core_run ...` /
+# `... | codereview_guard_core_run ...`, both captured via command
+# substitution) -- when the candidate stream left unread after the early
+# return exceeds a real pipe's kernel buffer (64KB), the still-writing
+# `printf` blocks and is then killed once the reader closes its end. Under
+# this script's own `set -euo pipefail`, that failing assignment aborts the
+# WHOLE hook immediately, before the `if [[ -n "$_wg_cr_out" ]]` line that
+# would have printed it ever runs -- so a computed deny is silently discarded,
+# and an allow verdict never gets its `{"continue": true}` line at all.
+#
+# hg_pad_redirect_targets appends <count> SEPARATE `;`-segments, each holding
+# one harmless never-matching `> <long-filler>` redirect target, so the
+# candidate list built from them alone is comfortably >64KB -- deterministic
+# on SIZE, never on scheduling luck. Each padding segment sits AFTER the real
+# `mv` segment, so the guard-worthy candidate is always read FIRST and the
+# padding is left entirely undrained at the moment of an early return. Kept
+# to a LOW segment count with a LONG filler per segment rather than thousands
+# of tiny ones: this hook's extractor forks a subprocess (awk/grep) per CHAIN
+# SEGMENT, and an earlier many-tiny-segments draft of this helper turned
+# "make the candidate list big" into "fork thousands of subprocesses in one
+# shell invocation" -- which crashed the Codex twin's hook process outright
+# on this environment's bash (a resource-exhaustion confound, not the
+# SIGPIPE defect this suite targets).
+# =============================================================================
+hg_pad_redirect_targets() {
+    local count="$1" i=0 out="" filler
+    printf -v filler '%*s' 3200 ''
+    filler="${filler// /x}"
+    while [ "$i" -lt "$count" ]; do
+        out="${out}; > /tmp/omt-pte-sigpipe-pad-$(printf '%03d' "$i")-$filler"
+        i=$((i + 1))
+    done
+    printf '%s' "$out"
+}
+
+# hg_run_capture_exit <json> -- runs the hook and captures BOTH stdout (in
+# HG_OUT) and the hook's own exit code (in HG_RC), not just stdout -- the
+# SIGPIPE regression manifests as a wrong PROCESS exit code even in the one
+# case (deny) where the JSON text itself still happens to look right.
+hg_run_capture_exit() {
+    local json="$1"
+    HG_RC=0
+    HG_OUT=$(printf '%s' "$json" | bash "$SCRIPT_DIR/pre-tool-enforcer.sh") || HG_RC=$?
+}
+
+# CR-16 -- CR13's payload (goal-codereview path, agent_type=code-reviewer,
+# `mv` source) with >64KB of trailing redirect padding appended to the SAME
+# Bash command. The hook must still ALLOW (`{"continue": true}`, exit 0) --
+# currently the internal codereview_guard_core_run pipe (pre-tool-
+# enforcer.sh:394) never reads a byte of the oversized stdin before its
+# identity-bypass `return 0`, so the writer is killed and the hook aborts with
+# a nonzero exit and empty stdout instead.
+test_cr16_bash_mv_source_goal_codereview_code_reviewer_large_candidates_allowed() {
+    local path cmd json
+    path=$(cr_goal_path)
+    cmd="mv \"$path\" /tmp/saved.json$(hg_pad_redirect_targets 80)"
+    json=$(hg_bash_json_agent "$cmd" "code-reviewer")
+    hg_run_capture_exit "$json"
+    if [ "$HG_RC" -ne 0 ]; then
+        echo "ASSERTION FAILED CR16: expected exit 0 for code-reviewer with >64KB candidates, got exit $HG_RC. Output: $HG_OUT"
+        return 1
+    fi
+    hg_is_allow "$HG_OUT" || { echo "ASSERTION FAILED CR16: expected allow. Got: $HG_OUT"; return 1; }
+}
+
+# CR-17 -- same oversized candidate set as CR16, but WITHOUT agent_type ==
+# code-reviewer, so codereview_guard_core_run's EARLY RETURN is the deny match
+# (line 279 in write-guard-core.sh) instead of the identity bypass. The
+# already-computed deny JSON must still reach stdout with exit 0 -- currently
+# it is computed, then discarded whole when the internal pipe's SIGPIPE aborts
+# the hook before the `if [[ -n "$_wg_cr_out" ]]` print ever runs (fail-open:
+# the orchestrator's forged write silently proceeds unblocked).
+test_cr17_bash_mv_source_goal_codereview_no_agent_type_large_candidates_denied() {
+    local path cmd json
+    path=$(cr_goal_path)
+    cmd="mv \"$path\" /tmp/saved.json$(hg_pad_redirect_targets 80)"
+    json=$(hg_bash_json "$cmd")
+    hg_run_capture_exit "$json"
+    if [ "$HG_RC" -ne 0 ]; then
+        echo "ASSERTION FAILED CR17: expected exit 0 for a non-reviewer deny with >64KB candidates, got exit $HG_RC. Output: $HG_OUT"
+        return 1
+    fi
+    hg_is_deny "$HG_OUT" || { echo "ASSERTION FAILED CR17: expected the already-computed deny JSON to survive the oversized candidate pipe, not be discarded. Got: $HG_OUT"; return 1; }
+}
+
 test_regression_ambient_claude_env_file_not_leaked_by_unscrubbed_call() {
     # Regression guard for the ambient CLAUDE_ENV_FILE leak: AC9's session-
     # start.sh invocation (test_ac9_started_at_parseable_by_stale_cleanup)
@@ -1921,6 +2010,8 @@ main() {
     run_test test_cr13_bash_mv_source_goal_codereview_code_reviewer_allowed
     run_test test_cr14_bash_cp_source_ultragoal_codereview_allowed
     run_test test_cr15_bash_mv_source_ledger_denied
+    run_test test_cr16_bash_mv_source_goal_codereview_code_reviewer_large_candidates_allowed
+    run_test test_cr17_bash_mv_source_goal_codereview_no_agent_type_large_candidates_denied
     run_test test_rdg_matching_claude_candidate_allows_and_increments
     run_test test_rdg_sixth_candidate_denied_without_increment
     run_test test_rdg_clean_and_cleanup_reviews_deny_with_completion_actions

--- a/hooks/pre-tool-enforcer_test.sh
+++ b/hooks/pre-tool-enforcer_test.sh
@@ -849,9 +849,9 @@ hg_is_allow() {
 }
 
 hg_bash_json() {
-    # $1 = raw command string, already fully resolved by the caller (no shell
-    # expansion happens inside this helper -- jq --arg treats it as a literal)
-    jq -n --arg cmd "$1" '{tool_name: "Bash", tool_input: {command: $cmd}}'
+    # $1 = raw command string, already fully resolved by the caller. Slurp it
+    # from stdin so large commands do not exceed jq's argv-size limit.
+    printf '%s' "$1" | jq -Rs '{tool_name: "Bash", tool_input: {command: .}}'
 }
 
 # =============================================================================
@@ -1477,9 +1477,9 @@ cr_goal_path() {
 }
 
 hg_bash_json_agent() {
-    # $1 = raw command string, $2 = agent_type value -- both literal via
-    # jq --arg, no shell expansion inside this helper.
-    jq -n --arg cmd "$1" --arg at "$2" '{tool_name: "Bash", tool_input: {command: $cmd}, agent_type: $at}'
+    # $1 = raw command string, $2 = agent_type value. Slurp the command from
+    # stdin so large commands do not exceed jq's argv-size limit.
+    printf '%s' "$1" | jq -Rs --arg at "$2" '{tool_name: "Bash", tool_input: {command: .}, agent_type: $at}'
 }
 
 hg_write_json_agent() {

--- a/hooks/write-guard-core.sh
+++ b/hooks/write-guard-core.sh
@@ -195,6 +195,23 @@ write_guard_core_check_dangerous_command() {
     return 0
 }
 
+# _wg_core_drain_stdin
+# Consumes whatever candidate lines remain on stdin. Every caller of the two
+# functions below pipes candidate paths in (`printf ... | write_guard_core_run
+# ...`), and both platform shims that pipe into this core run under
+# `set -o pipefail` + `set -e`. If a match is found early and the function
+# just `return`s without reading the rest, the still-writing upstream printf
+# gets SIGPIPE on its next write -> its exit status becomes 141 ->
+# `pipefail` promotes that 141 to the whole pipeline's exit code -> `set -e`
+# aborts the hook, discarding the deny JSON already printed. Draining here
+# lets the upstream writer finish normally so its exit status stays 0.
+# Pure bash (no `cat`) since this core runs on every guarded tool call.
+_wg_core_drain_stdin() {
+    local _wg_core_discard
+    while IFS= read -r _wg_core_discard; do :; done
+    return 0
+}
+
 write_guard_core_run() {
     local omt_dir="$1"
     local session_id="$2"
@@ -205,6 +222,7 @@ write_guard_core_run() {
         norm_candidate="$(_wg_core_normpath "$candidate")"
         if [ "$norm_candidate" = "$ledger_path" ]; then
             printf '%s\n' "$_wg_core_deny_json"
+            _wg_core_drain_stdin
             return 0
         fi
         # Glob candidate (e.g. `rm session-ledger-*.md`): never EXACT-matches,
@@ -228,6 +246,7 @@ write_guard_core_run() {
             *[*?[]*)
                 if _wg_core_pathwise_glob_match "$norm_candidate" "$ledger_path"; then
                     printf '%s\n' "$_wg_core_deny_json"
+                    _wg_core_drain_stdin
                     return 0
                 fi
                 ;;
@@ -259,6 +278,7 @@ codereview_guard_core_run() {
     local session_id="$2"
     local agent_type="${3:-}"
     if [ "$agent_type" = "code-reviewer" ]; then
+        _wg_core_drain_stdin
         return 0
     fi
     local ultragoal_path goal_path
@@ -269,6 +289,7 @@ codereview_guard_core_run() {
         norm_candidate="$(_wg_core_normpath "$candidate")"
         if [ "$norm_candidate" = "$ultragoal_path" ] || [ "$norm_candidate" = "$goal_path" ]; then
             printf '%s\n' "$_wg_core_codereview_deny_json"
+            _wg_core_drain_stdin
             return 0
         fi
         case "$norm_candidate" in
@@ -276,6 +297,7 @@ codereview_guard_core_run() {
                 if _wg_core_pathwise_glob_match "$norm_candidate" "$ultragoal_path" \
                     || _wg_core_pathwise_glob_match "$norm_candidate" "$goal_path"; then
                     printf '%s\n' "$_wg_core_codereview_deny_json"
+                    _wg_core_drain_stdin
                     return 0
                 fi
                 ;;

--- a/hooks/write-guard-core_test.sh
+++ b/hooks/write-guard-core_test.sh
@@ -758,6 +758,104 @@ test_codereview_guard_other_session_allows() {
 }
 
 # =============================================================================
+# SIGPIPE regression -- both write_guard_core_run and codereview_guard_core_run
+# early `return 0` (exact match, glob match, or the code-reviewer identity
+# bypass) WITHOUT draining the rest of stdin first. Every caller invokes these
+# functions at the end of a pipe (`printf ... | write_guard_core_run ...`), so
+# when the candidate stream left unread after the early return exceeds a real
+# pipe's kernel buffer (64KB), the still-writing `printf` blocks and then gets
+# SIGPIPE the moment this reader closes its end -- the pipeline's exit status
+# becomes 141 under `pipefail`, discarding whatever this function already
+# printed to its own stdout (a computed deny JSON, in two of the four cases
+# below). This is deterministic on SIZE alone (a candidate stream >64KB after
+# the matching line), never on scheduling luck -- `wg_oversized_candidates`
+# below always emits ~268KB of harmless, never-matching trailing lines.
+#
+# `wg_pipefail_run` executes the pipeline inside its OWN `set -o pipefail`
+# subshell (via the `$(...)` command substitution boundary), independent of
+# whatever pipefail state this suite's own top-of-file `set -euo pipefail`
+# happens to be in -- so a passing assertion here is never an artifact of how
+# this file is invoked. Bash 3.2 has no nameref; results land in the globals
+# WG_PF_OUT / WG_PF_RC by convention.
+# =============================================================================
+
+wg_oversized_candidates() {
+    local i=0
+    while [ "$i" -lt 4000 ]; do
+        printf '/tmp/omt-wg-sigpipe-pad-%05d-0123456789abcdefghijklmnopqrstuvwxyz\n' "$i"
+        i=$((i + 1))
+    done
+}
+
+wg_pipefail_run() {
+    # $1 = full stdin text (the matching candidate line(s) followed by the
+    # oversized trailing padding); $2 = the reader snippet (source the core,
+    # call the function under test).
+    local stdin_text="$1" reader="$2"
+    WG_PF_RC=0
+    WG_PF_OUT=$(set -o pipefail; printf '%s' "$stdin_text" | bash -c "$reader") || WG_PF_RC=$?
+}
+
+test_sigpipe_ledger_exact_match_early_return_survives_oversized_trailing_candidates() {
+    local expected stdin_text
+    expected='{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Blocked: direct write/delete targets the durable session ledger (session-ledger-*.md). Use hooks/omt-ledger.sh append/now instead."}}'
+    stdin_text="$(printf '%s\n' "$OD/session-ledger-$SID.md"; wg_oversized_candidates)"
+    wg_pipefail_run "$stdin_text" "source '$CORE'; write_guard_core_run '$OD' '$SID'"
+    if [ "$WG_PF_RC" -ne 0 ]; then
+        echo "ASSERTION FAILED sigpipe-ledger-exact: expected exit 0, got exit $WG_PF_RC (a nonzero writer exit -- 141 when SIGPIPE terminates it, 1 when this shell reports the write() EPIPE itself -- means the >64KB trailing candidates after the EXACT-match early return killed the writer). out='$WG_PF_OUT'"
+        return 1
+    fi
+    if [ "$WG_PF_OUT" != "$expected" ]; then
+        echo "ASSERTION FAILED sigpipe-ledger-exact: expected deny JSON intact, got '$WG_PF_OUT'"
+        return 1
+    fi
+}
+
+test_sigpipe_ledger_glob_match_early_return_survives_oversized_trailing_candidates() {
+    local expected stdin_text
+    expected='{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Blocked: direct write/delete targets the durable session ledger (session-ledger-*.md). Use hooks/omt-ledger.sh append/now instead."}}'
+    stdin_text="$(printf '%s\n' "$OD/session-ledger-*.md"; wg_oversized_candidates)"
+    wg_pipefail_run "$stdin_text" "source '$CORE'; write_guard_core_run '$OD' '$SID'"
+    if [ "$WG_PF_RC" -ne 0 ]; then
+        echo "ASSERTION FAILED sigpipe-ledger-glob: expected exit 0, got exit $WG_PF_RC (a nonzero writer exit -- 141 when SIGPIPE terminates it, 1 when this shell reports the write() EPIPE itself -- means the >64KB trailing candidates after the GLOB-match early return killed the writer). out='$WG_PF_OUT'"
+        return 1
+    fi
+    if [ "$WG_PF_OUT" != "$expected" ]; then
+        echo "ASSERTION FAILED sigpipe-ledger-glob: expected deny JSON intact, got '$WG_PF_OUT'"
+        return 1
+    fi
+}
+
+test_sigpipe_codereview_identity_bypass_survives_oversized_candidates() {
+    local stdin_text
+    stdin_text="$(printf '%s\n' "$OD/ultragoal-codereview-$CRSID.json"; wg_oversized_candidates)"
+    wg_pipefail_run "$stdin_text" "source '$CORE'; codereview_guard_core_run '$OD' '$CRSID' 'code-reviewer'"
+    if [ "$WG_PF_RC" -ne 0 ]; then
+        echo "ASSERTION FAILED sigpipe-codereview-identity-bypass: expected exit 0, got exit $WG_PF_RC (a nonzero writer exit -- 141 when SIGPIPE terminates it, 1 when this shell reports the write() EPIPE itself -- means the code-reviewer bypass, returning before reading ANY stdin, killed the writer against >64KB candidates). out='$WG_PF_OUT'"
+        return 1
+    fi
+    if [ -n "$WG_PF_OUT" ]; then
+        echo "ASSERTION FAILED sigpipe-codereview-identity-bypass: expected empty (ALLOW), got '$WG_PF_OUT'"
+        return 1
+    fi
+}
+
+test_sigpipe_codereview_deny_match_early_return_survives_oversized_trailing_candidates() {
+    local expected stdin_text
+    expected='{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Blocked: this code-review artifact (ultragoal-codereview-*.json / goal-codereview-*.json) may only be written by the code-reviewer subagent, not the orchestrator."}}'
+    stdin_text="$(printf '%s\n' "$OD/ultragoal-codereview-$CRSID.json"; wg_oversized_candidates)"
+    wg_pipefail_run "$stdin_text" "source '$CORE'; codereview_guard_core_run '$OD' '$CRSID' 'sisyphus-junior'"
+    if [ "$WG_PF_RC" -ne 0 ]; then
+        echo "ASSERTION FAILED sigpipe-codereview-deny: expected exit 0, got exit $WG_PF_RC (a nonzero writer exit -- 141 when SIGPIPE terminates it, 1 when this shell reports the write() EPIPE itself -- means the >64KB trailing candidates after the deny-match early return killed the writer). out='$WG_PF_OUT'"
+        return 1
+    fi
+    if [ "$WG_PF_OUT" != "$expected" ]; then
+        echo "ASSERTION FAILED sigpipe-codereview-deny: expected deny JSON intact, got '$WG_PF_OUT'"
+        return 1
+    fi
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -810,6 +908,10 @@ main() {
     run_test test_codereview_guard_verdict_artifact_allows
     run_test test_codereview_guard_durable_sink_candidates_allows
     run_test test_codereview_guard_other_session_allows
+    run_test test_sigpipe_ledger_exact_match_early_return_survives_oversized_trailing_candidates
+    run_test test_sigpipe_ledger_glob_match_early_return_survives_oversized_trailing_candidates
+    run_test test_sigpipe_codereview_identity_bypass_survives_oversized_candidates
+    run_test test_sigpipe_codereview_deny_match_early_return_survives_oversized_trailing_candidates
 
     echo "=========================================="
     echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"


### PR DESCRIPTION
## 📌 Summary

write-guard 가드 코어가 매치를 찾으면 stdin을 끝까지 읽지 않고 조기 return해, 상류 `printf`가 SIGPIPE로 죽고 호출 shim의 `set -o pipefail` + `set -e`가 훅을 통째로 중단시켰다. allow 케이스는 무출력으로 끝나고, **이미 계산해 출력한 deny JSON까지 함께 폐기되어 가드가 fail-open으로 뒤집혔다.** 공유 코어 한 곳에 stdin 배수를 추가해 Claude shim 2곳과 Codex twin 2곳을 shim 파일 변경 없이 함께 복구했다.

---

## 🔧 Changes

### write-guard 코어

- `_wg_core_drain_stdin` 헬퍼 추가 — stdin 잔여분을 끝까지 소비한다. 순수 bash(외부 프로세스 스폰 없음), macOS bash 3.2 호환
- `write_guard_core_run`의 조기 return 2곳(원장 경로 EXACT 매치 deny, 글롭 매치 deny)에서 반환 직전 호출
- `codereview_guard_core_run`의 조기 return 3곳(`agent_type == "code-reviewer"` 즉시 allow, EXACT 매치 deny, 글롭 매치 deny)에서 반환 직전 호출

두 함수는 stdin으로 개행 구분 후보 경로 목록을 받는데, 매치를 찾는 즉시 남은 입력을 버리고 반환했다. 호출부는 전부 파이프이고 두 shim 모두 `set -euo pipefail`이라, 리더가 먼저 종료하면 상류 `printf`가 EPIPE를 받아 141을 반환하고 `pipefail`이 그 141을 파이프라인 종료코드로 승격시킨 뒤 `set -e`가 훅을 중단시켰다.

**영향 범위**
- 호출 shim(`hooks/pre-tool-enforcer.sh`, `hooks/codex-write-guard.sh`)은 미변경 — 코어만 고쳐 4개 호출부가 함께 복구된다
- 함수의 관측 가능한 계약(stdout 바이트, 반환코드)은 불변. 달라지는 것은 stdin을 남기지 않는다는 점 하나뿐이다
- 기존 호출자 전수 확인 완료: shim 4곳 + 테스트 33곳 전부가 파이프로 stdin을 공급한다. stdin 없이 호출하는 곳이 없어 배수가 블로킹을 유발하지 않는다
- 신규 의존성 없음. 훅은 모든 도구 호출마다 실행되므로 배수에 `cat` 대신 bash 내장 루프를 썼다

### 회귀 테스트

- 코어 레벨 4건 — 조기 return 5곳 중 4개 분기를 파이프라인 종료코드로 직접 단언
- Claude shim 2건(CR-16 allow / CR-17 deny) — 훅 end-to-end
- Codex twin 2건 — 대칭 복사가 아니라 동일 불변식으로 작성

**영향 범위**
- shell 테스트 실행시간 약 16s 증가 (전체 146s 기준). 원인은 아래 Review Point 3 참조

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 호출부 4곳이 아니라 공유 코어 한 곳을 고친 이유

**배경 및 문제 상황:**

SIGPIPE가 발생하는 지점은 파이프라인이므로, 표면적으로는 호출부에서 막는 선택지가 먼저 보인다. 실제로 후보가 셋이었다.

- 호출부에서 파이프를 here-string(`<<<`)으로 바꿔 writer 자체를 없앤다
- 호출부 대입에 `|| true`를 붙여 `set -e` 중단만 막는다
- 코어 함수가 stdin을 다 읽고 반환하게 한다

**해결 방안:**

세 번째를 택했다. 근본 원인은 "stdin을 읽는 함수가 다 읽지 않고 빠져나간다"는 **함수 자신의 결함**이고, 앞의 두 안은 그 결함을 그대로 둔 채 호출부에서 증상만 가린다.

here-string 안은 현재 호출부 4곳을 고쳐도 이후 파이프로 호출하는 코드가 하나만 생기면 결함이 되살아난다. 게다가 후보 목록은 마지막 줄이 while-read에 먹히지 않도록 의도적으로 개행으로 끝나는데(`hooks/pre-tool-enforcer.sh`의 주석에 명시), `<<<`는 개행을 하나 더 붙여 빈 줄을 만든다 — 무해하지만 입력 바이트를 바꾼다.

`|| true` 안은 SIGPIPE만이 아니라 **모든** 실패를 함께 삼킨다. 가드 코드에서 실패를 구분 없이 무시하는 것은 이 결함이 만들어낸 fail-open과 성격이 같다.

**구현 세부사항:**

배수를 deny 출력 **뒤에** 둔다. 순서가 반대면 매치 직후 남은 후보를 다 읽는 동안 출력이 지연되는데, 실익 없이 관측 순서만 바뀐다. 반환코드도 `return 0`으로 고정해 배수 루프의 `read` EOF(nonzero)가 `set -e` 아래 호출자에게 새어나가지 않게 했다.

`agent_type == "code-reviewer"` 분기는 루프에 진입하기도 전에 반환하던 유일한 지점이라, 원래 stdin을 **한 줄도** 읽지 않았다. 나머지 네 곳은 최소 한 줄은 읽은 뒤 중단하는 경우다.

**관련 코드:**

```bash
# Before -- 매치 즉시 반환, 남은 stdin은 버려짐
if [ "$agent_type" = "code-reviewer" ]; then
    return 0
fi

# After -- 반환 전에 stdin을 비워 상류 writer가 정상 종료하게 한다
if [ "$agent_type" = "code-reviewer" ]; then
    _wg_core_drain_stdin
    return 0
fi
```

**선택과 트레이드오프:**

코어를 고치면 함수의 계약에 "stdin을 전부 소비한다"가 추가된다. 지금은 모든 호출자가 파이프로 stdin을 공급하므로 안전하지만, **stdin 없이 호출하면 배수 루프가 블로킹된다.** 특히 `code-reviewer` 즉시 반환 경로는 이전에는 stdin을 안 읽었으므로 stdin 없이도 동작했다. 이 리스크를 알고 택했고, 근거로 전 호출자(shim 4곳 + 테스트 33곳)를 확인했다. 훅은 사용자가 직접 호출하는 코드가 아니라 하네스가 고정된 형태로 호출하는 코드라 새 호출자가 임의로 늘지 않는다는 점도 감안했다.

리뷰어 의견을 듣고 싶은 지점: 이 계약을 코드로 강제할 방법이 마땅치 않다는 것. 함수 상단에 `[ -t 0 ] && return`류의 가드를 넣는 안을 검토했으나, stdin이 터미널이 아닌 비파이프 케이스(리다이렉트된 파일 등)를 못 걸러 반쪽짜리라 넣지 않았다.

### 2. 회귀 테스트를 반복·부하가 아니라 크기 축으로 결정론화한 이유

**배경 및 문제 상황:**

이 결함은 `make sync` 중 `pre-tool-enforcer_test.sh`의 기존 테스트 하나가 간헐 실패하면서 드러났다. 실패 메시지가 assertion 불일치가 아니라 **무출력**(`Got: ` 공란)이었다.

작은 페이로드에서는 `printf`가 파이프 버퍼(64KB)에 전량을 밀어넣고 끝나느냐, 리더가 먼저 종료하느냐의 경쟁이다. 평소엔 printf가 이겨서 통과하고, 부하 중에만 진다. 실제로 단독 30회 반복에서는 한 번도 재현되지 않았다.

**해결 방안:**

경쟁상태를 그대로 테스트하면 테스트 자체가 플레이키가 된다. 후보셋을 파이프 버퍼보다 크게 만들어 `printf`가 **반드시** 블로킹하게 하면, SIGPIPE가 스케줄링 운과 무관하게 100% 발생한다. 시간 축(반복·부하)의 비결정성을 크기 축의 결정성으로 치환한 것이다.

**구현 세부사항:**

출력만 보는 단정으로는 이 결함을 잡지 못한다. deny 케이스에서 가드는 JSON을 **정상적으로 출력한 뒤** 중단되므로, Codex twin처럼 출력을 변수에 담지 않는 호출부에서는 stdout만 보면 통과해버린다. 그래서 모든 신규 테스트가 파이프라인 **종료코드**를 단언한다. 코어 레벨 테스트는 `set -o pipefail`을 명시적으로 켠 서브셸에서 파이프라인을 돌려 종료코드를 잡는다.

수정 전 상태를 실제로 관측했다: 신규 8건 전부 실패, 기존 테스트는 전건 통과. Claude shim은 `exit 141` + 무출력, Codex twin은 `exit 141` + deny JSON 출력이었다 — 두 shim의 실패 모습이 다르다는 점이 대칭 복사가 아닌 동일 불변식으로 테스트를 쓴 이유다.

**선택과 트레이드오프:**

64KB 초과라는 조건은 결함을 결정론적으로 잡기 위한 최소 크기라 줄일 수 없다. 대신 실행시간을 지불한다 — 아래 Review Point 3의 첫 항목이 그 비용의 원인이다.

### 3. 이번 범위 밖으로 둔 인접 발견 3건

작업 중 실측했으나 이번 수정의 thesis와 무관해 손대지 않았다. 별도 처리 여부를 정하기 위해 남긴다.

**(1) `_wg_core_normpath`의 awk 프로세스 스폰 — 런타임 지연 직결**

경로 정규화가 후보 한 줄마다 `awk` 프로세스를 새로 띄운다. 실측:

```
small  payload=    113 bytes   hook=   34 ms
large  payload= 258263 bytes   hook= 4076 ms
```

120배다. 후보 수에 선형으로 늘어난다. 이번 회귀 테스트가 shell 테스트 시간을 약 16s 늘린 것도 전부 여기서 나온다. 더 중요한 것은 **이 코드가 모든 도구 호출마다 도는 PreToolUse 경로**라는 점이다. 테스트 시간이 아니라 실사용 지연 문제다. 경로 정규화는 순수 bash 문자열 연산으로 대체 가능하다.

**(2) 세그먼트 분할 추출기의 자원 고갈**

테스트 작성 중, `;`로 구분된 작은 세그먼트를 수천 개 만들어 64KB를 채우자 Codex 훅의 분할 추출기가 서브프로세스를 과다 포크해 **SIGSEGV(exit 139)로 죽었다.** 세그먼트 수를 줄이고 개당 크기를 키워(80개 × 약 3.2KB) 우회했으므로 이번 테스트에는 영향이 없지만, 추출기 자체의 취약점은 그대로 남아 있다. (1)의 awk 스폰과 같은 뿌리로 보인다.

**(3) 테스트 러너의 로그 절단으로 진단 불가**

`make test` 1회차에서 bun 테스트 1건이 실패했다가 재실행에서 통과했다(4819/1 → 4820/0, `bun test` 직접 실행도 4820/0). 그런데 `tools/run-tests.sh`가 실패 로그를 `tail -20`으로 자르는 탓에 **어느 테스트였는지 이름을 특정하지 못했다.** 이번 변경과의 무관함은 확인했다 — `write-guard-core`를 참조하는 bun 테스트가 하나도 없다. 별개의 플레이키로 남아 있고, 로그 절단은 다음에도 같은 진단 실패를 반복시킬 구조다.

---

## ✅ Checklist

### 가드 정상 동작 복구
- [ ] 64KB 초과 후보셋에서 `code-reviewer` allow 경로가 종료코드 0과 `{"continue": true}`를 낸다
  - `hooks/pre-tool-enforcer_test.sh`
- [ ] 64KB 초과 후보셋에서 비-`code-reviewer` deny JSON이 폐기되지 않고 stdout으로 출력되며 종료코드가 0이다
  - `hooks/pre-tool-enforcer_test.sh`
- [ ] `write_guard_core_run`의 원장 EXACT 매치·글롭 매치 조기 return에서 파이프라인 종료코드가 0이다
  - `hooks/write-guard-core_test.sh`
- [ ] `codereview_guard_core_run`의 즉시 allow·EXACT 매치 deny 조기 return에서 파이프라인 종료코드가 0이다
  - `hooks/write-guard-core_test.sh`

### Codex twin 패리티
- [ ] Codex shim에서도 64KB 초과 후보셋의 allow·deny 두 경로 모두 종료코드가 0이다
  - `hooks/codex-write-guard_test.sh`

### 계약 불변
- [ ] 두 함수의 stdout 바이트와 반환코드가 수정 전과 동일하다 (기존 테스트 전건 통과)
  - `hooks/write-guard-core.sh`
- [ ] 호출 shim 2개 파일이 변경되지 않았다
  - `hooks/pre-tool-enforcer.sh`
  - `hooks/codex-write-guard.sh`
- [ ] `make test` 전체가 통과한다
