### PR TITLE
검증 캐시 우회 금지 규칙 추가

### DIFF
--- a/rules/verification-discipline.md
+++ b/rules/verification-discipline.md
@@ -13,3 +13,7 @@ The final "is it done" check runs over the affected scope — the changed code p
 ## Projects declare the contract; the harness calls it by name
 
 Each project exposes its own verification commands — a fast changed-scope command for the inner loop, and an affected-scope command for the completion gate — under names the project owns. The harness invokes them by name and does not hardcode any language's tool. (For example, one project might name these `verify:quick` and `verify:full`; another might expose Gradle tasks or a Makefile target. The names belong to the project, not to this rule.)
+
+## CRITICAL: Never bypass verification caches
+
+MANDATORY: never pass a cache-bypass or forced-rerun flag (`--force` and equivalents) to a test or verification command, under any circumstances. A cache hit is a trustworthy verification result — build systems key it on input hashes, so any changed input already produces a miss on its own. Discarding a cache "to be sure" buys zero additional verification value at the cost of 30+ minutes of wasted rerun. If you have a concrete reason to distrust a cache, report it to the user instead of forcing a bypass run. A hook guard may block these flags outright; if blocked, do not look for another way around it.


### PR DESCRIPTION
## 배경

AI 에이전트(특히 Codex)가 algocare-home 레포에서 turbo 캐시를 `--force`로 우회하면서 30분 이상 걸리는 전체 재실행을 반복하는 문제가 있었다. 훅 가드(verify-entrypoint-gate)가 이미 이 우회를 차단하고 있지만, 규칙 계층에 명시적 금지 조항이 없어 에이전트가 계속 시도하는 상황이었다.

## 변경

전역 배포 규칙 `rules/verification-discipline.md`에 "CRITICAL: Never bypass verification caches" 섹션을 추가했다. 캐시 우회 플래그 사용을 절대 금지하고, 캐시 히트는 입력 해시를 키로 하므로 신뢰 가능한 결과임을 명시했다. 캐시가 의심스러울 때는 우회하지 말고 사용자에게 보고하도록 하고, 가드가 이미 차단한 경우에도 우회를 시도하지 말도록 했다.

## 배포 경로

`rules` 카테고리는 `config.yaml` 기준 배포 대상이 [claude, codex]다. 이번 PR이 main에 머지된 뒤 `make sync`를 실행하면 각 타겟 프로젝트에 반영된다.

## 관련 변경

algocare-home 레포 쪽에는 `--force` 사용을 안내하던 문서를 제거하는 별도 PR이 함께 올라간다. 이번 변경으로 규칙이 명시적으로 금지하는데 문서가 우회를 안내하는 모순이 해소된다.