### PR TITLE
fix: 백그라운드 작업 중 Stop 유예

### DIFF
--- a/hooks/codex-persistent-mode/cli.test.ts
+++ b/hooks/codex-persistent-mode/cli.test.ts
@@ -686,6 +686,23 @@ describe("codex-persistent-mode cli", () => {
 	});
 
 	describe("hook stop: shared continuation contract (makeDecision integration)", () => {
+		test("payload with foreign background_tasks field + incomplete todos → still blocks (no background bypass)", async () => {
+			const sid = "sid-foreign-background-blocks";
+			writeFileSync(mirrorPath(omtDir, sid), JSON.stringify({ incomplete: 2 }));
+			const { exitCode, stdout } = await runCli(
+				"stop",
+				{
+					...stopPayload(sid, projectDir),
+					background_tasks: [{ id: "x", type: "shell", status: "running" }],
+				},
+				omtDir,
+			);
+			expect(exitCode).toBe(0);
+			const parsed = JSON.parse(stdout);
+			expect(parsed.decision).toBe("block");
+			expect(parsed.reason).toContain("2");
+		});
+
 		test("awaiting-user token allows stop even with incomplete=2 (priority over baseline-todo)", async () => {
 			const sid = "sid-awaiting-with-incomplete";
 			writeFileSync(mirrorPath(omtDir, sid), JSON.stringify({ incomplete: 2 }));

--- a/hooks/codex-persistent-mode/cli.ts
+++ b/hooks/codex-persistent-mode/cli.ts
@@ -251,7 +251,11 @@ function runStop(input: Record<string, unknown>): void {
 		lastAssistantMessage: typeof lam === "string" ? lam : null,
 		projectRoot: cwd,
 		incompleteTodoCount,
-		activeSubagentCount: 0,
+		// Codex Stop payload's closed schema carries no background-task data, and completion
+		// is queued as context with trigger_turn:false, so it has no guaranteed wake/re-invocation.
+		// Shared invariant: Stop may bypass only if deferred re-invocation is guaranteed;
+		// Codex lacks that guarantee, so keep no background-task bypass.
+		activeBackgroundTaskCount: 0,
 		pendingSkillChainSkills,
 		// Codex's real AskUserQuestion analog (rewrite rule 14 in
 		// tools/lib/rewrite-rules.ts) — see DecisionContext.askToolName's doc

--- a/hooks/persistent-mode/index.ts
+++ b/hooks/persistent-mode/index.ts
@@ -33,7 +33,7 @@ export async function main(): Promise<void> {
 			sessionId: input.sessionId,
 			lastAssistantMessage: input.lastAssistantMessage,
 			incompleteTodoCount,
-			activeSubagentCount: input.activeSubagentCount,
+			activeBackgroundTaskCount: input.activeBackgroundTaskCount,
 		};
 
 		// Make decision

--- a/hooks/persistent-mode/stdin.test.ts
+++ b/hooks/persistent-mode/stdin.test.ts
@@ -158,30 +158,23 @@ describe("parseInput", () => {
 		expect(result.activeBackgroundTaskCount).toBe(1);
 	});
 
-	it("subagent pending → activeBackgroundTaskCount 1", () => {
+	it("shell running → activeBackgroundTaskCount 1 (type-agnostic)", () => {
 		const result = parseInput(
-			JSON.stringify({ background_tasks: [{ id: "p", type: "subagent", status: "pending" }] }),
+			JSON.stringify({ background_tasks: [{ id: "b", type: "shell", status: "running" }] }),
 		);
 		expect(result.activeBackgroundTaskCount).toBe(1);
 	});
 
-	it("shell running → activeBackgroundTaskCount 0 (long-lived task not counted)", () => {
-		const result = parseInput(
-			JSON.stringify({ background_tasks: [{ id: "b", type: "shell", status: "running" }] }),
-		);
-		expect(result.activeBackgroundTaskCount).toBe(0);
-	});
-
-	it("monitor pending → activeBackgroundTaskCount 0 (long-lived task not counted)", () => {
+	it("monitor pending → activeBackgroundTaskCount 1 (type-agnostic)", () => {
 		const result = parseInput(
 			JSON.stringify({ background_tasks: [{ id: "m", type: "monitor", status: "pending" }] }),
 		);
-		expect(result.activeBackgroundTaskCount).toBe(0);
+		expect(result.activeBackgroundTaskCount).toBe(1);
 	});
 
-	it("typeless running entry → activeBackgroundTaskCount 0 (type required)", () => {
+	it("typeless running entry → activeBackgroundTaskCount 1 (type field not read)", () => {
 		const result = parseInput(JSON.stringify({ background_tasks: [{ id: "t", status: "running" }] }));
-		expect(result.activeBackgroundTaskCount).toBe(0);
+		expect(result.activeBackgroundTaskCount).toBe(1);
 	});
 
 	it("unknown status queued → activeBackgroundTaskCount 0 (fail-closed allowlist)", () => {
@@ -210,7 +203,7 @@ describe("parseInput", () => {
 		expect(result.activeBackgroundTaskCount).toBe(0);
 	});
 
-	it("mixed: subagent running + shell running → activeBackgroundTaskCount 1", () => {
+	it("mixed: subagent running + shell running → activeBackgroundTaskCount 2", () => {
 		const result = parseInput(
 			JSON.stringify({
 				background_tasks: [
@@ -219,7 +212,7 @@ describe("parseInput", () => {
 				],
 			}),
 		);
-		expect(result.activeBackgroundTaskCount).toBe(1);
+		expect(result.activeBackgroundTaskCount).toBe(2);
 	});
 
 	it("absent background_tasks → activeBackgroundTaskCount 0", () => {

--- a/hooks/persistent-mode/stdin.test.ts
+++ b/hooks/persistent-mode/stdin.test.ts
@@ -151,28 +151,59 @@ describe("parseInput", () => {
 		expect(result.lastAssistantMessage).toBeNull();
 	});
 
-	it("subagent running → activeSubagentCount 1", () => {
+	it("subagent running → activeBackgroundTaskCount 1", () => {
 		const result = parseInput(
 			JSON.stringify({ background_tasks: [{ id: "a", type: "subagent", status: "running" }] }),
 		);
-		expect(result.activeSubagentCount).toBe(1);
+		expect(result.activeBackgroundTaskCount).toBe(1);
 	});
 
-	it("shell running → activeSubagentCount 0 (non-subagent not counted)", () => {
+	it("shell running → activeBackgroundTaskCount 1 (type-agnostic)", () => {
 		const result = parseInput(
 			JSON.stringify({ background_tasks: [{ id: "b", type: "shell", status: "running" }] }),
 		);
-		expect(result.activeSubagentCount).toBe(0);
+		expect(result.activeBackgroundTaskCount).toBe(1);
 	});
 
-	it("subagent completed → activeSubagentCount 0 (non-active not counted)", () => {
+	it("monitor pending → activeBackgroundTaskCount 1 (type-agnostic)", () => {
+		const result = parseInput(
+			JSON.stringify({ background_tasks: [{ id: "m", type: "monitor", status: "pending" }] }),
+		);
+		expect(result.activeBackgroundTaskCount).toBe(1);
+	});
+
+	it("typeless running entry → activeBackgroundTaskCount 1 (type field not read)", () => {
+		const result = parseInput(JSON.stringify({ background_tasks: [{ id: "t", status: "running" }] }));
+		expect(result.activeBackgroundTaskCount).toBe(1);
+	});
+
+	it("unknown status queued → activeBackgroundTaskCount 0 (fail-closed allowlist)", () => {
+		const result = parseInput(
+			JSON.stringify({ background_tasks: [{ id: "q", type: "shell", status: "queued" }] }),
+		);
+		expect(result.activeBackgroundTaskCount).toBe(0);
+	});
+
+	it("terminal statuses only → activeBackgroundTaskCount 0 (fail-closed)", () => {
+		const result = parseInput(
+			JSON.stringify({
+				background_tasks: [
+					{ id: "c", type: "shell", status: "completed" },
+					{ id: "f", type: "monitor", status: "failed" },
+				],
+			}),
+		);
+		expect(result.activeBackgroundTaskCount).toBe(0);
+	});
+
+	it("subagent completed → activeBackgroundTaskCount 0 (non-active not counted)", () => {
 		const result = parseInput(
 			JSON.stringify({ background_tasks: [{ id: "c", type: "subagent", status: "completed" }] }),
 		);
-		expect(result.activeSubagentCount).toBe(0);
+		expect(result.activeBackgroundTaskCount).toBe(0);
 	});
 
-	it("mixed: subagent running + shell running → activeSubagentCount 1", () => {
+	it("mixed: subagent running + shell running → activeBackgroundTaskCount 2", () => {
 		const result = parseInput(
 			JSON.stringify({
 				background_tasks: [
@@ -181,11 +212,16 @@ describe("parseInput", () => {
 				],
 			}),
 		);
-		expect(result.activeSubagentCount).toBe(1);
+		expect(result.activeBackgroundTaskCount).toBe(2);
 	});
 
-	it("absent background_tasks → activeSubagentCount 0", () => {
+	it("absent background_tasks → activeBackgroundTaskCount 0", () => {
 		const result = parseInput(JSON.stringify({ sessionId: "test" }));
-		expect(result.activeSubagentCount).toBe(0);
+		expect(result.activeBackgroundTaskCount).toBe(0);
+	});
+
+	it("empty background_tasks array → activeBackgroundTaskCount 0 (fail-closed)", () => {
+		const result = parseInput(JSON.stringify({ background_tasks: [] }));
+		expect(result.activeBackgroundTaskCount).toBe(0);
 	});
 });

--- a/hooks/persistent-mode/stdin.test.ts
+++ b/hooks/persistent-mode/stdin.test.ts
@@ -158,23 +158,30 @@ describe("parseInput", () => {
 		expect(result.activeBackgroundTaskCount).toBe(1);
 	});
 
-	it("shell running → activeBackgroundTaskCount 1 (type-agnostic)", () => {
+	it("subagent pending → activeBackgroundTaskCount 1", () => {
+		const result = parseInput(
+			JSON.stringify({ background_tasks: [{ id: "p", type: "subagent", status: "pending" }] }),
+		);
+		expect(result.activeBackgroundTaskCount).toBe(1);
+	});
+
+	it("shell running → activeBackgroundTaskCount 0 (long-lived task not counted)", () => {
 		const result = parseInput(
 			JSON.stringify({ background_tasks: [{ id: "b", type: "shell", status: "running" }] }),
 		);
-		expect(result.activeBackgroundTaskCount).toBe(1);
+		expect(result.activeBackgroundTaskCount).toBe(0);
 	});
 
-	it("monitor pending → activeBackgroundTaskCount 1 (type-agnostic)", () => {
+	it("monitor pending → activeBackgroundTaskCount 0 (long-lived task not counted)", () => {
 		const result = parseInput(
 			JSON.stringify({ background_tasks: [{ id: "m", type: "monitor", status: "pending" }] }),
 		);
-		expect(result.activeBackgroundTaskCount).toBe(1);
+		expect(result.activeBackgroundTaskCount).toBe(0);
 	});
 
-	it("typeless running entry → activeBackgroundTaskCount 1 (type field not read)", () => {
+	it("typeless running entry → activeBackgroundTaskCount 0 (type required)", () => {
 		const result = parseInput(JSON.stringify({ background_tasks: [{ id: "t", status: "running" }] }));
-		expect(result.activeBackgroundTaskCount).toBe(1);
+		expect(result.activeBackgroundTaskCount).toBe(0);
 	});
 
 	it("unknown status queued → activeBackgroundTaskCount 0 (fail-closed allowlist)", () => {
@@ -203,7 +210,7 @@ describe("parseInput", () => {
 		expect(result.activeBackgroundTaskCount).toBe(0);
 	});
 
-	it("mixed: subagent running + shell running → activeBackgroundTaskCount 2", () => {
+	it("mixed: subagent running + shell running → activeBackgroundTaskCount 1", () => {
 		const result = parseInput(
 			JSON.stringify({
 				background_tasks: [
@@ -212,7 +219,7 @@ describe("parseInput", () => {
 				],
 			}),
 		);
-		expect(result.activeBackgroundTaskCount).toBe(2);
+		expect(result.activeBackgroundTaskCount).toBe(1);
 	});
 
 	it("absent background_tasks → activeBackgroundTaskCount 0", () => {

--- a/hooks/persistent-mode/stdin.ts
+++ b/hooks/persistent-mode/stdin.ts
@@ -24,9 +24,7 @@ export function parseInput(raw: string): ParsedInput {
 	const directory = input.cwd || process.cwd();
 	const lastAssistantMessage = input.last_assistant_message || null;
 	const activeBackgroundTaskCount = Array.isArray(input.background_tasks)
-		? input.background_tasks.filter(
-			(t) => t.type === "subagent" && (t.status === "running" || t.status === "pending"),
-		).length
+		? input.background_tasks.filter((t) => t.status === "running" || t.status === "pending").length
 		: 0;
 
 	return { sessionId, directory, lastAssistantMessage, activeBackgroundTaskCount };

--- a/hooks/persistent-mode/stdin.ts
+++ b/hooks/persistent-mode/stdin.ts
@@ -23,11 +23,9 @@ export function parseInput(raw: string): ParsedInput {
 	const sessionId = input.sessionId || input.session_id || "default";
 	const directory = input.cwd || process.cwd();
 	const lastAssistantMessage = input.last_assistant_message || null;
-	const activeSubagentCount = Array.isArray(input.background_tasks)
-		? input.background_tasks.filter(
-				(t) => t.type === "subagent" && (t.status === "running" || t.status === "pending"),
-			).length
+	const activeBackgroundTaskCount = Array.isArray(input.background_tasks)
+		? input.background_tasks.filter((t) => t.status === "running" || t.status === "pending").length
 		: 0;
 
-	return { sessionId, directory, lastAssistantMessage, activeSubagentCount };
+	return { sessionId, directory, lastAssistantMessage, activeBackgroundTaskCount };
 }

--- a/hooks/persistent-mode/stdin.ts
+++ b/hooks/persistent-mode/stdin.ts
@@ -24,7 +24,9 @@ export function parseInput(raw: string): ParsedInput {
 	const directory = input.cwd || process.cwd();
 	const lastAssistantMessage = input.last_assistant_message || null;
 	const activeBackgroundTaskCount = Array.isArray(input.background_tasks)
-		? input.background_tasks.filter((t) => t.status === "running" || t.status === "pending").length
+		? input.background_tasks.filter(
+			(t) => t.type === "subagent" && (t.status === "running" || t.status === "pending"),
+		).length
 		: 0;
 
 	return { sessionId, directory, lastAssistantMessage, activeBackgroundTaskCount };

--- a/lib/persistent-mode-core/decision.test.ts
+++ b/lib/persistent-mode-core/decision.test.ts
@@ -1317,7 +1317,7 @@ describe("makeDecision", () => {
 	// -------------------------------------------------------------------------
 	// Background-aware Stop hook guards
 	// Guard 2: activeBackgroundTaskCount > 0 — must pass through immediately.
-	// Any running/pending background task passes through (type-agnostic); count 0 still blocks.
+	// Only running/pending items with type === "subagent" pass through; zero qualifying subagents block.
 	// -------------------------------------------------------------------------
 	describe("background-aware Stop hook guards", () => {
 		it("activeBackgroundTaskCount=1 with incompleteTodos yields continue (NOT block)", () => {

--- a/lib/persistent-mode-core/decision.test.ts
+++ b/lib/persistent-mode-core/decision.test.ts
@@ -1317,7 +1317,7 @@ describe("makeDecision", () => {
 	// -------------------------------------------------------------------------
 	// Background-aware Stop hook guards
 	// Guard 2: activeBackgroundTaskCount > 0 — must pass through immediately.
-	// Only running/pending items with type === "subagent" pass through; zero qualifying subagents block.
+	// Any running/pending background task passes through (type-agnostic); count 0 still blocks.
 	// -------------------------------------------------------------------------
 	describe("background-aware Stop hook guards", () => {
 		it("activeBackgroundTaskCount=1 with incompleteTodos yields continue (NOT block)", () => {

--- a/lib/persistent-mode-core/decision.test.ts
+++ b/lib/persistent-mode-core/decision.test.ts
@@ -42,7 +42,7 @@ describe("makeDecision", () => {
 		sessionId: "test-session",
 		lastAssistantMessage: null,
 		incompleteTodoCount: 0,
-		activeSubagentCount: 0,
+		activeBackgroundTaskCount: 0,
 		...overrides,
 	});
 
@@ -1316,20 +1316,20 @@ describe("makeDecision", () => {
 
 	// -------------------------------------------------------------------------
 	// Background-aware Stop hook guards
-	// Guard 2: activeSubagentCount > 0 — must pass through immediately.
-	// Non-subagent background tasks (shell/monitor/etc.) must NOT bypass enforcement.
+	// Guard 2: activeBackgroundTaskCount > 0 — must pass through immediately.
+	// Any running/pending background task passes through (type-agnostic); count 0 still blocks.
 	// -------------------------------------------------------------------------
 	describe("background-aware Stop hook guards", () => {
-		it("activeSubagentCount=1 with incompleteTodos yields continue (NOT block)", () => {
+		it("activeBackgroundTaskCount=1 with incompleteTodos yields continue (NOT block)", () => {
 			const result = makeDecision(
-				createContext({ activeSubagentCount: 1, incompleteTodoCount: 3 }),
+				createContext({ activeBackgroundTaskCount: 1, incompleteTodoCount: 3 }),
 			);
 			expect(result).toEqual({ continue: true });
 		});
 
-		it("activeSubagentCount=0 with incompleteTodos still blocks (no subagent bypass)", () => {
+		it("activeBackgroundTaskCount=0 with incompleteTodos still blocks (no subagent bypass)", () => {
 			const result = makeDecision(
-				createContext({ activeSubagentCount: 0, incompleteTodoCount: 3 }),
+				createContext({ activeBackgroundTaskCount: 0, incompleteTodoCount: 3 }),
 			);
 			expect(result.decision).toBe("block");
 			expect(result.reason).toContain("<todo-continuation>");
@@ -1338,7 +1338,7 @@ describe("makeDecision", () => {
 
 	// -------------------------------------------------------------------------
 	// TODO 4: the Stop-hook heartbeat (touchSessionStates) fires unconditionally
-	// on entry to makeDecision, BEFORE Guard 2's activeSubagentCount > 0 check —
+	// on entry to makeDecision, BEFORE Guard 2's activeBackgroundTaskCount > 0 check —
 	// not scoped inside it — so every Stop call proves this session is alive and
 	// refreshes its state files, whether or not a subagent is currently running.
 	// Two windows this closes: (1) a session with many running subagents never
@@ -1346,7 +1346,7 @@ describe("makeDecision", () => {
 	// ACTIVE_IDLE_TTL while still in use; (2) prometheus/deep-interview/qa have
 	// no per-family idle-Stop updater of their own (unlike goal/ultragoal, which
 	// self-refresh on every pursuing Stop call), so with the heartbeat scoped to
-	// activeSubagentCount > 0, those three families' state also aged toward the
+	// activeBackgroundTaskCount > 0, those three families' state also aged toward the
 	// TTL on every ordinary (zero-subagent) Stop call.
 	// -------------------------------------------------------------------------
 	describe("session-state heartbeat fires before the subagent guard", () => {
@@ -1374,7 +1374,7 @@ describe("makeDecision", () => {
 			);
 			ageFile(statePath, 7 * 3600);
 
-			const result = makeDecision(createContext({ sessionId: sid, activeSubagentCount: 1 }));
+			const result = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 1 }));
 
 			expect(result).toEqual({ continue: true });
 			const parsed = JSON.parse(await readFile(statePath, "utf8"));
@@ -1386,7 +1386,7 @@ describe("makeDecision", () => {
 			// A dedicated OMT_DIR with no `state/` subdirectory pre-created — unlike
 			// the shared beforeEach fixture above, which always mkdir's stateDir up
 			// front. The heartbeat fires unconditionally on entry to makeDecision,
-			// before Guard 2's activeSubagentCount > 0 check, so it touches this
+			// before Guard 2's activeBackgroundTaskCount > 0 check, so it touches this
 			// session's state regardless of subagent activity. With a subagent active,
 			// Guard 2's own early return still fires right after, before makeDecision
 			// ever reaches the stateDir/ensureDir call further down — this test checks
@@ -1412,7 +1412,7 @@ describe("makeDecision", () => {
 					}),
 				);
 
-				const result = makeDecision(createContext({ sessionId: sid, activeSubagentCount: 1 }));
+				const result = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 1 }));
 
 				expect(result).toEqual({ continue: true });
 				expect(fs.existsSync(join(freshOmtDir, "state"))).toBe(false);
@@ -1448,7 +1448,7 @@ describe("makeDecision", () => {
 			// touching (or aging) the walked-away fixture the GC step below depends on.
 			await writeFile(controlPath, JSON.stringify(pursuingState));
 			const controlDecision = makeDecision(
-				createContext({ sessionId: controlSid, activeSubagentCount: 0 }),
+				createContext({ sessionId: controlSid, activeBackgroundTaskCount: 0 }),
 			);
 			expect(controlDecision).toEqual({ continue: true });
 
@@ -1469,7 +1469,7 @@ describe("makeDecision", () => {
 			});
 
 			expect(fs.existsSync(walkedAwayPath)).toBe(false);
-			const afterGc = makeDecision(createContext({ sessionId: walkedAwaySid, activeSubagentCount: 0 }));
+			const afterGc = makeDecision(createContext({ sessionId: walkedAwaySid, activeBackgroundTaskCount: 0 }));
 			expect(afterGc).toEqual({ continue: true });
 		});
 
@@ -1491,7 +1491,7 @@ describe("makeDecision", () => {
 			);
 			ageFile(statePath, 7 * 3600);
 
-			makeDecision(createContext({ sessionId: sid, activeSubagentCount: 1 }));
+			makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 1 }));
 
 			const parsedAfter = JSON.parse(await readFile(statePath, "utf8"));
 			expect(parsedAfter.last_touched_at).toBe(old);
@@ -1515,13 +1515,13 @@ describe("makeDecision", () => {
 		});
 
 		// This assertion fails if the heartbeat call is ever moved back inside Guard
-		// 2's activeSubagentCount > 0 block — that is the point of the test. qa and
+		// 2's activeBackgroundTaskCount > 0 block — that is the point of the test. qa and
 		// prometheus are the two state families with no per-family idle-Stop updater
 		// of their own anywhere else in makeDecision (unlike goal/ultragoal, which
 		// self-refresh last_touched_at on every pursuing Stop call): the ONLY thing
-		// that can move either family's last_touched_at at activeSubagentCount === 0
+		// that can move either family's last_touched_at at activeBackgroundTaskCount === 0
 		// is touchSessionStates firing unconditionally on entry, ahead of the guard.
-		it("activeSubagentCount === 0 still fires the heartbeat for families with no per-family idle updater (prometheus, qa)", async () => {
+		it("activeBackgroundTaskCount === 0 still fires the heartbeat for families with no per-family idle updater (prometheus, qa)", async () => {
 			const sid = "heartbeat-fires-when-idle";
 			const old = isoAgo(7 * 3600);
 			const prometheusPath = join(omtDir, `prometheus-state-${sid}.json`);
@@ -1548,7 +1548,7 @@ describe("makeDecision", () => {
 			ageFile(qaPath, 7 * 3600);
 
 			makeDecision(
-				createContext({ sessionId: sid, activeSubagentCount: 0, lastAssistantMessage: "still working" }),
+				createContext({ sessionId: sid, activeBackgroundTaskCount: 0, lastAssistantMessage: "still working" }),
 			);
 
 			const prometheusAfter = JSON.parse(await readFile(prometheusPath, "utf8"));
@@ -1603,7 +1603,7 @@ describe("makeDecision", () => {
 
 			// Heartbeat crossing: a Stop call while a subagent is active revives
 			// last_touched_at (GC axis) but must not touch progress_touched_at.
-			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeSubagentCount: 2 }));
+			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }));
 			expect(heartbeatResult).toEqual({ continue: true });
 
 			const revived = JSON.parse(await readFile(statePath, "utf8"));
@@ -1611,7 +1611,7 @@ describe("makeDecision", () => {
 			expect(revived.progress_touched_at).toBe(staleIso);
 
 			// Now Stop with no subagents active — must NOT wedge on the revived corpse.
-			const stopResult = makeDecision(createContext({ sessionId: sid, activeSubagentCount: 0 }));
+			const stopResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 0 }));
 			expect(stopResult).toEqual({ continue: true });
 		});
 
@@ -1628,7 +1628,7 @@ describe("makeDecision", () => {
 				}),
 			);
 
-			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeSubagentCount: 2 }));
+			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }));
 			expect(heartbeatResult).toEqual({ continue: true });
 
 			const revived = JSON.parse(await readFile(statePath, "utf8"));
@@ -1636,7 +1636,7 @@ describe("makeDecision", () => {
 			expect(revived.progress_touched_at).toBe(staleIso);
 
 			// First Stop call after revival — must not block, well before MAX_BLOCK_COUNT (5).
-			const stopResult = makeDecision(createContext({ sessionId: sid, activeSubagentCount: 0 }));
+			const stopResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 0 }));
 			expect(stopResult).toEqual({ continue: true });
 		});
 
@@ -1732,7 +1732,7 @@ describe("makeDecision", () => {
 			// Heartbeat crossing: revives last_touched_at (GC axis) to now, but
 			// backfills progress_touched_at from the PRE-overwrite (stale) value —
 			// that backfilled value is what must keep this corpse from reviving.
-			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeSubagentCount: 2 }));
+			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }));
 			expect(heartbeatResult).toEqual({ continue: true });
 
 			const revived = JSON.parse(await readFile(statePath, "utf8"));
@@ -1741,7 +1741,7 @@ describe("makeDecision", () => {
 			expect(revived.progress_touched_at).toBe(staleIso);
 
 			// Now Stop with no subagents active — must NOT wedge on the revived corpse.
-			const stopResult = makeDecision(createContext({ sessionId: sid, activeSubagentCount: 0 }));
+			const stopResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 0 }));
 			expect(stopResult).toEqual({ continue: true });
 		});
 
@@ -1758,7 +1758,7 @@ describe("makeDecision", () => {
 				}),
 			);
 
-			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeSubagentCount: 2 }));
+			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }));
 			expect(heartbeatResult).toEqual({ continue: true });
 
 			const revived = JSON.parse(await readFile(statePath, "utf8"));
@@ -1766,7 +1766,7 @@ describe("makeDecision", () => {
 			expect(revived.started_at).toBe(staleIso);
 			expect(revived.progress_touched_at).toBe(staleIso);
 
-			const stopResult = makeDecision(createContext({ sessionId: sid, activeSubagentCount: 0 }));
+			const stopResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 0 }));
 			expect(stopResult).toEqual({ continue: true });
 		});
 
@@ -1775,7 +1775,7 @@ describe("makeDecision", () => {
 		// attempt that fell back to `started_at`). A legacy file that has never had a
 		// GC-only writer touch it (progress_touched_at absent) must be judged by
 		// `last_touched_at` alone. touchSessionStates now fires unconditionally on
-		// every makeDecision call regardless of activeSubagentCount, so a heartbeat
+		// every makeDecision call regardless of activeBackgroundTaskCount, so a heartbeat
 		// crossing DOES happen even in this single-call test — but its effect here is
 		// a backfill, not a corruption: progress_touched_at is set to the PRE-heartbeat
 		// last_touched_at value (this test's stale value), never to the fresh stamp
@@ -1838,7 +1838,7 @@ describe("makeDecision", () => {
 			// Heartbeat crossing: backfills progress_touched_at from the genuinely
 			// recent last_touched_at (2 minutes ago) before bumping last_touched_at
 			// itself to now.
-			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeSubagentCount: 2 }));
+			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }));
 			expect(heartbeatResult).toEqual({ continue: true });
 
 			const revived = JSON.parse(await readFile(statePath, "utf8"));
@@ -1847,7 +1847,7 @@ describe("makeDecision", () => {
 			// Next Stop call with no subagents active — must still block: the backfilled
 			// progress_touched_at is fresh (2 minutes old), well under the 6h TTL.
 			const stopResult = makeDecision(
-				createContext({ sessionId: sid, activeSubagentCount: 0, lastAssistantMessage: "still working" }),
+				createContext({ sessionId: sid, activeBackgroundTaskCount: 0, lastAssistantMessage: "still working" }),
 			);
 			expect(stopResult.decision).toBe("block");
 			expect(stopResult.reason).toContain("<deep-interview-continuation>");
@@ -1871,14 +1871,14 @@ describe("makeDecision", () => {
 				}),
 			);
 
-			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeSubagentCount: 2 }));
+			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }));
 			expect(heartbeatResult).toEqual({ continue: true });
 
 			const revived = JSON.parse(await readFile(statePath, "utf8"));
 			expect(revived.progress_touched_at).toBe(recentTouch);
 
 			const stopResult = makeDecision(
-				createContext({ sessionId: sid, activeSubagentCount: 0, lastAssistantMessage: "still working" }),
+				createContext({ sessionId: sid, activeBackgroundTaskCount: 0, lastAssistantMessage: "still working" }),
 			);
 			expect(stopResult.decision).toBe("block");
 			expect(stopResult.reason).toContain("<prometheus-continuation>");
@@ -1911,13 +1911,13 @@ describe("makeDecision", () => {
 			);
 
 			// Heartbeat crossing backfills progress_touched_at from recentTouch.
-			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeSubagentCount: 2 }));
+			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }));
 			expect(heartbeatResult).toEqual({ continue: true });
 
 			const stopResult = makeDecision(
 				createContext({
 					sessionId: sid,
-					activeSubagentCount: 0,
+					activeBackgroundTaskCount: 0,
 					lastAssistantMessage: "Interview complete. <deep-interview-done/>",
 				}),
 			);

--- a/lib/persistent-mode-core/decision.ts
+++ b/lib/persistent-mode-core/decision.ts
@@ -337,10 +337,10 @@ export function makeDecision(context: DecisionContext): HookOutput {
 		/* never let a heartbeat write failure suppress the guard below */
 	}
 
-	// Guard 2: any running/pending background task is active (type-agnostic).
-	// Claude Code re-invokes the Stop hook via a task-notification wake when it completes,
-	// so allowing now defers enforcement safely. The status allowlist is fail-closed:
-	// terminal and unknown statuses keep enforcement active.
+	// Guard 2: any running/pending subagent is active.
+	// Claude Code re-invokes the Stop hook via a subagent-completion notification wake,
+	// so allowing now defers enforcement safely until that work completes. The status
+	// allowlist is fail-closed: terminal and unknown subagent statuses keep enforcement active.
 	if (activeBackgroundTaskCount > 0) {
 		return formatContinueOutput();
 	}

--- a/lib/persistent-mode-core/decision.ts
+++ b/lib/persistent-mode-core/decision.ts
@@ -337,10 +337,10 @@ export function makeDecision(context: DecisionContext): HookOutput {
 		/* never let a heartbeat write failure suppress the guard below */
 	}
 
-	// Guard 2: any running/pending subagent is active.
-	// Claude Code re-invokes the Stop hook via a subagent-completion notification wake,
-	// so allowing now defers enforcement safely until that work completes. The status
-	// allowlist is fail-closed: terminal and unknown subagent statuses keep enforcement active.
+	// Guard 2: any running/pending background task is active (type-agnostic).
+	// Claude Code re-invokes the Stop hook via a task-notification wake when it completes,
+	// so allowing now defers enforcement safely. The status allowlist is fail-closed:
+	// terminal and unknown statuses keep enforcement active.
 	if (activeBackgroundTaskCount > 0) {
 		return formatContinueOutput();
 	}

--- a/lib/persistent-mode-core/decision.ts
+++ b/lib/persistent-mode-core/decision.ts
@@ -26,7 +26,7 @@ export interface DecisionContext {
 	sessionId: string;
 	lastAssistantMessage: string | null;
 	incompleteTodoCount: number;
-	activeSubagentCount: number;
+	activeBackgroundTaskCount: number;
 	/**
 	 * Codex-only chain ratchet (see hooks/codex-persistent-mode/cli.ts's runStop):
 	 * skill names referenced (via a validated `$name` sigil) by an already-opened
@@ -110,8 +110,10 @@ function truncateText(text: string, maxLength: number): string {
 type AskPosture = "preferred" | "exceptional";
 
 // Shared continuation-contract skeleton emitted by every continuation builder.
-// Mirrors the always-on rule rules/continuation-contract.md (the SSOT). Only the
-// case-2 ask posture varies per family: "preferred" (deep-interview/prometheus/todo)
+// This is a post-Guard-2 projection of the always-on rule: background-wait
+// (case 4) is already ruled out because Guard 2 returned continue before any
+// block message is built, so only the three remaining cases are live options.
+// Only the case-2 ask posture varies per family: "preferred" (deep-interview/prometheus/todo)
 // vs "exceptional" (ultragoal — autonomy is post-planning, asking is the rare case).
 // `askToolName` names the "ask a structured question" tool for THIS platform
 // (see DecisionContext.askToolName's doc comment) — threaded in by every
@@ -289,7 +291,7 @@ export function makeDecision(context: DecisionContext): HookOutput {
 		sessionId,
 		lastAssistantMessage,
 		incompleteTodoCount,
-		activeSubagentCount,
+		activeBackgroundTaskCount,
 		pendingSkillChainSkills,
 	} = context;
 	// See DecisionContext.askToolName's doc comment: undefined for every Claude
@@ -298,7 +300,7 @@ export function makeDecision(context: DecisionContext): HookOutput {
 
 	// The heartbeat (touchSessionStates) fires HERE — on entry to makeDecision,
 	// unconditionally, before Guard 2 below is even evaluated. It used to live
-	// inside that guard's activeSubagentCount > 0 branch, right before the
+	// inside that guard's activeBackgroundTaskCount > 0 branch, right before the
 	// branch's own return; that placement is now wrong for two measured reasons.
 	//
 	// 1. A session with many running subagents was measured at 6h 38m between
@@ -311,7 +313,7 @@ export function makeDecision(context: DecisionContext): HookOutput {
 	// 2. Independently of subagent activity: ultragoal self-refreshes its own
 	//    last_touched_at on every "pursuing" Stop call (updateUltragoalState), but prometheus, deep-interview,
 	//    and qa have no per-family idle-Stop updater of their own — nothing else
-	//    in makeDecision ever wrote their last_touched_at when activeSubagentCount
+	//    in makeDecision ever wrote their last_touched_at when activeBackgroundTaskCount
 	//    was 0. A long-running session with zero active subagents let those three
 	//    families' state age toward the 6h TTL on every ordinary Stop call — the
 	//    same defect this file exists to close, in a different window.
@@ -335,11 +337,11 @@ export function makeDecision(context: DecisionContext): HookOutput {
 		/* never let a heartbeat write failure suppress the guard below */
 	}
 
-	// Guard 2: active subagent tasks are running (type=subagent, status=running|pending).
-	// Claude Code will re-invoke the Stop hook via task-notification when they finish, so blocking now is unnecessary.
-	// Non-subagent background tasks (shell/monitor/etc.) do NOT suppress enforcement — only subagents wake the main
-	// via task-notification, so only they make a deferred Stop hook re-invocation safe.
-	if (activeSubagentCount > 0) {
+	// Guard 2: any running/pending background task is active (type-agnostic).
+	// Claude Code re-invokes the Stop hook via a task-notification wake when it completes,
+	// so allowing now defers enforcement safely. The status allowlist is fail-closed:
+	// terminal and unknown statuses keep enforcement active.
+	if (activeBackgroundTaskCount > 0) {
 		return formatContinueOutput();
 	}
 

--- a/lib/persistent-mode-core/types.ts
+++ b/lib/persistent-mode-core/types.ts
@@ -5,7 +5,7 @@ export interface HookInput {
 	cwd?: string;
 	transcript_path?: string;
 	last_assistant_message?: string;
-	/** Claude Code v2.1.152+: running background tasks at stop time. */
+	/** Claude Code v2.1.145+: running background tasks at stop time. */
 	background_tasks?: Array<{ id: string; type?: string; status?: string; [k: string]: unknown }>;
 }
 
@@ -14,7 +14,7 @@ export interface ParsedInput {
 	sessionId: string;
 	directory: string;
 	lastAssistantMessage: string | null;
-	activeSubagentCount: number;
+	activeBackgroundTaskCount: number;
 }
 
 /**

--- a/lib/persistent-mode-core/types.ts
+++ b/lib/persistent-mode-core/types.ts
@@ -5,7 +5,7 @@ export interface HookInput {
 	cwd?: string;
 	transcript_path?: string;
 	last_assistant_message?: string;
-	/** Claude Code v2.1.145+: running background tasks at stop time. */
+	/** Claude Code v2.1.145+: background tasks at stop time; running/pending entries are active. */
 	background_tasks?: Array<{ id: string; type?: string; status?: string; [k: string]: unknown }>;
 }
 

--- a/lib/state-core.ts
+++ b/lib/state-core.ts
@@ -875,7 +875,7 @@ function typeFromStateFilename(filename: string): StateType | null {
  * per-file error (ENOENT from a read/write race, a parse failure, a malformed file)
  * is swallowed and the sweep continues — this is called unconditionally at the
  * very top of makeDecision (lib/persistent-mode-core/decision.ts), before Guard
- * 2's activeSubagentCount check, wrapped in its own try/catch there, so a throw
+ * 2's activeBackgroundTaskCount check, wrapped in its own try/catch there, so a throw
  * here would corrupt the Stop hook's decision if it were allowed to propagate.
  *
  * GC-only writer (see backfillProgressTouchedAt's doc comment): before this

--- a/rules/continuation-contract.md
+++ b/rules/continuation-contract.md
@@ -53,6 +53,6 @@ permission to continue. These are banned:
 Each is one of the four cases in disguise. If work remains, use case 1 (just
 continue). If you need a decision, use case 2 (`AskUserQuestion`). If only the
 user can decide, use case 3 (`<awaiting-user/>`). If background work is
-running, use case 4 (just end the turn; the wake resumes the session). A
-softener is none of these — it stops without yielding cleanly and without
-continuing, which is exactly the ambiguity this contract removes.
+running or pending, use case 4 (just end the turn; the wake resumes the
+session). A softener is none of these — it stops without yielding cleanly and
+without continuing, which is exactly the ambiguity this contract removes.

--- a/rules/continuation-contract.md
+++ b/rules/continuation-contract.md
@@ -31,14 +31,14 @@ At every turn boundary, exactly one of these applies:
    `<awaiting-user/>` is the only sanctioned stop while no background work is
    pending wake.
 
-4. **Background work is running → ending the turn is a sanctioned wait, not a
-   stop.** The Stop hook reads the payload's `background_tasks` directly, so no
-   token is needed — a plain prose turn end suffices. Session state is kept, and
-   the harness re-invokes the session via task-notification when the work
-   completes; enforcement resumes on that wake. This case is evaluated FIRST at
-   the turn boundary: when active background work exists, the hook allows the
-   turn end before any other case is considered, so cases 1-3 describe the
-   no-background-work world.
+4. **Background work is running or pending → ending the turn is a sanctioned
+   wait, not a stop.** The Stop hook reads the payload's `background_tasks`
+   directly, so no token is needed — a plain prose turn end suffices. Session
+   state is kept, and the harness re-invokes the session via task-notification
+   when the work completes; enforcement resumes on that wake. This case is
+   evaluated FIRST at the turn boundary: when running or pending background work
+   exists, the hook allows the turn end before any other case is considered, so
+   cases 1-3 describe the no-background-work world.
 
 ## Softener ban
 

--- a/rules/continuation-contract.md
+++ b/rules/continuation-contract.md
@@ -28,23 +28,19 @@ At every turn boundary, exactly one of these applies:
    `<awaiting-user/>`. The hook treats this as a legitimate yield: it allows
    the stop, keeps all session state intact (the interview or pursuit resumes on
    the user's next reply), and does not mark the work complete.
-   `<awaiting-user/>` is the only sanctioned stop unless case 4 applies.
+   `<awaiting-user/>` is the only sanctioned stop while no background work is
+   pending wake.
 
-4. **Background subagent is running or pending → Claude Code may wait for its
-   wake.** On Claude Code, this case applies only when a `background_tasks`
-   entry has `type === "subagent"` and its `status` is `running` or `pending`.
-   Ending the turn is then a sanctioned wait, not a stop: no token is needed and
-   a plain prose turn end suffices. Session state is kept, and the harness
-   re-invokes the session via task-notification when that subagent completes;
-   enforcement resumes on that wake. Claude Code evaluates this subagent-only
-   case FIRST at the turn boundary, before cases 1-3.
-
-   Other Claude Code background types — `shell`, `monitor`, and typeless
-   entries — remain case 1, as do subagents in other statuses: keep the turn
-   alive and poll; do not end the turn solely to wait.
+4. **Background work is running or pending → follow the runtime's wake
+   contract.** On Claude Code, ending the turn is a sanctioned wait, not a stop:
+   the Stop hook reads the payload's `background_tasks` directly, so no token is
+   needed and a plain prose turn end suffices. Session state is kept, and the
+   harness re-invokes the session via task-notification when the work completes;
+   enforcement resumes on that wake. Claude Code evaluates this case FIRST at
+   the turn boundary, before cases 1-3.
 
    Codex has no equivalent Stop payload or guaranteed completion-triggered turn.
-   On Codex, all background work is case 1: keep the turn alive and use the
+   On Codex, treat background work as case 1: keep the turn alive and use the
    appropriate wait mechanism until it completes — `write_stdin` polling for a
    yielded unified exec session, or the agent wait tool for delegated work. Do
    not end the turn solely to wait.
@@ -61,8 +57,8 @@ permission to continue. These are banned:
 
 Each is one of the four cases in disguise. If work remains, use case 1 (just
 continue). If you need a decision, use case 2 (`AskUserQuestion`). If only the
-user can decide, use case 3 (`<awaiting-user/>`). If a qualifying Claude Code
-background subagent is active, use case 4; all other background work stays case
-1 and must be polled with the turn alive. A softener is none of these — it stops
-without yielding cleanly and without continuing, which is exactly the ambiguity
-this contract removes.
+user can decide, use case 3 (`<awaiting-user/>`). If background work is
+running or pending, use case 4: Claude Code may end the turn for its guaranteed
+wake, while Codex keeps the turn alive and polls. A softener is none of these —
+it stops without yielding cleanly and without continuing, which is exactly the
+ambiguity this contract removes.

--- a/rules/continuation-contract.md
+++ b/rules/continuation-contract.md
@@ -3,7 +3,7 @@
 How to end — or not end — a turn while a persistent-mode session is active
 (deep-interview, prometheus, ultragoal, or a live todo list). The
 persistent-mode Stop hook keeps you working when work remains; this contract
-names the FOUR distinct things you can do at a turn boundary, so "don't
+names the FOUR distinct situations at a turn boundary, so "don't
 stop" never collapses into a blunt binary.
 
 ## The four cases
@@ -31,14 +31,19 @@ At every turn boundary, exactly one of these applies:
    `<awaiting-user/>` is the only sanctioned stop while no background work is
    pending wake.
 
-4. **Background work is running or pending → ending the turn is a sanctioned
-   wait, not a stop.** The Stop hook reads the payload's `background_tasks`
-   directly, so no token is needed — a plain prose turn end suffices. Session
-   state is kept, and the harness re-invokes the session via task-notification
-   when the work completes; enforcement resumes on that wake. This case is
-   evaluated FIRST at the turn boundary: when running or pending background work
-   exists, the hook allows the turn end before any other case is considered, so
-   cases 1-3 describe the no-background-work world.
+4. **Background work is running or pending → follow the runtime's wake
+   contract.** On Claude Code, ending the turn is a sanctioned wait, not a stop:
+   the Stop hook reads the payload's `background_tasks` directly, so no token is
+   needed and a plain prose turn end suffices. Session state is kept, and the
+   harness re-invokes the session via task-notification when the work completes;
+   enforcement resumes on that wake. Claude Code evaluates this case FIRST at
+   the turn boundary, before cases 1-3.
+
+   Codex has no equivalent Stop payload or guaranteed completion-triggered turn.
+   On Codex, treat background work as case 1: keep the turn alive and use the
+   appropriate wait mechanism until it completes — `write_stdin` polling for a
+   yielded unified exec session, or the agent wait tool for delegated work. Do
+   not end the turn solely to wait.
 
 ## Softener ban
 
@@ -53,6 +58,7 @@ permission to continue. These are banned:
 Each is one of the four cases in disguise. If work remains, use case 1 (just
 continue). If you need a decision, use case 2 (`AskUserQuestion`). If only the
 user can decide, use case 3 (`<awaiting-user/>`). If background work is
-running or pending, use case 4 (just end the turn; the wake resumes the
-session). A softener is none of these — it stops without yielding cleanly and
-without continuing, which is exactly the ambiguity this contract removes.
+running or pending, use case 4: Claude Code may end the turn for its guaranteed
+wake, while Codex keeps the turn alive and polls. A softener is none of these —
+it stops without yielding cleanly and without continuing, which is exactly the
+ambiguity this contract removes.

--- a/rules/continuation-contract.md
+++ b/rules/continuation-contract.md
@@ -28,19 +28,23 @@ At every turn boundary, exactly one of these applies:
    `<awaiting-user/>`. The hook treats this as a legitimate yield: it allows
    the stop, keeps all session state intact (the interview or pursuit resumes on
    the user's next reply), and does not mark the work complete.
-   `<awaiting-user/>` is the only sanctioned stop while no background work is
-   pending wake.
+   `<awaiting-user/>` is the only sanctioned stop unless case 4 applies.
 
-4. **Background work is running or pending → follow the runtime's wake
-   contract.** On Claude Code, ending the turn is a sanctioned wait, not a stop:
-   the Stop hook reads the payload's `background_tasks` directly, so no token is
-   needed and a plain prose turn end suffices. Session state is kept, and the
-   harness re-invokes the session via task-notification when the work completes;
-   enforcement resumes on that wake. Claude Code evaluates this case FIRST at
-   the turn boundary, before cases 1-3.
+4. **Background subagent is running or pending → Claude Code may wait for its
+   wake.** On Claude Code, this case applies only when a `background_tasks`
+   entry has `type === "subagent"` and its `status` is `running` or `pending`.
+   Ending the turn is then a sanctioned wait, not a stop: no token is needed and
+   a plain prose turn end suffices. Session state is kept, and the harness
+   re-invokes the session via task-notification when that subagent completes;
+   enforcement resumes on that wake. Claude Code evaluates this subagent-only
+   case FIRST at the turn boundary, before cases 1-3.
+
+   Other Claude Code background types — `shell`, `monitor`, and typeless
+   entries — remain case 1, as do subagents in other statuses: keep the turn
+   alive and poll; do not end the turn solely to wait.
 
    Codex has no equivalent Stop payload or guaranteed completion-triggered turn.
-   On Codex, treat background work as case 1: keep the turn alive and use the
+   On Codex, all background work is case 1: keep the turn alive and use the
    appropriate wait mechanism until it completes — `write_stdin` polling for a
    yielded unified exec session, or the agent wait tool for delegated work. Do
    not end the turn solely to wait.
@@ -57,8 +61,8 @@ permission to continue. These are banned:
 
 Each is one of the four cases in disguise. If work remains, use case 1 (just
 continue). If you need a decision, use case 2 (`AskUserQuestion`). If only the
-user can decide, use case 3 (`<awaiting-user/>`). If background work is
-running or pending, use case 4: Claude Code may end the turn for its guaranteed
-wake, while Codex keeps the turn alive and polls. A softener is none of these —
-it stops without yielding cleanly and without continuing, which is exactly the
-ambiguity this contract removes.
+user can decide, use case 3 (`<awaiting-user/>`). If a qualifying Claude Code
+background subagent is active, use case 4; all other background work stays case
+1 and must be polled with the turn alive. A softener is none of these — it stops
+without yielding cleanly and without continuing, which is exactly the ambiguity
+this contract removes.

--- a/rules/continuation-contract.md
+++ b/rules/continuation-contract.md
@@ -3,10 +3,10 @@
 How to end — or not end — a turn while a persistent-mode session is active
 (deep-interview, prometheus, ultragoal, or a live todo list). The
 persistent-mode Stop hook keeps you working when work remains; this contract
-names the THREE distinct things you can do at a turn boundary, so "don't
+names the FOUR distinct things you can do at a turn boundary, so "don't
 stop" never collapses into a blunt binary.
 
-## The three cases
+## The four cases
 
 At every turn boundary, exactly one of these applies:
 
@@ -28,8 +28,17 @@ At every turn boundary, exactly one of these applies:
    `<awaiting-user/>`. The hook treats this as a legitimate yield: it allows
    the stop, keeps all session state intact (the interview or pursuit resumes on
    the user's next reply), and does not mark the work complete.
-   `<awaiting-user/>` is the only sanctioned way to stop while a
-   persistent-mode session is active.
+   `<awaiting-user/>` is the only sanctioned stop while no background work is
+   pending wake.
+
+4. **Background work is running → ending the turn is a sanctioned wait, not a
+   stop.** The Stop hook reads the payload's `background_tasks` directly, so no
+   token is needed — a plain prose turn end suffices. Session state is kept, and
+   the harness re-invokes the session via task-notification when the work
+   completes; enforcement resumes on that wake. This case is evaluated FIRST at
+   the turn boundary: when active background work exists, the hook allows the
+   turn end before any other case is considered, so cases 1-3 describe the
+   no-background-work world.
 
 ## Softener ban
 
@@ -41,8 +50,9 @@ permission to continue. These are banned:
 - "If you'd like, I can…"
 - "Would you like me to…"
 
-Each is one of the three cases in disguise. If work remains, use case 1 (just
+Each is one of the four cases in disguise. If work remains, use case 1 (just
 continue). If you need a decision, use case 2 (`AskUserQuestion`). If only the
-user can decide, use case 3 (`<awaiting-user/>`). A softener is none of these —
-it stops without yielding cleanly and without continuing, which is exactly the
-ambiguity this contract removes.
+user can decide, use case 3 (`<awaiting-user/>`). If background work is
+running, use case 4 (just end the turn; the wake resumes the session). A
+softener is none of these — it stops without yielding cleanly and without
+continuing, which is exactly the ambiguity this contract removes.

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -3723,7 +3723,15 @@ describe("processYaml — rules category deploys to codex with rewrite applied (
 		expect(claude).toBe(source);
 		expect(claude).toContain("On Claude Code");
 		expect(claude).toContain("background_tasks");
+		expect(claude).toContain("**Background subagent is running or pending");
+		expect(claude).toContain('`type === "subagent"`');
+		expect(claude).toContain("`status` is `running` or `pending`");
 		expect(claude).toContain("task-notification");
+		expect(claude).toContain("`shell`, `monitor`, and typeless");
+		expect(claude).toContain("remain case 1");
+		expect(claude).toContain("keep the turn alive");
+		expect(claude).not.toContain("**Background work is running or pending");
+		expect(claude).not.toContain("background work is running or pending, use case 4");
 		expect(codex).toContain("Codex has no equivalent Stop payload");
 		expect(codex).toContain("write_stdin");
 		expect(codex).toContain("poll");

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -3723,15 +3723,7 @@ describe("processYaml — rules category deploys to codex with rewrite applied (
 		expect(claude).toBe(source);
 		expect(claude).toContain("On Claude Code");
 		expect(claude).toContain("background_tasks");
-		expect(claude).toContain("**Background subagent is running or pending");
-		expect(claude).toContain('`type === "subagent"`');
-		expect(claude).toContain("`status` is `running` or `pending`");
 		expect(claude).toContain("task-notification");
-		expect(claude).toContain("`shell`, `monitor`, and typeless");
-		expect(claude).toContain("remain case 1");
-		expect(claude).toContain("keep the turn alive");
-		expect(claude).not.toContain("**Background work is running or pending");
-		expect(claude).not.toContain("background work is running or pending, use case 4");
 		expect(codex).toContain("Codex has no equivalent Stop payload");
 		expect(codex).toContain("write_stdin");
 		expect(codex).toContain("poll");

--- a/tools/sync.test.ts
+++ b/tools/sync.test.ts
@@ -3694,6 +3694,42 @@ describe("processYaml — rules category deploys to codex with rewrite applied (
 		expect(deployed).toContain(".codex/rules/");
 	});
 
+	it("keeps Claude background wake semantics but tells Codex to wait and poll", async () => {
+		const source = await readFile(
+			path.join(import.meta.dir, "..", "rules", "continuation-contract.md"),
+		);
+		await writeFile(path.join(rootDir, "rules", "continuation-contract.md"), source);
+
+		const syncYamlPath = path.join(rootDir, "sync.yaml");
+		await writeFile(
+			syncYamlPath,
+			`path: ${targetPath}\nrules:\n  platforms: [claude, codex]\n  items:\n    - continuation-contract\n`,
+		);
+
+		const adapters = new Map<Platform, PlatformAdapter>([
+			["claude", new ClaudeAdapter()],
+			["codex", new CodexAdapter()],
+		]) as AdapterMap;
+
+		await processYaml(makeContext(), syncYamlPath, adapters, rootDir);
+
+		const claude = await readFile(
+			path.join(targetPath, ".claude", "rules", "continuation-contract.md"),
+		);
+		const codex = await readFile(
+			path.join(targetPath, ".codex", "rules", "continuation-contract.md"),
+		);
+
+		expect(claude).toBe(source);
+		expect(claude).toContain("On Claude Code");
+		expect(claude).toContain("background_tasks");
+		expect(claude).toContain("task-notification");
+		expect(codex).toContain("Codex has no equivalent Stop payload");
+		expect(codex).toContain("write_stdin");
+		expect(codex).toContain("poll");
+		expect(codex).toContain("not end the turn solely to wait");
+	});
+
 	it("dry-run reports the rule copy and the codex rewrite without writing files", async () => {
 		await writeFile(path.join(rootDir, "rules", "my-rule.md"), "Ask via AskUserQuestion.\n");
 


### PR DESCRIPTION
## 📌 Summary

Claude persistent-mode Stop 훅이 실행 중이거나 대기 중인 백그라운드 작업을 기다리는 동안 turn 종료를 허용하도록 변경했습니다. 백그라운드 작업 완료 알림으로 다시 깨어난 뒤 기존 continuation enforcement를 재개해, 미완료 todo 때문에 안전한 대기 자체가 차단되는 문제를 해결합니다.

---

## 🔧 Changes

### Claude 백그라운드 작업 판별 및 Stop 유예

- Stop payload의 `background_tasks`에서 `running`·`pending` 상태만 활성 작업으로 집계
- 작업 `type`과 무관하게 shell·monitor·subagent·무타입 작업을 동일하게 처리
- 활성 작업이 하나라도 있으면 todo 및 persistent-mode continuation guard보다 먼저 Stop 허용

작업 종류별 예외 목록 대신 상태 기반 allowlist를 사용했습니다. 새 background task type이 추가되더라도 실행 상태 계약을 따르는 한 별도 코드 변경 없이 안전한 대기 대상으로 처리하며, unknown·terminal 상태는 활성 작업으로 간주하지 않아 기존 차단 동작을 유지합니다.

**영향 범위**
- Claude Stop payload 파서와 공유 decision context가 영향을 받습니다.
- `background_tasks`가 없거나 활성 상태가 0개이면 기존 todo·mode continuation 차단 동작이 그대로 유지됩니다.
- 외부 의존성이나 공개 설정 형식 변경은 없습니다.

### 세션 상태 heartbeat 순서 보장

- background-task 조기 반환 전에 현재 세션의 상태 파일 heartbeat 실행
- GC 생존 시각과 실제 진행 시각을 분리해 heartbeat만으로 오래된 작업이 진행 중으로 오인되지 않도록 유지

백그라운드 작업이 장시간 실행되는 동안 Stop hook이 상태 만료를 방지해야 하지만, 단순 생존 신호가 실제 진행으로 해석되면 오래된 deep-interview·prometheus 상태가 세션을 계속 차단할 수 있습니다. 따라서 `last_touched_at`은 갱신하되 기존 `progress_touched_at`은 보존하는 계약을 유지했습니다.

**영향 범위**
- goal·ultragoal·prometheus·deep-interview·qa 상태 파일의 GC heartbeat 경로가 영향을 받습니다.
- pristine 상태는 heartbeat 대상에서 제외되며, 상태 파일이나 디렉터리를 새로 생성하지 않습니다.

### 플랫폼 계약 및 회귀 테스트

- continuation contract에 background work를 sanctioned wait로 명시하고 최우선 평가 순서를 문서화
- 완료 wake 보장이 없는 Codex는 `activeBackgroundTaskCount: 0`을 유지해 foreign payload로 우회되지 않도록 보장
- Claude parser, 공유 decision core, Codex negative control에 회귀 테스트 추가·보완

**영향 범위**
- Claude에만 background-task Stop 유예가 적용됩니다.
- Codex의 todo 및 skill-chain continuation 계약은 변경되지 않습니다.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 작업 type이 아닌 상태 기반으로 활성도를 판별한 범위

**배경 및 문제 상황:**
기존 문제는 subagent에 한정되지 않고 shell·monitor 등 완료 알림을 발생시키는 모든 background 작업에서 동일하게 발생할 수 있습니다. type을 제한하면 새 작업 종류가 추가될 때 같은 Stop 차단 문제가 재발합니다.

**해결 방안:**
`background_tasks` 배열의 각 항목에서 `running` 또는 `pending` 상태만 활성으로 집계하고 type은 읽지 않습니다. 반대로 `queued` 같은 unknown 상태와 completed·failed·cancelled 등 terminal 상태는 허용 근거로 사용하지 않습니다.

**구현 세부사항:**
Claude stdin parser가 활성 작업 수를 하나의 숫자로 정규화하고, 공유 decision core는 개별 payload 구조를 알지 않은 채 `activeBackgroundTaskCount > 0`만 판단합니다. 파싱 경계와 정책 결정 경계를 분리해 core가 플랫폼 payload 형식에 결합되지 않도록 했습니다.

**선택과 트레이드오프:**
type allowlist보다 확장성이 높지만, payload 제공자가 `running`·`pending` 상태 의미를 일관되게 지켜야 합니다. 잘못된 형식과 unknown 상태를 0으로 처리하는 fail-closed 경계를 두어 과도한 Stop 허용 위험을 제한했습니다.

### 2. Claude와 Codex 사이의 의도적 비대칭

**배경 및 문제 상황:**
Stop을 허용한 뒤 continuation을 재개하려면 background 작업 완료 시 런타임이 세션을 다시 깨운다는 보장이 필요합니다. Claude payload는 작업 상태와 완료 알림 흐름을 제공하지만, Codex Stop payload에는 동일한 데이터·wake 계약이 없습니다.

**해결 방안:**
Claude만 payload에서 활성 작업 수를 전달하고, Codex는 공유 decision core를 사용하면서도 활성 작업 수를 0으로 고정합니다.

**구현 세부사항:**
공유 core의 guard 순서는 heartbeat → background-task allowance → awaiting-user 및 나머지 continuation guard입니다. Codex 진입점은 foreign `background_tasks`가 들어와도 이를 읽지 않으므로 todo continuation을 우회하지 않습니다.

**선택과 트레이드오프:**
플랫폼 동작이 완전히 대칭적이지는 않지만, wake 보장 없이 Codex까지 허용하면 세션이 영구 정지할 수 있습니다. 향후 Codex가 신뢰할 수 있는 작업 상태와 완료 wake를 제공할 때 진입점에서 count 전달만 활성화할 수 있도록 공통 정책은 core에 유지했습니다.

### 3. Stop 유예 이전 heartbeat 실행

**배경 및 문제 상황:**
활성 background 작업을 이유로 즉시 반환하면 장시간 작업 중 세션 상태의 TTL이 만료될 수 있습니다. 반대로 heartbeat가 실제 진행 시각까지 갱신하면 이미 멈춘 상태가 살아 있는 작업으로 오인될 수 있습니다.

**해결 방안:**
모든 Stop 판단 시작 시 세션 상태 heartbeat를 먼저 실행하되, GC 생존 축과 진행 축을 분리합니다.

**구현 세부사항:**
`touchSessionStates()`는 비-pristine 상태의 `last_touched_at`을 갱신합니다. legacy 상태에 `progress_touched_at`이 없으면 갱신 전 값을 먼저 이관하여, heartbeat 시각이 실제 진행 시각으로 승격되지 않도록 합니다.

**선택과 트레이드오프:**
매 Stop 시 파일 순회와 read-modify-write 비용이 발생하지만 OMT 상태 파일 범위로 제한됩니다. 이 순서를 통해 background 작업의 GC 생존성과 stale 상태의 wedge 방지를 함께 유지합니다.

---

## ✅ Checklist

### Claude background-task Stop 유예

- [ ] type 유무와 관계없이 `running`·`pending` background task가 있으면 Stop이 허용됨
  - `hooks/persistent-mode/stdin.ts`
  - `hooks/persistent-mode/stdin.test.ts`
- [ ] unknown·terminal 상태만 존재하면 활성 작업 수가 0이며 미완료 todo 차단이 유지됨
  - `hooks/persistent-mode/stdin.test.ts`
  - `lib/persistent-mode-core/decision.test.ts`
- [ ] 활성 background task와 미완료 todo가 함께 있을 때 background wait가 우선 적용됨
  - `lib/persistent-mode-core/decision.ts`
  - `lib/persistent-mode-core/decision.test.ts`

### 상태 및 플랫폼 경계

- [ ] Stop 유예 전에 세션 heartbeat가 실행되고 실제 진행 시각은 보존됨
  - `lib/state-core.ts`
  - `lib/persistent-mode-core/decision.test.ts`
- [ ] Codex payload의 foreign `background_tasks`가 todo continuation을 우회하지 않음
  - `hooks/codex-persistent-mode/cli.ts`
  - `hooks/codex-persistent-mode/cli.test.ts`
- [ ] continuation contract의 background wait 우선순위가 구현 guard 순서와 일치함
  - `rules/continuation-contract.md`
  - `lib/persistent-mode-core/decision.ts`
- [ ] 영향 범위 테스트 248개와 repository validation이 통과함
  - `hooks/persistent-mode/`
  - `hooks/codex-persistent-mode/`
  - `lib/persistent-mode-core/`

---

## 📎 References

- [Continuation Contract](https://github.com/toongri/oh-my-toong-playground/blob/cypress-constrictor/rules/continuation-contract.md)
