### PR TITLE
fix: make-pr 생성 판정을 로컬 커밋 수 기준으로 교체

### DIFF
--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -101,10 +101,11 @@ digraph make_pr_flow {
     "Present to User" [shape=box];
     "User Feedback" [shape=diamond];
     "Confirm PR Creation" [shape=diamond];
-    "CAS Freshness\nCheck" [shape=diamond];
+    "Ahead Check\n(commits not in base)" [shape=diamond];
     "gh pr create" [shape=box];
     "Return PR URL" [shape=ellipse];
     "Output Description Only" [shape=ellipse];
+    "Report Absorbed\n+ Stop" [shape=ellipse];
 
     "User Request" -> "0-A: Fetch & Analyze\nAll Remote Branches";
     "0-B: Check Diverge\n(behind count)" -> "Collect Git Metadata" [label="behind = 0"];
@@ -128,14 +129,9 @@ digraph make_pr_flow {
     "User Feedback" -> "Draft PR Description" [label="Revision requested"];
     "User Feedback" -> "Confirm PR Creation" [label="Approved"];
     "Confirm PR Creation" -> "Output Description Only" [label="Declined"];
-    "Confirm PR Creation" -> "CAS Freshness\nCheck" [label="Confirmed"];
-    "CAS Freshness\nCheck" -> "gh pr create" [label="Fresh"];
-    "CAS Re-sync\n(re-use or\nnew interview)" [shape=box];
-    "CAS Conflict\nResolution (→ 0-C)" [shape=box];
-    "CAS Freshness\nCheck" -> "CAS Re-sync\n(re-use or\nnew interview)" [label="Stale"];
-    "CAS Re-sync\n(re-use or\nnew interview)" -> "gh pr create" [label="sync complete"];
-    "CAS Re-sync\n(re-use or\nnew interview)" -> "CAS Conflict\nResolution (→ 0-C)" [label="conflict"];
-    "CAS Conflict\nResolution (→ 0-C)" -> "gh pr create";
+    "Confirm PR Creation" -> "Ahead Check\n(commits not in base)" [label="Confirmed"];
+    "Ahead Check\n(commits not in base)" -> "gh pr create" [label="ahead > 0"];
+    "Ahead Check\n(commits not in base)" -> "Report Absorbed\n+ Stop" [label="ahead = 0"];
     "gh pr create" -> "Return PR URL";
 }
 ```
@@ -191,16 +187,6 @@ Present the candidate table, then ask the user to select the target branch. Incl
 - An option to type a custom branch name if none of the candidates apply
 
 Use the confirmed value as `{base-branch}` in all subsequent git commands.
-
-**Phase 5 — Record baseline target SHA:**
-
-After user confirms the target branch, record the target branch tip SHA as the CAS baseline for Step 8 freshness check:
-
-```bash
-BASELINE_TARGET_SHA=$(git rev-parse origin/{base-branch})
-```
-
-This value is compared again at PR creation time (Step 8) to detect if the target branch tip has moved during the PR writing process.
 
 ---
 
@@ -498,34 +484,21 @@ Present the drafted PR description to the user and collect feedback.
 
 After user approves the PR description, ask if they want to create the PR.
 
-### Pre-creation Freshness Check (CAS Pattern)
+### Pre-creation Check
 
-Before pushing and creating the PR, verify the target branch hasn't changed since Step 0-A:
+Before pushing, verify the branch still holds commits that `{base-branch}` does not:
 
 ```bash
-# Re-fetch target branch
 git fetch origin {base-branch}
-
-# Check target branch tip
-CURRENT_TARGET_SHA=$(git rev-parse origin/{base-branch})
+AHEAD=$(git rev-list --count origin/{base-branch}..HEAD)
 ```
-
-**Compare with baseline:**
 
 | Condition | Action |
 |-----------|--------|
-| `CURRENT_TARGET_SHA == BASELINE_TARGET_SHA` | Target unchanged — proceed to push + `gh pr create` |
-| `CURRENT_TARGET_SHA != BASELINE_TARGET_SHA` | Target has moved — re-sync before creating PR |
+| `AHEAD > 0` | Proceed to push + `gh pr create` |
+| `AHEAD == 0` | The branch's commits already exist in `{base-branch}` — there is nothing to open a PR for. Tell the user and stop |
 
-**When target has moved:**
-
-1. Inform the user that the target branch has new commits since the analysis began
-2. If a strategy was selected in Step 0-B: re-use it automatically (do NOT re-interview)
-   If Step 0-B was skipped (behind was 0): ask the user via AskUserQuestion which strategy to use (merge/rebase)
-3. Execute the sync (merge or rebase)
-4. If conflict arises: follow Step 0-C conflict resolution interview
-5. After successful sync: proceed to push + `gh pr create`
-6. PR description is NOT re-written (the feature branch changes are the same; only the base has moved)
+`AHEAD` is a property of the current branch, so this check is evaluated once and its answer does not change when the target branch receives new commits meanwhile. It is also the only precondition `gh pr create` needs: GitHub computes the merge server-side, so the branch does not have to be up to date with the target. Synchronizing the branch with the target is handled earlier, by the Step 0-B merge/rebase that runs before the interview.
 
 - If user confirms: check branch name convention, push the branch, and run `gh pr create` with the approved title, description, assignee, and labels
 - If user declines: output the final PR description only
@@ -543,7 +516,7 @@ If `{branch-convention}` exists (Step 1 survey) and the current branch name does
 
 ```bash
 # Single PR (create after remote push)
-# If rebase was used (Step 0-B or Step 8 CAS re-sync):
+# If the Step 0-B synchronization used rebase:
 git push --force-with-lease -u origin HEAD
 # If merge was used or no sync was needed:
 git push -u origin HEAD

--- a/skills/make-pr/references/reference-tables.md
+++ b/skills/make-pr/references/reference-tables.md
@@ -14,7 +14,7 @@
 | Scope Assessment | Analyze thesis count, propose split if multi-thesis | Proxy signals trigger analysis, thesis isolation decides |
 | Write PR Title & Description | Follow output-format.md exactly; title + labels per surveyed conventions | Emoji headers, Impact Scope, file paths in Checklist. Labels only from `gh label list` |
 | User Review | Present and collect feedback | Repeat until approved |
-| PR Creation | CAS freshness check → re-sync if target moved → branch name convention check → `gh pr create` after user confirmation | Re-use Step 0-B strategy; re-interview only on conflict. Always `--assignee @me`; `--label` per selected label |
+| PR Creation | Pre-creation check (`origin/{base}..HEAD` ahead count > 0) → branch name convention check → `gh pr create` after user confirmation | Always `--assignee @me`; `--label` per selected label |
 
 ---
 
@@ -48,7 +48,8 @@
 | Proposing unnecessary split for single-thesis PR | User burden, workflow delay | If single thesis, proceed to Step 6 immediately |
 | Reading git diff file contents during scope assessment | Violates Non-Negotiable Rule | Use only git diff --stat and git log |
 | Deleting original branch after split | User cannot recover | Always preserve the original branch |
-| Skipping freshness check before PR creation | `gh pr create` fails or wrong diff when target branch moved | CAS pattern target SHA re-verification in Step 8 |
+| Pushing without confirming the branch has commits the base lacks | `gh pr create` fails with "No commits between base and head" | Check `git rev-list --count origin/{base-branch}..HEAD > 0` before push |
+| Gating PR creation on the remote target tip matching a SHA recorded earlier | On an active repo the target keeps moving during the interview, so the comparison never settles and the check re-fires indefinitely | Gate on the local ahead count instead — it is owned by the current branch and does not change when the target moves |
 | References를 클릭 불가능한 bare-text로 작성 | GitHub-renderable 아님; reviewer가 navigate 불가 | `[Title](URL)` markdown link 사용. URL 없으면 user에게 한 번 묻고, 없으면 bare-text 허용 (Slack 채널 단독 예외) |
 | Writing title from default style when the repo has a surveyed title convention | PR looks foreign in the repo's PR list | Survey result wins; defaults are fallback only |
 | Creating PR without `--assignee @me` | PR left unassigned; ownership unclear | Always include `--assignee @me` in `gh pr create` |

--- a/skills/make-pr/tests/test-scenarios.md
+++ b/skills/make-pr/tests/test-scenarios.md
@@ -2,7 +2,7 @@
 
 Skill type: Technique
 Testing approach: Application / Variation / Edge Case (per writing-skills guide)
-Last tested: 2026-07-30 (Round 11)
+Last tested: 2026-08-03 (Round 13)
 
 ---
 
@@ -1498,6 +1498,8 @@ Improvement context: Step 0를 확장하여 heuristic 기반 parent branch 감�
 **Type:** Edge Case
 **Purpose:** PR 작성 중 타겟 브랜치가 변경된 경우, Step 8에서 CAS 패턴으로 감지하고 자동 재동기화하는지 검증.
 
+> **SUPERSEDED (Round 13):** 이 시나리오가 검증하던 CAS 패턴은 비수렴 결함으로 제거됐다(Scenario 28 참조). 아래 GREEN 결과는 Round 12 시점의 기록이며 현재 스킬 동작이 아니다. 이 시나리오가 방어하려던 실패(`No commits between base and head`)는 Scenario 28의 로컬 ahead 검사가 대신 커버한다.
+
 ### Input
 
 - Git state: Step 0-A에서 `develop`을 타겟으로 선택, target SHA `abc123` 기록. Step 0-B에서 merge 선택. PR 작성 완료 후 Step 8 진입 시 `develop`에 새 커밋 추가되어 target SHA가 `def456`으로 변경됨.
@@ -1600,6 +1602,8 @@ Improvement context: Step 0를 확장하여 heuristic 기반 parent branch 감�
 **Type:** Edge Case
 **Purpose:** Step 0-B가 behind=0으로 스킵된 후 PR 작성 중 타겟 브랜치가 이동한 경우, Step 8에서 재동기화 전략을 사용자에게 질문하는지 검증.
 
+> **SUPERSEDED (Round 13):** CAS 패턴 제거로 Step 8 재동기화 분기 자체가 사라졌다(Scenario 28 참조). 아래 GREEN 결과는 Round 12 시점의 기록이며 현재 스킬 동작이 아니다.
+
 ### Input
 
 - Git state: Step 0-A에서 `main`을 타겟으로 선택, target SHA `aaa111` 기록. Step 0-B에서 behind=0이므로 동기화 스킵 (전략 선택 없음). PR 작성 완료 후 Step 8 진입 시 `main`에 새 커밋 추가되어 target SHA가 `bbb222`로 변경됨.
@@ -1659,6 +1663,8 @@ Improvement context: Step 0를 확장하여 heuristic 기반 parent branch 감�
 
 **Type:** Edge Case
 **Purpose:** Step 8 CAS freshness check에서 타겟 브랜치 이동 감지 후, 이전 전략(rebase) 자동 재사용으로 re-sync를 진행할 때 conflict가 발생하는 조합 케이스를 검증. Conflict 해결 후 Step 1으로 돌아가지 않고 `gh pr create`로 직행하는지가 핵심 검증 포인트.
+
+> **SUPERSEDED (Round 13):** CAS 패턴 제거로 Step 8 재동기화와 그에 딸린 conflict 분기가 사라졌다(Scenario 28 참조). 아래 GREEN 결과는 Round 12 시점의 기록이며 현재 스킬 동작이 아니다. 동기화 중 conflict 처리는 Step 0-B/0-C 경로(Scenario 23)가 계속 담당한다.
 
 ### Input
 
@@ -1747,7 +1753,7 @@ Improvement context: Step 0를 확장하여 heuristic 기반 parent branch 감�
 | 4 | 브랜치명 컨벤션 체크 | `git ls-remote` 원격 부재 확인 후 AskUserQuestion으로 rename 제안 |
 | 5 | `--assignee @me` 포함 | 최종 `gh pr create`에 항상 포함 |
 | 6 | `--label` 플래그 포함 | 선택된 label당 1회 |
-| 7 | 기존 플로우 회귀 없음 | CAS check, 일반 push(rebase 미사용 시), 사용자 확인 게이트, 한국어 |
+| 7 | 기존 플로우 회귀 없음 | 생성 전제 검사, 일반 push(rebase 미사용 시), 사용자 확인 게이트, 한국어 |
 
 ### Input (variation: convention-less repo)
 
@@ -1773,7 +1779,7 @@ Improvement context: Step 0를 확장하여 heuristic 기반 parent branch 감�
 | 4 | 브랜치명 컨벤션 체크 | **FAIL** | "no branch rename is part of this workflow"라고 명시 진술, `wobbly-otter` 그대로 push |
 | 5 | `--assignee @me` 포함 | **FAIL** | assignee 플래그 전무 |
 | 6 | `--label` 플래그 포함 | **FAIL** | 3번과 동일 |
-| 7 | 기존 플로우 회귀 없음 | PASS | CAS check·push·확인 게이트는 정상 |
+| 7 | 기존 플로우 회귀 없음 | PASS | 생성 전제 검사·push·확인 게이트는 정상 |
 
 **Summary: 1/7 PASS, 6/7 FAIL** — 컨벤션 서베이·assignee·label·브랜치명 체크 전부 구조적 부재.
 
@@ -1812,3 +1818,85 @@ PR #218 Codex 리뷰가 Scenario 27 도입분에서 P2 2건을 지적. 각각 �
 |--------|---------|------|------|
 | 제목 3-3 동률 (6건, 한국어 conventional 3 vs 영어 bare 3; 브랜치·label 축은 6/6 일관) | 제목 축 동률 여부만 | 제목 축만 미성립→한국어 fallback, 브랜치·label 축은 적용 | **PASS** — "3–3 is an exact tie... no convention" 판정, `feat: 한국어` 제목 + `enhancement` label + rename 미제안 |
 | 영어 bare 6/6 일관 | 제목 언어 컨벤션 성립 | 영어 제목 + 본문 한국어 + `--assignee @me` | **PASS** — `Add order created event publishing` 제목, 본문 한국어 명시, label·assignee 정상 |
+
+---
+
+## Scenario 28: 생성 전제 검사 비수렴 — 타겟이 다시 움직이는 경우
+
+**Type:** Edge Case
+**Round:** 13
+**Purpose:** PR 생성 직전 검사가 유한 횟수 안에 끝나고 `gh pr create`에 도달하는지 검증. 활발한 레포에서 타겟 브랜치가 작업 도중 두 번 이상 움직여도 검사가 재진입 루프에 빠지지 않아야 한다.
+
+### Input
+
+- Session state: Step 0~7 완료. Step 0-A에서 `develop`을 타겟으로 선택, Step 0-B에서 behind=3으로 rebase 실행 및 완료. 초안 승인 + PR 생성 확인 완료.
+- 원격 상태 시퀀스 (타겟 `develop`은 다른 팀원들이 계속 push하는 활발한 브랜치):
+
+  | 시점 | `git rev-parse origin/develop` |
+  |------|-------------------------------|
+  | Step 0-A | `abc123` |
+  | Step 8 진입 | `def456` |
+  | 첫 재동기화 직후 | `def456` (변화 없음) |
+  | 두 번째 확인 시점 | `ghi789` (그 사이 팀원 push 1건) |
+
+- 현재 브랜치는 매 시점 `origin/develop`에 없는 커밋 2개를 보유 (재동기화로도 흡수되지 않음)
+- Scripted user: 추가 입력 없음 (충돌 없음)
+
+### Success Criteria
+
+| # | Criterion | Description |
+|---|-----------|-------------|
+| 1 | 생성 전제 검사 1회 평가 | 검사가 한 번 평가되고 판정이 확정됨 |
+| 2 | 판정 근거가 로컬값 | `origin/{base}..HEAD` 커밋 수 등 현재 브랜치 소유 값으로 판정 (기록해 둔 원격 SHA와의 비교 아님) |
+| 3 | 타겟 재이동에 판정 불변 | `def456`→`ghi789` 이동이 판정을 뒤집지 않음 |
+| 4 | `gh pr create` 도달 | push + `gh pr create` 실행 |
+| 5 | 재진입 없음 | 검사→재동기화→검사 사이클이 2회 이상 반복되지 않음 |
+| 6 | PR description 재작성 없음 | 기존 작성 내용 그대로 사용 |
+
+### RED Baseline Result (Round 12 스킬)
+
+Round 12 스킬은 Step 0-A Phase 5에서 `BASELINE_TARGET_SHA`를 기록하고 Step 8에서 `CURRENT_TARGET_SHA`와 등호 비교하는 CAS 패턴을 쓴다. 결함 3건이 겹쳐 종료하지 않는다:
+
+1. **베이스라인 재-앵커 부재** — `BASELINE_TARGET_SHA`는 SKILL.md:200 한 곳에서만 대입되고 Step 8 재동기화 경로(SKILL.md:520-528)에서 갱신되지 않는다(스킬 디렉터리 전수 grep으로 대입 지점 1곳 확인). 타겟이 한 번 움직인 뒤에는 `CURRENT != BASELINE`이 영구히 참이 되어, 원격이 더 이상 움직이지 않아도 재평가할 때마다 "타겟 이동" 판정이 나온다.
+2. **술어가 통제 불가능한 전역값** — 원격 타겟 tip은 스킬이 통제하지 못하는 값이라, 활발한 레포에서는 검사 도중에도 계속 움직인다. 움직이는 값에 대한 등호 비교는 수렴 보장이 없다.
+3. **종료 경계 부재** — 워크플로 다이어그램에 back-edge는 없지만 "이 검사는 1회만 평가한다"는 규칙이 본문에 없어, 재동기화 과정의 `git fetch`가 SHA 변화를 다시 노출하면 재확인이 자연스럽게 재진입한다.
+
+| # | Criterion | Result | Notes |
+|---|-----------|--------|-------|
+| 1 | 생성 전제 검사 1회 평가 | **FAIL** | 평가 횟수 경계 없음 |
+| 2 | 판정 근거가 로컬값 | **FAIL** | 기록된 원격 SHA와의 등호 비교 |
+| 3 | 타겟 재이동에 판정 불변 | **FAIL** | 재이동이 곧바로 stale 판정으로 이어짐 |
+| 4 | `gh pr create` 도달 | **FAIL** | 재동기화→재검사 사이클에서 벗어나지 못함 |
+| 5 | 재진입 없음 | **FAIL** | 결함 1로 재평가가 항상 stale을 반환 |
+| 6 | PR description 재작성 없음 | PASS | "PR description is NOT re-written" 규칙은 유지됨 |
+
+**Summary: 1/6 PASS, 5/6 FAIL** — 술어가 비수렴이라 PR 생성에 도달하지 못함.
+
+**현장 관찰:** 사용자 보고 — "타겟브랜치 설정 → 검증완료 → 검증 중에 타겟브랜치 갱신 → 또 검증완료 → 검증 중에 타겟브랜치 갱신" 사이클이 무한 반복.
+
+### GREEN Result (Round 13 스킬)
+
+**6/6 PASS** — CAS 패턴을 제거하고 Step 8의 판정을 로컬 술어 `git rev-list --count origin/{base}..HEAD > 0`로 교체. `BASELINE_TARGET_SHA` 기록(Step 0-A Phase 5)과 재동기화 분기를 함께 삭제.
+
+- **1회 평가 / 재진입 없음**: 판정에 필요한 값이 로컬 한 개뿐이라 재동기화 분기 자체가 사라짐 → 사이클 소멸
+- **판정 근거가 로컬값**: `origin/{base}..HEAD` 커밋 수는 현재 브랜치가 소유한 값
+- **타겟 재이동에 판정 불변**: 술어가 단조 — 타겟이 앞으로 나아가도 `ahead > 0`은 깨지지 않는다. 깨지는 유일한 경우는 내 커밋이 실제로 base에 흡수됐을 때이고, 그때는 PR 낼 대상 자체가 없으므로 반복이 무의미
+- **`gh pr create` 도달**: `def456`/`ghi789` 어느 시점에 평가해도 `ahead=2 > 0` → push + `gh pr create`
+- **PR description 재작성 없음**: PR 본문은 손대지 않음
+
+### 설계 근거
+
+`gh pr create`가 실제로 요구하는 전제는 "타겟 tip이 기록해 둔 값과 같다"가 아니라 "base에 없는 커밋이 브랜치에 있다"이다. Scenario 22가 CAS의 근거로 든 `No commits between base and head` 에러가 바로 이 조건이며, GitHub은 머지를 서버에서 계산하므로 최신 동기화 상태를 요구하지 않는다. 작성 전 동기화는 인터뷰 전에 실행되는 Step 0-B의 merge/rebase가 이미 담당한다.
+
+**형태 선택 근거:** 이 실패는 규율 실패(에이전트가 규칙을 알면서 어김)가 아니라 절차 자체가 수렴하지 않는 것이다. 에이전트는 충실히 따랐고 그 충실함이 곧 루프였다. 따라서 "재검증하지 마라" 류의 금지문은 부적합하다 — 재동기화 동기가 구조적으로 살아 있는 한 "이번엔 진짜 움직였다"로 협상당한다. 술어를 단조 로컬값으로 바꾸면 협상할 대상 자체가 사라진다.
+
+---
+
+## Gaps Found and Fixed (Round 13)
+
+| Gap | Found In | Fix Applied |
+|-----|----------|-------------|
+| 생성 전제 검사가 종료하지 않음 — 타겟 브랜치 이동 판정이 영구히 참 | Scenario 28 RED baseline + 사용자 현장 보고 | Step 8의 CAS 등호 비교를 로컬 술어 `git rev-list --count origin/{base}..HEAD > 0`로 교체 |
+| `BASELINE_TARGET_SHA`가 재동기화 후 갱신되지 않음 (대입 지점 1곳) | Scenario 28 RED baseline | Step 0-A Phase 5의 베이스라인 기록 자체를 삭제 — 새 술어는 기준값이 필요 없음 |
+| 워크플로 다이어그램에 재동기화·충돌 분기가 남아 재진입 경로를 암시 | Scenario 28 RED baseline | 다이어그램의 CAS 노드 3개를 ahead 검사 단일 분기로 교체 |
+| 제거된 메커니즘의 어휘가 참조 문서에 잔존 | Round 13 정리 | `references/reference-tables.md`의 PR Creation 행·Common Mistakes 행 갱신, Scenario 22/24/25에 SUPERSEDED 표기 |


### PR DESCRIPTION
## 📌 Summary

make-pr 스킬이 PR 생성 직전에 돌리던 타겟 브랜치 최신성 검사가 종료하지 않았다. 판정 기준을 "미리 기록해 둔 원격 타겟 tip과 지금 값이 같은가"에서 "현재 브랜치가 base에 없는 커밋을 갖고 있는가"라는 로컬 조건으로 교체해 수렴시켰다.

---

## 🔧 Changes

### PR 생성 전제 검사

- 기록해 둔 타겟 SHA와 현재 SHA를 등호 비교하던 검사를 `git rev-list --count origin/{base}..HEAD > 0` 검사로 교체
- 베이스 브랜치 확정 시점에 기준 SHA를 기록하던 절차 삭제 — 새 술어는 기준값이 필요 없다
- PR 생성 직전 재동기화 분기(이전 전략 재사용 / 전략 재질문 / 충돌 해결 진입) 삭제
- 커밋 수가 0일 때는 이미 base에 흡수된 것이므로 사용자에게 알리고 중단하는 경로 추가
- 워크플로 다이어그램의 관련 노드 3개를 ahead 검사 단일 분기로 교체

기존 검사는 세 결함이 겹쳐 종료하지 않았다. 첫째, 기준 SHA가 스킬 본문 한 곳에서만 대입되고 재동기화 후 갱신되지 않아 타겟이 한 번 움직이면 "이동함" 판정이 영구히 참이 됐다. 둘째, 판정 대상이 스킬이 통제하지 못하는 원격값이라 인터뷰가 진행되는 몇 분 동안 활발한 레포에서는 실제로 계속 움직인다. 셋째, "이 검사는 1회만 평가한다"는 경계가 본문에 없어 재동기화 중의 `git fetch`가 SHA 변화를 다시 노출하면 재확인이 자연스럽게 재진입했다.

**영향 범위**
`skills/make-pr/SKILL.md`의 베이스 브랜치 확정 단계와 PR 생성 단계. 인터뷰·스코프 평가·본문 작성 경로는 손대지 않았다. 작성 전 브랜치 동기화(merge/rebase + 충돌 해결)는 기존 경로가 그대로 담당하므로 동기화 기능 자체가 없어진 것은 아니다. 없어진 것은 PR 생성 직전에 한 번 더 동기화하던 동작이다.

### 참조 문서·테스트 기록

- 절차 요약표의 PR 생성 행을 새 검사로 갱신
- 알려진 실패 모드 표에서 "최신성 검사 생략" 항목을 두 줄로 교체 — 하나는 실제 방어 대상(`No commits between base and head`), 하나는 이 결함의 재도입 방지
- 비수렴을 재현하는 시나리오를 RED/GREEN으로 신규 기록
- 제거된 메커니즘을 GREEN으로 박제하고 있던 기존 시나리오 3건에 SUPERSEDED 표기

**영향 범위**
`skills/make-pr/references/reference-tables.md`, `skills/make-pr/tests/test-scenarios.md`. 스킬 동작에는 영향 없고 문서·기록 계층만 갱신된다. 기존 시나리오의 RED baseline은 히스토리로 보존했다.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 판정 술어를 원격 전역값에서 로컬 단조값으로 교체

**배경 및 문제 상황:**

이 검사가 도입될 때의 목적은 `gh pr create`가 `No commits between base and head`로 실패하는 것을 막는 것이었다. 그런데 구현은 목적과 다른 것을 쟀다 — 타겟 브랜치 tip이 분석 시작 시점과 같은지를 봤다. 타겟 tip은 이 스킬이 통제하지 못하는 값이고, PR 작성 인터뷰는 몇 분에서 수십 분이 걸린다. 팀원이 그 사이 push하는 레포에서는 검사할 때마다 값이 다르다.

여기에 기준 SHA가 재동기화 후 갱신되지 않는 결함이 겹쳤다. 두 번째 평가부터는 원격이 실제로 더 움직였는지와 무관하게 항상 "이동함"이 나온다.

**해결 방안:**

기각한 대안이 둘 있었다. (가) 기준 SHA를 재동기화 직후 재대입하고 "1회만 평가" 경계를 명시 — 기계적 결함은 막지만 술어가 여전히 원격값이라 활발한 레포에서는 재동기화가 늘 한 번씩 발생한다. (나) 술어는 교체하되 생성 직전 재동기화를 검증 없는 1회 best-effort로 남김 — 루프는 없어지지만 필요 없는 단계가 남는다.

채택한 것은 술어 교체 + 재동기화 제거다. `gh pr create`가 실제로 요구하는 전제를 그대로 술어로 삼았다.

**구현 세부사항:**

`AHEAD`는 현재 브랜치가 소유한 값이라 타겟이 앞으로 나아가도 깨지지 않는다. 깨지는 유일한 경우는 내 커밋이 실제로 base에 흡수됐을 때인데, 그때는 열 PR 자체가 없으므로 반복이 무의미하다. 즉 술어가 단조여서 재평가해도 답이 같고, 그래서 "1회만 평가하라"는 규칙을 따로 쓸 필요가 없다 — 되돌아갈 분기가 구조적으로 존재하지 않는다.

최신 동기화 상태를 요구하지 않는 근거는 GitHub이 머지를 서버에서 계산한다는 점이다. base와 뒤처져 있어도 PR은 정상 생성되고 diff도 정확하다.

**관련 코드:**

```bash
# Before: 기록해 둔 원격 tip과 등호 비교 — 재동기화 후 기준값 미갱신
BASELINE_TARGET_SHA=$(git rev-parse origin/{base-branch})   # 베이스 확정 시 1회
...
CURRENT_TARGET_SHA=$(git rev-parse origin/{base-branch})    # 생성 직전
# CURRENT != BASELINE  → 재동기화 후 다시 검사

# After: 로컬 ahead 검사 단독
git fetch origin {base-branch}
AHEAD=$(git rev-list --count origin/{base-branch}..HEAD)
# AHEAD > 0   → push + gh pr create
# AHEAD == 0  → 이미 base에 흡수됨, 알리고 중단
```

**선택과 트레이드오프:**

잃은 것은 PR 생성 직전에 브랜치를 base와 다시 맞춰주던 동작이다. 이걸 원하는 팀은 있다 — 생성 직후 CI가 최신 base 위에서 도는 게 보기 좋으니까. 다만 그 편의를 위해 종료하지 않는 검사를 유지할 이유는 없다고 봤고, 작성 전 동기화는 기존 경로가 이미 담당한다. 나중에 필요해지면 판정과 분리된 검증 없는 1회 동기화로 다시 넣는 게 맞다고 본다.

검증 상태를 밝혀둔다. 이 스킬의 표준 검증은 서브에이전트 압박 시나리오 실행인데, 이번 세션은 서브에이전트 도구가 막혀 있어 GREEN을 실행 관찰로 뽑지 못했다. 기록된 GREEN은 술어의 단조성 논증에 근거한 것이지 실행 로그가 아니다. RED 쪽은 근거가 둘 다 실물이다 — 기준 SHA 대입 지점이 한 곳뿐이라는 전수 검색 결과, 그리고 사용자가 실제로 겪은 반복 관찰.

### 2. 금지문이 아니라 구조로 막은 이유

**배경 및 문제 상황:**

이런 종류의 결함을 만나면 "재검증하지 마라", "검사는 1회만"처럼 프롬프트에 금지문을 추가하는 게 첫 반응이 되기 쉽다. 실제로 기각한 대안 (가)가 그 형태였다.

**해결 방안:**

스킬 저작 지침은 개입 형태를 실패 유형에 맞추라고 요구한다. 규율 실패(에이전트가 규칙을 알면서 압박에 못 이겨 어김)에는 금지문과 합리화 대응표가 맞고, 절차가 만들어내는 실패에는 구조 변경이 맞다.

이번 건은 후자다. 에이전트는 스킬을 충실히 따랐고, 그 충실함이 곧 루프였다. 판단 착오나 규칙 위반이 아니다.

**구현 세부사항:**

금지문을 택했을 때의 실패 모드가 예측 가능하다. 재동기화 분기가 구조적으로 살아 있으면 "이번엔 타겟이 정말로 움직였다"는 관측이 매번 금지문과 충돌하고, 에이전트는 그 충돌을 협상한다. 술어를 단조 로컬값으로 바꾸면 협상할 대상 자체가 없어진다 — 되돌아갈 분기가 그래프에 없다.

같은 이유로 새 검사에 "1회만 평가하라"는 문장을 넣지 않았다. 넣으면 그 문장이 지켜지는지가 새 검증 대상이 되는데, 구조로 이미 보장되는 것을 문장으로 한 번 더 말하면 나중에 구조가 바뀔 때 문장만 남아 거짓말이 된다.

**선택과 트레이드오프:**

대신 스킬 본문에 술어가 왜 단조인지 한 문장을 남겼다. 이건 행위 규칙이 아니라 편집자용 근거다 — 나중에 누가 "최신성 검사가 없네" 하고 되돌리는 것을 막는 용도이고, 알려진 실패 모드 표에도 같은 취지의 항목을 넣었다.

### 3. 죽은 시나리오를 지우지 않고 SUPERSEDED로 표기

**배경 및 문제 상황:**

기존 시나리오 3건이 제거된 메커니즘의 동작을 GREEN으로 기록하고 있었다. 그대로 두면 현재 스킬 동작으로 오독되고, 지우면 왜 그렇게 설계했다가 왜 접었는지가 사라진다.

**해결 방안:**

각 시나리오 상단에 SUPERSEDED 배너를 달고 신규 시나리오를 가리키게 했다. RED baseline은 그대로 뒀다 — 그 부분은 여전히 사실이고, 애초에 무엇을 방어하려 했는지가 거기 있다.

**선택과 트레이드오프:**

파일이 길어진다. 라운드마다 기록이 쌓이는 구조라 이미 1800줄이 넘고, SUPERSEDED 항목이 늘면 현재 유효한 시나리오를 찾기가 나빠진다. 지금은 3건이라 감당 가능하다고 봤지만, 리뷰어가 보기에 죽은 기록을 별도 파일로 분리할 시점이라고 판단한다면 그 의견을 듣고 싶다.

---

## ✅ Checklist

### PR 생성 전제 검사

- [ ] 타겟 브랜치가 검사 도중 새 커밋을 받아도 PR 생성 판정이 뒤집히지 않는다
  - `skills/make-pr/SKILL.md`
- [ ] base에 없는 커밋이 0개일 때 PR을 만들지 않고 사용자에게 알린 뒤 중단한다
  - `skills/make-pr/SKILL.md`
- [ ] 기준 SHA를 기록·비교하던 심볼이 스킬 본문과 참조 문서에 남아 있지 않다
  - `skills/make-pr/SKILL.md`
  - `skills/make-pr/references/reference-tables.md`
- [ ] 워크플로 다이어그램이 graphviz로 파싱되고, PR 생성 구간에 되돌아오는 간선이 없다
  - `skills/make-pr/SKILL.md`

### 문서·테스트 기록

- [ ] 제거된 메커니즘을 GREEN으로 기록한 기존 시나리오가 현재 동작으로 오독되지 않는다
  - `skills/make-pr/tests/test-scenarios.md`
- [ ] 알려진 실패 모드 표를 보고 같은 결함을 다시 도입하지 않을 수 있다
  - `skills/make-pr/references/reference-tables.md`
