### PR TITLE
feat: finder 앵글을 sol·luna 혼합 구성으로 전환

### DIFF
--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -2922,6 +2922,171 @@ describe("cmdResumeMember", () => {
 			/session.*preserv|--resume.*persona|intentionally.*omit|not forwarded|session-preserving/i,
 		);
 	});
+
+	// ---------------------------------------------------------------------------
+	// workerPath opt: detached-spawn resume dispatch (in-process path above stays
+	// the legacy default for callers that never pass workerPath).
+	// ---------------------------------------------------------------------------
+
+	function makeSpawnStub() {
+		const calls: { command: string; args: string[]; options: Record<string, unknown> }[] = [];
+		const spawnFn = ((command: string, args: string[], options: Record<string, unknown>) => {
+			calls.push({ command, args, options });
+			return { unref: () => {} } as unknown as ReturnType<typeof spawn>;
+		}) as unknown as typeof spawn;
+		return { spawnFn, calls };
+	}
+
+	test("workerPath가 주어지면 resumeFn을 호출하지 않고 스폰만 한다", async () => {
+		const entityDir = path.join(jobDir, "members", "alice");
+		writeMemberStatus(entityDir, {
+			member: "alice",
+			state: "done",
+			sessionID: "sess-abc",
+			resume_count: 0,
+			command: "opencode",
+		});
+
+		const { spawnFn, calls } = makeSpawnStub();
+		let resumeFnCalled = false;
+
+		await cmdResumeMember(jobDir, "alice", "follow up", membersConfig, {
+			driverFactory: () => makeMockDriver(),
+			resumeOneTurnFn: async () => {
+				resumeFnCalled = true;
+				return { state: "done", sessionID: "sess-abc", text: "", exitCode: 0 };
+			},
+			workerPath: "/fake/worker.ts",
+			spawnFn,
+		});
+
+		expect(resumeFnCalled).toBe(false);
+		expect(calls.length).toBe(1);
+	});
+
+	test("workerPath 모드는 spawn을 detached로 호출하고 workerPath/--session/--prompt를 인자로 전달한다", async () => {
+		const entityDir = path.join(jobDir, "members", "alice");
+		writeMemberStatus(entityDir, {
+			member: "alice",
+			state: "done",
+			sessionID: "sess-abc",
+			resume_count: 0,
+			command: "opencode",
+			workerEnv: { CUSTOM: "val" },
+		});
+
+		const { spawnFn, calls } = makeSpawnStub();
+		await cmdResumeMember(jobDir, "alice", "follow up prompt", membersConfig, {
+			driverFactory: () => makeMockDriver(),
+			workerPath: "/fake/worker.ts",
+			spawnFn,
+		});
+
+		expect(calls.length).toBe(1);
+		const call = calls[0];
+		expect(call.command).toBe(process.execPath);
+		expect(call.args).toEqual([
+			"/fake/worker.ts",
+			"--job-dir",
+			jobDir,
+			"--member",
+			"alice",
+			"--command",
+			"opencode",
+			"--session",
+			"sess-abc",
+			"--prompt",
+			"follow up prompt",
+			"--env",
+			"CUSTOM=val",
+			"--timeout",
+			"300",
+		]);
+		expect(call.options).toMatchObject({ detached: true, stdio: "ignore" });
+	});
+
+	test("workerPath 모드는 spawn 전에 status.json을 queued로 전환하며 기존 필드를 보존한다", async () => {
+		const entityDir = path.join(jobDir, "members", "alice");
+		writeMemberStatus(entityDir, {
+			member: "alice",
+			state: "awaiting_resume",
+			sessionID: "sess-abc",
+			resume_count: 1,
+			command: "opencode",
+			workerEnv: { CUSTOM: "val" },
+			usage: { output_tokens: 42 },
+		});
+
+		const { spawnFn } = makeSpawnStub();
+		await cmdResumeMember(jobDir, "alice", "follow up", membersConfig, {
+			driverFactory: () => makeMockDriver(),
+			workerPath: "/fake/worker.ts",
+			spawnFn,
+		});
+
+		const status = readMemberStatus(entityDir);
+		expect(status.state).toBe("queued");
+		expect(typeof status.queuedAt).toBe("string");
+		expect(status.sessionID).toBe("sess-abc");
+		expect(status.command).toBe("opencode");
+		expect(status.workerEnv).toEqual({ CUSTOM: "val" });
+		expect(status.resume_count).toBe(2);
+		expect(status.usage).toEqual({ output_tokens: 42 });
+	});
+
+	test("workerPath 모드는 stdout에 dispatched ack를 출력하고 즉시 반환한다", async () => {
+		const entityDir = path.join(jobDir, "members", "alice");
+		writeMemberStatus(entityDir, {
+			member: "alice",
+			state: "done",
+			sessionID: "sess-abc",
+			resume_count: 0,
+			command: "opencode",
+		});
+
+		const { spawnFn } = makeSpawnStub();
+		let captured = "";
+		const origWrite = process.stdout.write.bind(process.stdout);
+		process.stdout.write = ((chunk: string | Uint8Array) => {
+			captured += String(chunk);
+			return true;
+		}) as typeof process.stdout.write;
+		try {
+			await expect(
+				cmdResumeMember(jobDir, "alice", "follow up", membersConfig, {
+					driverFactory: () => makeMockDriver(),
+					workerPath: "/fake/worker.ts",
+					spawnFn,
+				}),
+			).resolves.toBeUndefined();
+		} finally {
+			process.stdout.write = origWrite;
+		}
+
+		expect(JSON.parse(captured.trim())).toEqual({ state: "dispatched", member: "alice" });
+	});
+
+	test("workerPath 모드에서도 resume_count가 캡(3)이면 스폰 없이 reject한다", async () => {
+		const entityDir = path.join(jobDir, "members", "alice");
+		writeMemberStatus(entityDir, {
+			member: "alice",
+			state: "done",
+			sessionID: "sess-abc",
+			resume_count: 3,
+			command: "opencode",
+		});
+
+		const { spawnFn, calls } = makeSpawnStub();
+		await expect(
+			cmdResumeMember(jobDir, "alice", "follow up", membersConfig, {
+				driverFactory: () => makeMockDriver(),
+				workerPath: "/fake/worker.ts",
+				spawnFn,
+			}),
+		).rejects.toThrow("resume cap exceeded (3/3)");
+
+		expect(calls.length).toBe(0);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -2068,6 +2068,18 @@ export type ResumeMemberOpts = {
 	resumeOneTurnFn?: (sessionID: string, opts: RunOneTurnOpts) => Promise<OneTurnResult>;
 	/** Test-only: forwarded to resumeOneTurn for spawn-less e2e wire validation. */
 	runOnceFn?: typeof runOnce;
+	/**
+	 * Path to worker.ts to spawn for the resume turn (same script spawnWorkers dispatches the
+	 * initial turn to). When provided, cmdResumeMember dispatches the resume as a detached
+	 * process — mirroring spawnWorkers' initial-turn dispatch — instead of awaiting resumeFn
+	 * in-process, so a caller blocked on this call (e.g. a Bash tool invocation with its own
+	 * timeout) returns immediately rather than for the turn's full duration. Absent (legacy
+	 * callers that never pass it), the turn still runs in-process synchronously via resumeFn,
+	 * unchanged.
+	 */
+	workerPath?: string;
+	/** Test-only: override the detached spawn call itself. */
+	spawnFn?: typeof spawn;
 };
 
 export async function cmdResumeMember(
@@ -2131,7 +2143,8 @@ export async function cmdResumeMember(
 	// resume_count via read-then-write (line 449 of worker-utils.ts).
 	const resumeCount = typeof status.resume_count === "number" ? status.resume_count : 0;
 	if (resumeCount >= 3) throw new Error("resume cap exceeded (3/3)");
-	atomicWriteJson(statusPath, { ...status, resume_count: resumeCount + 1 });
+	const reservedStatus = { ...status, resume_count: resumeCount + 1 };
+	atomicWriteJson(statusPath, reservedStatus);
 	const [origProgram, ...origArgs] = tokens;
 
 	// P2-1: read timeoutSec from job.json instead of hardcoding
@@ -2148,9 +2161,56 @@ export async function cmdResumeMember(
 		/* keep default 300 */
 	}
 
-	// Note: promptsDir and fallbackFile are intentionally not forwarded here.
-	// session-preserving CLIs (claude --resume, opencode session resume, codex exec resume)
-	// retain persona + reviewContent server-side, making assemblePrompt re-injection redundant on resume.
+	// Note: promptsDir and fallbackFile are intentionally not forwarded here (spawn path below
+	// included). session-preserving CLIs (claude --resume, opencode session resume, codex exec
+	// resume) retain persona + reviewContent server-side, making assemblePrompt re-injection
+	// redundant on resume.
+
+	if (opts.workerPath) {
+		// Queued pre-transition: MUST land before spawn, not after. cmdCollect (above in this
+		// file) returns immediately without polling once overallState is "awaiting_resume" — the
+		// prior turn's own terminal write. Flipping to "queued" here is what makes the fresh
+		// resume turn observable to collect's poll loop again, the same as the initial dispatch.
+		// Preserves sessionID/command/workerEnv/resume_count(+1) — everything the cap-reservation
+		// write above already set, except state/queuedAt.
+		atomicWriteJson(statusPath, {
+			...reservedStatus,
+			state: "queued",
+			queuedAt: new Date().toISOString(),
+		});
+
+		const workerArgs = [
+			opts.workerPath,
+			"--job-dir",
+			jobDir,
+			"--member",
+			name,
+			"--command",
+			cmdStr,
+			"--session",
+			String(sessionID),
+			"--prompt",
+			prompt,
+		];
+		for (const [key, value] of Object.entries(storedWorkerEnv)) {
+			workerArgs.push("--env", `${key}=${value}`);
+		}
+		if (timeoutSec && Number.isFinite(timeoutSec) && timeoutSec > 0) {
+			workerArgs.push("--timeout", String(timeoutSec));
+		}
+
+		const spawnFn = opts.spawnFn ?? spawn;
+		const child = spawnFn(process.execPath, workerArgs, {
+			detached: true,
+			stdio: "ignore",
+			env: process.env,
+		});
+		child.unref();
+
+		process.stdout.write(`${JSON.stringify({ state: "dispatched", member: name })}\n`);
+		return;
+	}
+
 	const resumeFn = opts.resumeOneTurnFn ?? resumeOneTurn;
 	await resumeFn(String(sessionID), {
 		program: origProgram,

--- a/skills/orchestrate-review/SKILL.md
+++ b/skills/orchestrate-review/SKILL.md
@@ -30,14 +30,14 @@ When finders cannot deliver — none configured/available after filtering, or al
 You may ONLY execute these commands via Bash:
 - `bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" start --prompt-file "$PROMPT_FILE"` — start a review job
 - `bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" collect --timeout-ms 540000 "$JOB_DIR"` — collect results (blocks until done or the 540000ms timeout; no external sleep needed)
-- `bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" resume-member --job "$JOB_DIR" --member <member> --prompt "..."` — drive an incomplete finder to a complete answer (see Member Resume Policy; cap 3 attempts)
+- `bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" resume-member --job "$JOB_DIR" --member <member> --prompt "..."` — dispatch a resume turn for an incomplete finder; returns immediately with a dispatch ack, then poll via `collect` to observe it (see Member Resume Policy; cap 3 attempts)
 - `bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" results --manifest "$JOB_DIR"` — fetch the manifest directly (see Step 2)
 - `bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" stop "$JOB_DIR"` — SIGTERM any still-`running` finder (see Step 2)
 - `bun "${CLAUDE_SKILL_DIR}/scripts/usage-summary.ts" "$JOB_DIR"` — harvest per-member token usage; **run BEFORE `clean`** (job dir is deleted by clean)
 - `bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" clean "$JOB_DIR"` — remove the job dir and reap each worker's process group when its identity can still be verified; teardown step, run only after usage-summary and everything else is complete
 - `bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" clean --force "$JOB_DIR"` — same as `clean`, but skips the active-member guard; use it when an ordinary `clean` is refused for active members
 
-**CRITICAL**: Set `timeout: 600000` on `collect` and `resume-member` Bash calls — the Bash tool's default timeout would kill them mid-poll. See Member Resume Policy for what to do if Bash kills a `resume-member` call before it returns.
+**CRITICAL**: Set `timeout: 600000` on `collect` Bash calls — the Bash tool's default timeout would kill it mid-poll. `resume-member` returns immediately with a dispatch ack and does not need this extended timeout.
 
 ### Allowed Read Usage
 
@@ -73,8 +73,8 @@ bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" collect --timeout-ms 540000 "$JOB_DIR"
 ```
 
 - If response shows `"overallState": "done"` → proceed to Step 3.
-- If response shows `"overallState": "awaiting_resume"` → that response already carries the full manifest; find each entry whose `errorMessage` is `"awaiting_resume"` and run `resume-member` on that member per Member Resume Policy.
-- Otherwise (`"running"`, `"queued"`, etc., excluding `awaiting_resume` above), or if the Bash tool itself times out/force-kills the call with no JSON returned at all → call `collect` again (same command, foreground, timeout: 600000). **Cap: 6 calls total**, counting both cases.
+- If response shows `"overallState": "awaiting_resume"` → that response already carries the full manifest; find each entry whose `errorMessage` is `"awaiting_resume"` and run `resume-member` on that member per Member Resume Policy. `resume-member` returns immediately with a dispatch ack; the resume turn itself runs in the background. After dispatching, call `collect` again (same command) to poll for it — this counts as one of the calls in the cap below.
+- Otherwise (`"running"`, `"queued"`, etc., excluding `awaiting_resume` above), or if the Bash tool itself times out/force-kills the call with no JSON returned at all → call `collect` again (same command, foreground, timeout: 600000). **Cap: 6 calls total**, counting all cases (including post-resume-dispatch polls).
 - If the 6th call still does not report `"done"`:
   1. Run `stop "$JOB_DIR"` to SIGTERM any finder still `running`, and read `outputFilePath` per finder from the manifest JSON it prints per Allowed Read Usage.
   2. Apply the Degradation Policy table below to the resulting responded/N ratio — treating every finder that never produced a non-null `outputFilePath` as not-responded (denominator stays N = total dispatched).
@@ -127,7 +127,7 @@ Each finder CLI emits its native structured output (codex: NDJSON via `--json`; 
 
 **Member Resume Policy (`resume-member`):**
 
-Collect results. If any finder's answer is incomplete (still running, or a non-answer: plan/framing/waiting/partial), use `resume-member` to drive it to a complete answer (cap: 3 attempts). If a finder outright fails (`missing_cli`/`error`/`timed_out`/`canceled`/`non_retryable`), or an `awaiting_resume` member is still `awaiting_resume` after 3 `resume-member` attempts, fall back to in-session per the trigger logic below.
+Collect results. If any finder's answer is incomplete (still running, or a non-answer: plan/framing/waiting/partial), use `resume-member` to drive it to a complete answer (cap: 3 attempts per member). `resume-member` returns immediately: it prints a dispatch ack (`{"state":"dispatched","member":<name>}`) and exits, while the resume turn itself runs as a detached background worker. It does not block waiting for the resume turn to finish.
 
 ```
 bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" resume-member --job "$JOB_DIR" --member <member> --prompt "Please complete your candidate list."
@@ -135,7 +135,7 @@ bun "${CLAUDE_SKILL_DIR}/scripts/job.ts" resume-member --job "$JOB_DIR" --member
 
 The prompt is written by the Conductor to fit the situation. The above is a reference example only.
 
-**If the Bash tool itself kills a `resume-member` call before any JSON comes back: do NOT re-call `resume-member` for that member** — the attempt is already spent and the turn may still be live. Instead, call `collect` next: it will detect the stalled member and flip it to `"error"`, at which point treat it as an outright-failed finder per the trigger logic above.
+After dispatching, observe the resume turn the same way you observed the original turn: call `collect` again per Step 2. If `resume-member` itself exits with an error and no dispatch ack (e.g. `"resume cap exceeded (3/3)"`), that attempt is spent — do not re-call it for that member. If instead the dispatched worker later goes silent or hangs, `collect`'s staleness detection flips that member to `"error"` on its own; treat it as an outright-failed finder per the trigger logic below once that happens. If a finder outright fails (`missing_cli`/`error`/`timed_out`/`canceled`/`non_retryable`), or an `awaiting_resume` member is still `awaiting_resume` after 3 `resume-member` attempts, fall back to in-session per the trigger logic below.
 
 ## Aggregation
 

--- a/skills/orchestrate-review/orchestrate-review.config.yaml
+++ b/skills/orchestrate-review/orchestrate-review.config.yaml
@@ -67,21 +67,21 @@ chunk-review:
       effort_level: medium
       output_format: json
     - name: regression
-      command: codex exec -c agents.enabled=false
+      command: codex exec -c agents.enabled=false -c service_tier=fast
       model: gpt-5.6-luna
       emoji: "\U0001F5D1"
       color: "MAGENTA"
       effort_level: xhigh
       output_format: json
     - name: cleanup
-      command: codex exec -c agents.enabled=false
+      command: codex exec -c agents.enabled=false -c service_tier=fast
       model: gpt-5.6-luna
       emoji: "\U0001F9F9"
       color: "YELLOW"
       effort_level: xhigh
       output_format: json
     - name: requirement
-      command: codex exec -c agents.enabled=false
+      command: codex exec -c agents.enabled=false -c service_tier=fast
       model: gpt-5.6-luna
       emoji: "\U0001F4CB"
       color: "GREEN"

--- a/skills/orchestrate-review/orchestrate-review.config.yaml
+++ b/skills/orchestrate-review/orchestrate-review.config.yaml
@@ -14,31 +14,32 @@ chunk-review:
     # CONFIRMED/PLAUSIBLE/REFUTED) and ranks the survivors.
     #
     # Per-angle model: each member carries its own command/model, so any angle
-    # can run on a different CLI/model. Every angle runs on codex at gpt-5.6-sol,
-    # medium reasoning effort. 모델 하향도 effort 상향도 2026-07-31~08-01 실측 후
-    # 전부 기각했다 (리포트:
-    # `~/.omt/oh-my-toong-playground/reports/code-review-finder-tiering-verification-20260731.md`):
-    #   · terra/luna 하향 — 발견을 익명화해 판정자에 대조하니 sol/medium이 회당 확증
-    #     7.67건·확증 1건당 52초로 최저 비용이었다. 하향은 정밀도를 사는 거래가 아니다:
-    #     terra/medium은 확증률이 89%로 더 높은데 확증 1건당 70초로 오히려 비싸다.
-    #     결정타는 `requirement` 확증이 terra/medium·terra/high·luna/xhigh에서 0건인 것
-    #     (sol/medium은 6/6). 차단 클래스가 꺼지면 루프는 짧아지는 게 아니라 잘못 끝난다.
-    #     경량 모델에 effort를 올리면 정밀도가 되레 떨어진다(terra 89→67→64%).
-    #   · effort 상향 — 판정 축은 루프 종료다. `{gate}/references/completion-gate.md`대로
-    #     완료를 막는 것은 `correctness`·`requirement-gap` 클래스뿐이고 `cleanup`은
-    #     비차단이라, cleanup을 몇 건 더 찾아도 루프는 짧아지지 않는다. 그리고 그
-    #     차단 집합은 effort에 반응하지 않는다: 4앵글 전부 high는 회차당 도달이
-    #     8.00 → 8.33으로 사실상 그대로였고 xhigh는 8.00 → 6.67로 오히려 나빠졌다.
-    #   · cleanup만 high로 올리는 안도 같은 이유로 기각했다. 차단 집합 도달 Δ가
-    #     세 PR에서 +1.00 / −1.00 / 0.00으로 평균 0인데(애초에 앵글마다 별도
-    #     프로세스라 인과 경로가 없다), 회당 wall +49%·output +26%가 루프 전
-    #     회차에 곱해진다. 그 대가로 얻는 것은 6회 누적 비차단 cleanup +2건뿐이다.
-    #   · 앵글 하나만 내리는 안도 기각했다. `regression`은 sol에서 정밀도가 네 앵글 중
-    #     최저(44%)라 유일한 하향 후보였지만, 다른 레포에서 재현에 실패했다 — terra는
-    #     12건 중 2건만 제출했고 그 2건이 sol 확증 5종의 부분집합이었다. 확증률 100%가
-    #     엄선이 아니라 미제출인 경우다. 판정 축은 확증률이 아니라 회당 확증 수다.
-    # 즉 이 레버들로 지금 성능을 못 올린다. 실측이 드러낸 진짜 병목은 차단 3앵글의
-    # 수렴이다 — 28파일 diff에서 6회를 돌려도 차단 집합의 78%에서 멈췄다.
+    # can run on a different CLI/model. 현재 배정은 앵글별 이종 구성이다:
+    #   correctness=sol/medium · regression=luna/xhigh · cleanup=luna/xhigh ·
+    #   requirement=luna/max
+    # 근거는 2026-08-02~03 2차 실측 (리포트:
+    # `~/.omt/oh-my-toong-playground/reports/code-review-finder-impact-per-cost-20260803.md`,
+    # 판정식 = 앵글별 Σimpact(유효 finding, 블라인드 Claude 채점) ÷ USD, 6구성 ×
+    # 4앵글 × algocare-home PR 5개):
+    #   · luna/xhigh가 4앵글 전부 임팩트/$1 1위(총괄 52.9 대 sol/medium 4.8)이고,
+    #     구성 단위 중복 제거 후 절대 임팩트도 luna 103 ≥ sol 97. 고임팩트(≥5)
+    #     결함 6종 커버리지는 luna/xhigh = sol/medium = 6/6.
+    #   · correctness만 sol 유지: sol correctness의 단독 포착(업데이트 게이트 도달
+    #     불가 등)이 luna 두 구성에 없고, 절대 임팩트 37 대 30/25로 우위.
+    #   · requirement만 luna/max: 유효 5/6·임팩트 19로 전 구성 1위(sol 10, luna/xhigh
+    #     11). 이 혼합이 실측 합집합 112점으로 전-luna/max(115)에 근접하면서
+    #     regression·cleanup 레인은 xhigh로 wall을 아낀다. 단 requirement 레인이
+    #     luna/max인 이상 라운드 wall은 그 레인이 지배한다(~20분, 현행 sol 단일
+    #     구성 대비 약 4배) — 시간보다 임팩트를 우선한 의도적 트레이드다.
+    # 1차 실측(2026-07-31~08-01, `code-review-finder-tiering-verification-20260731.md`)은
+    # 같은 하향을 전부 기각했었다. 뒤집힌 원인은 모델이 아니라 측정 축 셋이다:
+    # ① 1차 비용 축에 달러 환산이 없었다(sol:luna output 단가 25배), ② 1차 collect
+    # 18분 예산이 luna를 절단시켰다(2차는 완주), ③ 판정자가 sol/high → 구성 은닉
+    # Claude로 바뀌었다("하향=requirement 침묵"도 미재현: luna/max requirement가
+    # 절대 1위). 축을 바꾸면 결론이 바뀐다 — 다음 재평가 때 두 리포트를 같이 볼 것.
+    # 미해소 유보: OMT 레포(하네스 코드) 교차 재현 없음 — 2차 검증 PR은 전부
+    # algocare-home 제품 코드다. 1차가 찾은 진짜 병목(차단 3앵글의 수렴: 28파일
+    # diff 6회에도 차단 집합 78%)은 luna 전환으로 재검하지 않았다.
     # `model` + `effort_level` + `output_format` (below) plus
     # `settings.deny.skills` (below) resolve (via buildAugmentedCommand) to:
     #   codex exec -c agents.enabled=false -m gpt-5.6-sol \
@@ -46,9 +47,11 @@ chunk-review:
     #     -c model_reasoning_effort=<this member's effort_level> --json --skip-git-repo-check
     # `agents.enabled=false` strips codex's subagent tool descriptions (spawn_agent etc.)
     # from the session entirely, so a finder can't spawn subagents even if asked to.
-    # Note: codex uses bare model ids (no `openai/` prefix). Git history attests
-    # codex with gpt-5.4 / gpt-5.3-codex (gpt-5.5 itself only ran via opencode);
-    # if codex rejects `gpt-5.6-sol`, fall back to `gpt-5.5`.
+    # Note: codex uses bare model ids (no `openai/` prefix). 2026-08-02 스모크로
+    # gpt-5.6-sol(low/medium)·gpt-5.6-luna(xhigh/max)·gpt-5.6-terra(high/xhigh)
+    # 전 조합의 codex 수용을 확인했다. codex에는 unsupported model id의 자동
+    # fallback이 없다 — 모델 교체 시 반드시 사전 스모크를 거칠 것. 긴급 폴백은
+    # 전 앵글 `gpt-5.6-sol`/medium(직전 검증 구성).
     # Change one member's `model`/`command` to run that angle on a different model/CLI.
     #
     # Angle set: 4 angles, each asking a distinct question about the diff —
@@ -65,24 +68,24 @@ chunk-review:
       output_format: json
     - name: regression
       command: codex exec -c agents.enabled=false
-      model: gpt-5.6-sol
+      model: gpt-5.6-luna
       emoji: "\U0001F5D1"
       color: "MAGENTA"
-      effort_level: medium
+      effort_level: xhigh
       output_format: json
     - name: cleanup
       command: codex exec -c agents.enabled=false
-      model: gpt-5.6-sol
+      model: gpt-5.6-luna
       emoji: "\U0001F9F9"
       color: "YELLOW"
-      effort_level: medium
+      effort_level: xhigh
       output_format: json
     - name: requirement
       command: codex exec -c agents.enabled=false
-      model: gpt-5.6-sol
+      model: gpt-5.6-luna
       emoji: "\U0001F4CB"
       color: "GREEN"
-      effort_level: medium
+      effort_level: max
       output_format: json
   settings:
     timeout: 1800

--- a/skills/orchestrate-review/orchestrate-review.config.yaml
+++ b/skills/orchestrate-review/orchestrate-review.config.yaml
@@ -88,7 +88,10 @@ chunk-review:
       effort_level: max
       output_format: json
   settings:
-    timeout: 1800
+    # 2700 = 행 킬 안전장치이지 정상 런 상한이 아니다. 1800이던 시절 37파일 diff에서
+    # luna 레인이 절단됐고(절단분까지가 그 앵글 최고점 — 즉 절단은 과소평가 방향),
+    # 정상 런은 이 값에 닿지 않는다. 절단 시에도 부분 출력은 수확된다(fail-soft).
+    timeout: 2700
     # No-op with the angle members above (no `claude` member to exclude); kept
     # for compatibility if a claude-hosted angle is added later.
     exclude_chairman_from_members: false

--- a/skills/orchestrate-review/scripts/job.test.ts
+++ b/skills/orchestrate-review/scripts/job.test.ts
@@ -2880,6 +2880,122 @@ describe("resume-member", () => {
 });
 
 // ---------------------------------------------------------------------------
+// resume-member CLI dispatch: detached-spawn contract (the actual `job.ts resume-member`
+// entry point, unlike the tests above which call cmdResumeMember directly and never pass
+// workerPath — that exercises the shared in-process fallback other skills still use). This is
+// the surface the deliverable targets: a resume turn must not block the caller (a Bash tool
+// call with its own timeout) for the turn's full duration.
+// ---------------------------------------------------------------------------
+
+describe("resume-member CLI 배선 — detached spawn 계약", () => {
+	const SCRIPT = path.join(import.meta.dirname, "job.ts");
+	let tmpDir: string;
+	let jobDir: string;
+	let memberDir: string;
+	let stubDir: string;
+
+	/**
+	 * Fake `opencode` binary on PATH: sleeps long enough that a caller blocking in-process on
+	 * it would observably block, then emits a minimal opencode NDJSON stream the real
+	 * opencodeDriver can parse (step_finish/stop + one text event) before exiting 0.
+	 */
+	function makeSlowOpencodeStub(sleepSec: number): string {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "resume-spawn-stub-"));
+		const stubPath = path.join(dir, "opencode");
+		fs.writeFileSync(
+			stubPath,
+			[
+				"#!/bin/sh",
+				`sleep ${sleepSec}`,
+				'echo \'{"type":"step_finish","sessionID":"sess-123","part":{"reason":"stop"}}\'',
+				'echo \'{"type":"text","part":{"text":"resumed done"}}\'',
+				"exit 0",
+			].join("\n"),
+			"utf8",
+		);
+		fs.chmodSync(stubPath, 0o755);
+		return dir;
+	}
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "resume-spawn-job-"));
+		jobDir = path.join(tmpDir, "job1");
+		memberDir = path.join(jobDir, "members", "opencode");
+		fs.mkdirSync(memberDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(memberDir, "status.json"),
+			JSON.stringify(
+				{
+					member: "opencode",
+					state: "awaiting_resume",
+					sessionID: "sess-existing",
+					resume_count: 0,
+					command: "opencode --format json",
+				},
+				null,
+				2,
+			),
+			"utf8",
+		);
+		stubDir = makeSlowOpencodeStub(2);
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+		fs.rmSync(stubDir, { recursive: true, force: true });
+	});
+
+	function readStatus(): Record<string, unknown> {
+		return JSON.parse(fs.readFileSync(path.join(memberDir, "status.json"), "utf8"));
+	}
+
+	test(
+		"resume-member 서브커맨드는 워커 완료를 기다리지 않고 즉시 dispatched ack로 반환한다",
+		async () => {
+			const start = Date.now();
+			const result = execFileSync(
+				process.execPath,
+				[SCRIPT, "resume-member", "--job", jobDir, "--member", "opencode", "--prompt", "continue"],
+				{ stdio: "pipe", env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` } },
+			);
+			const elapsedMs = Date.now() - start;
+
+			// The fake CLI sleeps 2s before it would ever finish a turn — a caller still blocking
+			// in-process on that turn would take at least that long. Returning in a small fraction
+			// of that window is the direct evidence dispatch is non-blocking.
+			expect(elapsedMs).toBeLessThan(1500);
+			expect(JSON.parse(result.toString())).toEqual({ state: "dispatched", member: "opencode" });
+
+			// Queued pre-transition: cmdCollect's "awaiting_resume already ended its own turn"
+			// early-return must not still apply to this freshly-dispatched resume.
+			const queuedStatus = readStatus();
+			expect(queuedStatus.state).toBe("queued");
+			expect(queuedStatus.sessionID).toBe("sess-existing");
+			expect(queuedStatus.command).toBe("opencode --format json");
+			expect(queuedStatus.resume_count).toBe(1);
+
+			// Poll for the detached worker to actually finish the turn — state transitions
+			// queued → running (runOnce's own status write, before the stub's 2s sleep resolves)
+			// → done (executeOneTurn's final write once stdout is parsed).
+			const deadline = Date.now() + 10000;
+			let finalStatus = readStatus();
+			while (
+				(finalStatus.state === "queued" || finalStatus.state === "running") &&
+				Date.now() < deadline
+			) {
+				await new Promise((resolve) => setTimeout(resolve, 200));
+				finalStatus = readStatus();
+			}
+
+			expect(finalStatus.state).toBe("done");
+			expect(finalStatus.sessionID).toBe("sess-123");
+			expect(finalStatus.resume_count).toBe(1);
+		},
+		15000,
+	);
+});
+
+// ---------------------------------------------------------------------------
 // cmdResults
 // ---------------------------------------------------------------------------
 

--- a/skills/orchestrate-review/scripts/job.ts
+++ b/skills/orchestrate-review/scripts/job.ts
@@ -785,7 +785,9 @@ async function main(): Promise<void> {
 		const promptArg = optionalString(options.prompt);
 		if (!promptArg) exitWithError("--prompt required");
 		try {
-			await _cmdResumeMember(jobDirArg, nameArg, promptArg, CHUNK_REVIEW_JOB_CONFIG);
+			await _cmdResumeMember(jobDirArg, nameArg, promptArg, CHUNK_REVIEW_JOB_CONFIG, {
+				workerPath: WORKER_PATH,
+			});
 		} catch (e: unknown) {
 			exitWithError(e instanceof Error ? e.message : String(e));
 		}

--- a/skills/orchestrate-review/scripts/worker.test.ts
+++ b/skills/orchestrate-review/scripts/worker.test.ts
@@ -323,6 +323,86 @@ describe("main() 배선: prompt.txt가 필터링되어 reviewContent로 전달�
 	);
 });
 
+// worker.ts's resume mode (--session + --prompt) is what cmdResumeMember's detached-worker
+// dispatch (lib/generic-job.ts) spawns instead of awaiting resumeOneTurn in-process. Drives the
+// real main() as a subprocess against a fake `opencode` binary on PATH — a real driver
+// (opencodeDriver) parses its stdout, so this proves resumeOneTurn (not runOneTurn) actually ran:
+// promptsDir is never forwarded to it, so assembled-prompt.txt must not appear, and the fake CLI
+// receives the resume-shaped `--session <id>` argv only driver.resumeCommand injects.
+describe("main() 배선: --session/--prompt는 resumeOneTurn 경로(assembled-prompt.txt 미생성)를 태운다", () => {
+	let tmpRoot: string;
+	let stubDir: string;
+
+	function makeJobDir(): string {
+		tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "chunk-worker-resume-test-"));
+		const jobDir = path.join(tmpRoot, "jobs", "chunk-review-resume-test");
+		fs.mkdirSync(path.join(jobDir, "members", "opencode"), { recursive: true });
+		return jobDir;
+	}
+
+	function makeOpencodeStub(): string {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "worker-resume-stub-"));
+		const stubPath = path.join(dir, "opencode");
+		fs.writeFileSync(
+			stubPath,
+			[
+				"#!/bin/sh",
+				`echo "$@" > ${JSON.stringify(path.join(dir, "argv.txt"))}`,
+				'echo \'{"type":"step_finish","sessionID":"sess-123","part":{"reason":"stop"}}\'',
+				'echo \'{"type":"text","part":{"text":"resumed"}}\'',
+				"exit 0",
+			].join("\n"),
+			"utf8",
+		);
+		fs.chmodSync(stubPath, 0o755);
+		return dir;
+	}
+
+	afterEach(() => {
+		fs.rmSync(tmpRoot, { recursive: true, force: true });
+		fs.rmSync(stubDir, { recursive: true, force: true });
+	});
+
+	// See the wiring test above for why an explicit timeout is required: reapOwnProcessGroup's
+	// fixed 5s SIGTERM grace runs before the worker process itself exits.
+	it(
+		"--session/--prompt가 있으면 assembled-prompt.txt를 만들지 않고 driver.resumeCommand의 --session 인자로 실제 CLI를 호출한다",
+		() => {
+			const jobDir = makeJobDir();
+			stubDir = makeOpencodeStub();
+
+			execFileSync(
+				process.execPath,
+				[
+					WORKER_PATH,
+					"--job-dir",
+					jobDir,
+					"--member",
+					"opencode",
+					"--command",
+					"opencode --format json",
+					"--session",
+					"sess-existing",
+					"--prompt",
+					"continue please",
+				],
+				{ stdio: "pipe", env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` } },
+			);
+
+			const memberDir = path.join(jobDir, "members", "opencode");
+			expect(fs.existsSync(path.join(memberDir, "assembled-prompt.txt"))).toBe(false);
+
+			const argv = fs.readFileSync(path.join(stubDir, "argv.txt"), "utf8");
+			expect(argv).toContain("--session sess-existing");
+
+			const status = JSON.parse(fs.readFileSync(path.join(memberDir, "status.json"), "utf8"));
+			expect(status.state).toBe("done");
+			expect(status.sessionID).toBe("sess-123");
+		},
+		20000,
+	);
+});
+
 // worker.ts 종료 경로에 lib/worker-utils.ts의 reapOwnProcessGroup이 실제로 연결돼
 // 있는지를 검증하는 헤르메틱 통합 테스트. 실제 worker.ts를 detached 자식으로 띄우고,
 // 그 워커가 실행하는 커맨드(셸 스크립트)가 백그라운드 자손(sleep)을 남긴 채 자신은

--- a/skills/orchestrate-review/scripts/worker.ts
+++ b/skills/orchestrate-review/scripts/worker.ts
@@ -6,7 +6,13 @@ import path from "path";
 import { initLogger, logInfo, logError, logStart, logEnd } from "@lib/logging";
 import { exitWithError, parseArgs, logRootForJobsDir } from "@lib/job-utils";
 import { getOmtDir } from "@lib/omt-dir";
-import { splitCommand, atomicWriteJson, runOneTurn, reapOwnProcessGroup } from "@lib/worker-utils";
+import {
+	splitCommand,
+	atomicWriteJson,
+	runOneTurn,
+	resumeOneTurn,
+	reapOwnProcessGroup,
+} from "@lib/worker-utils";
 import { detectCliType } from "@lib/generic-job";
 import type { CliType } from "@lib/agent-drivers/types";
 
@@ -193,19 +199,43 @@ function main() {
 	const detectedCliType = detectCliType(command);
 	const cliType: CliType = isCliType(detectedCliType) ? detectedCliType : "unknown";
 
-	runOneTurn({
-		program,
-		args,
-		prompt: EXECUTION_INSTRUCTION,
-		reviewContent: promptContent,
-		member,
-		memberDir,
-		command,
-		timeoutSec,
-		workerEnv,
-		cliType,
-		promptsDir: PROMPTS_DIR,
-	}).then(async (result) => {
+	// Resume mode: --session + --prompt together (spawned by cmdResumeMember's detached-worker
+	// dispatch, lib/generic-job.ts) select resumeOneTurn over the initial-turn runOneTurn below.
+	// promptsDir/reviewContent are deliberately NOT forwarded here — session-preserving CLIs
+	// (claude --resume, opencode session resume, codex exec resume) retain persona + review
+	// content server-side, making assemblePrompt re-injection redundant on resume (see
+	// cmdResumeMember's own comment in lib/generic-job.ts).
+	const session = options.session;
+	const resumePrompt = options.prompt;
+
+	const turnPromise =
+		typeof session === "string" && session !== "" && typeof resumePrompt === "string" && resumePrompt !== ""
+			? resumeOneTurn(session, {
+					program,
+					args,
+					prompt: resumePrompt,
+					member,
+					memberDir,
+					command,
+					timeoutSec,
+					workerEnv,
+					cliType,
+				})
+			: runOneTurn({
+					program,
+					args,
+					prompt: EXECUTION_INSTRUCTION,
+					reviewContent: promptContent,
+					member,
+					memberDir,
+					command,
+					timeoutSec,
+					workerEnv,
+					cliType,
+					promptsDir: PROMPTS_DIR,
+				});
+
+	turnPromise.then(async (result) => {
 		logInfo(`worker done: member=${member} state=${result.state} exitCode=${result.exitCode}`);
 		logEnd();
 		// Must run AFTER logging: the group SIGKILL this sends also terminates this


### PR DESCRIPTION
## 📌 Summary

2026-08-02~03 블라인드 임팩트 채점 실측(2개 실험, 구성×앵글×PR 11개)을 근거로 orchestrate-review finder 4앵글을 전-sol/medium 단일 구성에서 sol·luna 혼합 구성으로 전환합니다. 같은 실험에서 실측된 대형 diff 절단을 반영해 워커 타임아웃도 1800→2700초로 상향합니다.

---

## 🔧 Changes

### orchestrate-review finder 구성

- 앵글별 모델·effort 재배정: `correctness`=gpt-5.6-sol/medium(유지), `regression`·`cleanup`=gpt-5.6-luna/xhigh, `requirement`=gpt-5.6-luna/max
- config 주석에 판정식(앵글별 Σimpact(유효 finding)÷USD)·1차 실측과 결론이 뒤집힌 원인 3종·미해소 유보를 기록
- `settings.timeout` 1800→2700초 상향 및 근거 주석

**영향 범위**
code-review 파이프라인의 finder 단계 전체. 산출 계약(JSON finding 후보 목록)은 불변이라 하류 verifier는 변경 없음. 라운드 wall은 requirement 레인(luna/max)이 지배해 약 20분(현행 대비 약 4배)으로 늘고, 회당 API 비용은 1/3 이하로 감소. codex의 luna xhigh/max·sol medium 조합 수용은 사전 스모크로 확인됨(codex는 unsupported model id 자동 fallback이 없음).

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 단일 모델 통일 대신 앵글별 이종 혼합

**배경 및 문제 상황:**
1차 실측(2026-07-31~08-01)은 모든 모델 하향을 기각했으나, 판정 축에 결함이 셋 있었습니다 — ① 비용 축에 달러 환산이 없었고(sol:luna output 단가 25배), ② collect 18분 예산이 luna 출력을 절단시켰으며, ③ 판정자가 sol 계열이었습니다. 2차는 달러 환산·완주 보장·구성 은닉 블라인드 Claude 채점으로 재측정했고 결론이 뒤집혔습니다.

**해결 방안:**
전-luna 통일이나 전-sol 유지 대신, 앵글별로 실측 1위 구성을 배정했습니다.

**구현 세부사항:**
- luna/xhigh가 4앵글 전부 임팩트/$1 1위(총괄 약 11배), 구성 단위 중복 제거 후 절대 임팩트도 sol 동급~우위 → regression·cleanup에 배정
- requirement는 luna/max가 두 실험 모두 절대 1위(합산 55 대 sol 27)로 재현 → 유일하게 max 유지
- correctness는 sol과 luna가 11개 PR 합산 통계적 동률이나, sol의 단독 포착(업데이트 게이트 도달 불가 등)이 luna에 없어 sol 유지

**선택과 트레이드오프:**
- wall 약 4배(20분)는 시간보다 임팩트를 우선한 의도적 트레이드입니다. regression·cleanup을 max가 아닌 xhigh로 둔 것이 그 완충입니다.
- 고임팩트(≥5) 결함 커버리지가 단일 구성으로는 전부 구멍이 있었고(sol 8/8이지만 luna 단독 포착 결함 존재, luna/xhigh 7/8, luna/max 6/8), 혼합은 모델 다양성으로 8/8을 유지합니다.
- 미해소 유보 둘: 검증 PR이 전부 algocare-home 제품 코드라 OMT 레포(하네스 코드) 교차 재현이 없고, 1차가 지적한 루프 수렴 축은 luna 전환 후 재검하지 않았습니다. 긴급 폴백은 전 앵글 sol/medium(직전 검증 구성)입니다.

### 2. 워커 타임아웃 1800→2700초

**배경 및 문제 상황:**
37파일 diff에서 luna 레인이 1800초에 절단되는 것이 실측됐습니다. 절단된 부분 출력까지가 해당 앵글 최고점이었으므로 절단은 luna를 과소평가하는 방향으로만 작용했지만, 대형 diff에서 finding을 잃는 경로임은 동일합니다.

**해결 방안:**
타임아웃은 행 킬 안전장치이지 정상 런 상한이 아니므로(정상 런은 이 값에 닿지 않음) 2700초로 상향. 절단 시 부분 출력 수확(fail-soft)은 그대로 유지됩니다.

**선택과 트레이드오프:**
진짜 행에 걸린 워커의 킬이 최대 15분 늦어지는 비용 대 대형 diff 절단 제거의 교환입니다. 절단이 재현된 유일한 사례가 37파일 diff였으므로 상한을 무한정 올리지 않고 실측 절단 지점 +50%로 잡았습니다.

---

## ✅ Checklist

### finder 구성
- [ ] correctness 멤버만 `gpt-5.6-sol`이고 regression·cleanup·requirement는 `gpt-5.6-luna`다
  - `skills/orchestrate-review/orchestrate-review.config.yaml`
- [ ] requirement의 `effort_level`이 `max`, regression·cleanup은 `xhigh`, correctness는 `medium`이다
  - `skills/orchestrate-review/orchestrate-review.config.yaml`
- [ ] `settings.timeout`이 2700이다
  - `skills/orchestrate-review/orchestrate-review.config.yaml`
- [ ] orchestrate-review 테스트 스위트(214건)가 통과한다
  - `skills/orchestrate-review/`

---

## 📎 References
- [#225 cleanup finder effort를 high로 상향](https://github.com/toongri/oh-my-toong-playground/pull/225) — 1차 실측 계열의 직전 튜닝
- [#226 cleanup finder effort를 medium으로 되돌림](https://github.com/toongri/oh-my-toong-playground/pull/226) — 위 상향의 revert