### PR TITLE
feat: ultragoal 무진전 실행 제어 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,11 +30,16 @@ bun test                                   # All TypeScript tests
 
 ### Prerequisites
 
-`bun`, `bash` (macOS 3.2 compatible), `jq`
+`bun`, `bash` (macOS 3.2 compatible), `jq`, `sqlite3`
 
 `jq` is a runtime prerequisite, not just a dev tool: the shipped hooks parse their
 payloads with it and **fail open (no guard) when it is absent**. macOS
 15+ ships it in the base system at `/usr/bin/jq`; older macOS needs it installed.
+
+`sqlite3` is a runtime prerequisite for Codex's active-ultragoal child detector. If
+the binary, state database, query, or rollout data is unavailable or malformed,
+`codex-persistent-mode` emits one diagnostic to stderr and fails open by counting
+zero active children.
 
 ## Architecture
 
@@ -131,8 +136,8 @@ skills:
 - **label-commit-gate.sh** / **codex-label-commit-gate.sh**: Hard-blocks a commit whose message subject contains an invented/opaque label
 - **label-edit-warn.sh** / **codex-label-edit-warn.sh**: Soft-warns (never blocks) when just-written content contains a bare invented/opaque label
 - **mermaid-render-gate.sh**: PostToolUse gate — renders every mermaid block of a just-written markdown file through `mmdc` (real mermaid inside headless Chromium, so layout-stage crashes surface too, not just parse errors) and blocks with the failing block located by file line number. Fails open when `mmdc` is absent (`npm i -g @mermaid-js/mermaid-cli` to enable); Claude-only, no Codex twin
-- **persistent-mode/** / **codex-persistent-mode/**: Prevents stopping when work remains incomplete (shared `makeDecision`)
-- **pre-tool-enforcer.sh** / **codex-write-guard.sh**: PreToolUse gates — TaskOutput blocking, session-ledger write guard, code-review artifact identity guard, user-only ultragoal-state command guard (`approve-review-dispatch-renewal` / `dismiss-review-finding` — both clear the loop's own completion gate, so the AI's Bash path is denied and the user runs them); Codex twin additionally denies dangerous commands (`rm -rf`, `git push --force`)
+- **persistent-mode/** / **codex-persistent-mode/**: Prevents stopping when work remains incomplete (shared `makeDecision`); for an active ultragoal, consecutive no-progress Stops increment the iteration counter, observed diff-carrying commits or story transitions reset it, background-work waits are not counted, and the cap soft-stops as `budget_limited` for user-only `resume-pursuit` recovery
+- **pre-tool-enforcer.sh** / **codex-write-guard.sh**: PreToolUse gates — TaskOutput blocking, session-ledger write guard, code-review artifact identity guard, user-only ultragoal-state command guard (`approve-review-dispatch-renewal` / `dismiss-review-finding` / `resume-pursuit` — each is user-authorized; the AI's Bash path is denied and the user runs them); Codex twin additionally denies dangerous commands (`rm -rf`, `git push --force`)
 - **review-dispatch-gate-core.sh** / **pre-tool-enforcer.sh** / **codex-review-dispatch-gate.sh**: Shared final-review dispatch budget — Claude/Codex shims atomically claim only active `phase=pursuing` `code-reviewer` dispatches; the initial five-dispatch window denies cap exhaustion or completion-eligible re-dispatch until explicit user approval renews the cap by 5.
 - **review-exec-guard.sh** / **codex-review-exec-guard.sh**: Review-context PreToolUse guards — enforce the shared static-review execution invariant for `orchestrate-review`; block tests, builds, installs, and linters only while member or conductor review context is active
 - **codex-spawn-depth-gate.sh**: Codex PreToolUse gate capping subagent spawn depth at 2 (Claude enforces the same cap natively via `claude.yaml`'s `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH`)

--- a/README.en.md
+++ b/README.en.md
@@ -69,7 +69,8 @@ The details of the library's skills (43) and agents (13) live under `docs/`.
 
 - Claude Code CLI installed
 - Node.js v18+ (for HUD functionality)
-- `jq` (hooks parse payloads with it — guards silently fail open without it)
+- `jq` (hooks parse payloads with it — guards do not block when it is unavailable)
+- `sqlite3` (the Codex detector queries the `state_5.sqlite` state database with it — when unavailable, the detector counts zero and emits one stderr diagnostic)
 - macOS or Linux
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ oh-my-toong은 **에이전트 중앙 관리 프로젝트**입니다. 스킬, 에
 
 - Claude Code CLI 설치됨
 - Node.js v18+ (HUD 기능용)
-- `jq` (훅이 페이로드 파싱에 사용 — 없으면 가드가 조용히 열림)
+- `jq` (훅이 페이로드 파싱에 사용 — 없으면 가드가 차단하지 않음)
+- `sqlite3` (Codex detector가 `state_5.sqlite` 상태 데이터베이스를 조회하는 데 사용 — 없으면 detector가 0건을 세고 stderr에 진단 1건을 출력)
 - macOS 또는 Linux
 
 ### 설정

--- a/docs/ORCHESTRATION.en.md
+++ b/docs/ORCHESTRATION.en.md
@@ -105,6 +105,12 @@ flowchart TD
 - **Role**: Executes plan stories sequentially
 - **Workflow**: Dispatches each story to `/sisyphus` in sequence and starts the next story only after the previous one completes
 
+#### Iteration budget, no-progress, and resume
+
+- During pursuit, `iteration` counts consecutive Stops with no observed progress. A diff-carrying commit or Story status transition resets it to `0`; Stops that wait for background work are not counted.
+- Reaching `max_iterations` (default 10) soft-stops without dispatching new work as non-complete `budget_limited`, preserving state. After in-flight work drains and the completion gate is checked, only the user may run `resume-pursuit` to restore `pursuing` with `iteration=0`.
+- `blocked` is separate: it is reported only for B1 (no actionable incomplete work) or when the configured `blocked-stop` predicate is met.
+
 ### sisyphus (The Orchestrator)
 
 - **Role**: Execution and delegation
@@ -158,6 +164,8 @@ With a plan ready, `/ultragoal` sequentially dispatches its stories to `/sisyphu
 5. **Commit**: on APPROVE/COMMENT, mnemosyne is dispatched to commit that task's changes
 6. **Iteration**: Continues until all stories and tasks pass review
 
+`ultragoal`'s `iteration` counts consecutive no-progress Stops and resets to 0 on a diff-carrying commit or Story status transition; waiting for background work does not consume it. At `max_iterations` (default 10), it soft-stops as non-complete `budget_limited`, preserves state, and dispatches no new work. After in-flight work drains and the completion gate is checked, only the user-run `resume-pursuit` restores `pursuing` at iteration 0. `blocked` is separate and occurs only for B1 (no actionable incomplete work) or the configured `blocked-stop` predicate.
+
 ---
 
 ## 5. Commands
@@ -203,7 +211,7 @@ Contain all TODOs in one plan file. This prevents context fragmentation and make
 | Problem | Solution |
 |---------|----------|
 | Prometheus keeps interviewing | It needs more context. Answer thoroughly or say "generate plan now". |
-| Sisyphus won't stop | This is by design. It persists until verification passes. |
+| Sisyphus won't stop | This is by design. ultragoal counts consecutive no-progress Stops and may soft-stop as `budget_limited` at `max_iterations` (default 10), preserving state. |
 | Inline verify keeps failing | Review the feedback carefully. The issues are real. |
 
 ---

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -105,6 +105,12 @@ flowchart TD
 - **역할**: 계획의 스토리를 순서대로 실행
 - **워크플로우**: 각 스토리를 `/sisyphus`에 순차적으로 전달하고, 이전 스토리가 끝난 뒤 다음 스토리를 시작
 
+#### 반복 예산·진전 없음·재개
+
+- pursuit 중 `iteration`은 진전이 관찰되지 않은 Stop의 연속 횟수입니다. diff를 포함한 커밋이나 Story 상태 전환이 발생하면 `0`으로 리셋되며, 백그라운드 작업을 기다리는 Stop은 집계하지 않습니다.
+- `max_iterations`(기본 10)에 도달하면 새 작업을 디스패치하지 않고 상태를 보존한 비완료 `budget_limited`로 소프트 정지합니다. 진행 중 작업을 비운 뒤 completion gate를 확인하고, 사용자만 `resume-pursuit`를 실행해 `pursuing`과 `iteration=0`을 복원할 수 있습니다.
+- `blocked`는 별도 경로입니다. 실행 가능한 미완료 항목이 없는 B1이거나 설정한 `blocked-stop` 조건이 충족될 때만 보고합니다.
+
 ### sisyphus (오케스트레이터)
 
 - **역할**: 실행과 위임
@@ -158,6 +164,8 @@ flowchart TD
 5. **커밋**: APPROVE/COMMENT가 나오면 mnemosyne을 디스패치해 해당 태스크의 변경을 커밋
 6. **반복**: 모든 스토리와 태스크가 리뷰를 통과할 때까지 계속
 
+`ultragoal`의 `iteration`은 진전 없는 Stop의 연속 횟수이며, diff-carrying commit 또는 Story 상태 전환에서 0으로 돌아갑니다. 백그라운드 작업 대기는 소비하지 않습니다. `max_iterations`(기본 10)에 도달하면 상태를 보존한 비완료 `budget_limited`로 소프트 정지하고 새 작업을 디스패치하지 않습니다. 진행 중 작업과 completion gate를 확인한 뒤 사용자만 `resume-pursuit`로 `pursuing` 및 iteration 0을 복원합니다. `blocked`는 B1(실행 가능한 미완료 항목 없음) 또는 설정한 `blocked-stop`일 때만 별도로 발생합니다.
+
 ---
 
 ## 5. 명령어
@@ -203,7 +211,7 @@ prometheus 도중 요구사항을 반복적으로 명확히 해야 한다면, �
 | 문제 | 해결책 |
 |------|--------|
 | Prometheus가 계속 인터뷰함 | 더 많은 컨텍스트가 필요합니다. 자세히 답하거나 "지금 계획을 생성해"라고 말하세요. |
-| Sisyphus가 멈추지 않음 | 설계된 대로입니다. 검증 통과까지 지속됩니다. |
+| Sisyphus가 멈추지 않음 | 설계된 대로입니다. ultragoal은 진전 없는 Stop을 `iteration`으로 세고, `max_iterations`(기본 10)에서 `budget_limited`로 상태를 보존한 채 소프트 정지할 수 있습니다. |
 | 인라인 검증이 계속 실패함 | 피드백을 주의 깊게 검토하세요. 이슈는 실제입니다. |
 
 ---

--- a/docs/skills/core-pipeline.en.md
+++ b/docs/skills/core-pipeline.en.md
@@ -185,6 +185,10 @@ flowchart TB
 
 **Dismissing a wrong blocking finding**: the only exit when a blocking finding is wrong. The AI proposes a dismissal only when it can quote the source line that makes the finding's failure scenario unreachable; on explicit user approval the USER runs `dismiss-review-finding --ref <file:line> --class <correctness|requirement-gap> --rationale <refutation>`. One dismissal removes one finding from the blocking set, pinned to that artifact's raw bytes so it does not carry into the next review round.
 
+### ultragoal iteration budget, no-progress, and resume
+
+`ultragoal` pursuit `iteration` counts consecutive Stops with no observed progress. A diff-carrying commit or Story status transition resets it to `0`; Stops waiting for background work do not consume it. At `max_iterations` (default 10), pursuit soft-stops as non-complete `budget_limited`, preserves state, and dispatches no new work. After in-flight work drains and the completion gate is checked, only the user-run `resume-pursuit` restores `pursuing` at iteration 0. `blocked` is separate and occurs only for B1 (no actionable incomplete work) or the configured `blocked-stop` predicate.
+
 ---
 
 ## 6. Supporting Skills

--- a/docs/skills/core-pipeline.md
+++ b/docs/skills/core-pipeline.md
@@ -185,6 +185,10 @@ flowchart TB
 
 **잘못된 차단 finding 무효화**: 차단 finding이 틀렸을 때의 유일한 탈출구입니다. AI는 그 finding을 무력화하는 소스 줄을 인용할 수 있을 때만 무효화를 제안하고, 사용자가 승인하면 사용자가 직접 `dismiss-review-finding --ref <file:line> --class <correctness|requirement-gap> --rationale <근거>`를 실행합니다. 한 번에 finding 하나만 차단 집합에서 빠지며, 무효화는 해당 artifact의 raw 바이트에 고정되어 다음 리뷰 라운드에는 이월되지 않습니다.
 
+### ultragoal 반복 예산·진전 없음·재개
+
+`ultragoal` pursuit의 `iteration`은 진전이 관찰되지 않은 Stop의 연속 횟수입니다. diff를 포함한 커밋이나 Story 상태 전환은 카운터를 `0`으로 리셋하고, 백그라운드 작업을 기다리는 Stop은 소비하지 않습니다. `max_iterations`(기본 10)에 도달하면 새 작업 없이 상태를 보존한 비완료 `budget_limited`로 소프트 정지합니다. 진행 중 작업을 비우고 completion gate를 확인한 뒤 사용자만 `resume-pursuit`를 실행해 `pursuing`과 iteration 0을 복원합니다. `blocked`는 별도이며 B1(실행 가능한 미완료 항목 없음) 또는 설정한 `blocked-stop` 조건에서만 발생합니다.
+
 ---
 
 ## 6. 보조 스킬

--- a/hooks/codex-persistent-mode/cli.test.ts
+++ b/hooks/codex-persistent-mode/cli.test.ts
@@ -20,9 +20,11 @@ import {
 	readFileSync,
 	existsSync,
 	readdirSync,
+	utimesSync,
+	chmodSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 
 const CLI_PATH = join(import.meta.dirname, "cli.ts");
 
@@ -64,16 +66,42 @@ function stopPayload(sessionId: string, cwd: string, lastAssistantMessage?: stri
 	return payload;
 }
 
+function writeUltragoalState(omtDir: string, sid: string, iteration = 0): void {
+	writeFileSync(
+		join(omtDir, `ultragoal-state-${sid}.json`),
+		JSON.stringify({
+			active: true,
+			phase: "pursuing",
+			iteration,
+			max_iterations: 20,
+			objective_verdict: "absent",
+		}),
+	);
+}
+
+function makeChildDb(home: string, sid: string, rollout: string): void {
+	mkdirSync(home, { recursive: true });
+	const db = join(home, "state_5.sqlite");
+	const sql = [
+		"CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT);",
+		"CREATE TABLE thread_spawn_edges (parent_thread_id TEXT, child_thread_id TEXT, status TEXT);",
+		`INSERT INTO threads VALUES ('child-1', '${rollout}');`,
+		`INSERT INTO thread_spawn_edges VALUES ('${sid}', 'child-1', 'open');`,
+	].join(" ");
+	expect(Bun.spawnSync(["sqlite3", db, sql]).exitCode).toBe(0);
+}
+
 async function runCli(
 	subcommand: "post-tool-use" | "stop",
 	input: unknown,
 	omtDir: string,
+	extraEnv: Record<string, string> = {},
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
 	const proc = Bun.spawn(["bun", "run", CLI_PATH, "hook", subcommand], {
 		stdin: new TextEncoder().encode(JSON.stringify(input)),
 		stdout: "pipe",
 		stderr: "pipe",
-		env: { ...process.env, OMT_DIR: omtDir },
+		env: { ...process.env, OMT_DIR: omtDir, ...extraEnv },
 	});
 	const exitCode = await proc.exited;
 	const stdout = await new Response(proc.stdout).text();
@@ -177,7 +205,10 @@ describe("codex-persistent-mode cli", () => {
 					stderr: "",
 				});
 				const written = JSON.parse(readFileSync(mirrorPath(omtDir, c.sid), "utf8"));
-				expect({ sid: c.sid, written }).toEqual({ sid: c.sid, written: { incomplete: c.expected } });
+				expect({ sid: c.sid, written }).toEqual({
+					sid: c.sid,
+					written: { incomplete: c.expected },
+				});
 			}
 		});
 	});
@@ -540,7 +571,9 @@ describe("codex-persistent-mode cli", () => {
 					omtDir,
 				);
 				expect(exitCode).toBe(0);
-				expect(JSON.parse(readFileSync(mirrorPath(omtDir, sid), "utf8"))).toEqual({ incomplete: 1 });
+				expect(JSON.parse(readFileSync(mirrorPath(omtDir, sid), "utf8"))).toEqual({
+					incomplete: 1,
+				});
 			}
 
 			// tool_response field absent entirely (not merely null).
@@ -551,7 +584,9 @@ describe("codex-persistent-mode cli", () => {
 			delete (payloadAbsent as Record<string, unknown>)["tool_response"];
 			const { exitCode: exitCodeAbsent } = await runCli("post-tool-use", payloadAbsent, omtDir);
 			expect(exitCodeAbsent).toBe(0);
-			expect(JSON.parse(readFileSync(mirrorPath(omtDir, sidAbsent), "utf8"))).toEqual({ incomplete: 1 });
+			expect(JSON.parse(readFileSync(mirrorPath(omtDir, sidAbsent), "utf8"))).toEqual({
+				incomplete: 1,
+			});
 		});
 
 		test("arm 6 (failure-predicate axis): isError/error-string/status=error each block the write", async () => {
@@ -604,7 +639,10 @@ describe("codex-persistent-mode cli", () => {
 			const sid = "sid-chain-stop-allow";
 			writeFileSync(
 				mirrorPath(omtDir, sid),
-				JSON.stringify({ openedSkills: ["chain-alpha", "chain-bravo"], expectedSkills: ["chain-bravo"] }),
+				JSON.stringify({
+					openedSkills: ["chain-alpha", "chain-bravo"],
+					expectedSkills: ["chain-bravo"],
+				}),
 			);
 			const { exitCode, stdout } = await runCli("stop", stopPayload(sid, projectDir), omtDir);
 			expect(exitCode).toBe(0);
@@ -649,6 +687,255 @@ describe("codex-persistent-mode cli", () => {
 	});
 
 	describe("hook stop (reader, G6-1 / G6-3)", () => {
+		test("active pursuing ultragoal child keeps stop blocked", async () => {
+			const sid = "sid-child-live";
+			const codexHome = join(projectDir, "codex-home");
+			mkdirSync(codexHome, { recursive: true });
+			const rollout = join(codexHome, "child.jsonl");
+			writeFileSync(
+				rollout,
+				JSON.stringify({ type: "event_msg", payload: { type: "task_started" } }) + "\n",
+			);
+			const db = join(codexHome, "state_5.sqlite");
+			const sql = [
+				"CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT);",
+				"CREATE TABLE thread_spawn_edges (parent_thread_id TEXT, child_thread_id TEXT, status TEXT);",
+				`INSERT INTO threads VALUES ('child-1', '${rollout}');`,
+				`INSERT INTO thread_spawn_edges VALUES ('${sid}', 'child-1', 'open');`,
+			].join(" ");
+			const created = Bun.spawnSync(["sqlite3", db, sql]);
+			expect(created.exitCode).toBe(0);
+			writeFileSync(
+				join(omtDir, `ultragoal-state-${sid}.json`),
+				JSON.stringify({
+					active: true,
+					phase: "pursuing",
+					iteration: 0,
+					max_iterations: 10,
+					objective_verdict: "absent",
+				}),
+			);
+			const result = await runCli("stop", stopPayload(sid, projectDir), omtDir, {
+				CODEX_HOME: codexHome,
+			});
+			expect(result.exitCode).toBe(0);
+			expect(JSON.parse(result.stdout).decision).toBe("block");
+			expect(result.stdout).toContain("[ULTRAGOAL - WAITING ON BACKGROUND WORK]");
+			expect(
+				JSON.parse(readFileSync(join(omtDir, `ultragoal-state-${sid}.json`), "utf8")).iteration,
+			).toBe(0);
+		});
+
+		test("lifecycle and stale truth table counts only a live last task_started", async () => {
+			const cases = [
+				["live", ["task_started"], false],
+				["finished", ["task_started", "task_complete"], false],
+				["aborted", ["task_started", "turn_aborted"], false],
+				["open-only", ["other"], false],
+				["stale", ["task_started"], true],
+			] as const;
+			for (const [name, markers, stale] of cases) {
+				const sid = `sid-${name}`;
+				const home = join(projectDir, name);
+				const rollout = join(home, "child.jsonl");
+				mkdirSync(home, { recursive: true });
+				writeFileSync(
+					rollout,
+					markers
+						.map((type) => JSON.stringify({ type: "event_msg", payload: { type } }))
+						.join("\n") + "\n",
+				);
+				if (stale) {
+					const old = new Date(Date.now() - 1901 * 1000);
+					utimesSync(rollout, old, old);
+				}
+				makeChildDb(home, sid, rollout);
+				writeUltragoalState(omtDir, sid);
+				const result = await runCli("stop", stopPayload(sid, projectDir), omtDir, {
+					CODEX_HOME: home,
+				});
+				expect(result.exitCode).toBe(0);
+				expect(result.stderr).toBe("");
+				expect(
+					JSON.parse(readFileSync(join(omtDir, `ultragoal-state-${sid}.json`), "utf8")).iteration,
+				).toBe(name === "live" ? 0 : 1);
+			}
+		});
+
+		test("ten sequential live-child Stops preserve pursuit iteration", async () => {
+			const sid = "sid-ten-live";
+			const home = join(projectDir, "ten");
+			const rollout = join(home, "child.jsonl");
+			mkdirSync(home, { recursive: true });
+			writeFileSync(
+				rollout,
+				JSON.stringify({ type: "event_msg", payload: { type: "task_started" } }) + "\n",
+			);
+			makeChildDb(home, sid, rollout);
+			writeUltragoalState(omtDir, sid);
+			for (let i = 0; i < 10; i++) {
+				await runCli("stop", stopPayload(sid, projectDir), omtDir, { CODEX_HOME: home });
+				const state = JSON.parse(readFileSync(join(omtDir, `ultragoal-state-${sid}.json`), "utf8"));
+				expect(state.iteration).toBe(0);
+				expect(state.phase).toBe("pursuing");
+			}
+		});
+
+		test("inactive or planning ultragoal skips detector entirely", async () => {
+			for (const [name, state] of [
+				["absent", undefined],
+				["inactive", { active: false, phase: "complete", iteration: 0, max_iterations: 20 }],
+				["planning", { active: true, phase: "planning", iteration: 0, max_iterations: 20 }],
+			] as const) {
+				const sid = `sid-gate-${name}`;
+				const home = join(projectDir, name);
+				mkdirSync(home, { recursive: true });
+				if (state)
+					writeFileSync(join(omtDir, `ultragoal-state-${sid}.json`), JSON.stringify(state));
+				const result = await runCli("stop", stopPayload(sid, projectDir), omtDir, {
+					CODEX_HOME: home,
+				});
+				expect(result.exitCode).toBe(0);
+				expect(result.stderr).toBe("");
+			}
+		});
+
+		test("detector failures fail open with exactly one diagnostic", async () => {
+			const cases = [
+				["missing-db", "missing-db", "none"],
+				["malformed-sqlite", "malformed-sqlite", "db"],
+				["malformed-json", "malformed-json", "{broken"],
+				["scalar-json", "scalar-json", "42"],
+				["unreadable-rollout", "unreadable-rollout", undefined],
+			] as const;
+			for (const [name, dirName, content] of cases) {
+				const sid = `sid-failure-${name}`;
+				const home = join(projectDir, dirName);
+				mkdirSync(home, { recursive: true });
+				if (name === "malformed-sqlite") {
+					writeFileSync(join(home, "state_5.sqlite"), "not sqlite");
+				} else if (name !== "missing-db") {
+					const rollout = join(home, "child.jsonl");
+					if (content !== undefined) writeFileSync(rollout, content);
+					else writeFileSync(rollout, "");
+					makeChildDb(home, sid, rollout);
+					if (name === "unreadable-rollout") chmodSync(rollout, 0o000);
+				}
+				writeUltragoalState(omtDir, sid);
+				const result = await runCli("stop", stopPayload(sid, projectDir), omtDir, {
+					CODEX_HOME: home,
+				});
+				expect(result.exitCode).toBe(0);
+				expect(
+					JSON.parse(readFileSync(join(omtDir, `ultragoal-state-${sid}.json`), "utf8")).iteration,
+				).toBe(1);
+				expect(
+					result.stderr
+						.split("\n")
+						.filter((line) => line.includes("codex-persistent-mode: child detector failed")).length,
+				).toBe(1);
+			}
+		});
+
+		test("bounded rollout tail uses the final complete in-tail marker", async () => {
+			const sid = "sid-tail-bound";
+			const home = join(projectDir, "tail");
+			const rollout = join(home, "child.jsonl");
+			mkdirSync(home, { recursive: true });
+			const prefix =
+				JSON.stringify({ type: "event_msg", payload: { type: "task_started" } }) +
+				"\n" +
+				"x".repeat(70000);
+			writeFileSync(
+				rollout,
+				prefix +
+					"\n" +
+					JSON.stringify({ type: "event_msg", payload: { type: "task_complete" } }) +
+					"\n",
+			);
+			makeChildDb(home, sid, rollout);
+			writeUltragoalState(omtDir, sid);
+			const result = await runCli("stop", stopPayload(sid, projectDir), omtDir, {
+				CODEX_HOME: home,
+			});
+			expect(result.exitCode).toBe(0);
+			expect(result.stderr).toBe("");
+			expect(
+				JSON.parse(readFileSync(join(omtDir, `ultragoal-state-${sid}.json`), "utf8")).iteration,
+			).toBe(1);
+		});
+
+		test("missing sqlite binary fails open with one diagnostic", async () => {
+			const sid = "sid-no-sqlite";
+			const home = join(projectDir, "no-sqlite");
+			mkdirSync(home, { recursive: true });
+			writeUltragoalState(omtDir, sid);
+			const pathWithoutSqlite = join(dirname(process.execPath), ":/bin");
+			const result = await runCli("stop", stopPayload(sid, projectDir), omtDir, {
+				CODEX_HOME: home,
+				PATH: pathWithoutSqlite,
+			});
+			expect(result.exitCode).toBe(0);
+			expect(
+				JSON.parse(readFileSync(join(omtDir, `ultragoal-state-${sid}.json`), "utf8")).iteration,
+			).toBe(1);
+			expect(
+				result.stderr
+					.split("\n")
+					.filter((line) => line.includes("codex-persistent-mode: child detector failed")).length,
+			).toBe(1);
+		});
+
+		test("sqlite invocation includes -readonly", async () => {
+			const sid = "sid-readonly-argv";
+			const home = join(projectDir, "argv");
+			const bin = join(home, "bin");
+			mkdirSync(bin, { recursive: true });
+			const real = Bun.spawnSync(["sh", "-c", "command -v sqlite3"], { stdout: "pipe" })
+				.stdout.toString()
+				.trim();
+			const log = join(home, "argv.log");
+			const shim = join(bin, "sqlite3");
+			writeFileSync(shim, `#!/bin/sh\nprintf '%s\\n' "$@" > '${log}'\nexec '${real}' "$@"\n`);
+			chmodSync(shim, 0o755);
+			const rollout = join(home, "child.jsonl");
+			writeFileSync(
+				rollout,
+				JSON.stringify({ type: "event_msg", payload: { type: "task_complete" } }) + "\n",
+			);
+			makeChildDb(home, sid, rollout);
+			writeUltragoalState(omtDir, sid);
+			const result = await runCli("stop", stopPayload(sid, projectDir), omtDir, {
+				CODEX_HOME: home,
+				PATH: `${bin}:${dirname(process.execPath)}:/bin:/usr/bin`,
+			});
+			expect(result.exitCode).toBe(0);
+			expect(readFileSync(log, "utf8").split("\n")).toContain("-readonly");
+		});
+
+		test("malformed sqlite output row fails open once", async () => {
+			const sid = "sid-bad-sql-output";
+			const home = join(projectDir, "bad-output");
+			const bin = join(home, "bin");
+			mkdirSync(bin, { recursive: true });
+			const shim = join(bin, "sqlite3");
+			writeFileSync(shim, "#!/bin/sh\nprintf '%s\\n' 'too|many|fields'\n");
+			chmodSync(shim, 0o755);
+			writeUltragoalState(omtDir, sid);
+			const result = await runCli("stop", stopPayload(sid, projectDir), omtDir, {
+				CODEX_HOME: home,
+				PATH: `${bin}:${dirname(process.execPath)}:/bin:/usr/bin`,
+			});
+			expect(result.exitCode).toBe(0);
+			expect(
+				JSON.parse(readFileSync(join(omtDir, `ultragoal-state-${sid}.json`), "utf8")).iteration,
+			).toBe(1);
+			expect(
+				result.stderr
+					.split("\n")
+					.filter((line) => line.includes("codex-persistent-mode: child detector failed")).length,
+			).toBe(1);
+		});
 		test("G6-1: incomplete:2 blocks with a non-empty reason naming the count", async () => {
 			const sid = "sid-block-1";
 			writeFileSync(mirrorPath(omtDir, sid), JSON.stringify({ incomplete: 2 }));
@@ -766,7 +1053,9 @@ describe("codex-persistent-mode cli", () => {
 						// refused while zero non-goals carry a non-empty decider, so the
 						// allow-stop path requires at least one recorded decider — mirrors
 						// decision.test.ts UC13 "cleans up when … non-empty decider".
-						non_goals: [{ item: "out-of-scope thing", decider: "user confirmed out of scope in round 2" }],
+						non_goals: [
+							{ item: "out-of-scope thing", decider: "user confirmed out of scope in round 2" },
+						],
 					},
 				}),
 			);

--- a/hooks/codex-persistent-mode/cli.test.ts
+++ b/hooks/codex-persistent-mode/cli.test.ts
@@ -694,7 +694,9 @@ describe("codex-persistent-mode cli", () => {
 			const rollout = join(codexHome, "child.jsonl");
 			writeFileSync(
 				rollout,
-				JSON.stringify({ type: "event_msg", payload: { type: "task_started" } }) + "\n",
+				JSON.stringify({ type: "event_msg", payload: { type: "task_started" } }) +
+					"\n" +
+					'{"type":"event_msg","payload":{"type":"task_started"',
 			);
 			const db = join(codexHome, "state_5.sqlite");
 			const sql = [
@@ -804,7 +806,7 @@ describe("codex-persistent-mode cli", () => {
 			const cases = [
 				["missing-db", "missing-db", "none"],
 				["malformed-sqlite", "malformed-sqlite", "db"],
-				["malformed-json", "malformed-json", "{broken"],
+				["malformed-json", "malformed-json", "{broken\n"],
 				["scalar-json", "scalar-json", "42"],
 				["unreadable-rollout", "unreadable-rollout", undefined],
 			] as const;

--- a/hooks/codex-persistent-mode/cli.test.ts
+++ b/hooks/codex-persistent-mode/cli.test.ts
@@ -726,7 +726,7 @@ describe("codex-persistent-mode cli", () => {
 			).toBe(0);
 		});
 
-		test("lifecycle and stale truth table counts only a live last task_started", async () => {
+		test("detector lifecycle and stale truth table counts only a live last task_started", async () => {
 			const cases = [
 				["live", ["task_started"], false],
 				["finished", ["task_started", "task_complete"], false],

--- a/hooks/codex-persistent-mode/cli.test.ts
+++ b/hooks/codex-persistent-mode/cli.test.ts
@@ -687,7 +687,7 @@ describe("codex-persistent-mode cli", () => {
 	});
 
 	describe("hook stop (reader, G6-1 / G6-3)", () => {
-		test("active pursuing ultragoal child keeps stop blocked", async () => {
+		test("live child blocks without consuming", async () => {
 			const sid = "sid-child-live";
 			const codexHome = join(projectDir, "codex-home");
 			mkdirSync(codexHome, { recursive: true });
@@ -762,7 +762,7 @@ describe("codex-persistent-mode cli", () => {
 			}
 		});
 
-		test("ten sequential live-child Stops preserve pursuit iteration", async () => {
+		test("waiting-only stop chain does not exhaust budget", async () => {
 			const sid = "sid-ten-live";
 			const home = join(projectDir, "ten");
 			const rollout = join(home, "child.jsonl");
@@ -800,7 +800,7 @@ describe("codex-persistent-mode cli", () => {
 			}
 		});
 
-		test("detector failures fail open with exactly one diagnostic", async () => {
+		test("fail-open emits stderr diagnostic", async () => {
 			const cases = [
 				["missing-db", "missing-db", "none"],
 				["malformed-sqlite", "malformed-sqlite", "db"],

--- a/hooks/codex-persistent-mode/cli.test.ts
+++ b/hooks/codex-persistent-mode/cli.test.ts
@@ -867,6 +867,30 @@ describe("codex-persistent-mode cli", () => {
 			).toBe(1);
 		});
 
+		test("fresh oversized open rollout with no terminal marker in tail blocks without consuming", async () => {
+			const sid = "sid-tail-fresh-open";
+			const home = join(projectDir, "tail-fresh-open");
+			const rollout = join(home, "child.jsonl");
+			mkdirSync(home, { recursive: true });
+			const started = JSON.stringify({ type: "event_msg", payload: { type: "task_started" } });
+			const filler = JSON.stringify({ type: "event_msg", payload: { type: "other" } }) + "\n";
+			const fillerLines = Math.ceil((64 * 1024) / filler.length) + 1;
+			writeFileSync(rollout, started + "\n" + filler.repeat(fillerLines));
+			makeChildDb(home, sid, rollout);
+			writeUltragoalState(omtDir, sid);
+
+			const result = await runCli("stop", stopPayload(sid, projectDir), omtDir, {
+				CODEX_HOME: home,
+			});
+			expect(result.exitCode).toBe(0);
+			expect(result.stderr).toBe("");
+			expect(JSON.parse(result.stdout).decision).toBe("block");
+			expect(result.stdout).toContain("[ULTRAGOAL - WAITING ON BACKGROUND WORK]");
+			expect(
+				JSON.parse(readFileSync(join(omtDir, `ultragoal-state-${sid}.json`), "utf8")).iteration,
+			).toBe(0);
+		});
+
 		test("missing sqlite binary fails open with one diagnostic", async () => {
 			const sid = "sid-no-sqlite";
 			const home = join(projectDir, "no-sqlite");

--- a/hooks/codex-persistent-mode/cli.ts
+++ b/hooks/codex-persistent-mode/cli.ts
@@ -343,7 +343,8 @@ function detectActiveCodexChildren(sessionId: string): number {
 			const fields = line.split("|");
 			if (fields.length !== 2 || !fields[0] || !fields[1]) return fail("malformed sqlite output");
 			const rolloutPath = fields[1];
-			const ageSeconds = (Date.now() - statSync(rolloutPath).mtimeMs) / 1000;
+			const rolloutStat = statSync(rolloutPath);
+			const ageSeconds = (Date.now() - rolloutStat.mtimeMs) / 1000;
 			if (ageSeconds > CODEX_CHILD_STALE_TTL_SECONDS) continue;
 			const content = readRolloutTail(rolloutPath);
 			let lastMarker: string | undefined;
@@ -364,7 +365,15 @@ function detectActiveCodexChildren(sessionId: string): number {
 					lastMarker = marker;
 				}
 			}
-			if (lastMarker === "task_started") count++;
+			if (
+				lastMarker === "task_started" ||
+				(lastMarker === undefined && rolloutStat.size > ROLLOUT_TAIL_BYTES)
+			) {
+				// A fresh open rollout may have its initial task_started marker before
+				// the bounded tail. Without a retained terminal marker, conservatively
+				// treat that child as active; terminal markers in the tail still win.
+				count++;
+			}
 		}
 		return count;
 	} catch (error) {

--- a/hooks/codex-persistent-mode/cli.ts
+++ b/hooks/codex-persistent-mode/cli.ts
@@ -43,13 +43,23 @@
  * rationale on the mirror file itself.
  */
 
-import { mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import {
+	mkdirSync,
+	readFileSync,
+	writeFileSync,
+	existsSync,
+	statSync,
+	openSync,
+	readSync,
+	closeSync,
+} from "node:fs";
 import { stdin as processStdin } from "node:process";
 import { join, dirname, basename, resolve, isAbsolute } from "node:path";
 
 import { isSafeSessionId } from "@lib/state-core";
 import { resolveOmtDir } from "@lib/omt-dir";
 import { makeDecision, DecisionContext } from "@lib/persistent-mode-core/decision";
+import { readUltragoalStateRaw } from "@lib/persistent-mode-core/state";
 import { isFailedToolResponse } from "@lib/tool-response";
 
 // Declared before the top-level dispatch below (not after): this module uses
@@ -57,6 +67,8 @@ import { isFailedToolResponse } from "@lib/tool-response";
 // textually positioned after the dispatch block would still be uninitialized
 // (TDZ) when a handler invoked from within that same await resolves.
 const COMMAND_TOOL_NAMES = new Set(["bash", "shell_command", "exec_command"]);
+const CODEX_CHILD_STALE_TTL_SECONDS = 1800;
+const ROLLOUT_TAIL_BYTES = 64 * 1024;
 
 const command = process.argv[2];
 const subcommand = process.argv[3];
@@ -189,7 +201,11 @@ function recordSkillChain(input: Record<string, unknown>, sessionId: string): vo
 
 	writeFileSync(
 		path,
-		JSON.stringify({ ...mirror, openedSkills: [...openedSkills], expectedSkills: [...expectedSkills] }),
+		JSON.stringify({
+			...mirror,
+			openedSkills: [...openedSkills],
+			expectedSkills: [...expectedSkills],
+		}),
 	);
 }
 
@@ -246,6 +262,11 @@ function runStop(input: Record<string, unknown>): void {
 	// (codex-rs/hooks/schema/generated/stop.command.input.schema.json의 required 필드, StopCommandInput).
 	// Stop/SubagentStop 이벤트만 이 필드를 실음. 부재 시 null fail-open(토큰 미발화).
 	const lam = input["last_assistant_message"];
+	const ultragoalState = readUltragoalStateRaw(sessionId);
+	const activeBackgroundTaskCount =
+		ultragoalState?.active === true && ultragoalState.phase === "pursuing"
+			? detectActiveCodexChildren(sessionId)
+			: 0;
 	const context: DecisionContext = {
 		sessionId,
 		lastAssistantMessage: typeof lam === "string" ? lam : null,
@@ -255,7 +276,8 @@ function runStop(input: Record<string, unknown>): void {
 		// is queued as context with trigger_turn:false, so it has no guaranteed wake/re-invocation.
 		// Shared invariant: Stop may bypass only if deferred re-invocation is guaranteed;
 		// Codex lacks that guarantee, so keep no background-task bypass.
-		activeBackgroundTaskCount: 0,
+		activeBackgroundTaskCount,
+		deferredStopWakeGuaranteed: false,
 		pendingSkillChainSkills,
 		// Codex's real AskUserQuestion analog (rewrite rule 14 in
 		// tools/lib/rewrite-rules.ts) — see DecisionContext.askToolName's doc
@@ -284,6 +306,78 @@ function countIncomplete(toolInput: unknown): number {
 		if (!isRecord(entry) || entry["status"] !== "completed") count++;
 	}
 	return count;
+}
+
+/**
+ * Reads Codex's private state DB only for an active ultragoal pursuit. The
+ * detector is deliberately fail-open: any unavailable/malformed input emits
+ * one diagnostic and contributes zero active children.
+ */
+function detectActiveCodexChildren(sessionId: string): number {
+	const fail = (reason: string): number => {
+		process.stderr.write(`codex-persistent-mode: child detector failed (${reason})\n`);
+		return 0;
+	};
+	try {
+		const which = Bun.spawnSync(["sh", "-c", "command -v sqlite3"], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		if (which.exitCode !== 0) return fail("sqlite3 unavailable");
+		const codexHome = process.env.CODEX_HOME || join(process.env.HOME || "", ".codex");
+		const dbPath = join(codexHome, "state_5.sqlite");
+		if (!existsSync(dbPath)) return fail("state database unavailable");
+		const escapedSession = sessionId.replace(/'/g, "''");
+		const query =
+			"SELECT t.id, t.rollout_path FROM thread_spawn_edges e JOIN threads t ON t.id=e.child_thread_id " +
+			`WHERE e.parent_thread_id='${escapedSession}' AND e.status='open';`;
+		const result = Bun.spawnSync(["sqlite3", "-readonly", "-separator", "|", dbPath, query], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		if (result.exitCode !== 0) return fail("sqlite query failed");
+		const output = new TextDecoder().decode(result.stdout).trim();
+		if (!output) return 0;
+		let count = 0;
+		for (const line of output.split("\n")) {
+			const fields = line.split("|");
+			if (fields.length !== 2 || !fields[0] || !fields[1]) return fail("malformed sqlite output");
+			const rolloutPath = fields[1];
+			const ageSeconds = (Date.now() - statSync(rolloutPath).mtimeMs) / 1000;
+			if (ageSeconds > CODEX_CHILD_STALE_TTL_SECONDS) continue;
+			const content = readRolloutTail(rolloutPath);
+			let lastMarker: string | undefined;
+			for (const rawLine of content.split("\n")) {
+				if (!rawLine.trim()) continue;
+				const event: unknown = JSON.parse(rawLine);
+				if (!isRecord(event)) return fail("unreadable or malformed rollout");
+				const payload = event["payload"];
+				const marker = isRecord(payload) ? payload["type"] : undefined;
+				if (marker === "task_started" || marker === "task_complete" || marker === "turn_aborted") {
+					lastMarker = marker;
+				}
+			}
+			if (lastMarker === "task_started") count++;
+		}
+		return count;
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : "unknown";
+		return fail(`unreadable or malformed rollout: ${detail}`);
+	}
+}
+
+function readRolloutTail(path: string): string {
+	const fd = openSync(path, "r");
+	try {
+		const size = statSync(path).size;
+		const length = Math.min(size, ROLLOUT_TAIL_BYTES);
+		const buffer = Buffer.alloc(length);
+		readSync(fd, buffer, 0, length, Math.max(0, size - length));
+		const text = buffer.toString("utf8");
+		return size > length ? text.slice(text.indexOf("\n") + 1) : text;
+	} finally {
+		closeSync(fd);
+	}
 }
 
 function mirrorPath(omtDir: string, sessionId: string): string {

--- a/hooks/codex-persistent-mode/cli.ts
+++ b/hooks/codex-persistent-mode/cli.ts
@@ -56,7 +56,7 @@ import {
 import { stdin as processStdin } from "node:process";
 import { join, dirname, basename, resolve, isAbsolute } from "node:path";
 
-import { isSafeSessionId } from "@lib/state-core";
+import { isSafeSessionId, TERMINAL_TTL_SECONDS } from "@lib/state-core";
 import { resolveOmtDir } from "@lib/omt-dir";
 import { makeDecision, DecisionContext } from "@lib/persistent-mode-core/decision";
 import { readUltragoalStateRaw } from "@lib/persistent-mode-core/state";
@@ -67,7 +67,7 @@ import { isFailedToolResponse } from "@lib/tool-response";
 // textually positioned after the dispatch block would still be uninitialized
 // (TDZ) when a handler invoked from within that same await resolves.
 const COMMAND_TOOL_NAMES = new Set(["bash", "shell_command", "exec_command"]);
-const CODEX_CHILD_STALE_TTL_SECONDS = 1800;
+const CODEX_CHILD_STALE_TTL_SECONDS = TERMINAL_TTL_SECONDS;
 const ROLLOUT_TAIL_BYTES = 64 * 1024;
 
 const command = process.argv[2];

--- a/hooks/codex-persistent-mode/cli.ts
+++ b/hooks/codex-persistent-mode/cli.ts
@@ -347,9 +347,16 @@ function detectActiveCodexChildren(sessionId: string): number {
 			if (ageSeconds > CODEX_CHILD_STALE_TTL_SECONDS) continue;
 			const content = readRolloutTail(rolloutPath);
 			let lastMarker: string | undefined;
-			for (const rawLine of content.split("\n")) {
+			const lines = content.split("\n");
+			for (const [index, rawLine] of lines.entries()) {
 				if (!rawLine.trim()) continue;
-				const event: unknown = JSON.parse(rawLine);
+				let event: unknown;
+				try {
+					event = JSON.parse(rawLine);
+				} catch {
+					if (index === lines.length - 1 && !content.endsWith("\n")) continue;
+					throw new Error("malformed rollout line");
+				}
 				if (!isRecord(event)) return fail("unreadable or malformed rollout");
 				const payload = event["payload"];
 				const marker = isRecord(payload) ? payload["type"] : undefined;

--- a/hooks/codex-write-guard_test.sh
+++ b/hooks/codex-write-guard_test.sh
@@ -1439,6 +1439,61 @@ test_ac_dangerous_exec_command_rm_rf_denies() {
     fi
 }
 
+# User-authorized ultragoal-state command wiring: the Codex shim must route the
+# whole Bash command through the shared deny for resume-pursuit, including the
+# same indirection/order/whitespace shapes covered by the core tests.
+test_user_authorized_resume_pursuit_direct_denies() {
+    new_sandbox
+    local cmd out result=0
+    cmd="bun /Users/x/.claude/skills/ultragoal/scripts/ultragoal-state.ts resume-pursuit"
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED user-authorized-resume-pursuit-direct: expected deny, got '$out'"
+        result=1
+    fi
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_user_authorized_resume_pursuit_variable_indirection_denies() {
+    new_sandbox
+    local cmd out result=0
+    cmd='sub=resume-pursuit; bun /Users/x/.claude/skills/ultragoal/scripts/ultragoal-state.ts "$sub"'
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED user-authorized-resume-pursuit-variable-indirection: expected deny, got '$out'"
+        result=1
+    fi
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_user_authorized_resume_pursuit_reverse_order_denies() {
+    new_sandbox
+    local cmd out result=0
+    cmd='s=resume-pursuit && bun /Users/x/.claude/skills/ultragoal/scripts/ultragoal-state.ts "$s"'
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED user-authorized-resume-pursuit-reverse-order: expected deny, got '$out'"
+        result=1
+    fi
+    rm -rf "$SBX"
+    return "$result"
+}
+
+test_user_authorized_resume_pursuit_whitespace_run_denies() {
+    new_sandbox
+    local cmd out result=0
+    cmd='bun  /Users/x/.claude/skills/ultragoal/scripts/ultragoal-state.ts   resume-pursuit   --reason x'
+    out=$(jq -n --arg cmd "$cmd" --arg cwd "$GITDIR" '{tool_name:"Bash", tool_input:{command:$cmd}, session_id:"cx", cwd:$cwd}' | run_hook)
+    if ! printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        echo "ASSERTION FAILED user-authorized-resume-pursuit-whitespace-run: expected deny, got '$out'"
+        result=1
+    fi
+    rm -rf "$SBX"
+    return "$result"
+}
+
 # CONFIRMED BYPASS regression: a `<<EOF` token sitting inside a quoted string
 # opens no heredoc at real execution time, but the heredoc stripper used to
 # read it as an opener and drop every following line through `EOF` -- which
@@ -2657,6 +2712,10 @@ main() {
     run_test test_ac_dangerous_rm_rf_denies
     run_test test_ac_dangerous_git_push_force_denies
     run_test test_ac_dangerous_exec_command_rm_rf_denies
+    run_test test_user_authorized_resume_pursuit_direct_denies
+    run_test test_user_authorized_resume_pursuit_variable_indirection_denies
+    run_test test_user_authorized_resume_pursuit_reverse_order_denies
+    run_test test_user_authorized_resume_pursuit_whitespace_run_denies
     run_test test_ac4_negative_plain_rm_allows
     run_test test_ac4_negative_rm_r_allows
     run_test test_ac4_negative_git_push_no_force_allows

--- a/hooks/persistent-mode/index.ts
+++ b/hooks/persistent-mode/index.ts
@@ -34,6 +34,7 @@ export async function main(): Promise<void> {
 			lastAssistantMessage: input.lastAssistantMessage,
 			incompleteTodoCount,
 			activeBackgroundTaskCount: input.activeBackgroundTaskCount,
+			deferredStopWakeGuaranteed: true,
 		};
 
 		// Make decision

--- a/hooks/pre-tool-enforcer_test.sh
+++ b/hooks/pre-tool-enforcer_test.sh
@@ -807,6 +807,13 @@ hg_bash_json() {
     printf '%s' "$1" | jq -Rs '{tool_name: "Bash", tool_input: {command: .}}'
 }
 
+test_user_authorized_resume_pursuit_reaches_claude_shared_guard() {
+    local out
+    out=$(printf '%s' "$(hg_bash_json 'bun /Users/x/.claude/skills/ultragoal/scripts/ultragoal-state.ts resume-pursuit')" \
+        | bash "$SCRIPT_DIR/pre-tool-enforcer.sh")
+    hg_is_deny "$out" || { echo "ASSERTION FAILED Claude resume-pursuit wiring: expected shared deny. Got: $out"; return 1; }
+}
+
 # =============================================================================
 # Ledger write-guard (compaction-continuous-record plan, TODO 7, D5).
 # Corpus (a)-(i): each case is a decisive gate for the blacklist arming
@@ -1937,6 +1944,7 @@ main() {
     run_test test_wg_s1_quoted_paren_in_substitution_ledger_rm_denied
     run_test test_wg_s2_substitution_closing_paren_adjacent_ledger_rm_denied
     run_test test_wg_s3_substitution_nonledger_allows
+    run_test test_user_authorized_resume_pursuit_reaches_claude_shared_guard
 
     # Defect 5 -- Claude<->Codex ledger-guard parity (double-quote masking)
     run_test test_defect5_row1_plain_redirect_denies

--- a/hooks/write-guard-core.sh
+++ b/hooks/write-guard-core.sh
@@ -205,11 +205,12 @@ write_guard_core_check_dangerous_command() {
 }
 
 # write_guard_core_check_user_authorized_command <command-segment>
-# Denies the two ultragoal-state subcommands whose authority row reads
+# Denies the three ultragoal-state subcommands whose authority row reads
 # "orchestrator, only after explicit user approval":
 #   approve-review-dispatch-renewal -- extends the code-review dispatch budget
 #   dismiss-review-finding          -- removes a blocking finding from the gate
-# Both let the loop clear its own completion gate, so leaving them to prose
+#   resume-pursuit                  -- resumes a previously paused pursuit
+# All three let the loop clear its own completion gate, so leaving them to prose
 # ("run this only after the user approves") makes the authorization
 # vigilance-based -- the exact property ultragoal/SKILL.md rejects for its
 # other gates. Denying the AI's Bash path makes it structural instead: the
@@ -243,7 +244,7 @@ write_guard_core_check_user_authorized_command() {
     case "$seg" in
         *"ultragoal-state.ts"*)
             case "$seg" in
-                *"dismiss-review-finding"* | *"approve-review-dispatch-renewal"*)
+                *"dismiss-review-finding"* | *"approve-review-dispatch-renewal"* | *"resume-pursuit"*)
                     printf '%s\n' "$_wg_core_user_authorized_deny_json"
                     return 0
                     ;;

--- a/hooks/write-guard-core_test.sh
+++ b/hooks/write-guard-core_test.sh
@@ -581,6 +581,54 @@ test_user_authorized_approve_renewal_denies() {
     fi
 }
 
+test_user_authorized_resume_pursuit_denies() {
+    local out
+    out=$(bash -c "source '$CORE'; write_guard_core_check_user_authorized_command \"\$1\"" _ \
+        "$UGCLI resume-pursuit")
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED user-authorized-resume-pursuit: expected deny, got '$out'"
+        return 1
+    fi
+}
+
+test_user_authorized_resume_pursuit_variable_indirection_denies() {
+    local out
+    out=$(bash -c "source '$CORE'; write_guard_core_check_user_authorized_command \"\$1\"" _ \
+        "sub=resume-pursuit; $UGCLI \"\$sub\"")
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED user-authorized-resume-pursuit-variable-indirection: expected deny, got '$out'"
+        return 1
+    fi
+}
+
+test_user_authorized_resume_pursuit_reverse_order_denies() {
+    local out
+    out=$(bash -c "source '$CORE'; write_guard_core_check_user_authorized_command \"\$1\"" _ \
+        "s=resume-pursuit && $UGCLI \"\$s\"")
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED user-authorized-resume-pursuit-reverse-order: expected deny, got '$out'"
+        return 1
+    fi
+}
+
+test_user_authorized_resume_pursuit_whitespace_run_denies() {
+    local out
+    out=$(bash -c "source '$CORE'; write_guard_core_check_user_authorized_command \"\$1\"" _ \
+        "$UGCLI  resume-pursuit   --reason x")
+    if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then
+        return 0
+    else
+        echo "ASSERTION FAILED user-authorized-resume-pursuit-whitespace-run: expected deny, got '$out'"
+        return 1
+    fi
+}
+
 # Whitespace-run tolerance, same hazard the dangerous-command guard fixed: a
 # real shell treats any run of spaces/tabs as one separator, so a literal
 # single-space pattern would silently ALLOW the identical command.
@@ -1046,6 +1094,10 @@ main() {
     run_test test_dangerous_git_push_force_multispace_denies
     run_test test_user_authorized_dismiss_review_finding_denies
     run_test test_user_authorized_approve_renewal_denies
+    run_test test_user_authorized_resume_pursuit_denies
+    run_test test_user_authorized_resume_pursuit_variable_indirection_denies
+    run_test test_user_authorized_resume_pursuit_reverse_order_denies
+    run_test test_user_authorized_resume_pursuit_whitespace_run_denies
     run_test test_user_authorized_variable_indirection_denies
     run_test test_user_authorized_reverse_order_denies
     run_test test_user_authorized_whitespace_run_denies

--- a/lib/persistent-mode-core/decision.test.ts
+++ b/lib/persistent-mode-core/decision.test.ts
@@ -16,6 +16,13 @@ describe("makeDecision", () => {
 
 	beforeAll(async () => {
 		await mkdir(stateDir, { recursive: true });
+		await mkdir(projectRoot, { recursive: true });
+		execFileSync("git", ["init", "-q"], { cwd: projectRoot });
+		execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: projectRoot });
+		execFileSync("git", ["config", "user.name", "Test"], { cwd: projectRoot });
+		await writeFile(join(projectRoot, "baseline"), "baseline");
+		execFileSync("git", ["add", "baseline"], { cwd: projectRoot });
+		execFileSync("git", ["commit", "-qm", "baseline"], { cwd: projectRoot });
 	});
 
 	afterAll(async () => {
@@ -147,7 +154,9 @@ describe("makeDecision", () => {
 
 			expect(result.decision).toBe("block");
 			expect(fs.existsSync(join(stateDir, "block-count-skill-chain-test-session"))).toBe(true);
-			expect(fs.readFileSync(join(stateDir, "block-count-skill-chain-test-session"), "utf-8")).toBe("3");
+			expect(fs.readFileSync(join(stateDir, "block-count-skill-chain-test-session"), "utf-8")).toBe(
+				"3",
+			);
 		});
 	});
 
@@ -516,9 +525,7 @@ describe("makeDecision", () => {
 						current_ambiguity: 0.05,
 						threshold: 0.15,
 						topology: {
-							components: [
-								{ id: "c1", name: "C1", status: "active", clarity_scores: SCORED_DIMS },
-							],
+							components: [{ id: "c1", name: "C1", status: "active", clarity_scores: SCORED_DIMS }],
 						},
 						non_goals: [{ item: "out-of-scope thing", decider: "user confirmed out of scope" }],
 					},
@@ -712,9 +719,7 @@ describe("makeDecision", () => {
 						current_ambiguity: 0.05,
 						threshold: 0.15,
 						topology: {
-							components: [
-								{ id: "c1", name: "C1", status: "active", clarity_scores: SCORED_DIMS },
-							],
+							components: [{ id: "c1", name: "C1", status: "active", clarity_scores: SCORED_DIMS }],
 						},
 						// non_goals intentionally absent.
 					},
@@ -745,9 +750,7 @@ describe("makeDecision", () => {
 						current_ambiguity: 0.05,
 						threshold: 0.15,
 						topology: {
-							components: [
-								{ id: "c1", name: "C1", status: "active", clarity_scores: SCORED_DIMS },
-							],
+							components: [{ id: "c1", name: "C1", status: "active", clarity_scores: SCORED_DIMS }],
 						},
 						non_goals: [],
 					},
@@ -778,9 +781,7 @@ describe("makeDecision", () => {
 						current_ambiguity: 0.05,
 						threshold: 0.15,
 						topology: {
-							components: [
-								{ id: "c1", name: "C1", status: "active", clarity_scores: SCORED_DIMS },
-							],
+							components: [{ id: "c1", name: "C1", status: "active", clarity_scores: SCORED_DIMS }],
 						},
 						non_goals: [
 							{ item: "out-of-scope thing", decider: "" },
@@ -814,11 +815,11 @@ describe("makeDecision", () => {
 						current_ambiguity: 0.05,
 						threshold: 0.15,
 						topology: {
-							components: [
-								{ id: "c1", name: "C1", status: "active", clarity_scores: SCORED_DIMS },
-							],
+							components: [{ id: "c1", name: "C1", status: "active", clarity_scores: SCORED_DIMS }],
 						},
-						non_goals: [{ item: "out-of-scope thing", decider: "user confirmed out of scope in round 2" }],
+						non_goals: [
+							{ item: "out-of-scope thing", decider: "user confirmed out of scope in round 2" },
+						],
 					},
 				}),
 			);
@@ -847,7 +848,9 @@ describe("makeDecision", () => {
 				}),
 			);
 
-			const result = makeDecision(createContext({ lastAssistantMessage: "some message without done token" }));
+			const result = makeDecision(
+				createContext({ lastAssistantMessage: "some message without done token" }),
+			);
 
 			const { existsSync } = await import("fs");
 			expect(existsSync(markerPath)).toBe(true);
@@ -868,9 +871,7 @@ describe("makeDecision", () => {
 						current_ambiguity: 0.05,
 						threshold: 0.15,
 						topology: {
-							components: [
-								{ id: "c1", name: "C1", status: "active", clarity_scores: SCORED_DIMS },
-							],
+							components: [{ id: "c1", name: "C1", status: "active", clarity_scores: SCORED_DIMS }],
 						},
 						// non_goals absent — but staleness must still fall through to cleanup.
 					},
@@ -1183,6 +1184,16 @@ describe("makeDecision", () => {
 			const { readFileSync } = await import("fs");
 			return JSON.parse(readFileSync(ultragoalPath, "utf8"));
 		};
+		const runGit = (args: string[]) => execFileSync("git", args, { cwd: projectRoot });
+		const commitProject = async (file: string, value: string) => {
+			await writeFile(join(projectRoot, file), value);
+			runGit(["add", file]);
+			runGit(["commit", "-qm", value]);
+			return execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: projectRoot,
+				encoding: "utf8",
+			}).trim();
+		};
 
 		it("ultragoal blocks with <ultragoal-continuation> and increments iteration when objective unmet during pursuit", async () => {
 			await writeUltragoal({
@@ -1198,9 +1209,161 @@ describe("makeDecision", () => {
 
 			expect(result.decision).toBe("block");
 			expect(result.reason).toContain("<ultragoal-continuation>");
-			expect(result.reason).toContain("[ULTRAGOAL - ITERATION 3/10]");
+			expect(result.reason).toContain("[ULTRAGOAL - NO-PROGRESS 3/10]");
 			const after = await readUltragoalFile();
 			expect(after.iteration).toBe(3);
+		});
+
+		it("iteration 9 with unchanged HEAD reaches no-progress limit on the 10th Stop", async () => {
+			await writeUltragoal({
+				active: true,
+				phase: "pursuing",
+				iteration: 9,
+				max_iterations: 10,
+				outcome: "objective",
+			});
+			const result = makeDecision(createContext());
+			expect(result.reason).toContain("[ULTRAGOAL - NO-PROGRESS LIMIT REACHED 10/10]");
+			expect(result.reason).toContain("no diff-carrying commit, no story transition");
+			const after = await readUltragoalFile();
+			expect(after.phase).toBe("budget_limited");
+			expect(after.active).toBe(false);
+		});
+
+		it("a diff-carrying commit resets no-progress iteration and advances fingerprint", async () => {
+			const head = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: projectRoot,
+				encoding: "utf8",
+			}).trim();
+			await writeUltragoal({
+				active: true,
+				phase: "pursuing",
+				iteration: 9,
+				max_iterations: 10,
+				last_seen_head: head,
+				outcome: "objective",
+			});
+			await writeFile(join(projectRoot, "progress"), "progress");
+			execFileSync("git", ["add", "progress"], { cwd: projectRoot });
+			execFileSync("git", ["commit", "-qm", "progress"], { cwd: projectRoot });
+			const result = makeDecision(createContext());
+			expect(result.reason).toContain("[ULTRAGOAL - NO-PROGRESS 0/10]");
+			const after = await readUltragoalFile();
+			expect(after.iteration).toBe(0);
+			expect(after.last_seen_head).not.toBe(head);
+		});
+
+		it("a story status transition resets no-progress iteration", async () => {
+			const head = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: projectRoot,
+				encoding: "utf8",
+			}).trim();
+			const digest = "invalidated-by-transition";
+			await writeUltragoal({
+				active: true,
+				phase: "pursuing",
+				iteration: 5,
+				max_iterations: 10,
+				last_seen_head: head,
+				last_seen_stories_digest: digest,
+				stories: [{ id: "s1", status: "pending" }],
+				outcome: "objective",
+			});
+			const result = makeDecision(createContext());
+			expect(result.reason).toContain("[ULTRAGOAL - NO-PROGRESS 0/10]");
+			expect((await readUltragoalFile()).iteration).toBe(0);
+		});
+
+		it("max_iterations 3 limits on the third unchanged Stop", async () => {
+			for (const iteration of [0, 1]) {
+				await writeUltragoal({
+					active: true,
+					phase: "pursuing",
+					iteration,
+					max_iterations: 3,
+					outcome: "objective",
+				});
+				makeDecision(createContext());
+			}
+			await writeUltragoal({
+				active: true,
+				phase: "pursuing",
+				iteration: 2,
+				max_iterations: 3,
+				outcome: "objective",
+			});
+			const result = makeDecision(createContext());
+			expect(result.reason).toContain("[ULTRAGOAL - NO-PROGRESS LIMIT REACHED 3/3]");
+		});
+
+		it("empty commit after an observed baseline increments no-progress", async () => {
+			const prior = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: projectRoot,
+				encoding: "utf8",
+			}).trim();
+			runGit(["commit", "--allow-empty", "-qm", "empty"]);
+			await writeUltragoal({
+				active: true,
+				phase: "pursuing",
+				iteration: 5,
+				max_iterations: 10,
+				last_seen_head: prior,
+				outcome: "objective",
+			});
+			const result = makeDecision(createContext());
+			expect(result.reason).toContain("[ULTRAGOAL - NO-PROGRESS 6/10]");
+			expect((await readUltragoalFile()).iteration).toBe(6);
+		});
+
+		it("amending the observed prior HEAD increments no-progress", async () => {
+			const prior = await commitProject("amend-boundary", "amend");
+			runGit(["commit", "--amend", "--allow-empty", "--no-edit"]);
+			await writeUltragoal({
+				active: true,
+				phase: "pursuing",
+				iteration: 5,
+				max_iterations: 10,
+				last_seen_head: prior,
+				outcome: "objective",
+			});
+			expect(makeDecision(createContext()).reason).toContain("[ULTRAGOAL - NO-PROGRESS 6/10]");
+		});
+
+		it("rebasing the observed prior HEAD increments no-progress", async () => {
+			const base = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: projectRoot,
+				encoding: "utf8",
+			}).trim();
+			const prior = await commitProject("rebase-boundary", "rebase");
+			runGit(["checkout", "-qb", "rebased-boundary"]);
+			runGit(["rebase", "--onto", base, base, "rebased-boundary"]);
+			await writeUltragoal({
+				active: true,
+				phase: "pursuing",
+				iteration: 5,
+				max_iterations: 10,
+				last_seen_head: prior,
+				outcome: "objective",
+			});
+			expect(makeDecision(createContext()).reason).toContain("[ULTRAGOAL - NO-PROGRESS 6/10]");
+		});
+
+		it("commit then revert from observed baseline increments no-progress", async () => {
+			const prior = execFileSync("git", ["rev-parse", "HEAD"], {
+				cwd: projectRoot,
+				encoding: "utf8",
+			}).trim();
+			await commitProject("revert-boundary", "revert");
+			runGit(["revert", "--no-edit", "HEAD"]);
+			await writeUltragoal({
+				active: true,
+				phase: "pursuing",
+				iteration: 5,
+				max_iterations: 10,
+				last_seen_head: prior,
+				outcome: "objective",
+			});
+			expect(makeDecision(createContext()).reason).toContain("[ULTRAGOAL - NO-PROGRESS 6/10]");
 		});
 
 		it("terminal complete ultragoal-state still allows the stop", async () => {
@@ -1412,7 +1575,9 @@ describe("makeDecision", () => {
 					}),
 				);
 
-				const result = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 1 }));
+				const result = makeDecision(
+					createContext({ sessionId: sid, activeBackgroundTaskCount: 1 }),
+				);
 
 				expect(result).toEqual({ continue: true });
 				expect(fs.existsSync(join(freshOmtDir, "state"))).toBe(false);
@@ -1469,7 +1634,9 @@ describe("makeDecision", () => {
 			});
 
 			expect(fs.existsSync(walkedAwayPath)).toBe(false);
-			const afterGc = makeDecision(createContext({ sessionId: walkedAwaySid, activeBackgroundTaskCount: 0 }));
+			const afterGc = makeDecision(
+				createContext({ sessionId: walkedAwaySid, activeBackgroundTaskCount: 0 }),
+			);
 			expect(afterGc).toEqual({ continue: true });
 		});
 
@@ -1548,7 +1715,11 @@ describe("makeDecision", () => {
 			ageFile(qaPath, 7 * 3600);
 
 			makeDecision(
-				createContext({ sessionId: sid, activeBackgroundTaskCount: 0, lastAssistantMessage: "still working" }),
+				createContext({
+					sessionId: sid,
+					activeBackgroundTaskCount: 0,
+					lastAssistantMessage: "still working",
+				}),
 			);
 
 			const prometheusAfter = JSON.parse(await readFile(prometheusPath, "utf8"));
@@ -1603,7 +1774,9 @@ describe("makeDecision", () => {
 
 			// Heartbeat crossing: a Stop call while a subagent is active revives
 			// last_touched_at (GC axis) but must not touch progress_touched_at.
-			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }));
+			const heartbeatResult = makeDecision(
+				createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }),
+			);
 			expect(heartbeatResult).toEqual({ continue: true });
 
 			const revived = JSON.parse(await readFile(statePath, "utf8"));
@@ -1611,7 +1784,9 @@ describe("makeDecision", () => {
 			expect(revived.progress_touched_at).toBe(staleIso);
 
 			// Now Stop with no subagents active — must NOT wedge on the revived corpse.
-			const stopResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 0 }));
+			const stopResult = makeDecision(
+				createContext({ sessionId: sid, activeBackgroundTaskCount: 0 }),
+			);
 			expect(stopResult).toEqual({ continue: true });
 		});
 
@@ -1628,7 +1803,9 @@ describe("makeDecision", () => {
 				}),
 			);
 
-			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }));
+			const heartbeatResult = makeDecision(
+				createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }),
+			);
 			expect(heartbeatResult).toEqual({ continue: true });
 
 			const revived = JSON.parse(await readFile(statePath, "utf8"));
@@ -1636,7 +1813,9 @@ describe("makeDecision", () => {
 			expect(revived.progress_touched_at).toBe(staleIso);
 
 			// First Stop call after revival — must not block, well before MAX_BLOCK_COUNT (5).
-			const stopResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 0 }));
+			const stopResult = makeDecision(
+				createContext({ sessionId: sid, activeBackgroundTaskCount: 0 }),
+			);
 			expect(stopResult).toEqual({ continue: true });
 		});
 
@@ -1732,7 +1911,9 @@ describe("makeDecision", () => {
 			// Heartbeat crossing: revives last_touched_at (GC axis) to now, but
 			// backfills progress_touched_at from the PRE-overwrite (stale) value —
 			// that backfilled value is what must keep this corpse from reviving.
-			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }));
+			const heartbeatResult = makeDecision(
+				createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }),
+			);
 			expect(heartbeatResult).toEqual({ continue: true });
 
 			const revived = JSON.parse(await readFile(statePath, "utf8"));
@@ -1741,7 +1922,9 @@ describe("makeDecision", () => {
 			expect(revived.progress_touched_at).toBe(staleIso);
 
 			// Now Stop with no subagents active — must NOT wedge on the revived corpse.
-			const stopResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 0 }));
+			const stopResult = makeDecision(
+				createContext({ sessionId: sid, activeBackgroundTaskCount: 0 }),
+			);
 			expect(stopResult).toEqual({ continue: true });
 		});
 
@@ -1758,7 +1941,9 @@ describe("makeDecision", () => {
 				}),
 			);
 
-			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }));
+			const heartbeatResult = makeDecision(
+				createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }),
+			);
 			expect(heartbeatResult).toEqual({ continue: true });
 
 			const revived = JSON.parse(await readFile(statePath, "utf8"));
@@ -1766,7 +1951,9 @@ describe("makeDecision", () => {
 			expect(revived.started_at).toBe(staleIso);
 			expect(revived.progress_touched_at).toBe(staleIso);
 
-			const stopResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 0 }));
+			const stopResult = makeDecision(
+				createContext({ sessionId: sid, activeBackgroundTaskCount: 0 }),
+			);
 			expect(stopResult).toEqual({ continue: true });
 		});
 
@@ -1838,7 +2025,9 @@ describe("makeDecision", () => {
 			// Heartbeat crossing: backfills progress_touched_at from the genuinely
 			// recent last_touched_at (2 minutes ago) before bumping last_touched_at
 			// itself to now.
-			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }));
+			const heartbeatResult = makeDecision(
+				createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }),
+			);
 			expect(heartbeatResult).toEqual({ continue: true });
 
 			const revived = JSON.parse(await readFile(statePath, "utf8"));
@@ -1847,7 +2036,11 @@ describe("makeDecision", () => {
 			// Next Stop call with no subagents active — must still block: the backfilled
 			// progress_touched_at is fresh (2 minutes old), well under the 6h TTL.
 			const stopResult = makeDecision(
-				createContext({ sessionId: sid, activeBackgroundTaskCount: 0, lastAssistantMessage: "still working" }),
+				createContext({
+					sessionId: sid,
+					activeBackgroundTaskCount: 0,
+					lastAssistantMessage: "still working",
+				}),
 			);
 			expect(stopResult.decision).toBe("block");
 			expect(stopResult.reason).toContain("<deep-interview-continuation>");
@@ -1871,14 +2064,20 @@ describe("makeDecision", () => {
 				}),
 			);
 
-			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }));
+			const heartbeatResult = makeDecision(
+				createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }),
+			);
 			expect(heartbeatResult).toEqual({ continue: true });
 
 			const revived = JSON.parse(await readFile(statePath, "utf8"));
 			expect(revived.progress_touched_at).toBe(recentTouch);
 
 			const stopResult = makeDecision(
-				createContext({ sessionId: sid, activeBackgroundTaskCount: 0, lastAssistantMessage: "still working" }),
+				createContext({
+					sessionId: sid,
+					activeBackgroundTaskCount: 0,
+					lastAssistantMessage: "still working",
+				}),
 			);
 			expect(stopResult.decision).toBe("block");
 			expect(stopResult.reason).toContain("<prometheus-continuation>");
@@ -1911,7 +2110,9 @@ describe("makeDecision", () => {
 			);
 
 			// Heartbeat crossing backfills progress_touched_at from recentTouch.
-			const heartbeatResult = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }));
+			const heartbeatResult = makeDecision(
+				createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }),
+			);
 			expect(heartbeatResult).toEqual({ continue: true });
 
 			const stopResult = makeDecision(
@@ -2055,7 +2256,6 @@ describe("makeDecision", () => {
 			expect(reason).toContain("request_user_input");
 			expect(reason).not.toContain("AskUserQuestion");
 		});
-
 	});
 
 	// Codex-only chain ratchet: the codex-persistent-mode Stop reader derives
@@ -2157,7 +2357,9 @@ describe("makeDecision", () => {
 
 			// Chain A resolves (the referenced skill got opened) — pendingSkillChainSkills
 			// goes empty on the next two turns, no other blocking condition fires.
-			expect(makeDecision(createContext({ pendingSkillChainSkills: [] }))).toEqual({ continue: true });
+			expect(makeDecision(createContext({ pendingSkillChainSkills: [] }))).toEqual({
+				continue: true,
+			});
 			expect(makeDecision(createContext())).toEqual({ continue: true });
 
 			// The counter must be gone — NOT sitting at 3.

--- a/lib/persistent-mode-core/decision.test.ts
+++ b/lib/persistent-mode-core/decision.test.ts
@@ -1214,7 +1214,7 @@ describe("makeDecision", () => {
 			expect(after.iteration).toBe(3);
 		});
 
-		it("iteration 9 with unchanged HEAD reaches no-progress limit on the 10th Stop", async () => {
+		it("tenth consecutive no-progress stop transitions to budget_limited", async () => {
 			await writeUltragoal({
 				active: true,
 				phase: "pursuing",
@@ -1230,7 +1230,7 @@ describe("makeDecision", () => {
 			expect(after.active).toBe(false);
 		});
 
-		it("a diff-carrying commit resets no-progress iteration and advances fingerprint", async () => {
+		it("diff commit resets no-progress counter", async () => {
 			const head = execFileSync("git", ["rev-parse", "HEAD"], {
 				cwd: projectRoot,
 				encoding: "utf8",
@@ -1253,7 +1253,7 @@ describe("makeDecision", () => {
 			expect(after.last_seen_head).not.toBe(head);
 		});
 
-		it("a story status transition resets no-progress iteration", async () => {
+		it("story transition resets counter", async () => {
 			const head = execFileSync("git", ["rev-parse", "HEAD"], {
 				cwd: projectRoot,
 				encoding: "utf8",
@@ -1274,7 +1274,7 @@ describe("makeDecision", () => {
 			expect((await readUltragoalFile()).iteration).toBe(0);
 		});
 
-		it("max_iterations 3 limits on the third unchanged Stop", async () => {
+		it("max_iterations override transitions on the third no-progress stop", async () => {
 			for (const iteration of [0, 1]) {
 				await writeUltragoal({
 					active: true,
@@ -1296,7 +1296,7 @@ describe("makeDecision", () => {
 			expect(result.reason).toContain("[ULTRAGOAL - NO-PROGRESS LIMIT REACHED 3/3]");
 		});
 
-		it("empty commit after an observed baseline increments no-progress", async () => {
+		it("empty commit does not reset counter", async () => {
 			const prior = execFileSync("git", ["rev-parse", "HEAD"], {
 				cwd: projectRoot,
 				encoding: "utf8",
@@ -1400,6 +1400,23 @@ describe("makeDecision", () => {
 			expect(after.budget_limit_notified).toBe(true);
 		});
 
+		it("budget limit message states drain policy", async () => {
+			await writeUltragoal({
+				active: true,
+				phase: "pursuing",
+				iteration: 9,
+				max_iterations: 10,
+				outcome: "objective",
+			});
+			const reason = makeDecision(createContext()).reason ?? "";
+			expect(reason).toContain("[ULTRAGOAL - NO-PROGRESS LIMIT REACHED 10/10]");
+			expect(reason).toContain("Let in-flight delegated work FINISH — harvest results and commit them.");
+			expect(reason).toContain("Do NOT dispatch new stories.");
+			expect(reason).toContain("Do NOT interrupt running executors.");
+			expect(reason).toContain("resume-pursuit");
+			expect(reason).not.toMatch(/(?:^|\n)\s*(?:kill|interrupt)\b/i);
+		});
+
 		it("ultragoal active non-pursuing (planning) suppresses baseline todo branch", async () => {
 			await writeUltragoal({
 				active: true,
@@ -1483,7 +1500,7 @@ describe("makeDecision", () => {
 	// Any running/pending background task passes through (type-agnostic); count 0 still blocks.
 	// -------------------------------------------------------------------------
 	describe("background-aware Stop hook guards", () => {
-		it("activeBackgroundTaskCount=1 with incompleteTodos yields continue (NOT block)", () => {
+		it("background tasks with wake guarantee continue without consuming", () => {
 			const result = makeDecision(
 				createContext({
 					activeBackgroundTaskCount: 1,
@@ -1494,7 +1511,7 @@ describe("makeDecision", () => {
 			expect(result).toEqual({ continue: true });
 		});
 
-		it("active work without a wake guarantee blocks ultragoal without consuming progress", async () => {
+		it("background tasks without wake guarantee block without consuming", async () => {
 			await writeFile(
 				join(omtDir, "ultragoal-state-test-session.json"),
 				JSON.stringify({
@@ -1519,7 +1536,7 @@ describe("makeDecision", () => {
 			expect(after.last_seen_stories_digest).toBe("d");
 		});
 
-		it("active work without a wake guarantee falls through when no ultragoal pursues", () => {
+		it("no active ultragoal falls through guard 2 unchanged", () => {
 			const noWake = makeDecision(
 				createContext({
 					activeBackgroundTaskCount: 1,

--- a/lib/persistent-mode-core/decision.test.ts
+++ b/lib/persistent-mode-core/decision.test.ts
@@ -1280,6 +1280,26 @@ describe("makeDecision", () => {
 			expect((await readUltragoalFile()).last_seen_head).toEqual(expect.any(String));
 		});
 
+		it("empty last_seen_head initializes then detects a later diff commit", async () => {
+			await writeUltragoal({
+				active: true,
+				phase: "pursuing",
+				iteration: 0,
+				max_iterations: 10,
+				last_seen_head: "",
+				outcome: "objective",
+			});
+			makeDecision(createContext());
+			const first = await readUltragoalFile();
+			expect(first.last_seen_head).toEqual(expect.any(String));
+			const baseline = first.last_seen_head;
+			await commitProject("empty-head-progress", "progress");
+			makeDecision(createContext());
+			const after = await readUltragoalFile();
+			expect(after.iteration).toBe(0);
+			expect(after.last_seen_head).not.toBe(baseline);
+		});
+
 		it("story transition resets counter", async () => {
 			const head = execFileSync("git", ["rev-parse", "HEAD"], {
 				cwd: projectRoot,

--- a/lib/persistent-mode-core/decision.test.ts
+++ b/lib/persistent-mode-core/decision.test.ts
@@ -1315,7 +1315,7 @@ describe("makeDecision", () => {
 			expect((await readUltragoalFile()).iteration).toBe(6);
 		});
 
-		it("amending the observed prior HEAD increments no-progress", async () => {
+		it("amend reads as no commit progress", async () => {
 			const prior = await commitProject("amend-boundary", "amend");
 			runGit(["commit", "--amend", "--allow-empty", "--no-edit"]);
 			await writeUltragoal({
@@ -1348,7 +1348,7 @@ describe("makeDecision", () => {
 			expect(makeDecision(createContext()).reason).toContain("[ULTRAGOAL - NO-PROGRESS 6/10]");
 		});
 
-		it("commit then revert from observed baseline increments no-progress", async () => {
+		it("commit then revert reads as no commit progress", async () => {
 			const prior = execFileSync("git", ["rev-parse", "HEAD"], {
 				cwd: projectRoot,
 				encoding: "utf8",

--- a/lib/persistent-mode-core/decision.test.ts
+++ b/lib/persistent-mode-core/decision.test.ts
@@ -1485,9 +1485,56 @@ describe("makeDecision", () => {
 	describe("background-aware Stop hook guards", () => {
 		it("activeBackgroundTaskCount=1 with incompleteTodos yields continue (NOT block)", () => {
 			const result = makeDecision(
-				createContext({ activeBackgroundTaskCount: 1, incompleteTodoCount: 3 }),
+				createContext({
+					activeBackgroundTaskCount: 1,
+					deferredStopWakeGuaranteed: true,
+					incompleteTodoCount: 3,
+				}),
 			);
 			expect(result).toEqual({ continue: true });
+		});
+
+		it("active work without a wake guarantee blocks ultragoal without consuming progress", async () => {
+			await writeFile(
+				join(omtDir, "ultragoal-state-test-session.json"),
+				JSON.stringify({
+					active: true,
+					phase: "pursuing",
+					iteration: 4,
+					max_iterations: 10,
+					last_seen_head: "h",
+					last_seen_stories_digest: "d",
+					outcome: "objective",
+				}),
+			);
+			const result = makeDecision(createContext({ activeBackgroundTaskCount: 1 }));
+			expect(result.decision).toBe("block");
+			expect(result.reason).toContain("[ULTRAGOAL - WAITING ON BACKGROUND WORK]");
+			expect(result.reason).toContain("Do NOT dispatch new stories");
+			const after = JSON.parse(
+				await readFile(join(omtDir, "ultragoal-state-test-session.json"), "utf8"),
+			);
+			expect(after.iteration).toBe(4);
+			expect(after.last_seen_head).toBe("h");
+			expect(after.last_seen_stories_digest).toBe("d");
+		});
+
+		it("active work without a wake guarantee falls through when no ultragoal pursues", () => {
+			const noWake = makeDecision(
+				createContext({
+					activeBackgroundTaskCount: 1,
+					incompleteTodoCount: 2,
+					sessionId: "no-wake",
+				}),
+			);
+			const control = makeDecision(
+				createContext({
+					activeBackgroundTaskCount: 0,
+					incompleteTodoCount: 2,
+					sessionId: "control",
+				}),
+			);
+			expect(noWake).toEqual(control);
 		});
 
 		it("activeBackgroundTaskCount=0 with incompleteTodos still blocks (no subagent bypass)", () => {
@@ -1537,7 +1584,13 @@ describe("makeDecision", () => {
 			);
 			ageFile(statePath, 7 * 3600);
 
-			const result = makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 1 }));
+			const result = makeDecision(
+				createContext({
+					sessionId: sid,
+					activeBackgroundTaskCount: 1,
+					deferredStopWakeGuaranteed: true,
+				}),
+			);
 
 			expect(result).toEqual({ continue: true });
 			const parsed = JSON.parse(await readFile(statePath, "utf8"));
@@ -1576,7 +1629,11 @@ describe("makeDecision", () => {
 				);
 
 				const result = makeDecision(
-					createContext({ sessionId: sid, activeBackgroundTaskCount: 1 }),
+					createContext({
+						sessionId: sid,
+						activeBackgroundTaskCount: 1,
+						deferredStopWakeGuaranteed: true,
+					}),
 				);
 
 				expect(result).toEqual({ continue: true });
@@ -1658,7 +1715,13 @@ describe("makeDecision", () => {
 			);
 			ageFile(statePath, 7 * 3600);
 
-			makeDecision(createContext({ sessionId: sid, activeBackgroundTaskCount: 1 }));
+			makeDecision(
+				createContext({
+					sessionId: sid,
+					activeBackgroundTaskCount: 1,
+					deferredStopWakeGuaranteed: true,
+				}),
+			);
 
 			const parsedAfter = JSON.parse(await readFile(statePath, "utf8"));
 			expect(parsedAfter.last_touched_at).toBe(old);
@@ -1775,7 +1838,11 @@ describe("makeDecision", () => {
 			// Heartbeat crossing: a Stop call while a subagent is active revives
 			// last_touched_at (GC axis) but must not touch progress_touched_at.
 			const heartbeatResult = makeDecision(
-				createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }),
+				createContext({
+					sessionId: sid,
+					activeBackgroundTaskCount: 2,
+					deferredStopWakeGuaranteed: true,
+				}),
 			);
 			expect(heartbeatResult).toEqual({ continue: true });
 
@@ -1804,7 +1871,11 @@ describe("makeDecision", () => {
 			);
 
 			const heartbeatResult = makeDecision(
-				createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }),
+				createContext({
+					sessionId: sid,
+					activeBackgroundTaskCount: 2,
+					deferredStopWakeGuaranteed: true,
+				}),
 			);
 			expect(heartbeatResult).toEqual({ continue: true });
 
@@ -1912,7 +1983,11 @@ describe("makeDecision", () => {
 			// backfills progress_touched_at from the PRE-overwrite (stale) value —
 			// that backfilled value is what must keep this corpse from reviving.
 			const heartbeatResult = makeDecision(
-				createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }),
+				createContext({
+					sessionId: sid,
+					activeBackgroundTaskCount: 2,
+					deferredStopWakeGuaranteed: true,
+				}),
 			);
 			expect(heartbeatResult).toEqual({ continue: true });
 
@@ -1942,7 +2017,11 @@ describe("makeDecision", () => {
 			);
 
 			const heartbeatResult = makeDecision(
-				createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }),
+				createContext({
+					sessionId: sid,
+					activeBackgroundTaskCount: 2,
+					deferredStopWakeGuaranteed: true,
+				}),
 			);
 			expect(heartbeatResult).toEqual({ continue: true });
 
@@ -2026,7 +2105,11 @@ describe("makeDecision", () => {
 			// recent last_touched_at (2 minutes ago) before bumping last_touched_at
 			// itself to now.
 			const heartbeatResult = makeDecision(
-				createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }),
+				createContext({
+					sessionId: sid,
+					activeBackgroundTaskCount: 2,
+					deferredStopWakeGuaranteed: true,
+				}),
 			);
 			expect(heartbeatResult).toEqual({ continue: true });
 
@@ -2065,7 +2148,11 @@ describe("makeDecision", () => {
 			);
 
 			const heartbeatResult = makeDecision(
-				createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }),
+				createContext({
+					sessionId: sid,
+					activeBackgroundTaskCount: 2,
+					deferredStopWakeGuaranteed: true,
+				}),
 			);
 			expect(heartbeatResult).toEqual({ continue: true });
 
@@ -2111,7 +2198,11 @@ describe("makeDecision", () => {
 
 			// Heartbeat crossing backfills progress_touched_at from recentTouch.
 			const heartbeatResult = makeDecision(
-				createContext({ sessionId: sid, activeBackgroundTaskCount: 2 }),
+				createContext({
+					sessionId: sid,
+					activeBackgroundTaskCount: 2,
+					deferredStopWakeGuaranteed: true,
+				}),
 			);
 			expect(heartbeatResult).toEqual({ continue: true });
 

--- a/lib/persistent-mode-core/decision.test.ts
+++ b/lib/persistent-mode-core/decision.test.ts
@@ -1238,7 +1238,7 @@ describe("makeDecision", () => {
 			await writeUltragoal({
 				active: true,
 				phase: "pursuing",
-				iteration: 9,
+				iteration: 10,
 				max_iterations: 10,
 				last_seen_head: head,
 				outcome: "objective",
@@ -1251,6 +1251,33 @@ describe("makeDecision", () => {
 			const after = await readUltragoalFile();
 			expect(after.iteration).toBe(0);
 			expect(after.last_seen_head).not.toBe(head);
+		});
+
+		it("partial fingerprint with head only initializes missing digest", async () => {
+			const head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: projectRoot, encoding: "utf8" }).trim();
+			await writeUltragoal({
+				active: true,
+				phase: "pursuing",
+				iteration: 0,
+				max_iterations: 10,
+				last_seen_head: head,
+				outcome: "objective",
+			});
+			makeDecision(createContext());
+			expect((await readUltragoalFile()).last_seen_stories_digest).toEqual(expect.any(String));
+		});
+
+		it("partial fingerprint with digest only initializes missing head", async () => {
+			await writeUltragoal({
+				active: true,
+				phase: "pursuing",
+				iteration: 0,
+				max_iterations: 10,
+				last_seen_stories_digest: "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+				outcome: "objective",
+			});
+			makeDecision(createContext());
+			expect((await readUltragoalFile()).last_seen_head).toEqual(expect.any(String));
 		});
 
 		it("story transition resets counter", async () => {
@@ -1394,6 +1421,9 @@ describe("makeDecision", () => {
 			const result = makeDecision(createContext());
 
 			expect(result.decision).toBe("block");
+			expect(result.reason).toContain("[ULTRAGOAL - NO-PROGRESS LIMIT REACHED 10/10]");
+			expect(result.reason).toContain("Let in-flight delegated work FINISH — harvest results and commit them.");
+			expect(result.reason).not.toContain("[ULTRAGOAL - BUDGET LIMIT REACHED");
 			const after = await readUltragoalFile();
 			expect(after.phase).toBe("budget_limited");
 			expect(after.active).toBe(false);

--- a/lib/persistent-mode-core/decision.ts
+++ b/lib/persistent-mode-core/decision.ts
@@ -20,6 +20,7 @@ import { generateAttemptId, ensureDir } from "./utils.ts";
 import { join } from "path";
 import { getOmtDir } from "@lib/omt-dir";
 import { isPristine, isProgressLive, touchSessionStates } from "@lib/state-core";
+import { evaluateProgress } from "./progress.ts";
 
 export interface DecisionContext {
 	projectRoot: string;
@@ -236,7 +237,7 @@ function buildUltragoalContinuationMessage(
 
 	return `<ultragoal-continuation>
 
-[ULTRAGOAL - ITERATION ${iteration}/${ultragoal.max_iterations}]
+[ULTRAGOAL - NO-PROGRESS ${iteration}/${ultragoal.max_iterations}]
 
 The objective is NOT verified complete yet. Keep pursuing it.
 
@@ -283,6 +284,10 @@ INSTRUCTIONS:
 
 ---
 `;
+}
+
+function buildUltragoalNoProgressLimitMessage(ultragoal: UltragoalState): string {
+	return `<ultragoal-no-progress-limit>\n\n[ULTRAGOAL - NO-PROGRESS LIMIT REACHED ${ultragoal.iteration}/${ultragoal.max_iterations}]\n\nThe pursuit is paused: ${ultragoal.max_iterations} consecutive Stops passed with no observed progress (no diff-carrying commit, no story transition). Let in-flight delegated work FINISH — harvest results and commit them. Do NOT dispatch new stories. Do NOT interrupt running executors. To resume pursuit, resolve your ultragoal skill scripts directory and present the user the full runnable command bun <resolved path>/ultragoal-state.ts resume-pursuit to run themselves — the AI's own execution is denied by a PreToolUse guard.\n\n</ultragoal-no-progress-limit>\n\n---\n`;
 }
 
 export function makeDecision(context: DecisionContext): HookOutput {
@@ -392,16 +397,52 @@ export function makeDecision(context: DecisionContext): HookOutput {
 				}
 				return formatBlockOutput(message); // NO iteration++
 			}
+			const progress = evaluateProgress(ultragoal, projectRoot);
+			const hasFingerprint =
+				ultragoal.last_seen_head !== undefined || ultragoal.last_seen_stories_digest !== undefined;
+			const persistedFingerprint = {
+				...(progress.newFingerprint.last_seen_head === null
+					? {}
+					: { last_seen_head: progress.newFingerprint.last_seen_head }),
+				last_seen_stories_digest: progress.newFingerprint.last_seen_stories_digest,
+			};
+			const fingerprintPatch = !hasFingerprint ? persistedFingerprint : {};
+			if (progress.progressed) {
+				const message = buildUltragoalContinuationMessage(ultragoal, 0, askToolName);
+				try {
+					updateUltragoalState(sessionId, { iteration: 0, ...persistedFingerprint });
+					cleanupBlockCountFiles(stateDir, attemptId);
+					return formatBlockOutput(message);
+				} catch {
+					/* fall through to the write-failure escape below */
+				}
+			}
 			// Budget remains. verdict in {APPROVE, REQUEST_CHANGES, COMMENT, absent} → block +
 			// continuation + iteration++: the loop itself writes
 			// objective_verdict via set-verdict, so trusting it here would let the loop stop
 			// itself before request-complete's gate ever runs.
 			const newIteration = ultragoal.iteration + 1;
+			if (newIteration >= ultragoal.max_iterations) {
+				const limited = { ...ultragoal, iteration: newIteration };
+				const message = buildUltragoalNoProgressLimitMessage(limited);
+				try {
+					updateUltragoalState(sessionId, {
+						...fingerprintPatch,
+						iteration: newIteration,
+						phase: "budget_limited",
+						active: false,
+						budget_limit_notified: true,
+					});
+				} catch {
+					/* M1 */
+				}
+				return formatBlockOutput(message);
+			}
 			const message = buildUltragoalContinuationMessage(ultragoal, newIteration, askToolName); // build FIRST (E1)
 			let writeOk = true;
 			// M1: swallow write failure — STILL block, never degrade to continue.
 			try {
-				updateUltragoalState(sessionId, { iteration: newIteration });
+				updateUltragoalState(sessionId, { ...fingerprintPatch, iteration: newIteration });
 			} catch {
 				writeOk = false;
 			}
@@ -531,7 +572,8 @@ export function makeDecision(context: DecisionContext): HookOutput {
 			// separate `!isPristine(...)` fall-through further down, unrelated to this flag.
 			const nonGoals = deepInterviewStateRaw.state?.non_goals;
 			const nonEmptyDeciderCount = Array.isArray(nonGoals)
-				? nonGoals.filter((ng) => typeof ng?.decider === "string" && ng.decider.trim() !== "").length
+				? nonGoals.filter((ng) => typeof ng?.decider === "string" && ng.decider.trim() !== "")
+						.length
 				: 0;
 			const hasNoNonGoalDecider = nonEmptyDeciderCount === 0;
 
@@ -633,7 +675,9 @@ export function makeDecision(context: DecisionContext): HookOutput {
 			return formatContinueOutput();
 		}
 		incrementBlockCount(stateDir, chainAttemptId);
-		return formatBlockOutput(buildSkillChainContinuationMessage(pendingSkillChainSkills, askToolName));
+		return formatBlockOutput(
+			buildSkillChainContinuationMessage(pendingSkillChainSkills, askToolName),
+		);
 	}
 
 	// No blocking needed. Reset the skill-chain counter here (mirroring ultragoal's

--- a/lib/persistent-mode-core/decision.ts
+++ b/lib/persistent-mode-core/decision.ts
@@ -377,7 +377,8 @@ export function makeDecision(context: DecisionContext): HookOutput {
 				last_seen_stories_digest: progress.newFingerprint.last_seen_stories_digest,
 			};
 			const fingerprintPatch = {
-				...(ultragoal.last_seen_head === undefined && progress.newFingerprint.last_seen_head !== null
+				...((typeof ultragoal.last_seen_head !== "string" || ultragoal.last_seen_head.trim() === "") &&
+				progress.newFingerprint.last_seen_head !== null
 					? { last_seen_head: progress.newFingerprint.last_seen_head }
 					: {}),
 				...(ultragoal.last_seen_stories_digest === undefined

--- a/lib/persistent-mode-core/decision.ts
+++ b/lib/persistent-mode-core/decision.ts
@@ -269,28 +269,6 @@ ${continuationContract("exceptional", askToolName)}
 `;
 }
 
-// Ultragoal-scoped budget-limit message.
-function buildUltragoalBudgetLimitMessage(ultragoal: UltragoalState): string {
-	return `<ultragoal-budget-limit>
-
-[ULTRAGOAL - BUDGET LIMIT REACHED ${ultragoal.iteration}/${ultragoal.max_iterations}]
-
-The iteration budget for this objective is exhausted. The objective is NOT verified complete.
-
-INSTRUCTIONS:
-1. Do NOT start any new work.
-2. Do NOT call request-complete unless the objective is genuinely achieved AND you can cite
-   concrete artifacts as evidence. The request-complete gate will reject unsubstantiated claims.
-   If the gate rejects, report the blocker honestly and stop — do not retry.
-3. Write a short progress summary of what was accomplished so far.
-4. State the single next step that would resume progress if the gate rejects.
-
-</ultragoal-budget-limit>
-
----
-`;
-}
-
 function buildUltragoalNoProgressLimitMessage(ultragoal: UltragoalState): string {
 	return `<ultragoal-no-progress-limit>\n\n[ULTRAGOAL - NO-PROGRESS LIMIT REACHED ${ultragoal.iteration}/${ultragoal.max_iterations}]\n\nThe pursuit is paused: ${ultragoal.max_iterations} consecutive Stops passed with no observed progress (no diff-carrying commit, no story transition). Let in-flight delegated work FINISH — harvest results and commit them. Do NOT dispatch new stories. Do NOT interrupt running executors. To resume pursuit, resolve your ultragoal skill scripts directory and present the user the full runnable command bun <resolved path>/ultragoal-state.ts resume-pursuit to run themselves — the AI's own execution is denied by a PreToolUse guard.\n\n</ultragoal-no-progress-limit>\n\n---\n`;
 }
@@ -391,31 +369,21 @@ export function makeDecision(context: DecisionContext): HookOutput {
 		// Single read; derive the active-only view locally (no second I/O, no TOCTOU).
 		const ultragoal = ultragoalRaw.active ? ultragoalRaw : null;
 		if (ultragoal && ultragoal.phase === "pursuing") {
-			if (ultragoal.iteration >= ultragoal.max_iterations) {
-				// Cap reached — always soft-stop via budget_limited.
-				const message = buildUltragoalBudgetLimitMessage(ultragoal); // build FIRST (E1)
-				// M1: swallow write failure — STILL soft-stop.
-				try {
-					updateUltragoalState(sessionId, {
-						phase: "budget_limited",
-						active: false,
-						budget_limit_notified: true,
-					});
-				} catch {
-					/* M1 */
-				}
-				return formatBlockOutput(message); // NO iteration++
-			}
 			const progress = evaluateProgress(ultragoal, projectRoot);
-			const hasFingerprint =
-				ultragoal.last_seen_head !== undefined || ultragoal.last_seen_stories_digest !== undefined;
 			const persistedFingerprint = {
 				...(progress.newFingerprint.last_seen_head === null
 					? {}
 					: { last_seen_head: progress.newFingerprint.last_seen_head }),
 				last_seen_stories_digest: progress.newFingerprint.last_seen_stories_digest,
 			};
-			const fingerprintPatch = !hasFingerprint ? persistedFingerprint : {};
+			const fingerprintPatch = {
+				...(ultragoal.last_seen_head === undefined && progress.newFingerprint.last_seen_head !== null
+					? { last_seen_head: progress.newFingerprint.last_seen_head }
+					: {}),
+				...(ultragoal.last_seen_stories_digest === undefined
+					? { last_seen_stories_digest: progress.newFingerprint.last_seen_stories_digest }
+					: {}),
+			};
 			if (progress.progressed) {
 				const message = buildUltragoalContinuationMessage(ultragoal, 0, askToolName);
 				try {
@@ -430,7 +398,7 @@ export function makeDecision(context: DecisionContext): HookOutput {
 			// continuation + iteration++: the loop itself writes
 			// objective_verdict via set-verdict, so trusting it here would let the loop stop
 			// itself before request-complete's gate ever runs.
-			const newIteration = ultragoal.iteration + 1;
+			const newIteration = Math.min(ultragoal.iteration + 1, ultragoal.max_iterations);
 			if (newIteration >= ultragoal.max_iterations) {
 				const limited = { ...ultragoal, iteration: newIteration };
 				const message = buildUltragoalNoProgressLimitMessage(limited);

--- a/lib/persistent-mode-core/decision.ts
+++ b/lib/persistent-mode-core/decision.ts
@@ -28,6 +28,7 @@ export interface DecisionContext {
 	lastAssistantMessage: string | null;
 	incompleteTodoCount: number;
 	activeBackgroundTaskCount: number;
+	deferredStopWakeGuaranteed?: boolean;
 	/**
 	 * Codex-only chain ratchet (see hooks/codex-persistent-mode/cli.ts's runStop):
 	 * skill names referenced (via a validated `$name` sigil) by an already-opened
@@ -81,6 +82,10 @@ function formatBlockOutput(reason: string): HookOutput {
 
 function formatContinueOutput(): HookOutput {
 	return { continue: true };
+}
+
+function buildUltragoalWaitingOnBackgroundMessage(): string {
+	return `<ultragoal-background-wait>\n\n[ULTRAGOAL - WAITING ON BACKGROUND WORK]\n\nBackground work is still running. Use the platform wait mechanism and harvest its results when it finishes. Do NOT dispatch new stories. This turn is not counted toward no-progress.\n\n</ultragoal-background-wait>\n\n---\n`;
 }
 
 const MAX_PROMPT_LENGTH = 2000;
@@ -347,7 +352,11 @@ export function makeDecision(context: DecisionContext): HookOutput {
 	// so allowing now defers enforcement safely. The status allowlist is fail-closed:
 	// terminal and unknown statuses keep enforcement active.
 	if (activeBackgroundTaskCount > 0) {
-		return formatContinueOutput();
+		if (context.deferredStopWakeGuaranteed === true) return formatContinueOutput();
+		const waitingState = readUltragoalStateRaw(sessionId);
+		if (waitingState?.active && waitingState.phase === "pursuing") {
+			return formatBlockOutput(buildUltragoalWaitingOnBackgroundMessage());
+		}
 	}
 
 	const stateDir = join(getOmtDir(), "state");

--- a/lib/persistent-mode-core/progress.test.ts
+++ b/lib/persistent-mode-core/progress.test.ts
@@ -50,11 +50,19 @@ describe("progress fingerprint", () => {
 		});
 	});
 
-	it("reports no progress for an empty commit range", async () => {
+	it("empty commit reports no progress", async () => {
 		const cwd = await repo("empty");
 		const head = await commit(cwd, "a", "a");
 		run(cwd, ["commit", "--allow-empty", "-qm", "empty"]);
 		expect(evaluateProgress(state({ last_seen_head: head }), cwd).progressed).toBe(false);
+	});
+
+	it("work commit followed by empty commit reports progress", async () => {
+		const cwd = await repo("work-empty-cumulative");
+		const baseline = await commit(cwd, "a", "a");
+		await commit(cwd, "b", "b");
+		run(cwd, ["commit", "--allow-empty", "-qm", "empty"]);
+		expect(evaluateProgress(state({ last_seen_head: baseline }), cwd).progressed).toBe(true);
 	});
 
 	it("ignores worktree changes and an empty commit", async () => {
@@ -65,14 +73,14 @@ describe("progress fingerprint", () => {
 		expect(evaluateProgress(state({ last_seen_head: head }), cwd).progressed).toBe(false);
 	});
 
-	it("reports a non-empty descendant range", async () => {
+	it("diff-carrying commit on top of seen head reports progress", async () => {
 		const cwd = await repo("diff");
 		const first = await commit(cwd, "a", "a");
 		await commit(cwd, "b", "b");
 		expect(evaluateProgress(state({ last_seen_head: first }), cwd).progressed).toBe(true);
 	});
 
-	it("does not count a diverged checkout", async () => {
+	it("checkout to diverged branch reports no progress", async () => {
 		const cwd = await repo("diverged");
 		const first = await commit(cwd, "a", "a");
 		const second = await commit(cwd, "b", "b");
@@ -151,7 +159,7 @@ describe("progress fingerprint", () => {
 		);
 	});
 
-	it("preserves fingerprint fields through raw state reads", async () => {
+	it("fingerprint fields survive raw read", async () => {
 		const dir = join(root, "omt");
 		await mkdir(dir, { recursive: true });
 		const previous = process.env.OMT_DIR;

--- a/lib/persistent-mode-core/progress.test.ts
+++ b/lib/persistent-mode-core/progress.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, rm, writeFile } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { evaluateProgress } from "./progress.ts";
+import { readUltragoalStateRaw } from "./state.ts";
+
+const root = join(tmpdir(), `progress-fingerprint-${Date.now()}`);
+const run = (cwd: string, args: string[]) => Bun.spawnSync(["git", ...args], { cwd }).exitCode;
+const out = (cwd: string, args: string[]) =>
+	Bun.spawnSync(["git", ...args], { cwd })
+		.stdout.toString()
+		.trim();
+
+async function repo(name: string) {
+	const cwd = join(root, name);
+	await mkdir(cwd, { recursive: true });
+	run(cwd, ["init", "-q"]);
+	run(cwd, ["config", "user.email", "test@example.com"]);
+	run(cwd, ["config", "user.name", "Test"]);
+	return cwd;
+}
+
+async function commit(cwd: string, file: string, value: string) {
+	await writeFile(join(cwd, file), value);
+	run(cwd, ["add", file]);
+	run(cwd, ["commit", "-qm", value]);
+	return out(cwd, ["rev-parse", "HEAD"]);
+}
+
+function state(
+	fingerprint: { last_seen_head?: string; last_seen_stories_digest?: string },
+	stories: Array<{ id: string; status: string; [key: string]: unknown }> = [],
+) {
+	return { ...fingerprint, stories };
+}
+
+describe("progress fingerprint", () => {
+	beforeEach(async () => mkdir(root, { recursive: true }));
+	afterEach(async () => rm(root, { recursive: true, force: true }));
+
+	it("initializes without reporting progress", async () => {
+		const cwd = await repo("first");
+		const head = await commit(cwd, "a", "a");
+		const result = evaluateProgress(state({}), cwd);
+		expect(result.progressed).toBe(false);
+		expect(result.newFingerprint).toEqual({
+			last_seen_head: head,
+			last_seen_stories_digest: expect.any(String),
+		});
+	});
+
+	it("reports no progress for an empty commit range", async () => {
+		const cwd = await repo("empty");
+		const head = await commit(cwd, "a", "a");
+		run(cwd, ["commit", "--allow-empty", "-qm", "empty"]);
+		expect(evaluateProgress(state({ last_seen_head: head }), cwd).progressed).toBe(false);
+	});
+
+	it("ignores worktree changes and an empty commit", async () => {
+		const cwd = await repo("work-empty");
+		const head = await commit(cwd, "a", "a");
+		await writeFile(join(cwd, "a"), "changed");
+		run(cwd, ["commit", "--allow-empty", "-qm", "empty"]);
+		expect(evaluateProgress(state({ last_seen_head: head }), cwd).progressed).toBe(false);
+	});
+
+	it("reports a non-empty descendant range", async () => {
+		const cwd = await repo("diff");
+		const first = await commit(cwd, "a", "a");
+		await commit(cwd, "b", "b");
+		expect(evaluateProgress(state({ last_seen_head: first }), cwd).progressed).toBe(true);
+	});
+
+	it("does not count a diverged checkout", async () => {
+		const cwd = await repo("diverged");
+		const first = await commit(cwd, "a", "a");
+		const second = await commit(cwd, "b", "b");
+		run(cwd, ["reset", "--hard", "-q", first]);
+		await commit(cwd, "c", "c");
+		expect(evaluateProgress(state({ last_seen_head: second }), cwd).progressed).toBe(false);
+	});
+
+	it("does not count an amended prior HEAD", async () => {
+		const cwd = await repo("amend");
+		await commit(cwd, "a", "a");
+		const prior = await commit(cwd, "b", "b");
+		run(cwd, ["commit", "--amend", "--allow-empty", "--no-edit"]);
+		expect(evaluateProgress(state({ last_seen_head: prior }), cwd).progressed).toBe(false);
+	});
+
+	it("does not count a rebased prior HEAD", async () => {
+		const cwd = await repo("rebase");
+		const first = await commit(cwd, "a", "a");
+		const prior = await commit(cwd, "b", "b");
+		run(cwd, ["checkout", "-qb", "rewritten"]);
+		run(cwd, ["rebase", "--onto", first, first, "rewritten"]);
+		expect(evaluateProgress(state({ last_seen_head: prior }), cwd).progressed).toBe(false);
+	});
+
+	it("does not count a commit followed by its revert", async () => {
+		const cwd = await repo("revert");
+		const prior = await commit(cwd, "a", "a");
+		await commit(cwd, "a", "changed");
+		run(cwd, ["revert", "--no-edit", "HEAD"]);
+		expect(evaluateProgress(state({ last_seen_head: prior }), cwd).progressed).toBe(false);
+	});
+
+	it("reports story transitions without git progress", async () => {
+		const cwd = await repo("stories");
+		const head = await commit(cwd, "a", "a");
+		const before = evaluateProgress(
+			state({ last_seen_head: head }, [{ id: "s1", status: "pending" }]),
+			cwd,
+		);
+		const after = evaluateProgress(
+			state(
+				{
+					last_seen_head: head,
+					last_seen_stories_digest: before.newFingerprint.last_seen_stories_digest,
+				},
+				[{ id: "s1", status: "completed" }],
+			),
+			cwd,
+		);
+		expect(after.progressed).toBe(true);
+	});
+
+	it("fails open outside a git repository", () => {
+		expect(evaluateProgress(state({ last_seen_head: "deadbeef" }), root).progressed).toBe(false);
+	});
+
+	it("digests only sorted id/status pairs", async () => {
+		const cwd = await repo("digest");
+		const a = evaluateProgress(
+			state({}, [
+				{ id: "b", status: "pending", title: "x" },
+				{ id: "a", status: "completed" },
+			]),
+			cwd,
+		);
+		const b = evaluateProgress(
+			state({}, [
+				{ id: "a", status: "completed", title: "changed" },
+				{ id: "b", status: "pending" },
+			]),
+			cwd,
+		);
+		expect(a.newFingerprint.last_seen_stories_digest).toBe(
+			b.newFingerprint.last_seen_stories_digest,
+		);
+	});
+
+	it("preserves fingerprint fields through raw state reads", async () => {
+		const dir = join(root, "omt");
+		await mkdir(dir, { recursive: true });
+		const previous = process.env.OMT_DIR;
+		process.env.OMT_DIR = dir;
+		await writeFile(
+			join(dir, "ultragoal-state-raw.json"),
+			JSON.stringify({
+				active: true,
+				phase: "pursuing",
+				iteration: 1,
+				max_iterations: 2,
+				last_seen_head: "h",
+				last_seen_stories_digest: "d",
+			}),
+		);
+		expect(readUltragoalStateRaw("raw")).toMatchObject({
+			last_seen_head: "h",
+			last_seen_stories_digest: "d",
+		});
+		if (previous === undefined) delete process.env.OMT_DIR;
+		else process.env.OMT_DIR = previous;
+	});
+});

--- a/lib/persistent-mode-core/progress.ts
+++ b/lib/persistent-mode-core/progress.ts
@@ -1,0 +1,66 @@
+import { createHash } from "node:crypto";
+import type { GoalState } from "./types.ts";
+
+type StoryLike = { id?: unknown; status?: unknown; [key: string]: unknown };
+type ProgressState = Pick<GoalState, "last_seen_head" | "last_seen_stories_digest"> & {
+	stories?: StoryLike[];
+	todos?: StoryLike[];
+};
+
+export interface ProgressEvaluation {
+	progressed: boolean;
+	newFingerprint: {
+		last_seen_head: string | null;
+		last_seen_stories_digest: string;
+	};
+}
+
+function git(cwd: string, args: string[]): { code: number; stdout: string } | null {
+	try {
+		const result = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "ignore" });
+		return { code: result.exitCode, stdout: result.stdout.toString().trim() };
+	} catch {
+		return null;
+	}
+}
+
+function digestStories(state: ProgressState): string {
+	const source = Array.isArray(state.stories)
+		? state.stories
+		: Array.isArray(state.todos)
+			? state.todos
+			: [];
+	const pairs = source
+		.filter(
+			(story): story is Required<Pick<StoryLike, "id" | "status">> =>
+				story?.id != null && story?.status != null,
+		)
+		.map((story) => [String(story.id), String(story.status)] as const)
+		.sort(([a, as], [b, bs]) => (a < b ? -1 : a > b ? 1 : as < bs ? -1 : as > bs ? 1 : 0));
+	return createHash("sha256").update(JSON.stringify(pairs)).digest("hex");
+}
+
+export function evaluateProgress(state: ProgressState, cwd: string): ProgressEvaluation {
+	const storiesDigest = digestStories(state);
+	const headResult = git(cwd, ["rev-parse", "HEAD"]);
+	const head = headResult?.code === 0 && headResult.stdout ? headResult.stdout : null;
+	const priorHead = typeof state.last_seen_head === "string" ? state.last_seen_head : null;
+	let commitProgress = false;
+	if (head && priorHead) {
+		const ancestor = git(cwd, ["merge-base", "--is-ancestor", priorHead, head]);
+		if (ancestor?.code === 0) {
+			const diff = git(cwd, ["diff", "--quiet", `${priorHead}..${head}`]);
+			commitProgress = diff?.code === 1;
+		}
+	}
+	const priorDigest =
+		typeof state.last_seen_stories_digest === "string" ? state.last_seen_stories_digest : null;
+	const storyProgress = priorDigest !== null && priorDigest !== storiesDigest;
+	return {
+		progressed: commitProgress || storyProgress,
+		newFingerprint: {
+			last_seen_head: head,
+			last_seen_stories_digest: storiesDigest,
+		},
+	};
+}

--- a/lib/persistent-mode-core/progress.ts
+++ b/lib/persistent-mode-core/progress.ts
@@ -32,8 +32,9 @@ function digestStories(state: ProgressState): string {
 			: [];
 	const pairs = source
 		.filter(
-			(story): story is Required<Pick<StoryLike, "id" | "status">> =>
-				story?.id != null && story?.status != null,
+				(story): story is Required<Pick<StoryLike, "id" | "status">> =>
+					story?.id !== null && story?.id !== undefined &&
+					story?.status !== null && story?.status !== undefined,
 		)
 		.map((story) => [String(story.id), String(story.status)] as const)
 		.sort(([a, as], [b, bs]) => (a < b ? -1 : a > b ? 1 : as < bs ? -1 : as > bs ? 1 : 0));

--- a/lib/persistent-mode-core/state-lock.test.ts
+++ b/lib/persistent-mode-core/state-lock.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { withStateLock } from "./state-lock.ts";
+
+describe("withStateLock", () => {
+	let testDir: string;
+	let stateFilePath: string;
+	let lockPath: string;
+
+	beforeEach(() => {
+		testDir = mkdtempSync(join(tmpdir(), "persistent-state-lock-"));
+		stateFilePath = join(testDir, "ultragoal-state-session.json");
+		lockPath = `${stateFilePath}.lock`;
+	});
+
+	afterEach(() => {
+		rmSync(testDir, { recursive: true, force: true });
+	});
+
+	test("fresh live-owner contention fails closed without running the callback", () => {
+		mkdirSync(lockPath);
+		writeFileSync(
+			join(lockPath, "owner.json"),
+			JSON.stringify({ ownerPid: process.pid, token: "live-owner", startedAt: Date.now() }),
+		);
+		let called = false;
+
+		expect(() => withStateLock(stateFilePath, () => {
+			called = true;
+		})).toThrow("ultragoal-state: state lock contended; refusing unlocked write");
+		expect(called).toBe(false);
+		expect(existsSync(lockPath)).toBe(true);
+	});
+
+	test("stale ownerless lock is recovered before running the callback", () => {
+		mkdirSync(lockPath);
+		const stale = new Date(Date.now() - 31_000);
+		utimesSync(lockPath, stale, stale);
+
+		expect(withStateLock(stateFilePath, () => "written")).toBe("written");
+		expect(existsSync(lockPath)).toBe(false);
+	});
+
+	test("release preserves a successor lock when its owner token changed", () => {
+		withStateLock(stateFilePath, () => {
+			writeFileSync(
+				join(lockPath, "owner.json"),
+				JSON.stringify({ ownerPid: process.pid, token: "successor", startedAt: Date.now() }),
+			);
+		});
+
+		expect(existsSync(lockPath)).toBe(true);
+		expect(JSON.parse(readFileSync(join(lockPath, "owner.json"), "utf8")).token).toBe("successor");
+	});
+});

--- a/lib/persistent-mode-core/state-lock.test.ts
+++ b/lib/persistent-mode-core/state-lock.test.ts
@@ -62,4 +62,26 @@ describe("withStateLock", () => {
 		expect(existsSync(lockPath)).toBe(true);
 		expect(JSON.parse(readFileSync(join(lockPath, "owner.json"), "utf8")).token).toBe("successor");
 	});
+
+	test("owner release waits for a long fresh recovery guard before allowing a subsequent writer", async () => {
+		const recoveryPath = `${lockPath}.recovery`;
+		let recoveryReleaser: ReturnType<typeof Bun.spawn> | undefined;
+
+		withStateLock(stateFilePath, () => {
+			mkdirSync(recoveryPath);
+			recoveryReleaser = Bun.spawn([
+				"sh",
+				"-c",
+				"sleep 0.7; rm -rf \"$1\"",
+				"release-recovery",
+				recoveryPath,
+			]);
+		});
+
+		expect(recoveryReleaser).toBeDefined();
+		expect(await recoveryReleaser!.exited).toBe(0);
+		expect(existsSync(lockPath)).toBe(false);
+		expect(withStateLock(stateFilePath, () => "written")).toBe("written");
+		expect(existsSync(lockPath)).toBe(false);
+	});
 });

--- a/lib/persistent-mode-core/state-lock.ts
+++ b/lib/persistent-mode-core/state-lock.ts
@@ -149,9 +149,20 @@ function isolateAndRemoveStaleLock(lockPath: string): void {
 }
 
 function releaseStateLock(lockPath: string, token: string): void {
-	withStateLockRecoveryGuard(lockPath, () => {
-		if (readStateLockOwner(lockPath)?.token === token) {
-			rmSync(lockPath, { recursive: true, force: true });
+	// Keep waiting until the recovery guard is acquired; abandoned guards are
+	// reclaimed by withStateLockRecoveryGuard's existing stale-TTL path.
+	while (true) {
+		if (
+			withStateLockRecoveryGuard(lockPath, () => {
+				if (readStateLockOwner(lockPath)?.token === token) {
+					rmSync(lockPath, { recursive: true, force: true });
+				}
+			})
+		) {
+			return;
 		}
-	});
+		// A fresh recovery guard may belong to a concurrent stale-lock observer;
+		// wait for it rather than leaving our own primary lock behind.
+		Atomics.wait(STATE_LOCK_SLEEP, 0, 0, STATE_LOCK_RETRY_MS);
+	}
 }

--- a/lib/persistent-mode-core/state-lock.ts
+++ b/lib/persistent-mode-core/state-lock.ts
@@ -1,0 +1,157 @@
+import {
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+
+const STATE_LOCK_RETRIES = 100;
+const STATE_LOCK_RETRY_MS = 5;
+const STATE_LOCK_SLEEP = new Int32Array(new SharedArrayBuffer(4));
+const STATE_LOCK_STALE_TTL_MS = 30_000;
+const STATE_LOCK_OWNER_FILE = "owner.json";
+
+type StateLockOwner = { ownerPid: number; token: string; startedAt: number };
+
+/**
+ * Minimal mkdir lock for every read-modify-write of an ultragoal state file. A
+ * contention timeout fails closed; callers never fall back to an unlocked write.
+ */
+export function withStateLock<T>(stateFilePath: string, callback: () => T): T {
+	const lockPath = `${stateFilePath}.lock`;
+	for (let attempt = 0; attempt < STATE_LOCK_RETRIES; attempt += 1) {
+		const token = randomUUID();
+		try {
+			mkdirSync(lockPath);
+			writeFileSync(
+				join(lockPath, STATE_LOCK_OWNER_FILE),
+				JSON.stringify({
+					ownerPid: process.pid,
+					token,
+					startedAt: Date.now(),
+				} satisfies StateLockOwner),
+			);
+			try {
+				return callback();
+			} finally {
+				releaseStateLock(lockPath, token);
+			}
+		} catch (err) {
+			if (isErrnoException(err) && err.code === "EEXIST") {
+				if (!recoverStaleStateLock(lockPath)) {
+					Atomics.wait(STATE_LOCK_SLEEP, 0, 0, STATE_LOCK_RETRY_MS);
+				}
+				continue;
+			}
+			throw err;
+		}
+	}
+	throw new Error("ultragoal-state: state lock contended; refusing unlocked write");
+}
+
+function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
+	return typeof err === "object" && err !== null && "code" in err;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readStateLockOwner(lockPath: string): StateLockOwner | undefined {
+	try {
+		const value: unknown = JSON.parse(readFileSync(join(lockPath, STATE_LOCK_OWNER_FILE), "utf8"));
+		if (
+			isRecord(value) &&
+			typeof value.ownerPid === "number" &&
+			Number.isInteger(value.ownerPid) &&
+			value.ownerPid > 0 &&
+			typeof value.token === "string" &&
+			value.token.length > 0 &&
+			typeof value.startedAt === "number"
+		) {
+			return { ownerPid: value.ownerPid, token: value.token, startedAt: value.startedAt };
+		}
+	} catch {
+		return undefined;
+	}
+	return undefined;
+}
+
+function isStateLockStale(lockPath: string): boolean {
+	const owner = readStateLockOwner(lockPath);
+	if (owner !== undefined && !isPidAlive(owner.ownerPid)) return true;
+	try {
+		return statSync(lockPath).mtimeMs + STATE_LOCK_STALE_TTL_MS < Date.now();
+	} catch {
+		return true;
+	}
+}
+
+function isPidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return isErrnoException(err) && err.code === "EPERM";
+	}
+}
+
+/** Serializes stale recovery so a second observer cannot rename a successor lock. */
+function recoverStaleStateLock(lockPath: string): boolean {
+	let recovered = false;
+	if (
+		!withStateLockRecoveryGuard(lockPath, () => {
+			if (!isStateLockStale(lockPath)) return;
+			isolateAndRemoveStaleLock(lockPath);
+			recovered = true;
+		})
+	) {
+		return false;
+	}
+	return recovered;
+}
+
+/** Prevents stale recovery from racing a token-checked holder release. */
+function withStateLockRecoveryGuard(lockPath: string, callback: () => void): boolean {
+	const recoveryPath = `${lockPath}.recovery`;
+	for (let attempt = 0; attempt < 2; attempt += 1) {
+		try {
+			mkdirSync(recoveryPath);
+		} catch (err) {
+			if (!(isErrnoException(err) && err.code === "EEXIST")) throw err;
+			if (!isStateLockStale(recoveryPath)) return false;
+			isolateAndRemoveStaleLock(recoveryPath);
+			continue;
+		}
+		try {
+			callback();
+			return true;
+		} finally {
+			rmSync(recoveryPath, { recursive: true, force: true });
+		}
+	}
+	return false;
+}
+
+function isolateAndRemoveStaleLock(lockPath: string): void {
+	const stalePath = `${lockPath}.stale-${process.pid}-${randomUUID()}`;
+	try {
+		renameSync(lockPath, stalePath);
+	} catch (err) {
+		if (isErrnoException(err) && (err.code === "ENOENT" || err.code === "EEXIST")) return;
+		throw err;
+	}
+	rmSync(stalePath, { recursive: true, force: true });
+}
+
+function releaseStateLock(lockPath: string, token: string): void {
+	withStateLockRecoveryGuard(lockPath, () => {
+		if (readStateLockOwner(lockPath)?.token === token) {
+			rmSync(lockPath, { recursive: true, force: true });
+		}
+	});
+}

--- a/lib/persistent-mode-core/state.test.ts
+++ b/lib/persistent-mode-core/state.test.ts
@@ -901,6 +901,8 @@ describe("Ultragoal state management", () => {
 				max_iterations: 10,
 				outcome: "Ship the multi-story feature",
 				schema_version: 1,
+				stories: [{ id: "S1", story: "Keep this", status: "confirmed" }],
+				approved_review_artifact_sha256: "unchanged-hash",
 			}),
 		);
 
@@ -911,12 +913,38 @@ describe("Ultragoal state management", () => {
 		expect(parsed.iteration).toBe(3);
 		expect(parsed.outcome).toBe("Ship the multi-story feature");
 		expect(parsed.schema_version).toBe(1);
+		expect(parsed.stories).toEqual([{ id: "S1", story: "Keep this", status: "confirmed" }]);
+		expect(parsed.approved_review_artifact_sha256).toBe("unchanged-hash");
 
 		const absentSessionId = "nonexistent-ultragoal-update";
 		const absentFile = join(omtDir, `ultragoal-state-${absentSessionId}.json`);
 		expect(existsSync(absentFile)).toBe(false);
 		updateUltragoalState(absentSessionId, { iteration: 3 });
 		expect(existsSync(absentFile)).toBe(false);
+	});
+
+	it("ultragoal: updateUltragoalState fails closed under fresh lock contention without changing bytes", async () => {
+		const stateFile = join(omtDir, `ultragoal-state-${sessionId}.json`);
+		const original = JSON.stringify({
+			active: true,
+			phase: "pursuing",
+			objective_verdict: "absent",
+			iteration: 1,
+			max_iterations: 10,
+			stories: [{ id: "S1", status: "confirmed" }],
+		});
+		await writeFile(stateFile, original);
+		const lockPath = `${stateFile}.lock`;
+		await mkdir(lockPath);
+		await writeFile(
+			join(lockPath, "owner.json"),
+			JSON.stringify({ ownerPid: process.pid, token: "live-owner", startedAt: Date.now() }),
+		);
+
+		expect(() => updateUltragoalState(sessionId, { iteration: 2 })).toThrow(
+			"ultragoal-state: state lock contended; refusing unlocked write",
+		);
+		expect(await readFile(stateFile, "utf8")).toBe(original);
 	});
 });
 

--- a/lib/persistent-mode-core/state.ts
+++ b/lib/persistent-mode-core/state.ts
@@ -1,6 +1,7 @@
 import { DeepInterviewState, PrometheusState, GoalState, UltragoalState } from "./types.ts";
 import { readFileOrNull, writeFileSafe, deleteFile, ensureDir } from "./utils.ts";
 import { writeFileNoCreate, backfillProgressTouchedAt } from "@lib/state-core";
+import { withStateLock } from "./state-lock.ts";
 import { join } from "path";
 import { getOmtDir } from "@lib/omt-dir";
 
@@ -202,28 +203,32 @@ export function readUltragoalStateRaw(sessionId: string): UltragoalState | null 
 // — including the empty-partial-vs-genuine-write progress_touched_at split).
 export function updateUltragoalState(sessionId: string, partial: Partial<UltragoalState>): void {
 	const path = join(getOmtDir(), `ultragoal-state-${sessionId}.json`);
-	const content = readFileOrNull(path);
-	if (!content) return;
+	withStateLock(path, () => {
+		const content = readFileOrNull(path);
+		if (!content) return;
 
-	let raw: Record<string, unknown>;
-	try {
-		raw = JSON.parse(content);
-	} catch {
-		return;
-	}
+		let raw: Record<string, unknown>;
+		try {
+			raw = JSON.parse(content);
+		} catch {
+			return;
+		}
 
-	const ts = nowStamp();
-	const progressPatch =
-		Object.keys(partial).length === 0 ? backfillProgressTouchedAt(raw) : { progress_touched_at: ts };
-	try {
-		writeFileNoCreate(
-			path,
-			JSON.stringify({ ...raw, ...partial, ...progressPatch, last_touched_at: ts }, null, 2),
-		);
-	} catch (err) {
-		if (err !== null && typeof err === "object" && "code" in err && err.code === "ENOENT") return;
-		throw err;
-	}
+		const ts = nowStamp();
+		const progressPatch =
+			Object.keys(partial).length === 0
+				? backfillProgressTouchedAt(raw)
+				: { progress_touched_at: ts };
+		try {
+			writeFileNoCreate(
+				path,
+				JSON.stringify({ ...raw, ...partial, ...progressPatch, last_touched_at: ts }, null, 2),
+			);
+		} catch (err) {
+			if (err !== null && typeof err === "object" && "code" in err && err.code === "ENOENT") return;
+			throw err;
+		}
+	});
 }
 
 // Block counting for stuck agent escape hatch

--- a/lib/persistent-mode-core/types.ts
+++ b/lib/persistent-mode-core/types.ts
@@ -111,6 +111,9 @@ export interface GoalState {
 	completion_evidence_paths?: string[];
 	/** Set by the hook when it emits the budget-limit notice (write-once guard). */
 	budget_limit_notified?: boolean;
+	/** Last observed repository and story fingerprints used by progress detection. */
+	last_seen_head?: string;
+	last_seen_stories_digest?: string;
 	/** Refreshed on every write (heartbeat). Used by the GC liveness check. */
 	last_touched_at?: string;
 }

--- a/skills/design-review/scripts/job.test.ts
+++ b/skills/design-review/scripts/job.test.ts
@@ -27,6 +27,48 @@ function writeConfig(configPath: string) {
 	);
 }
 
+const ACTIVE_STATES = new Set(["queued", "running", "retrying", "awaiting_resume"]);
+
+/**
+ * Detached workers can still be in their queued startup window after `stop`
+ * returns. Keep the job directory until the terminal state has been stable
+ * long enough for that worker process to exit, then `clean` can safely enforce
+ * its active-member guard without racing the worker's final status write.
+ */
+async function waitForStableTerminal(jobDir: string, stableMs = 500): Promise<void> {
+	const deadline = Date.now() + 15_000;
+	let terminalSince: number | null = null;
+	while (Date.now() < deadline) {
+		const membersDir = path.join(jobDir, "reviewers");
+		let allTerminal = fs.existsSync(membersDir);
+		if (allTerminal) {
+			for (const entry of fs.readdirSync(membersDir)) {
+				try {
+					const status = JSON.parse(
+						fs.readFileSync(path.join(membersDir, entry, "status.json"), "utf8"),
+					);
+					if (ACTIVE_STATES.has(String(status.state))) {
+						allTerminal = false;
+						break;
+					}
+				} catch {
+					allTerminal = false;
+					break;
+				}
+			}
+		}
+
+		if (allTerminal) {
+			terminalSince ??= Date.now();
+			if (Date.now() - terminalSince >= stableMs) return;
+		} else {
+			terminalSince = null;
+		}
+		await new Promise<void>((resolve) => setTimeout(resolve, 50));
+	}
+	throw new Error(`worker did not reach a stable terminal state: ${jobDir}`);
+}
+
 describe("design-review job lifecycle", () => {
 	let tmpDir: string;
 
@@ -38,7 +80,7 @@ describe("design-review job lifecycle", () => {
 		fs.rmSync(tmpDir, { recursive: true, force: true });
 	});
 
-	test("start creates jobDir and job.json with expected fields", () => {
+	test("start creates jobDir and job.json with expected fields", async () => {
 		const configPath = path.join(tmpDir, "diagnose.config.yaml");
 		writeConfig(configPath);
 		const jobsDir = path.join(tmpDir, "jobs");
@@ -84,6 +126,7 @@ describe("design-review job lifecycle", () => {
 		try {
 			execFileSync(process.execPath, [SCRIPT, "stop", output.jobDir], { stdio: "pipe" });
 		} catch {}
+		await waitForStableTerminal(output.jobDir);
 		try {
 			execFileSync(process.execPath, [SCRIPT, "clean", output.jobDir, "--jobs-dir", jobsDir], {
 				stdio: "pipe",
@@ -91,7 +134,7 @@ describe("design-review job lifecycle", () => {
 		} catch {}
 	});
 
-	test("clean removes jobDir", () => {
+	test("clean removes jobDir", async () => {
 		const configPath = path.join(tmpDir, "diagnose.config.yaml");
 		writeConfig(configPath);
 		const jobsDir = path.join(tmpDir, "jobs");
@@ -119,6 +162,7 @@ describe("design-review job lifecycle", () => {
 		try {
 			execFileSync(process.execPath, [SCRIPT, "stop", jobDir], { stdio: "pipe" });
 		} catch {}
+		await waitForStableTerminal(jobDir);
 		execFileSync(process.execPath, [SCRIPT, "clean", jobDir, "--jobs-dir", jobsDir], {
 			stdio: "pipe",
 		});
@@ -126,7 +170,46 @@ describe("design-review job lifecycle", () => {
 		expect(fs.existsSync(jobDir)).toBe(false);
 	});
 
-	test("start returns plain jobDir path without --json flag", () => {
+	test("queued stop cleanup waits for terminal worker before deleting jobDir", async () => {
+		const configPath = path.join(tmpDir, "slow.config.yaml");
+		fs.writeFileSync(
+			configPath,
+			[
+				"review:",
+				"  members:",
+				"    - name: tester",
+				"      command: sleep 0.5",
+				"  settings:",
+				"    timeout: 10",
+			].join("\n"),
+			"utf8",
+		);
+		const jobsDir = path.join(tmpDir, "jobs");
+		fs.mkdirSync(jobsDir, { recursive: true });
+
+		const { jobDir } = JSON.parse(
+			execFileSync(
+				process.execPath,
+				[SCRIPT, "start", "--config", configPath, "--jobs-dir", jobsDir, "--json", "queued race"],
+				{ stdio: "pipe" },
+			).toString(),
+		);
+
+		// `stop` may observe the freshly-written queued state and return without
+		// signaling. Waiting for a stable terminal state is therefore required
+		// before clean; clean's queued-member refusal remains intentional.
+		try {
+			execFileSync(process.execPath, [SCRIPT, "stop", jobDir], { stdio: "pipe" });
+		} catch {}
+		await waitForStableTerminal(jobDir);
+		execFileSync(process.execPath, [SCRIPT, "clean", jobDir, "--jobs-dir", jobsDir], {
+			stdio: "pipe",
+		});
+
+		expect(fs.existsSync(jobDir)).toBe(false);
+	});
+
+	test("start returns plain jobDir path without --json flag", async () => {
 		const configPath = path.join(tmpDir, "diagnose.config.yaml");
 		writeConfig(configPath);
 		const jobsDir = path.join(tmpDir, "jobs");
@@ -146,6 +229,7 @@ describe("design-review job lifecycle", () => {
 		try {
 			execFileSync(process.execPath, [SCRIPT, "stop", jobDir], { stdio: "pipe" });
 		} catch {}
+		await waitForStableTerminal(jobDir);
 		try {
 			execFileSync(process.execPath, [SCRIPT, "clean", jobDir, "--jobs-dir", jobsDir], {
 				stdio: "pipe",
@@ -193,7 +277,7 @@ describe("design-review job lifecycle", () => {
 		expect(anyJobJson).toBe(false);
 	});
 
-	test("status returns JSON with members after start", () => {
+	test("status returns JSON with members after start", async () => {
 		const configPath = path.join(tmpDir, "diagnose.config.yaml");
 		writeConfig(configPath);
 		const jobsDir = path.join(tmpDir, "jobs");
@@ -219,6 +303,7 @@ describe("design-review job lifecycle", () => {
 		try {
 			execFileSync(process.execPath, [SCRIPT, "stop", jobDir], { stdio: "pipe" });
 		} catch {}
+		await waitForStableTerminal(jobDir);
 		try {
 			execFileSync(process.execPath, [SCRIPT, "clean", jobDir, "--jobs-dir", jobsDir], {
 				stdio: "pipe",

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -35,9 +35,12 @@ Subcommands used by this orchestrator:
 | `claim-review-dispatch` | PreToolUse hook only | Atomically reserves one final code-review dispatch. The initial cap is 5; it persists the reservation before allowing the dispatch. The orchestrator never calls this command directly. |
 | `approve-review-dispatch-renewal` | **user only** — a PreToolUse guard denies it on the orchestrator's Bash path; present the command and have the user run it | Adds exactly 5 to the review-dispatch cap; when a valid code-review artifact exists, also records the SHA-256 of its exact raw bytes as the user-approved marker (an absent/invalid artifact still renews — sole recovery when all dispatches died before writing one). |
 | `dismiss-review-finding --ref <file:line> --class <correctness\|requirement-gap> --rationale <text>` | **user only** — same PreToolUse guard; propose it, never run it | Removes ONE wrong blocking code-review finding from the completion gate's blocking set. Refuses unless EXACTLY ONE `CONFIRMED` finding with that exact `ref` and `class` is in the current artifact (two are indistinguishable to a dismissal, so clearing one would clear both), and pins the dismissal to that artifact's raw bytes so it lapses on the next review round. Propose per `references/completion-gate.md`; never run it on your own judgment. |
+| `resume-pursuit` | **user only** — a PreToolUse guard denies it on the orchestrator's Bash path; present the command and have the user run it | Recovers only a `budget_limited` pursuit, restoring `phase=pursuing`, `active=true`, and `iteration=0`; refuses from any other phase. |
 | `get` / `status` | read | Inspect current state / derived status. |
 
 `set-budget-limited` and `set-blocked --reason <text>` are system-only setters (the hook layer writes `budget_limited`; `set-blocked` records a reported blocker). The orchestrator never writes `complete`, `budget_limited`, or a fabricated verdict by any other route — the narrow gates are structural, not vigilance-based.
+
+During pursuit, `iteration` counts consecutive Stop turns with no observed progress. A diff-carrying commit or a story status transition resets it to `0`; Stops waiting for background work are not counted. Reaching `max_iterations` soft-stops the pursuit as `budget_limited` (state is preserved and no new work is dispatched). After draining any in-flight work and checking the completion gate, recovery from that pause requires the user to run `resume-pursuit`, which resets the counter and re-arms the pursuing phase.
 
 ---
 

--- a/skills/ultragoal/references/completion-gate.md
+++ b/skills/ultragoal/references/completion-gate.md
@@ -131,7 +131,7 @@ Use stdin (`-`) with a **quoted** heredoc here too: the snapshot echoes the regi
 
 **Omitting `--codex-goal-json` when it is required is a refusal, not a silent pass.** Once `set --codex-goal-objective` has armed the cross-check, a missing, unparseable, or non-matching snapshot leaves `phase` at `pursuing` — the safe, never-false-complete direction — and `request-complete`'s own refusal message names this condition, so read that message rather than retrying the same call.
 
-Evidence is recorded BEFORE the verdict flips so the full gate (verdict + evidence + per-story artifact checks) is satisfiable the moment `objective_verdict=APPROVE` appears. `request-complete` is the ONLY path to `phase=complete` — the hook layer never writes `complete` (cap reached → `budget_limited` block). A `budget_limited` state does not bar `request-complete` in the same turn: complete wins over a prior `budget_limited`. If `request-complete` is refused, report the blocker honestly and stop.
+Evidence is recorded BEFORE the verdict flips so the full gate (verdict + evidence + per-story artifact checks) is satisfiable the moment `objective_verdict=APPROVE` appears. `request-complete` is the ONLY path to `phase=complete` — the hook layer never writes `complete` (the no-progress cap reached → `budget_limited` block). A `budget_limited` state does not bar `request-complete` in the same turn: drain any in-flight delegated work, harvest and commit its results, then run the completion gate; completion wins over a prior `budget_limited` when every gate passes. Do not dispatch new stories or interrupt running executors during this drain. If the gate is refused, report the blocker honestly and stop; the user can recover the preserved pursuit by running `bun ${CLAUDE_SKILL_DIR}/scripts/ultragoal-state.ts resume-pursuit`, which restores `pursuing` and resets the no-progress counter to `0`.
 
 APPROVE alone does NOT leave the ultragoal pursuit pursuing/active — the `request-complete` handoff is what transitions to terminal `complete` (and it is structurally gated on completion-evidence, so a write that never reached the gate cannot false-complete).
 
@@ -152,7 +152,7 @@ Every non-APPROVE verdict drives a concrete progress action — never action-les
 
 ### Blocked-stop
 
-Pursuit stops as blocked (non-complete) ONLY on a decidable, point-in-time predicate — there is no cross-iteration stall detector; `max_iterations` absorbs genuine stalls. Exactly two conditions trip blocked:
+Pursuit stops as blocked (non-complete) ONLY on a decidable, point-in-time predicate. The no-progress cap is a separate soft-stop: consecutive Stops without a diff-carrying commit or story transition accumulate toward `max_iterations`, while observed progress resets the counter; reaching the cap yields `budget_limited`, preserves state, and requires user-run `resume-pursuit` after any drain. Exactly two conditions trip blocked:
 
 - **B1** — the objective self-check names NO actionable incomplete work item while the objective is still unmet (no valid progress path: nothing to re-dispatch and the verification surface is not satisfied).
 - **B2** — the captured **blocked-stop** slot's objective-specific condition is met.

--- a/skills/ultragoal/references/planning.md
+++ b/skills/ultragoal/references/planning.md
@@ -12,7 +12,7 @@ Five content slots (from capture):
 
 Two minted slots (not in the request — this orchestrator supplies them):
 
-6. **iteration-policy** → `max_iterations` (`--max-iterations <n>`) — the finite cap on pursuit blocks. Default **10** when not overridden at invocation; invocation-overridable. This is the SOLE soft-stop bound: when pursuit hits `max_iterations` the loop soft-stops (state preserved), it does NOT hard-kill.
+6. **iteration-policy** → `max_iterations` (`--max-iterations <n>`) — the finite cap on **consecutive no-progress Stop turns**. Default **10** when not overridden at invocation; invocation-overridable. A diff-carrying commit or a story status transition is observed progress and resets the counter to `0`; a Stop while background work is still running is a wait and is not counted. When the counter reaches `max_iterations`, the loop soft-stops as `budget_limited` (state is preserved; it does NOT hard-kill or dispatch new work). After in-flight work is drained, only the user may resume the pursuit with `resume-pursuit`, which re-arms `pursuing` and resets the counter to `0`.
 7. **blocked-stop** (`--blocked-stop <text>`) — the objective-specific predicate that means "no valid path forward". A decidable, point-in-time condition (no cross-iteration memory); when met, pursuit stops and reports the blocker, non-complete.
 
 Seed example (run at the first `planning` transition):

--- a/skills/ultragoal/scripts/ultragoal-state.test.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.test.ts
@@ -286,6 +286,30 @@ describe("review dispatch stale-lock recovery", () => {
 });
 
 describe("goal state", () => {
+	test("fingerprint fields survive an unrelated merge write byte-identically", () => {
+		const path = resolveStatePath(S);
+		const seeded = JSON.parse(readFileSync(path, "utf8"));
+		const lastSeenHead = "abc123\nwith-newline";
+		const lastSeenStoriesDigest = "sha256:deadbeef==";
+		writeFileSync(
+			path,
+			JSON.stringify({ ...seeded, last_seen_head: lastSeenHead, last_seen_stories_digest: lastSeenStoriesDigest }),
+			"utf8",
+		);
+
+		setGoalState(S, { phase: "planning", resume_summary: "unrelated write" });
+
+		const persisted = JSON.parse(readFileSync(path, "utf8"));
+		expect(persisted.last_seen_head).toBe(lastSeenHead);
+		expect(persisted.last_seen_stories_digest).toBe(lastSeenStoriesDigest);
+	});
+
+	test("fingerprint fields are omitted from a fresh seed", () => {
+		const persisted = JSON.parse(readFileSync(resolveStatePath(S), "utf8"));
+		expect(Object.prototype.hasOwnProperty.call(persisted, "last_seen_head")).toBe(false);
+		expect(Object.prototype.hasOwnProperty.call(persisted, "last_seen_stories_digest")).toBe(false);
+	});
+
 	// AC #1
 	test("merge-write preserves prior fields and never re-seeds started_at", () => {
 		// First write: a full set of content/loop-control slots

--- a/skills/ultragoal/scripts/ultragoal-state.test.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.test.ts
@@ -1352,13 +1352,17 @@ describe("get subcommand includes pristine field", () => {
 });
 
 describe("recovery-and-guards: resume-pursuit", () => {
-	test("status shows budget_limited while get keeps inactive-fold contract", () => {
+	test("status shows budget_limited", () => {
 		setBudgetLimited(S);
 		expect(runCli("status")).toBe("budget_limited\n");
+	});
+
+	test("get keeps active-fold contract", () => {
+		setBudgetLimited(S);
 		expect(readGoalGet(S)).toBeNull();
 	});
 
-	test("success resumes budget_limited and preserves stories and other fields", () => {
+	test("resume-pursuit restores pursuing state", () => {
 		setGoalState(S, { phase: "planning", outcome: "keep me", resume_summary: "summary" });
 		setStories(S, [{ id: "S1", story: "story", acceptance_criteria: ["works"], verification_surface: "tests", status: "confirmed" }]);
 		setBudgetLimited(S);
@@ -1368,7 +1372,20 @@ describe("recovery-and-guards: resume-pursuit", () => {
 		expect(state.stories).toHaveLength(1);
 	});
 
-	test("refuses pursuing, blocked, complete, absent, and corrupt without changing bytes", () => {
+	test("resume-pursuit refreshes stale heartbeat timestamps", () => {
+		setBudgetLimited(S);
+		const path = resolveStatePath(S);
+		const stale = "2020-01-01T00:00:00";
+		const prior = JSON.parse(readFileSync(path, "utf8"));
+		writeFileSync(path, JSON.stringify({ ...prior, last_touched_at: stale, progress_touched_at: stale }), "utf8");
+
+		resumePursuit(S);
+		const resumed = JSON.parse(readFileSync(path, "utf8"));
+		expect(resumed.last_touched_at).not.toBe(stale);
+		expect(resumed.progress_touched_at).not.toBe(stale);
+	});
+
+	test("resume-pursuit refuses outside budget_limited", () => {
 		for (const phase of ["pursuing", "blocked", "complete"] as const) {
 			writeFileSync(resolveStatePath(S), JSON.stringify({ ...rawState(), phase, active: phase === "pursuing" }), "utf8");
 			const before = readFileSync(resolveStatePath(S), "utf8");
@@ -1383,7 +1400,7 @@ describe("recovery-and-guards: resume-pursuit", () => {
 		expect(readFileSync(resolveStatePath(S), "utf8")).toBe("{broken");
 	});
 
-	test("terminal lock survives refusal", () => {
+	test("terminal lock survives new seed attempt", () => {
 		setBudgetLimited(S);
 		const lock = `${resolveStatePath(S)}.lock`;
 		mkdirSync(lock);

--- a/skills/ultragoal/scripts/ultragoal-state.test.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.test.ts
@@ -288,7 +288,7 @@ describe("review dispatch stale-lock recovery", () => {
 });
 
 describe("goal state", () => {
-	test("fingerprint fields survive an unrelated merge write byte-identically", () => {
+	test("fingerprint fields survive merge write", () => {
 		const path = resolveStatePath(S);
 		const seeded = JSON.parse(readFileSync(path, "utf8"));
 		const lastSeenHead = "abc123\nwith-newline";
@@ -306,7 +306,7 @@ describe("goal state", () => {
 		expect(persisted.last_seen_stories_digest).toBe(lastSeenStoriesDigest);
 	});
 
-	test("fingerprint fields are omitted from a fresh seed", () => {
+	test("fresh seed omits fingerprint fields", () => {
 		const persisted = JSON.parse(readFileSync(resolveStatePath(S), "utf8"));
 		expect(Object.prototype.hasOwnProperty.call(persisted, "last_seen_head")).toBe(false);
 		expect(Object.prototype.hasOwnProperty.call(persisted, "last_seen_stories_digest")).toBe(false);

--- a/skills/ultragoal/scripts/ultragoal-state.test.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import {
 	mkdtempSync,
+	mkdirSync,
 	rmSync,
 	readFileSync,
 	writeFileSync,
@@ -16,6 +17,7 @@ import {
 	readGoalState,
 	setGoalState,
 	setBudgetLimited,
+	resumePursuit,
 	setBlocked,
 	requestComplete,
 	setVerdict,
@@ -1346,6 +1348,58 @@ describe("get subcommand includes pristine field", () => {
 		const parsed = JSON.parse(out);
 		expect(typeof parsed.pristine).toBe("boolean");
 		expect(parsed.pristine).toBe(true);
+	});
+});
+
+describe("recovery-and-guards: resume-pursuit", () => {
+	test("status shows budget_limited while get keeps inactive-fold contract", () => {
+		setBudgetLimited(S);
+		expect(runCli("status")).toBe("budget_limited\n");
+		expect(readGoalGet(S)).toBeNull();
+	});
+
+	test("success resumes budget_limited and preserves stories and other fields", () => {
+		setGoalState(S, { phase: "planning", outcome: "keep me", resume_summary: "summary" });
+		setStories(S, [{ id: "S1", story: "story", acceptance_criteria: ["works"], verification_surface: "tests", status: "confirmed" }]);
+		setBudgetLimited(S);
+		resumePursuit(S);
+		const state = rawState();
+		expect(state).toMatchObject({ phase: "pursuing", active: true, iteration: 0, budget_limit_notified: false, outcome: "keep me", resume_summary: "summary" });
+		expect(state.stories).toHaveLength(1);
+	});
+
+	test("refuses pursuing, blocked, complete, absent, and corrupt without changing bytes", () => {
+		for (const phase of ["pursuing", "blocked", "complete"] as const) {
+			writeFileSync(resolveStatePath(S), JSON.stringify({ ...rawState(), phase, active: phase === "pursuing" }), "utf8");
+			const before = readFileSync(resolveStatePath(S), "utf8");
+			expect(() => resumePursuit(S)).toThrow();
+			expect(readFileSync(resolveStatePath(S), "utf8")).toBe(before);
+		}
+		rmSync(resolveStatePath(S));
+		expect(() => resumePursuit(S)).toThrow();
+		expect(existsSync(resolveStatePath(S))).toBe(false);
+		writeFileSync(resolveStatePath(S), "{broken", "utf8");
+		expect(() => resumePursuit(S)).toThrow();
+		expect(readFileSync(resolveStatePath(S), "utf8")).toBe("{broken");
+	});
+
+	test("terminal lock survives refusal", () => {
+		setBudgetLimited(S);
+		const lock = `${resolveStatePath(S)}.lock`;
+		mkdirSync(lock);
+		writeFileSync(`${lock}/owner.json`, JSON.stringify({ ownerPid: process.pid, token: "live", startedAt: Date.now() }), "utf8");
+		const before = readFileSync(resolveStatePath(S), "utf8");
+		expect(() => resumePursuit(S)).toThrow();
+		expect(readFileSync(resolveStatePath(S), "utf8")).toBe(before);
+		expect(existsSync(lock)).toBe(true);
+		rmSync(lock, { recursive: true, force: true });
+	});
+
+	test("CLI registers resume-pursuit usage and succeeds", () => {
+		setBudgetLimited(S);
+		expect(runCli("resume-pursuit")).toBe("");
+		const usage = runCliCaptured("unknown");
+		expect(usage.stderr).toContain("resume-pursuit");
 	});
 });
 

--- a/skills/ultragoal/scripts/ultragoal-state.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.ts
@@ -29,6 +29,7 @@
  *       [--blocked-stop ..] [--plan-path ..] [--resume-summary ..]
  *       [--completion-evidence p1,p2] [--codex-goal-objective <text>]
  *   set-budget-limited                       (system-only)
+ *   resume-pursuit                            (user-only recovery from budget_limited)
  *   set-blocked --reason <text>              (system-only)
  *   request-complete [--codex-goal-json <json|path>]
  *                                         (gated: requires objective_verdict=APPROVE and completion
@@ -545,6 +546,13 @@ function releaseStateLock(lockPath: string, token: string): void {
 // ---------------------------------------------------------------------------
 
 export function readGoalState(sessionId: string): GoalState | null {
+	const state = readGoalStateRaw(sessionId);
+	if (state === null || !state.active) return null;
+	return state;
+}
+
+/** Schema-validated state read that preserves terminal (active:false) phases. */
+export function readGoalStateRaw(sessionId: string): GoalState | null {
 	const content = readFileOrNull(resolveStatePath(sessionId));
 	if (!content) return null;
 	try {
@@ -572,7 +580,6 @@ export function readGoalState(sessionId: string): GoalState | null {
 		) {
 			return null;
 		}
-		if (!state.active) return null;
 		// The shared seed skeleton predates review dispatch state. Keep reads compatible
 		// with those files without making a re-plan reset an already-persisted budget.
 		return {
@@ -821,6 +828,25 @@ export function setBudgetLimited(sessionId: string): void {
 		phase: "budget_limited",
 		active: false,
 		budget_limit_notified: true,
+	});
+}
+
+/**
+ * User-only recovery edge: budget_limited → pursuing. This is deliberately a
+ * strict raw read/validate/write path: it never seeds or performs a generic merge.
+ */
+export function resumePursuit(sessionId: string): void {
+	const stateFilePath = resolveStatePath(sessionId);
+	withStateLock(stateFilePath, () => {
+		const raw = readFileOrNull(stateFilePath);
+		if (raw === null) throw new Error("resume-pursuit: refused — state file is absent");
+		const prior = parseClaimableState(raw);
+		if (prior === null) throw new Error("resume-pursuit: refused — state is corrupt or invalid");
+		if (prior.phase !== "budget_limited") {
+			throw new Error(`resume-pursuit: refused — phase must be budget_limited (got "${String(prior.phase)}")`);
+		}
+		const next = { ...prior, phase: "pursuing", active: true, iteration: 0, budget_limit_notified: false };
+		writeFileNoCreate(stateFilePath, JSON.stringify(next, null, 2));
 	});
 }
 
@@ -2275,6 +2301,8 @@ function main(): void {
 			setVerdict(sessionId, v);
 		} else if (subcommand === "set-budget-limited") {
 			setBudgetLimited(sessionId);
+		} else if (subcommand === "resume-pursuit") {
+			resumePursuit(sessionId);
 		} else if (subcommand === "set-blocked") {
 			setBlocked(sessionId, String(args["reason"] ?? ""));
 		} else if (subcommand === "request-complete") {
@@ -2332,7 +2360,7 @@ function main(): void {
 		} else if (subcommand === "get") {
 			process.stdout.write(JSON.stringify(readGoalGet(sessionId)) + "\n");
 		} else if (subcommand === "status") {
-			const state = readGoalState(sessionId);
+			const state = readGoalStateRaw(sessionId);
 			process.stdout.write((state ? deriveStatus(state) : "absent") + "\n");
 		} else if (subcommand === "list-others") {
 			const candidates = listOthers("ultragoal");
@@ -2512,7 +2540,7 @@ function main(): void {
 			process.stdout.write(JSON.stringify(serializeReviewContext(sessionId)) + "\n");
 		} else {
 			process.stderr.write(
-				"Usage: ultragoal-state.ts <set|set-verdict|set-budget-limited|set-blocked|request-complete|claim-review-dispatch|approve-review-dispatch-renewal|dismiss-review-finding|get|status|list-others|adopt|set-stories|confirm-story|confirm-all-stories|reorder-stories|revise-story|add-story|retire-story|split-story|serialize-requirements|serialize-review-context> [options]\n",
+				"Usage: ultragoal-state.ts <set|set-verdict|set-budget-limited|resume-pursuit|set-blocked|request-complete|claim-review-dispatch|approve-review-dispatch-renewal|dismiss-review-finding|get|status|list-others|adopt|set-stories|confirm-story|confirm-all-stories|reorder-stories|revise-story|add-story|retire-story|split-story|serialize-requirements|serialize-review-context> [options]\n",
 			);
 			process.exit(1);
 		}

--- a/skills/ultragoal/scripts/ultragoal-state.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.ts
@@ -204,6 +204,10 @@ export interface GoalState {
 	 * CLI branch below for why.
 	 */
 	codex_goal_objective: string;
+	/** Last observed repository HEAD used by progress-fingerprint callers. */
+	last_seen_head?: string;
+	/** Digest of the last observed story set used by progress-fingerprint callers. */
+	last_seen_stories_digest?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -342,6 +346,10 @@ function mergeWriteLocked(sessionId: string, stateFilePath: string, next: Partia
 		// `set --phase pursuing` (no codex flag) would silently wipe the last-registered
 		// native-goal objective back to "" on every unrelated write.
 		codex_goal_objective: next.codex_goal_objective ?? prior.codex_goal_objective ?? "",
+		// Progress fingerprints are caller-owned metadata. Enumerate them here so an
+		// unrelated merge write cannot silently drop the last observed values.
+		last_seen_head: next.last_seen_head ?? prior.last_seen_head,
+		last_seen_stories_digest: next.last_seen_stories_digest ?? prior.last_seen_stories_digest,
 		review_dispatch_used: validNonNegativeInteger(reviewDispatchUsedCandidate)
 			? reviewDispatchUsedCandidate
 			: 0,

--- a/skills/ultragoal/scripts/ultragoal-state.ts
+++ b/skills/ultragoal/scripts/ultragoal-state.ts
@@ -55,18 +55,11 @@
  *   or whitespace-only values are refused (ADR D-4).
  */
 
-import {
-	mkdirSync,
-	readFileSync,
-	renameSync,
-	rmSync,
-	statSync,
-	unlinkSync,
-	writeFileSync,
-} from "node:fs";
+import { readFileSync, unlinkSync } from "node:fs";
 import { execSync } from "child_process";
 import { createHash } from "crypto";
 import { getOmtDir } from "@lib/omt-dir";
+import { withStateLock } from "@lib/persistent-mode-core/state-lock";
 import {
 	mergeWithHeartbeat,
 	resolveSessionIdOrThrow,
@@ -76,8 +69,6 @@ import {
 	isPristine,
 	ensureSeed,
 } from "@lib/state-core";
-
-import { join } from "node:path";
 
 export type GoalPhase = "planning" | "pursuing" | "budget_limited" | "blocked" | "complete";
 export type ObjectiveVerdict = "APPROVE" | "REQUEST_CHANGES" | "COMMENT" | "absent";
@@ -140,9 +131,6 @@ export interface DismissedReviewFinding {
 
 const DEFAULT_MAX_ITERATIONS = 10;
 const DEFAULT_REVIEW_DISPATCH_CAP = 5;
-const REVIEW_LOCK_RETRIES = 100;
-const REVIEW_LOCK_RETRY_MS = 5;
-const REVIEW_LOCK_SLEEP = new Int32Array(new SharedArrayBuffer(4));
 
 export interface GoalState {
 	// --- 5 content slots ---
@@ -410,135 +398,6 @@ function parseClaimableState(raw: string): Partial<GoalState> | null {
 	} catch {
 		return null;
 	}
-}
-
-/**
- * Minimal mkdir lock for every read-modify-write of this state file. A contention
- * timeout fails closed; we never perform an unlocked fallback after a lock error.
- */
-const REVIEW_LOCK_STALE_TTL_MS = 30_000;
-const REVIEW_LOCK_OWNER_FILE = "owner.json";
-
-type ReviewLockOwner = { ownerPid: number; token: string; startedAt: number };
-
-function withStateLock<T>(stateFilePath: string, callback: () => T): T {
-	const lockPath = `${stateFilePath}.lock`;
-	for (let attempt = 0; attempt < REVIEW_LOCK_RETRIES; attempt += 1) {
-		const token = crypto.randomUUID();
-		try {
-			mkdirSync(lockPath);
-			writeFileSync(join(lockPath, REVIEW_LOCK_OWNER_FILE), JSON.stringify({
-				ownerPid: process.pid,
-				token,
-				startedAt: Date.now(),
-			} satisfies ReviewLockOwner));
-			try {
-				return callback();
-			} finally {
-				releaseStateLock(lockPath, token);
-			}
-		} catch (err) {
-			if (isErrnoException(err) && err.code === "EEXIST") {
-				if (!recoverStaleStateLock(lockPath)) {
-					Atomics.wait(REVIEW_LOCK_SLEEP, 0, 0, REVIEW_LOCK_RETRY_MS);
-				}
-				continue;
-			}
-			throw err;
-		}
-	}
-	throw new Error("ultragoal-state: state lock contended; refusing unlocked write");
-}
-
-function readStateLockOwner(lockPath: string): ReviewLockOwner | undefined {
-	try {
-		const value: unknown = JSON.parse(readFileSync(join(lockPath, REVIEW_LOCK_OWNER_FILE), "utf8"));
-		if (
-			isRecord(value) &&
-			typeof value.ownerPid === "number" &&
-			Number.isInteger(value.ownerPid) &&
-			value.ownerPid > 0 &&
-			typeof value.token === "string" &&
-			value.token.length > 0 &&
-			typeof value.startedAt === "number"
-		) {
-			return { ownerPid: value.ownerPid, token: value.token, startedAt: value.startedAt };
-		}
-	} catch {
-		return undefined;
-	}
-	return undefined;
-}
-
-function isStateLockStale(lockPath: string): boolean {
-	const owner = readStateLockOwner(lockPath);
-	if (owner !== undefined && !isPidAlive(owner.ownerPid)) return true;
-	try {
-		return statSync(lockPath).mtimeMs + REVIEW_LOCK_STALE_TTL_MS < Date.now();
-	} catch {
-		return true;
-	}
-}
-
-function isPidAlive(pid: number): boolean {
-	try {
-		process.kill(pid, 0);
-		return true;
-	} catch (err) {
-		return isErrnoException(err) && err.code === "EPERM";
-	}
-}
-
-/** Serializes stale recovery so a second observer cannot rename a successor lock. */
-function recoverStaleStateLock(lockPath: string): boolean {
-	let recovered = false;
-	if (!withStateLockRecoveryGuard(lockPath, () => {
-		if (!isStateLockStale(lockPath)) return;
-		isolateAndRemoveStaleLock(lockPath);
-		recovered = true;
-	})) return false;
-	return recovered;
-}
-
-/** Prevents stale recovery from racing a token-checked holder release. */
-function withStateLockRecoveryGuard(lockPath: string, callback: () => void): boolean {
-	const recoveryPath = `${lockPath}.recovery`;
-	for (let attempt = 0; attempt < 2; attempt += 1) {
-		try {
-			mkdirSync(recoveryPath);
-		} catch (err) {
-			if (!(isErrnoException(err) && err.code === "EEXIST")) throw err;
-			if (!isStateLockStale(recoveryPath)) return false;
-			isolateAndRemoveStaleLock(recoveryPath);
-			continue;
-		}
-		try {
-			callback();
-			return true;
-		} finally {
-			rmSync(recoveryPath, { recursive: true, force: true });
-		}
-	}
-	return false;
-}
-
-function isolateAndRemoveStaleLock(lockPath: string): void {
-	const stalePath = `${lockPath}.stale-${process.pid}-${crypto.randomUUID()}`;
-	try {
-		renameSync(lockPath, stalePath);
-	} catch (err) {
-		if (isErrnoException(err) && (err.code === "ENOENT" || err.code === "EEXIST")) return;
-		throw err;
-	}
-	rmSync(stalePath, { recursive: true, force: true });
-}
-
-function releaseStateLock(lockPath: string, token: string): void {
-	withStateLockRecoveryGuard(lockPath, () => {
-		if (readStateLockOwner(lockPath)?.token === token) {
-			rmSync(lockPath, { recursive: true, force: true });
-		}
-	});
 }
 
 // ---------------------------------------------------------------------------
@@ -845,8 +704,12 @@ export function resumePursuit(sessionId: string): void {
 		if (prior.phase !== "budget_limited") {
 			throw new Error(`resume-pursuit: refused — phase must be budget_limited (got "${String(prior.phase)}")`);
 		}
-		const next = { ...prior, phase: "pursuing", active: true, iteration: 0, budget_limit_notified: false };
-		writeFileNoCreate(stateFilePath, JSON.stringify(next, null, 2));
+		mergeWriteLocked(sessionId, stateFilePath, {
+			phase: "pursuing",
+			active: true,
+			iteration: 0,
+			budget_limit_notified: false,
+		});
 	});
 }
 


### PR DESCRIPTION
## 📌 Summary

ultragoal이 실제 진전 없이 Stop 루프를 반복하지 않도록 진전을 판별·기록하고, 반복 한도 도달 시 안전하게 중단한 뒤 사용자 승인으로만 재개하도록 개선합니다. Claude와 Codex의 실행 경로 및 최종 완료 조건을 같은 안전성 계약으로 정렬했습니다.

---

## 🔧 Changes

### 무진전 진단과 bounded continuation

- Git의 실제 변경이 있는 commit과 story 상태 전이만 진전으로 판정하는 fingerprint를 추가했습니다.
- 진전이 있으면 무진전 카운터를 초기화하고, 진전이 없으면 반복 횟수를 증가시킵니다.
- 반복 한도에 도달하면 `budget_limited` 상태로 전이해 자동 continuation을 멈춥니다.

**영향 범위**

- ultragoal pursuit의 Stop 결정과 반복 동작이 변경됩니다.
- working tree 변경, empty commit, rebase/diverge는 진전으로 계산하지 않습니다.

### 상태 보존·복구·완료 게이트

- 상태 갱신을 공통 lock으로 직렬화하고 contention 시 unlocked write를 허용하지 않습니다.
- heartbeat와 실제 progress 시각을 분리해 GC 생존 갱신이 무진전 판정을 되살리지 않도록 했습니다.
- `resume-pursuit`, 리뷰 예산 갱신, finding dismissal 등 완료 게이트를 해제하는 명령을 사용자 전용으로 제한했습니다.
- objective·story evidence·독립 code review를 모두 충족할 때만 완료 상태로 전이하도록 강화했습니다.

**영향 범위**

- 상태 파일의 동시 갱신 안전성과 ultragoal 재개 권한이 강화됩니다.
- 기존 자동 완료 경로 대신 검증 가능한 완료 증적이 필요합니다.

### Claude/Codex 실행 경로 정렬

- Claude Stop hook과 Codex persistent-mode CLI가 공통 decision core를 사용하도록 연결했습니다.
- Codex 자식 작업 감지를 active pursuit에만 적용하고, mirror·sqlite·rollout 조회 오류는 기존 fail-open 동작을 유지하며 진단만 남깁니다.

**영향 범위**

- 플랫폼별 payload 형식은 유지됩니다.
- background child 감지 실패가 Stop hook 자체의 장애로 확대되지 않습니다.

### 분리 작업자 테스트 격리

- design-review 작업자가 terminal 상태로 안정화된 뒤에만 job directory를 정리하도록 테스트 수명주기를 보완했습니다.
- `queued → stop → clean` 경쟁 상태를 재현하는 회귀 테스트를 추가했습니다.

**영향 범위**

- 테스트 전용 변경입니다.
- 활성 작업자에 대한 `clean` 거부 정책은 유지됩니다.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 진전의 정의를 “관찰 가능한 상태 변화”로 제한

**배경 및 문제 상황:**

Stop hook이 반복 호출되더라도 실제 작업이 진행 중인 경우와, 같은 상태에서 멈춘 경우를 구분해야 합니다. 단순 heartbeat나 working tree 변경을 진전으로 인정하면 멈춘 루프가 계속 살아날 수 있습니다.

**해결 방안:**

HEAD 사이에 실제 diff를 갖는 commit이 생겼거나 story의 id/status 조합이 바뀐 경우만 진전으로 인정했습니다.

**구현 세부사항:**

fingerprint는 story의 내용 전체가 아니라 id/status의 정렬된 digest를 사용합니다. 이전 HEAD가 현재 HEAD의 조상이 아닌 경우, empty commit, commit 없이 남아 있는 변경은 카운터 초기화 조건에서 제외합니다.

**선택과 트레이드오프:**

설명·acceptance criteria만 수정하는 경우는 진전으로 세지 않습니다. 더 넓은 변경을 진전으로 인정하면 false reset 위험이 커지므로, 사용자가 명시적으로 재개하는 쪽을 선택했습니다.

---

### 2. 자동 중단은 보수적으로, 재개·완료는 명시적으로

**배경 및 문제 상황:**

무진전 상태에서 자동 루프가 계속되면 자원 낭비와 거짓 완료 위험이 생깁니다. 반대로 상태 갱신 경쟁에서 필드가 유실되면 잘못된 재개나 완료로 이어질 수 있습니다.

**해결 방안:**

반복 한도 도달 시 `budget_limited`로 상태를 보존하고, 재개·리뷰 예산 갱신·finding dismissal은 사용자만 실행하도록 제한했습니다. 상태 writer는 동일 lock을 공유합니다.

**구현 세부사항:**

heartbeat의 GC 생존 시각과 실제 progress 시각을 분리했습니다. 완료는 objective 승인, story evidence, 독립 code-review 완료를 모두 통과한 `request-complete` 경로에서만 허용합니다.

**선택과 트레이드오프:**

lock contention에서 fallback write를 하면 가용성은 높아지지만 상태 유실 가능성이 생깁니다. 이 경로는 false completion보다 보수적 중단이 안전하므로 fail-closed를 선택했습니다.

---

### 3. 플랫폼별 입력 차이는 유지하고 decision 계약은 공유

**배경 및 문제 상황:**

Claude와 Codex는 Stop payload와 background 작업 관찰 방식이 다르지만, 무진전 제어의 결과가 달라지면 운영 규칙이 플랫폼마다 갈라집니다.

**해결 방안:**

각 플랫폼은 자신의 입력을 해석하되, 공통 decision core와 continuation 계약을 사용하도록 정렬했습니다.

**구현 세부사항:**

Codex는 active pursuit일 때만 자식 작업 감지를 수행합니다. mirror, sqlite, rollout 조회가 실패하면 child 수를 0으로 처리하고 진단을 남겨 기존 fail-open 특성을 보존합니다.

**선택과 트레이드오프:**

감지기 오류를 Stop hook 전체 오류로 전파하지 않는 대신, 오류 상황에서 background 작업을 보수적으로 놓칠 수 있습니다. 플랫폼 hook의 가용성을 우선했습니다.

---

## ✅ Checklist

### 무진전 실행 제어

- [ ] 실제 변경 commit 또는 story id/status 전이가 있을 때만 무진전 카운터가 초기화된다.
  - `lib/persistent-mode-core/progress.ts`
  - `lib/persistent-mode-core/decision.ts`

- [ ] 무진전 반복 한도에 도달하면 pursuit가 `budget_limited`로 전이하고 자동 continuation이 중단된다.
  - `lib/persistent-mode-core/decision.ts`

- [ ] 상태 갱신은 lock contention에서 unlocked write 없이 실패하며, load-bearing 필드를 보존한다.
  - `lib/persistent-mode-core/state-lock.ts`
  - `lib/persistent-mode-core/state.ts`

- [ ] 재개와 완료 게이트 해제 명령은 에이전트가 직접 실행할 수 없다.
  - `hooks/write-guard-core.sh`
  - `skills/ultragoal/scripts/ultragoal-state.ts`

### 플랫폼 연동과 회귀 검증

- [ ] Claude와 Codex가 동일한 무진전 decision 규칙을 적용한다.
  - `hooks/persistent-mode/index.ts`
  - `hooks/codex-persistent-mode/cli.ts`

- [ ] queued 상태의 분리 작업자는 terminal 상태가 안정화된 뒤에만 clean된다.
  - `skills/design-review/scripts/job.test.ts`

- [ ] `make typecheck`, `make test`, `make lint`가 통과한다.
  - `lib/persistent-mode-core/*.test.ts`
  - `hooks/codex-persistent-mode/cli.test.ts`
  - `skills/design-review/scripts/job.test.ts`

---

## 📎 References

- 관련 이슈·외부 설계 문서 없음