### PR TITLE
docs: FSD 케이스 문서 3차 리뷰 지적 3건 정정

### DIFF
--- a/projects/loop-pack-fe-l2-vol1/docs/architecture/cases-api-and-types.md
+++ b/projects/loop-pack-fe-l2-vol1/docs/architecture/cases-api-and-types.md
@@ -140,9 +140,16 @@ export type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 // ✅ entities/product/model/types.ts — Product를 아는 사람이 여기를 본다
 export interface Product { id: string; name: string; price: number; }
 
-// ✅ entities/order/model/types.ts
+// ✅ entities/product/@x/order.ts — order slice에게만 공개하는 진입점
+export type { Product } from "../model/types";
+
+// ✅ entities/order/model/types.ts — 다른 Entity 타입은 @x 진입점으로만
+import type { Product } from "@/entities/product/@x/order";
+
 export interface Order { id: string; items: Product[]; }
 ```
+
+`Order`가 `Product` 타입을 쓰는 순간 엔티티 간 의존이 생긴다 — 같은 레이어 slice를 직접 import하는 대신 @x 진입점을 경유한다. 바로 아래 케이스 5가 이 시나리오를 다룬다.
 
 ## 케이스 5 — 엔티티 간 타입 순환 참조: `@x` 실전
 

--- a/projects/loop-pack-fe-l2-vol1/docs/architecture/cases-structure.md
+++ b/projects/loop-pack-fe-l2-vol1/docs/architecture/cases-structure.md
@@ -160,7 +160,7 @@ import { applyFilter } from "@/features/photo-editing/effects";
 
 ### ESLint `import/no-restricted-paths` — cross-feature와 역방향 import 차단
 
-하위 레이어가 상위 레이어를 참조하는 것은 zones로 막는다. cross-feature 차단은 slice별로 zone을 하나씩 열거해야 하는데, 여기엔 함정이 있다: target/from에 glob을 쓰면 glob 규약으로 매치되고 `*` 하나는 경로 구분자를 넘지 못한다 — `./src/features`에 `*`를 붙인 형태는 `src/features/photo/ui/Photo.tsx` 같은 중첩 파일에 매치되지 않는 no-op zone이 된다. glob 없는 디렉토리 경로는 그 아래 전부에 재귀 매치되므로, slice 디렉토리를 그대로 target으로 쓴다(bulletproof-react 방식).
+하위 레이어가 상위 레이어를 참조하는 것은 zones로 막는다. zone의 `target`은 import 문이 있는 쪽 — 위반의 주체 — 을 선택하고, `from`은 그 파일들이 import하면 안 되는 곳이다. cross-feature 차단은 slice별로 zone을 하나씩 열거해야 하는데, 여기엔 함정이 있다: target/from에 glob을 쓰면 glob 규약으로 매치되고 `*` 하나는 경로 구분자를 넘지 못한다 — `./src/features`에 `*`를 붙인 형태는 `src/features/photo/ui/Photo.tsx` 같은 중첩 파일에 매치되지 않는 no-op zone이 된다. glob 없는 디렉토리 경로는 그 아래 전부에 재귀 매치되므로, slice 디렉토리를 그대로 target으로 쓴다(bulletproof-react 방식).
 
 ```json
 {
@@ -187,7 +187,7 @@ import { applyFilter } from "@/features/photo-editing/effects";
 }
 ```
 
-첫 번째 zone이 케이스 3의 `gallery-page → effects` 내부 참조 같은 것을 기계적으로 막고, 두 번째 zone이 케이스 2에서 `shared`가 `widgets`를 import하려던 실수를 빌드 단계에서 잡는다. 다만 이 방식은 slice마다 zone을 하나씩 열거해야 한다(위 `photo` 것을 다른 slice마다 반복). 열거 없이 일반형으로 같은 레이어 간 import를 잡는 것은 아래 Steiger의 `forbidden-imports`가 담당한다.
+위 zone은 `photo`가 다른 feature를 import하는 것을 막는다. 케이스 3의 `gallery-page → effects`를 잡으려면 `gallery-page`를 target으로 한 zone이 따로 있어야 한다 — 그래서 이 방식은 slice마다 zone을 하나씩 열거해야 한다. 두 번째 zone은 케이스 2에서 `shared`가 `widgets`를 import하려던 실수를 빌드 단계에서 잡는다. 열거 없이 일반형으로 같은 레이어 간 import를 잡는 것은 아래 Steiger의 `forbidden-imports`가 담당한다.
 
 ### Steiger — FSD 전용 정적 분석이 잡는 위반
 

--- a/projects/loop-pack-fe-l2-vol1/docs/architecture/error-layers.md
+++ b/projects/loop-pack-fe-l2-vol1/docs/architecture/error-layers.md
@@ -23,27 +23,34 @@
 
 ## Error Boundary 계층 배치
 
-전역 Boundary 안에 페이지 Boundary를 중첩한다. 폴백 컴포넌트는 재시도를 위한 `reset`을 받는다.
+전역 Boundary 안에 페이지 Boundary를 중첩한다. 폴백 컴포넌트는 재시도를 위한 `reset`을 받는다. 재시도 버튼이 Boundary만 리셋하면 query가 에러 상태로 남아 같은 에러를 즉시 다시 던진다 — TanStack Query의 `QueryErrorResetBoundary`가 주는 `reset`을 Boundary의 `onReset`에 함께 물린다.
 
 ```tsx
+import { QueryErrorResetBoundary } from "@tanstack/react-query";
+import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
+
 function App() {
   return (
-    <ErrorBoundary fallback={GlobalErrorFallback}>
+    <ErrorBoundary FallbackComponent={GlobalErrorFallback}>
       <Header />
-      <ErrorBoundary fallback={PageErrorFallback}>
-        <Outlet />
-      </ErrorBoundary>
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary onReset={reset} FallbackComponent={PageErrorFallback}>
+            <Outlet />
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
       <Footer />
     </ErrorBoundary>
   );
 }
 
-function PageErrorFallback({ error, reset }: { error: Error; reset: () => void }) {
+function PageErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
   return (
     <div>
       <h2>페이지를 불러오는데 실패했습니다</h2>
       <p>{error.message}</p>
-      <button onClick={reset}>다시 시도</button>
+      <button onClick={() => resetErrorBoundary()}>다시 시도</button>
     </div>
   );
 }


### PR DESCRIPTION
## 📌 Summary

PR #231(FSD 아키텍처 문서 기반)이 머지된 뒤 도착한 3차 코드리뷰 지적 3건을 정정하는 후속 PR이다. 세 건 모두 "규범 서술은 맞는데 예제/해설이 그 규범 또는 라이브러리의 실제 의미론을 배반"하는 유형으로, 전부 공식 문서 실측으로 확인 후 수정했다.

---

## 🔧 Changes

### docs/architecture 3편 정정 (커밋 `a9437d33`)

- `cases-structure.md`: ESLint `import/no-restricted-paths` zone의 `target`이 **import 문이 있는 쪽(위반의 주체)** 을 선택한다는 의미론을 명시하고, photo를 target으로 한 예제 zone이 케이스 3의 `gallery-page → effects`를 잡는다던 해설을 정정 — 그 위반을 잡으려면 `gallery-page`를 target으로 한 zone이 따로 필요하다
- `error-layers.md`: 재시도 버튼이 React Error Boundary만 리셋해 query의 캐시된 에러가 즉시 다시 던져지던 예제를, `QueryErrorResetBoundary`의 `reset`을 Boundary `onReset`에 배선하는 TanStack 공식 패턴으로 교체
- `cases-api-and-types.md`: 케이스 4의 `Order`가 `items: Product[]`로 인해 같은 레이어 Entity를 암묵 import해야 했던 것을 `entities/product/@x/order` 진입점 경유로 교체 — 바로 아래 케이스 5(@x 실전)로 논지가 이어진다

**영향 범위**
문서 3편의 예제·산문 정정만 있으며 실행 코드 변경은 없다. `make validate` 통과, 문서 300줄 상한·상대링크 무결 확인.

---

## ✅ Checklist

- [ ] `make validate` 통과
- [ ] 세 문서의 예제가 각자 서술하는 규범(같은 레이어 import 금지, zone target 의미론, query 에러 리셋)과 모순되지 않음
  - `projects/loop-pack-fe-l2-vol1/docs/architecture/`

---

## 📎 References
- [PR #231 — FSD 아키텍처 문서 기반 구축](https://github.com/toongri/oh-my-toong-playground/pull/231) (3차 리뷰 지적의 출처)
- [eslint-plugin-import no-restricted-paths](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-restricted-paths.md)
- [TanStack Query — QueryErrorResetBoundary](https://tanstack.com/query/latest/docs/framework/react/reference/QueryErrorResetBoundary)
