### PR TITLE
feat: deep-interview 불변식 슬롯 + diagnose codex 전환

### DIFF
--- a/docs/skills/core-pipeline.en.md
+++ b/docs/skills/core-pipeline.en.md
@@ -213,7 +213,7 @@ flowchart TB
 
 **Purpose**: Provide architecture analysis, bug debugging, root-cause identification, and technical recommendations.
 
-**Core constraint**: **It is read-only — it diagnoses but never implements.** It delegates the analysis request to a detached worker (Hephaestus) and collects results by polling. The worker runs with subagent spawning and OMT skill loading blocked (`settings.deny`). If the worker is unavailable, it falls back to in-session analysis.
+**Core constraint**: **It is read-only — it diagnoses but never implements.** It delegates the analysis request to a detached Codex worker running `codex exec` (`gpt-5.6-sol`, high reasoning effort) and collects results by polling. If the worker is unavailable or fails because the CLI is missing, times out, errors, or is canceled, it falls back to in-session analysis. generic-job enforces both `settings.deny` and `settings.mcps.allow` for the worker; the MCP allowlist is opt-in/fail-closed. diagnose currently allows only `codegraph`.
 
 **When to use**: Use it for requests like "root cause", "what's wrong", "architecture review", "investigate" — when you need an analysis report, not a PASS/FAIL verdict. (When delegated, it is invoked as the oracle agent.)
 

--- a/docs/skills/core-pipeline.md
+++ b/docs/skills/core-pipeline.md
@@ -213,7 +213,7 @@ flowchart TB
 
 **목적**: 아키텍처 분석, 버그 디버깅, 근본 원인 식별, 기술적 권고를 제공합니다.
 
-**핵심 제약**: **읽기 전용입니다 — 진단하되 구현하지 않습니다.** 분석 요청을 detached 워커(Hephaestus)에 위임하고 폴링으로 결과를 거둡니다. 워커는 서브에이전트 스폰과 OMT 스킬 로딩이 차단된 상태로 돕니다(`settings.deny`). 워커가 불가하면 in-session 분석으로 폴백합니다.
+**핵심 제약**: **읽기 전용입니다 — 진단하되 구현하지 않습니다.** 분석 요청을 `codex exec`로 실행하는 detached Codex 워커(`gpt-5.6-sol`, 높은 추론 강도)에 위임하고 폴링으로 결과를 거둡니다. 워커를 사용할 수 없거나 CLI 누락·타임아웃·오류·취소 등으로 실패하면 in-session 분석으로 폴백합니다. 워커는 generic-job이 `settings.deny`와 `settings.mcps.allow`를 함께 집행하며, MCP allowlist는 opt-in/fail-closed로 동작합니다. 현재 diagnose는 `codegraph`만 허용합니다.
 
 **언제 쓰나**: "원인 분석", "뭐가 문제", "아키텍처 리뷰", "조사해" 같은 요청에 씁니다. 판정(PASS/FAIL)이 아니라 분석 보고서가 필요할 때입니다. (위임 시에는 oracle 에이전트로 호출합니다.)
 

--- a/docs/skills/review-quality.en.md
+++ b/docs/skills/review-quality.en.md
@@ -99,7 +99,7 @@ oh-my-toong's review and quality skills systematically verify the completeness o
 - Architectural considerations — boundaries, dependencies, scalability
 - Builds the strongest counter-argument, then provides counterpoints to it
 
-**Workflow**: By default, dispatches analysis to a Codex `gpt-5.6-sol` member with `high` reasoning via a job. The member runs with subagent spawning and OMT skill loading blocked (`settings.deny`). Falls back to in-session analysis if no member is available (`missing_cli`, timeout, empty config).
+**Workflow**: By default, dispatches analysis to a Codex `gpt-5.6-sol` member with `high` reasoning via a job. `generic-job` enforces both `settings.deny` and `settings.mcps.allow` when running the member. The MCP allowlist is opt-in and fail-closed; the current `design-review.config.yaml` allows only `codegraph`. Falls back to in-session analysis if no member is available (`missing_cli`, timeout, empty config).
 
 **When to use**: Architecture decisions, implementation plan reviews, tradeoff analysis. Trigger phrases: "design review", "plan review", "review the plan", "architectural soundness", "설계 검토", "플랜 리뷰", "아키텍처 건전성", "트레이드오프 분석".
 

--- a/docs/skills/review-quality.md
+++ b/docs/skills/review-quality.md
@@ -99,7 +99,7 @@ oh-my-toong의 리뷰 & 품질 스킬은 코드·설계·슬라이드에 걸쳐 
 - 아키텍처적 고려사항 — 경계, 의존성, 확장성
 - 반론을 최대한 강하게 세운 뒤 그에 대한 카운터도 제시
 
-**워크플로우**: 기본적으로 Codex `gpt-5.6-sol`(`high` reasoning) 멤버에게 job을 dispatch하여 분석을 받습니다. 멤버는 서브에이전트 스폰과 OMT 스킬 로딩이 차단된 상태로 돕니다(`settings.deny`). 멤버를 사용할 수 없는 경우(`missing_cli`, 타임아웃, 설정 없음) in-session fallback으로 직접 분석합니다.
+**워크플로우**: 기본적으로 Codex `gpt-5.6-sol`(`high` reasoning) 멤버에게 job을 dispatch하여 분석을 받습니다. `generic-job`은 멤버 실행 시 `settings.deny`와 `settings.mcps.allow`를 함께 집행합니다. MCP allowlist는 opt-in·fail-closed이며, 현재 `design-review.config.yaml`은 `codegraph`만 허용합니다. 멤버를 사용할 수 없는 경우(`missing_cli`, 타임아웃, 설정 없음) in-session fallback으로 직접 분석합니다.
 
 **언제 사용하나**: 아키텍처 결정, 구현 계획 검토, 트레이드오프 분석이 필요할 때. 트리거 키워드: "design review", "plan review", "설계 검토", "플랜 리뷰", "아키텍처 건전성", "트레이드오프 분석".
 

--- a/lib/generic-job.test.ts
+++ b/lib/generic-job.test.ts
@@ -46,6 +46,7 @@ import {
 	assertMcpAllowShape,
 	enumerateConfiguredMcpServers,
 	computeMcpBlockList,
+	prepareMcpEntities,
 	findOrphanJobs,
 	reapOrphanJobs,
 	doctorOrphanJobs,
@@ -907,6 +908,66 @@ describe("computeMcpBlockList", () => {
 		for (const name of result) {
 			expect(["codegraph", "linear"]).toContain(name);
 		}
+	});
+});
+
+describe("prepareMcpEntities", () => {
+	let tmpDir: string;
+	beforeEach(() => {
+		tmpDir = makeTmpDir();
+	});
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test("malformed mcps.allow is rejected through assertMcpAllowShape", () => {
+		const settings = { mcps: { allow: ["bad.name"] } };
+		const originalExit = process.exit;
+		try {
+			(process as any).exit = (code?: number) => {
+				throw new Error(`process.exit(${code})`);
+			};
+			expect(() =>
+				prepareMcpEntities(settings, [], councilConfig, "/tmp/config.yaml", tmpDir),
+			).toThrow("process.exit(1)");
+		} finally {
+			process.exit = originalExit;
+		}
+	});
+
+	test("computes blocks per member CODEX_HOME and preserves input", () => {
+		const homeA = path.join(tmpDir, "a");
+		const homeB = path.join(tmpDir, "b");
+		fs.mkdirSync(homeA);
+		fs.mkdirSync(homeB);
+		fs.writeFileSync(path.join(homeA, "config.toml"), "[mcp_servers.alpha]\n[mcp_servers.shared]\n");
+		fs.writeFileSync(path.join(homeB, "config.toml"), "[mcp_servers.beta]\n[mcp_servers.shared]\n");
+		const settings = { mcps: { allow: ["shared"] } };
+		const entities = [
+			{ name: "a", command: "codex exec", env: { CODEX_HOME: homeA } },
+			{ name: "b", command: "codex exec", env: { CODEX_HOME: homeB } },
+			{ name: "c", command: "claude -p" },
+		];
+		const snapshot = structuredClone(entities);
+		const result = prepareMcpEntities(settings, entities, councilConfig, "/tmp/config.yaml", tmpDir);
+		expect(result).toEqual([
+			{ ...entities[0], mcpBlock: ["alpha"] },
+			{ ...entities[1], mcpBlock: ["beta"] },
+			{ ...entities[2], mcpBlock: [] },
+		]);
+		expect(entities).toEqual(snapshot);
+	});
+
+	test("uses conductor fallback for codex members without CODEX_HOME", () => {
+		fs.writeFileSync(path.join(tmpDir, "config.toml"), "[mcp_servers.alpha]\n");
+		const result = prepareMcpEntities(
+			{ mcps: { allow: [] } },
+			[{ name: "a", command: "codex exec" }],
+			councilConfig,
+			"/tmp/config.yaml",
+			tmpDir,
+		);
+		expect(result[0].mcpBlock).toEqual(["alpha"]);
 	});
 });
 

--- a/lib/generic-job.ts
+++ b/lib/generic-job.ts
@@ -11,6 +11,7 @@
 
 import fs from "fs";
 import path from "path";
+import os from "os";
 import { spawn, execSync } from "child_process";
 
 import {
@@ -368,6 +369,35 @@ export function computeMcpBlockList(
 	// never declared makes codex fail to boot ("Error loading config.toml:
 	// invalid transport").
 	return configuredNames.filter((name) => !allow.has(name)).sort();
+}
+
+/**
+ * Attach the MCP block list to job entities without mutating the source list.
+ * MCP enforcement is Codex-only; other CLIs receive an explicit empty list.
+ */
+export function prepareMcpEntities(
+	settings: Record<string, unknown>,
+	entities: readonly Record<string, unknown>[],
+	config: JobConfig,
+	configPath: string,
+	conductorCodexHome?: string,
+): Record<string, unknown>[] {
+	assertMcpAllowShape(settings, config, configPath);
+	const fallbackHome =
+		conductorCodexHome ?? (process.env.CODEX_HOME || path.join(os.homedir(), ".codex"));
+	const configuredByHome = new Map<string, string[]>();
+	return entities.map((entity) => {
+		const cliType = detectCliType(entity.command);
+		if (cliType !== "codex") return { ...entity, mcpBlock: [] };
+		const env = isRecord(entity.env) ? entity.env : {};
+		const codexHome = env.CODEX_HOME ? String(env.CODEX_HOME) : fallbackHome;
+		let configured = configuredByHome.get(codexHome);
+		if (configured === undefined) {
+			configured = enumerateConfiguredMcpServers(codexHome);
+			configuredByHome.set(codexHome, configured);
+		}
+		return { ...entity, mcpBlock: computeMcpBlockList(settings, configured) };
+	});
 }
 
 export function buildAugmentedCommand(

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -482,7 +482,7 @@ When the Design Interview phase has exited with all design branches resolved, or
 
 2. **Write to file**: `$OMT_DIR/deep-interview/{slug}.md`
 
-**Inline self-review** (after writing), 5 checks: placeholder / consistency / scope / non-goal-decider / ambiguity — confirm no unfilled placeholders, no section contradictions, full interview coverage, every Non-Goals bullet carries a decider, no ambiguous text remains.
+**Inline self-review** (after writing), 6 checks: placeholder / consistency / scope / non-goal-decider / invariant / ambiguity — confirm no unfilled placeholders, no section contradictions, full interview coverage, every Non-Goals bullet carries a decider, every Invariants bullet carries `paths:` and `check:` with no path listed there contradicted by a Risks entry, no ambiguous text remains.
 
 3. **Emit the handoff token** in the final assistant message before proceeding to Phase 5. The literal token `<deep-interview-done/>` must appear in the assistant turn that announces spec completion. This signals downstream hooks that the interview phase is complete and state cleanup may proceed.
 
@@ -543,8 +543,8 @@ Each execution option's Action: invoke `Skill(skill: "{chosen}")` with the spec 
 - [ ] Every round explicitly names the weakest dimension and why it is the next target
 - [ ] Challenge stances selected by the Step 2-head Dialectic Rhythm Guard at the correct rotation conditions (Contrarian round 4+, Simplifier round 6+, Ontologist on stall or round 8+ with ambiguity > 0.3)
 - [ ] Spec file written to `$OMT_DIR/deep-interview/{slug}.md`
-- [ ] Inline self-review (5 checks: placeholder / consistency / scope / non-goal-decider / ambiguity) performed
-- [ ] Spec includes: goal, constraints, acceptance criteria, Approach & Design Decisions, clarity breakdown, transcript
+- [ ] Inline self-review (6 checks: placeholder / consistency / scope / non-goal-decider / invariant / ambiguity) performed
+- [ ] Spec includes: goal, constraints, invariants, acceptance criteria, Approach & Design Decisions, clarity breakdown, transcript
 - [ ] Token `<deep-interview-done/>` emitted in the final assistant message before handoff
 - [ ] Execution bridge presented via AskUserQuestion
 - [ ] Selected execution mode invoked via Skill() (never direct implementation)

--- a/skills/deep-interview/SKILL.test.ts
+++ b/skills/deep-interview/SKILL.test.ts
@@ -948,26 +948,94 @@ describe("decider-gate: Phase 4 self-review gains a 5th check for non-goal decid
 		expect(skillMd).not.toContain("4 checks: placeholder / consistency / scope / ambiguity");
 	});
 
-	test('inline self-review line names 5 checks including "non-goal-decider"', () => {
-		expect(skillMd).toContain("5 checks: placeholder / consistency / scope / non-goal-decider / ambiguity");
+	test('stale 5-check phrasing (pre-invariant) is gone everywhere', () => {
+		expect(skillMd).not.toContain(
+			"5 checks: placeholder / consistency / scope / non-goal-decider / ambiguity",
+		);
 	});
 
-	test("Final_Checklist line carries the identical 5-check list (no count/name drift between the two locations)", () => {
-		expect(skillMd).toContain("(5 checks: placeholder / consistency / scope / non-goal-decider / ambiguity)");
+	test('inline self-review line names 6 checks including "non-goal-decider" and "invariant"', () => {
+		expect(skillMd).toContain(
+			"6 checks: placeholder / consistency / scope / non-goal-decider / invariant / ambiguity",
+		);
+	});
+
+	test("Final_Checklist line carries the identical 6-check list (no count/name drift between the two locations)", () => {
+		expect(skillMd).toContain(
+			"(6 checks: placeholder / consistency / scope / non-goal-decider / invariant / ambiguity)",
+		);
 	});
 
 	test("the inline self-review's non-goal-decider check requires every Non-Goals bullet to carry a decider", () => {
 		const idx = skillMd.indexOf("**Inline self-review**");
 		expect(idx).toBeGreaterThan(-1);
-		const region = skillMd.slice(idx, idx + 400);
+		const region = skillMd.slice(idx, idx + 500);
 		// Anchored on both sides of the quantifier clause: a negator (e.g. "not")
 		// inserted immediately before "every" breaks this exact substring, unlike
 		// a bare `toContain("every Non-Goals bullet carries a decider")` which the
 		// negated form would still contain verbatim.
-		expect(region).toContain(
-			"full interview coverage, every Non-Goals bullet carries a decider, no ambiguous text remains",
-		);
+		expect(region).toContain("full interview coverage, every Non-Goals bullet carries a decider,");
 		expect(region).not.toMatch(/not every Non-Goals bullet carries a decider/);
+	});
+
+	test("the inline self-review's invariant check names both required fields and the Risks cross-check", () => {
+		const idx = skillMd.indexOf("**Inline self-review**");
+		expect(idx).toBeGreaterThan(-1);
+		const region = skillMd.slice(idx, idx + 500);
+		// Same anchoring discipline as the decider check above: the quantifier and
+		// both field names are inside the matched substring, so dropping either
+		// field -- or negating the quantifier -- breaks the assertion.
+		expect(region).toContain(
+			"every Invariants bullet carries `paths:` and `check:` with no path listed there contradicted by a Risks entry",
+		);
+		expect(region).not.toMatch(/not every Invariants bullet carries/);
+	});
+});
+
+describe("invariant-slot: spec template carries an Invariants section between Constraints and Non-Goals", () => {
+	const start = template.indexOf("## Invariants");
+	const end = template.indexOf("\n## ", start + 1);
+	const section = end === -1 ? template.slice(start) : template.slice(start, end);
+
+	test('"## Invariants" heading is present', () => {
+		expect(start).toBeGreaterThan(-1);
+	});
+
+	test("it sits after Constraints and before Non-Goals", () => {
+		// Ordering is the contract, not decoration: the section only does its job
+		// if the writer meets it while the constraint-shaped material is still in
+		// hand, before Non-Goals pulls attention to exclusions.
+		const constraints = template.indexOf("## Constraints");
+		const nonGoals = template.indexOf("## Non-Goals");
+		expect(constraints).toBeGreaterThan(-1);
+		expect(nonGoals).toBeGreaterThan(-1);
+		expect(start).toBeGreaterThan(constraints);
+		expect(start).toBeLessThan(nonGoals);
+	});
+
+	test("each Invariants bullet is formatted with both a paths clause and a check clause", () => {
+		const bulletLines = section
+			.split("\n")
+			.filter((line) => line.trim().startsWith("- "))
+			.filter((line) => line.trim() !== "- ...");
+		expect(bulletLines.length).toBeGreaterThan(0);
+		for (const line of bulletLines) {
+			expect(line).toContain("| paths:");
+			expect(line).toContain("| check:");
+		}
+	});
+
+	test("the section separates an invariant from a Constraint and an Acceptance Criterion", () => {
+		// Without this contrast the slot fills with restated constraints: the
+		// no-guidance baseline produced constraint-shaped transcription 5/5 and
+		// recorded zero path-quantified propositions.
+		expect(section).toContain("Constraint");
+		expect(section).toContain("Acceptance Criterion");
+		expect(section).toContain("EVERY");
+	});
+
+	test("the section forbids demoting an unresolved property into Risks", () => {
+		expect(section).toContain("Risks & Unresolved Forks");
 	});
 });
 

--- a/skills/deep-interview/deep-interview-spec-template.md
+++ b/skills/deep-interview/deep-interview-spec-template.md
@@ -33,6 +33,14 @@
 - {constraint 2}
 - ...
 
+## Invariants
+Properties that must hold in EVERY state, on EVERY path that can change what they constrain. Distinct from the three neighbouring sections: a **Constraint** is an environmental limit given to you (8 slots, app-only surface), an **Acceptance Criterion** is one scenario observed once (dispense → count drops by 1), an **Invariant** is a proposition quantified over all paths. When a property is true across paths, it belongs here — recording it only as the scenario that made you notice it loses the quantifier.
+
+`paths:` is what makes the claim checkable: enumerate every operation that can change the constrained value, not just the one the interview discussed. A path the interview never resolved goes in the list as `<path> 미확정` — the property stays recorded and the hole stays visible. Dropping the property into **Risks & Unresolved Forks** instead is the failure this section exists to prevent, and asserting it here while listing a path that violates it under Risks is a contradiction the self-review must catch.
+
+- {property, stated so a violation is observable} | paths: {every operation that can change it} | check: {how a violation would be caught — assertion, test, DB constraint}
+- ...
+
 ## Non-Goals
 - {explicitly excluded scope 1} | decider: {how to tell a finding belongs to this exclusion}
 - {explicitly excluded scope 2} | decider: {how to tell a finding belongs to this exclusion}

--- a/skills/design-review/SKILL.md
+++ b/skills/design-review/SKILL.md
@@ -83,6 +83,6 @@ You are done only when BOTH hold:
 
 ## Reference Files
 
-- `design-review.config.yaml`: Job configuration — `members` list (each entry needs `name` and `command`) and `settings.timeout` (seconds)
+- `design-review.config.yaml`: Job configuration — `members` list (each entry needs `name` and `command`) and `settings.timeout` (seconds). `generic-job` enforces both `settings.deny` and `settings.mcps.allow`; the MCP allowlist is opt-in and fail-closed, and the current configuration allows only `codegraph`.
 - `scripts/job.ts`: Job manager (start/collect/clean/status/results/stop)
 - `prompts/default.md`: in-session analysis framework — loaded only during fallback

--- a/skills/design-review/design-review.config.yaml
+++ b/skills/design-review/design-review.config.yaml
@@ -80,3 +80,19 @@ review:
         - ultraresearch
         - visual-qa
         - writing-skills
+    mcps:
+      # This reviewer's codex process inherits every MCP server declared in
+      # ~/.codex/config.toml regardless of whether it's used. Only codegraph is
+      # used — it's how the reviewer checks a design claim against the real call
+      # graph instead of a grep/read guess. Unlisted here means blocked, for
+      # every server this engine can enumerate: this allowlist is opt-in
+      # (fail-closed), the opposite default from `deny.skills` above — an
+      # unspecified `mcps` or `mcps.allow` blocks every server
+      # `enumerateConfiguredMcpServers` (lib/generic-job.ts) enumerates from
+      # config.toml. Two carve-outs in that same function: a server under a
+      # quoted TOML header (`[mcp_servers."weird name"]`) is left unenumerated
+      # and stays enabled — its name can't be passed safely as a
+      # `-c mcp_servers.<name>.enabled=false` argument — and an unreadable
+      # config.toml fails OPEN.
+      allow:
+        - codegraph

--- a/skills/design-review/scripts/job.test.ts
+++ b/skills/design-review/scripts/job.test.ts
@@ -486,3 +486,107 @@ describe("settings.deny 배관", () => {
 		expect(output).toContain("settings.deny.subagents' must be a boolean");
 	});
 });
+
+describe("settings.mcps 배관", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = makeTmpDir();
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test("allow 목록을 job metadata와 실제 codex argv에 적용한다", async () => {
+		const configPath = path.join(tmpDir, "design-review.config.yaml");
+		fs.writeFileSync(
+			configPath,
+			[
+				"review:",
+				"  members:",
+				"    - name: tester",
+				"      command: codex exec",
+				"      model: gpt-5.6-sol",
+				"      effort_level: high",
+				"      env:",
+				"        REVIEW_MARKER: preserved",
+				"  settings:",
+				"    timeout: 10",
+				"    deny:",
+				"      subagents: true",
+				"      skills: [design-review]",
+				"    mcps:",
+				"      allow:",
+				"        - codegraph",
+			].join("\n"),
+			"utf8",
+		);
+		const jobsDir = path.join(tmpDir, "jobs");
+		const codexHome = path.join(tmpDir, "codex-home");
+		const binDir = path.join(tmpDir, "bin");
+		fs.mkdirSync(binDir, { recursive: true });
+		fs.mkdirSync(codexHome, { recursive: true });
+		fs.writeFileSync(
+			path.join(codexHome, "config.toml"),
+			'[mcp_servers.codegraph]\ncommand = "stub"\n\n[mcp_servers.blocked]\ncommand = "stub"\n',
+		);
+		const argvPath = path.join(tmpDir, "codex-argv.txt");
+		const stubPath = path.join(binDir, "codex");
+		fs.writeFileSync(stubPath, '#!/bin/sh\nprintf "%s\\n" "$@" > "$STUB_CODEX_ARGV"\n', "utf8");
+		fs.chmodSync(stubPath, 0o755);
+		const env = {
+			...process.env,
+			CODEX_HOME: codexHome,
+			STUB_CODEX_ARGV: argvPath,
+			PATH: `${binDir}:${process.env.PATH || ""}`,
+		};
+		const result = execFileSync(
+			process.execPath,
+			[SCRIPT, "start", "--config", configPath, "--jobs-dir", jobsDir, "--json", "mcp test"],
+			{ stdio: "pipe", env },
+		);
+		const output = JSON.parse(result.toString());
+		const member = output.members[0];
+		expect(member.mcpBlock).toEqual(["blocked"]);
+		expect(member.model).toBe("gpt-5.6-sol");
+		expect(member.effort_level).toBe("high");
+		expect(member.env).toEqual({ REVIEW_MARKER: "preserved" });
+		for (let i = 0; i < 30 && !fs.existsSync(argvPath); i++)
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		expect(fs.existsSync(argvPath)).toBe(true);
+		const argv = fs.readFileSync(argvPath, "utf8").split("\n").filter(Boolean);
+		expect(argv).toContain("mcp_servers.blocked.enabled=false");
+		expect(argv).not.toContain("mcp_servers.codegraph.enabled=false");
+	});
+
+	test("malformed allow 목록은 worker와 job 생성 전에 거부한다", () => {
+		const configPath = path.join(tmpDir, "design-review.config.yaml");
+		fs.writeFileSync(
+			configPath,
+			[
+				"review:",
+				"  members:",
+				"    - name: tester",
+				"      command: codex exec",
+				"  settings:",
+				"    mcps:",
+				"      allow: [blocked.name]",
+			].join("\n"),
+			"utf8",
+		);
+		const jobsDir = path.join(tmpDir, "jobs");
+		fs.mkdirSync(jobsDir, { recursive: true });
+		let error: any;
+		try {
+			execFileSync(process.execPath, [SCRIPT, "start", "--config", configPath, "--jobs-dir", jobsDir, "bad mcp"], {
+				stdio: "pipe",
+			});
+		} catch (caught) {
+			error = caught;
+		}
+		expect(error?.status).toBe(1);
+		expect(`${error?.stderr?.toString() || ""}`).toContain("settings.mcps.allow");
+		expect(fs.readdirSync(jobsDir)).toEqual([]);
+	});
+});

--- a/skills/design-review/scripts/job.ts
+++ b/skills/design-review/scripts/job.ts
@@ -17,6 +17,7 @@ import {
 	assertMembersOrExit,
 	assertDenyEnforceable,
 	assertDenyShape,
+	prepareMcpEntities,
 	extractDenySkills,
 	extractDenySubagents,
 	computeStatus as frameworkComputeStatus,
@@ -153,6 +154,10 @@ async function cmdStart(options: Record<string, unknown>, prompt: string) {
 	const denySkills = extractDenySkills(settings);
 	const denySubagents = extractDenySubagents(settings);
 	assertDenyEnforceable(members, denySkills, DESIGN_REVIEW_CONFIG, configPath, denySubagents);
+	// Resolve the Codex MCP allowlist before creating any job artifacts. The
+	// prepared entities carry the same per-member mcpBlock into both metadata
+	// and worker dispatch, while preserving each member's env/deny settings.
+	const preparedMembers = prepareMcpEntities(settings, members, DESIGN_REVIEW_CONFIG, configPath);
 
 	const jobId = generateJobId();
 	const jobDir = path.join(jobsDir, `themis-${jobId}`);
@@ -170,7 +175,7 @@ async function cmdStart(options: Record<string, unknown>, prompt: string) {
 			denySkills,
 			denySubagents,
 		},
-		members: members.map((m) => ({
+		members: preparedMembers.map((m) => ({
 			name: String(m.name),
 			command: String(m.command),
 			emoji: m.emoji ? String(m.emoji) : null,
@@ -178,12 +183,14 @@ async function cmdStart(options: Record<string, unknown>, prompt: string) {
 			model: m.model || null,
 			effort_level: m.effort_level || null,
 			output_format: m.output_format || null,
+			env: m.env ?? {},
+			mcpBlock: m.mcpBlock ?? [],
 		})),
 	};
 	atomicWriteJson(path.join(jobDir, "job.json"), jobMeta);
 
 	frameworkSpawnWorkers({
-		entities: members.map((m) => ({ ...m, deny: denySkills, denySubagents })),
+		entities: preparedMembers.map((m) => ({ ...m, deny: denySkills, denySubagents })),
 		workerPath: WORKER_PATH,
 		jobDir,
 		entitiesDir: reviewersDir,

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -85,6 +85,6 @@ You are done only when BOTH hold:
 
 ## Reference Files
 
-- `diagnose.config.yaml`: reviewer dispatch config — `members` list + `settings.timeout`
+- `diagnose.config.yaml`: reviewer dispatch config — `members` list + `settings.timeout`; generic-job enforces both `settings.deny` and `settings.mcps.allow`, whose MCP allowlist is opt-in/fail-closed (diagnose currently allows only `codegraph`)
 - `scripts/job.ts`: Job manager (start/collect/clean/status/results/stop)
 - `prompts/default.md`: in-session analysis framework — loaded only during fallback

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -7,7 +7,7 @@ description: Use when asked to analyze architecture, debug issues, identify root
 
 ## Overview
 
-Delegates architecture analysis and debugging to the Hephaestus opencode agent, which runs as a detached worker you observe by polling. This skill is finished only once you have pulled a definitive answer out of the job — nothing notifies you when the worker is done. If the agent is unavailable (CLI not installed, timeout, error, or canceled), falls back to in-session analysis using the in-session fallback framework.
+Delegates architecture analysis and debugging to a codex analyst, which runs as a detached worker you observe by polling. This skill is finished only once you have pulled a definitive answer out of the job — nothing notifies you when the worker is done. If the agent is unavailable (CLI not installed, timeout, error, or canceled), falls back to in-session analysis using the in-session fallback framework.
 
 ---
 

--- a/skills/diagnose/diagnose.config.yaml
+++ b/skills/diagnose/diagnose.config.yaml
@@ -1,12 +1,17 @@
 # Diagnose Configuration
-# Single-reviewer configuration for opencode Hephaestus agent.
+# External dispatch: one codex analyst (gpt-5.6-sol, high reasoning) via `codex exec`.
+# model + effort_level + output_format resolve to:
+#   codex exec -m gpt-5.6-sol -c model_reasoning_effort=high --json --skip-git-repo-check
+# codex uses bare model ids (no `openai/` prefix).
 
 review:
   members:
-    - name: hephaestus
-      command: opencode run --agent "Hephaestus - Deep Agent"
+    - name: gpt
+      command: codex exec
       emoji: "🔨"
       color: "BLUE"
+      model: "gpt-5.6-sol"
+      effort_level: "high"
       output_format: json
 
   settings:
@@ -14,7 +19,7 @@ review:
     deny:
       # Subagent axis: the analyst diagnoses alone. Spawning is a second fan-out beneath this
       # one — unbudgeted cost, and findings no analysis prompt shaped. Translated per member CLI
-      # by `buildAugmentedCommand` (opencode: `permission.task: deny`); a member on a CLI with
+      # by `buildAugmentedCommand` (codex: `-c agents.enabled=false`); a member on a CLI with
       # no such lever fails `start` rather than running unguarded.
       subagents: true
       # Three separate reasons, not one list: (1) self-recursion fan-out guard, 3 skills — this
@@ -75,3 +80,19 @@ review:
         - ultraresearch
         - visual-qa
         - writing-skills
+    mcps:
+      # This analyst's codex process inherits every MCP server declared in
+      # ~/.codex/config.toml regardless of whether it's used. Only codegraph is
+      # used — it's how the analyst grounds a root cause in the real call graph
+      # instead of a grep/read guess, which is the whole difference between a
+      # named cause and a plausible one. Unlisted here means blocked, for every
+      # server this engine can enumerate: this allowlist is opt-in (fail-closed),
+      # the opposite default from `deny.skills` above — an unspecified `mcps` or
+      # `mcps.allow` blocks every server `enumerateConfiguredMcpServers`
+      # (lib/generic-job.ts) enumerates from config.toml. Two carve-outs in that
+      # same function: a server under a quoted TOML header
+      # (`[mcp_servers."weird name"]`) is left unenumerated and stays enabled —
+      # its name can't be passed safely as a `-c mcp_servers.<name>.enabled=false`
+      # argument — and an unreadable config.toml fails OPEN.
+      allow:
+        - codegraph

--- a/skills/diagnose/scripts/job.test.ts
+++ b/skills/diagnose/scripts/job.test.ts
@@ -6,6 +6,8 @@ import path from "path";
 import os from "os";
 import { execFileSync } from "child_process";
 
+import { buildAugmentedCommand } from "@lib/generic-job";
+
 const SCRIPT = path.join(import.meta.dirname, "job.ts");
 
 function makeTmpDir() {
@@ -457,5 +459,60 @@ describe("settings.deny 배관", () => {
 		}
 		expect(exitCode).toBe(1);
 		expect(output).toContain("settings.deny.subagents' must be a boolean");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 배포되는 실제 diagnose.config.yaml — 픽스처가 아니라 프로덕션 파일을 읽고,
+// buildAugmentedCommand로 실제 전송되는 커맨드라인까지 해석해 검사한다.
+// 문자열이 파일에 있는지가 아니라 그 선언이 무엇으로 resolve되는지가 계약이다.
+// ---------------------------------------------------------------------------
+
+describe("배포 config의 외부 디스패치 계약", () => {
+	const CONFIG_PATH = path.join(import.meta.dirname, "..", "diagnose.config.yaml");
+
+	function readMember(): Record<string, unknown> {
+		const parsed = Bun.YAML.parse(fs.readFileSync(CONFIG_PATH, "utf8")) as Record<string, any>;
+		const members = parsed?.review?.members;
+		if (!Array.isArray(members) || members.length !== 1) {
+			throw new Error(`${CONFIG_PATH}: 'review.members'는 단일 멤버 배열이어야 한다`);
+		}
+		return members[0] as Record<string, unknown>;
+	}
+
+	test("멤버는 codex exec를 gpt-5.6-sol/high로 실행한다", () => {
+		const member = readMember();
+		expect(member.command).toBe("codex exec");
+		expect(member.model).toBe("gpt-5.6-sol");
+		expect(member.effort_level).toBe("high");
+	});
+
+	test("opencode·Hephaestus 잔여 참조가 없다", () => {
+		const raw = fs.readFileSync(CONFIG_PATH, "utf8");
+		expect(raw).not.toContain("opencode");
+		expect(raw.toLowerCase()).not.toContain("hephaestus");
+	});
+
+	test("codegraph만 MCP 허용 목록에 있다", () => {
+		const parsed = Bun.YAML.parse(fs.readFileSync(CONFIG_PATH, "utf8")) as Record<string, any>;
+		expect(parsed?.review?.settings?.mcps?.allow).toEqual(["codegraph"]);
+	});
+
+	test("해석된 커맨드라인이 모델·추론강도·subagent 차단을 함께 싣는다", () => {
+		const member = readMember();
+		const parsed = Bun.YAML.parse(fs.readFileSync(CONFIG_PATH, "utf8")) as Record<string, any>;
+		const { command } = buildAugmentedCommand(
+			{
+				command: member.command,
+				model: member.model,
+				effort_level: member.effort_level,
+				output_format: member.output_format,
+				denySubagents: parsed?.review?.settings?.deny?.subagents,
+			},
+			"codex",
+		);
+		expect(command).toContain("-m gpt-5.6-sol");
+		expect(command).toContain("model_reasoning_effort=high");
+		expect(command).toContain("agents.enabled=false");
 	});
 });

--- a/skills/diagnose/scripts/job.test.ts
+++ b/skills/diagnose/scripts/job.test.ts
@@ -95,7 +95,7 @@ describe("diagnose job lifecycle", () => {
 		} catch {}
 	});
 
-	test("clean removes jobDir", () => {
+	test("clean removes jobDir", async () => {
 		const configPath = path.join(tmpDir, "diagnose.config.yaml");
 		writeConfig(configPath);
 		const jobsDir = path.join(tmpDir, "jobs");
@@ -123,6 +123,33 @@ describe("diagnose job lifecycle", () => {
 		try {
 			execFileSync(process.execPath, [SCRIPT, "stop", jobDir], { stdio: "pipe" });
 		} catch {}
+
+		// stop can observe a queued worker (or a running worker before its pid is
+		// persisted) and return before that worker writes its terminal status.
+		// Wait with a bounded, non-busy poll so clean does not race the status
+		// transition and refuse an otherwise safe deletion.
+		const pollStartedAt = Date.now();
+		const pollTimeoutMs = 5_000;
+		const pollIntervalMs = 50;
+		let overallState = "";
+		while (Date.now() - pollStartedAt < pollTimeoutMs) {
+			try {
+				const statusResult = execFileSync(process.execPath, [SCRIPT, "status", jobDir], {
+					stdio: "pipe",
+				});
+				const status = JSON.parse(statusResult.toString()) as { overallState?: unknown };
+				overallState = typeof status.overallState === "string" ? status.overallState : "";
+			} catch {}
+			if (overallState === "done") break;
+			if (Date.now() - pollStartedAt >= pollTimeoutMs) break;
+			await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+		}
+		if (overallState !== "done") {
+			throw new Error(
+				`clean lifecycle: worker status did not become terminal within ${pollTimeoutMs}ms (overallState=${overallState || "unavailable"})`,
+			);
+		}
+
 		execFileSync(process.execPath, [SCRIPT, "clean", jobDir, "--jobs-dir", jobsDir], {
 			stdio: "pipe",
 		});

--- a/skills/diagnose/scripts/job.test.ts
+++ b/skills/diagnose/scripts/job.test.ts
@@ -258,6 +258,58 @@ describe("diagnose job lifecycle", () => {
 			});
 		} catch {}
 	});
+
+	test("start applies settings.mcps.allow to job metadata and the real codex argv", async () => {
+		const configPath = path.join(tmpDir, "diagnose.config.yaml");
+		fs.writeFileSync(
+			configPath,
+			[
+				"review:",
+				"  members:",
+				"    - name: tester",
+				"      command: codex exec",
+				"  settings:",
+				"    timeout: 10",
+				"    mcps:",
+				"      allow:",
+				"        - codegraph",
+			].join("\n"),
+			"utf8",
+		);
+		const jobsDir = path.join(tmpDir, "jobs");
+		const codexHome = path.join(tmpDir, "codex-home");
+		const binDir = path.join(tmpDir, "bin");
+		fs.mkdirSync(binDir, { recursive: true });
+		fs.mkdirSync(codexHome, { recursive: true });
+		fs.writeFileSync(
+			path.join(codexHome, "config.toml"),
+			'[mcp_servers.codegraph]\ncommand = "stub"\n\n[mcp_servers.blocked]\ncommand = "stub"\n',
+		);
+		const argvPath = path.join(tmpDir, "codex-argv.txt");
+		const stubPath = path.join(binDir, "codex");
+		fs.writeFileSync(stubPath, '#!/bin/sh\nprintf "%s\\n" "$@" > "$STUB_CODEX_ARGV"\n', "utf8");
+		fs.chmodSync(stubPath, 0o755);
+		const env = {
+			...process.env,
+			CODEX_HOME: codexHome,
+			STUB_CODEX_ARGV: argvPath,
+			PATH: `${binDir}:${process.env.PATH || ""}`,
+		};
+		const result = execFileSync(
+			process.execPath,
+			[SCRIPT, "start", "--config", configPath, "--jobs-dir", jobsDir, "--json", "mcp test"],
+			{ stdio: "pipe", env },
+		);
+		const output = JSON.parse(result.toString());
+		const member = output.members[0];
+		expect(member.mcpBlock).toEqual(["blocked"]);
+		for (let i = 0; i < 30 && !fs.existsSync(argvPath); i++)
+			await new Promise((r) => setTimeout(r, 20));
+		expect(fs.existsSync(argvPath)).toBe(true);
+		const argv = fs.readFileSync(argvPath, "utf8").split("\n").filter(Boolean);
+		expect(argv).toContain("mcp_servers.blocked.enabled=false");
+		expect(argv).not.toContain("mcp_servers.codegraph.enabled=false");
+	});
 });
 
 describe("settings fallback 병합", () => {

--- a/skills/diagnose/scripts/job.ts
+++ b/skills/diagnose/scripts/job.ts
@@ -17,6 +17,7 @@ import {
 	assertMembersOrExit,
 	assertDenyEnforceable,
 	assertDenyShape,
+	prepareMcpEntities,
 	extractDenySkills,
 	extractDenySubagents,
 	computeStatus as frameworkComputeStatus,
@@ -161,6 +162,10 @@ async function cmdStart(options: Record<string, unknown>, prompt: string) {
 	const denySkills = extractDenySkills(settings);
 	const denySubagents = extractDenySubagents(settings);
 	assertDenyEnforceable(members, denySkills, DIAGNOSE_CONFIG, configPath, denySubagents);
+	// Resolve the Codex MCP allowlist before creating any job artifacts. The
+	// prepared entities carry the same per-member mcpBlock into both metadata
+	// and worker dispatch, while preserving each member's env/deny settings.
+	const preparedMembers = prepareMcpEntities(settings, members, DIAGNOSE_CONFIG, configPath);
 
 	const jobId = generateJobId();
 	const jobDir = path.join(jobsDir, `diagnose-${jobId}`);
@@ -178,7 +183,7 @@ async function cmdStart(options: Record<string, unknown>, prompt: string) {
 			denySkills,
 			denySubagents,
 		},
-		members: members.map((m) => ({
+		members: preparedMembers.map((m) => ({
 			name: String(m.name),
 			command: String(m.command),
 			emoji: m.emoji ? String(m.emoji) : null,
@@ -187,12 +192,13 @@ async function cmdStart(options: Record<string, unknown>, prompt: string) {
 			effort_level: m.effort_level || null,
 			output_format: m.output_format || null,
 			env: m.env ?? {},
+			mcpBlock: m.mcpBlock ?? [],
 		})),
 	};
 	atomicWriteJson(path.join(jobDir, "job.json"), jobMeta);
 
 	frameworkSpawnWorkers({
-		entities: members.map((m) => ({ ...m, deny: denySkills, denySubagents })),
+		entities: preparedMembers.map((m) => ({ ...m, deny: denySkills, denySubagents })),
 		workerPath: WORKER_PATH,
 		jobDir,
 		entitiesDir: reviewersDir,

--- a/skills/diagnose/scripts/job.ts
+++ b/skills/diagnose/scripts/job.ts
@@ -116,10 +116,12 @@ async function cmdStart(options: Record<string, unknown>, prompt: string) {
 	const defaultReview: RawReviewConfig = {
 		members: [
 			{
-				name: "hephaestus",
-				command: 'opencode run --agent "Hephaestus - Deep Agent"',
+				name: "gpt",
+				command: "codex exec",
 				emoji: "🔨",
 				color: "BLUE",
+				model: "gpt-5.6-sol",
+				effort_level: "high",
 				output_format: "json",
 			},
 		],

--- a/skills/orchestrate-review/scripts/job.test.ts
+++ b/skills/orchestrate-review/scripts/job.test.ts
@@ -4317,6 +4317,15 @@ describe("parseChunkReviewConfig settings.mcps.allow", () => {
 // mcpBlockByMember.
 // ---------------------------------------------------------------------------
 
+describe("job.ts MCP preparation architecture", () => {
+	test("delegates per-member MCP preparation to prepareMcpEntities", () => {
+		const source = fs.readFileSync(path.join(import.meta.dirname, "job.ts"), "utf8");
+		expect(source).toContain("prepareMcpEntities");
+		expect(source).not.toContain("enumerateConfiguredMcpServers");
+		expect(source).not.toContain("computeMcpBlockList");
+	});
+});
+
 describe("start: settings.mcps.allow recorded in job.json members[].mcpBlock", () => {
 	let tmpDir: string;
 	let jobsDir: string;
@@ -4362,7 +4371,7 @@ describe("start: settings.mcps.allow recorded in job.json members[].mcpBlock", (
 				"    role: none",
 				"  members:",
 				"    - name: bob",
-				"      command: echo bob",
+				"      command: codex",
 				"  settings:",
 				"    exclude_chairman_from_members: false",
 				"    timeout: 10",
@@ -4411,9 +4420,9 @@ describe("start: settings.mcps.allow recorded in job.json members[].mcpBlock", (
 				"    role: none",
 				"  members:",
 				"    - name: bob",
-				"      command: echo bob",
+				"      command: codex",
 				"    - name: carol",
-				"      command: echo carol",
+				"      command: codex",
 				"      env:",
 				`        CODEX_HOME: ${memberCodexHome}`,
 				"  settings:",
@@ -4934,9 +4943,9 @@ describe("start: mcpBlock reaches spawnWorkers entities", () => {
 				"    role: none",
 				"  members:",
 				"    - name: alice",
-				"      command: echo alice",
+				"      command: codex",
 				"    - name: bob",
-				"      command: echo bob",
+				"      command: codex",
 				"  settings:",
 				"    exclude_chairman_from_members: false",
 				"    timeout: 10",

--- a/skills/orchestrate-review/scripts/job.ts
+++ b/skills/orchestrate-review/scripts/job.ts
@@ -32,8 +32,7 @@ import {
 	assertMcpAllowShape,
 	extractDenySkills,
 	extractDenySubagents,
-	enumerateConfiguredMcpServers,
-	computeMcpBlockList,
+	prepareMcpEntities,
 	detectCliType,
 	buildAugmentedCommand,
 	gcStaleJobs as _gcStaleJobs,
@@ -585,30 +584,19 @@ async function cmdStart(options: Record<string, unknown>, prompt: string): Promi
 	const denySubagents = extractDenySubagents(config["chunk-review"].settings);
 	assertDenyEnforceable(members, denySkills, CHUNK_REVIEW_JOB_CONFIG, configPath, denySubagents);
 
-	// The block list is per-member, not per-job: a member's own `env:` may set
-	// CODEX_HOME, and that override does reach the spawned codex process
-	// (buildAugmentedCommand seeds --env from entity.env, and worker-utils
-	// spawns with it). Enumerating once from the conductor's home would then
-	// compute against the wrong config.toml in both directions — a server only
-	// the member declares escapes the whitelist, and a server only the
-	// conductor declares yields `-c mcp_servers.<name>.enabled=false` for a
-	// name the member never declares, which makes codex fail to boot
-	// ("Error loading config.toml: invalid transport").
-	//
-	// Memoized per resolved home so N members sharing one home read config.toml
-	// once — the common case, where no member overrides CODEX_HOME at all.
 	const conductorCodexHome = process.env.CODEX_HOME || path.join(os.homedir(), ".codex");
-	const mcpServersByHome = new Map<string, string[]>();
-	const mcpBlockByMember = members.map((member) => {
-		const env = isRecord(member.env) ? member.env : {};
-		const codexHome = env.CODEX_HOME ? String(env.CODEX_HOME) : conductorCodexHome;
-		let configured = mcpServersByHome.get(codexHome);
-		if (configured === undefined) {
-			configured = enumerateConfiguredMcpServers(codexHome);
-			mcpServersByHome.set(codexHome, configured);
-		}
-		return computeMcpBlockList(config["chunk-review"].settings, configured);
-	});
+	const memberEntities = members.map((r) => ({
+		...r,
+		deny: denySkills,
+		denySubagents,
+	}));
+	const preparedMembers = prepareMcpEntities(
+		config["chunk-review"].settings,
+		memberEntities,
+		CHUNK_REVIEW_JOB_CONFIG,
+		configPath,
+		conductorCodexHome,
+	);
 
 	const jobId = generateJobId();
 	initLogger("chunk-review-job", logRootForJobsDir(jobsDir), jobId);
@@ -672,7 +660,7 @@ async function cmdStart(options: Record<string, unknown>, prompt: string): Promi
 			effort_level: r.effort_level || null,
 			output_format: r.output_format || null,
 			env: r.env ?? {},
-			mcpBlock: mcpBlockByMember[i],
+			mcpBlock: preparedMembers[i].mcpBlock,
 			workerPgid: unsetWorkerPgid(),
 			workerPgidStartedAt: unsetWorkerPgidStartedAt(),
 		})),
@@ -680,12 +668,7 @@ async function cmdStart(options: Record<string, unknown>, prompt: string): Promi
 	atomicWriteJson(path.join(jobDir, "job.json"), jobMeta);
 
 	const spawned: SpawnedWorker[] = _spawnWorkers({
-		entities: members.map((r, i) => ({
-			...r,
-			deny: denySkills,
-			denySubagents,
-			mcpBlock: mcpBlockByMember[i],
-		})),
+		entities: preparedMembers,
 		workerPath: WORKER_PATH,
 		jobDir,
 		entitiesDir: membersDir,


### PR DESCRIPTION
커밋 3개, 서로 독립적입니다.

## 1. `diagnose` 외부 분석을 codex `gpt-5.6-sol`로 전환

opencode 경로가 인증 실패로 죽어 있었습니다. 다른 job 계열 스킬과 같은 `codex exec` 디스패치로 맞췄고, `gpt-5.6-sol` + high 추론 조합은 `design-review`가 이미 프로덕션에서 쓰고 있습니다. 기록된 스모크 집합에 sol의 high가 없어서 착지 전에 직접 스모크를 돌려 codex 수용을 확인했습니다(codex에는 unsupported model id의 자동 fallback이 없습니다).

**같은 커밋에 MCP allowlist를 넣은 이유** — 조용한 리그레션 하나가 걸려 있습니다. MCP 차단은 codex에서만 적용되고(`lib/generic-job.ts`), 미지정 `mcps`는 fail-closed입니다. opencode에서는 차단이 아예 적용되지 않았으므로, allowlist 없이 엔진만 바꾸면 `codegraph`가 **새로** 차단됩니다. 근거를 실제 콜그래프에 대는 경로가 그거라서, 없으면 grep/read 추측으로 내려앉습니다.

계약 테스트는 문자열 존재가 아니라 **해석된 커맨드라인**을 검사합니다 — `buildAugmentedCommand(..., "codex")`가 `-m gpt-5.6-sol`, `model_reasoning_effort=high`, `agents.enabled=false`를 함께 싣는지.

## 2. `design-review`에 codegraph MCP 허용 명시

1번에서 드러난 fail-closed 기본값을 같은 방식으로 명시했습니다. 엔진 변경은 없고 allowlist 선언만 추가합니다.

## 3. `deep-interview` 스펙에 불변식 섹션 신설

`## Constraints` 다음, `## Non-Goals` 앞에 `## Invariants`를 넣었습니다. 불릿 형식은 기존 Non-Goals의 `| decider:` 관용을 따라 `{property} | paths: {값을 바꿀 수 있는 모든 연산} | check: {위반이 잡히는 방법}`입니다. 스펙을 써 내려가는 단계(Crystallize Spec)의 인라인 self-review는 5→6 체크가 됐습니다.

### 왜 — 대조 측정

디스펜서 슬롯 재고 인터뷰 기록(Q&A 9라운드) 하나로 5회씩 두 번 돌렸습니다. 이 기록의 6번째 답변("앱에서 수동으로 재고를 조정할 수 있어야 한다")이, 아무도 진술하지 않은 음수 재고 구멍을 만듭니다.

| | 슬롯 없음 (5회) | 슬롯 있음 (5회) |
|---|---|---|
| `## Invariants` 존재 | 0/5 | 5/5 |
| 음수 재고 성질을 전칭 명제로 기록 | 0/5 | 5/5 |
| 불릿의 `paths:`+`check:` | 0 | 27/27 |
| 성질이 Risks의 열린 질문으로 강등 | 5/5 | 0/5 |

**실패 모드는 "못 알아봄"이 아니었습니다.** 슬롯이 없을 때도 5/5 전원이 음수 재고 구멍을 알아챘고, 5/5 전원이 그것을 항상 참인 성질이 아니라 `## Risks & Unresolved Forks`의 미해결 질문으로 적었습니다. 놓을 칸이 없어서입니다.

그중 2건은 같은 문서 안에서 자기모순까지 냈습니다. 한 건은 `## Constraints`에 "즉 재고 하한은 0"이라 단언해놓고, 150줄 뒤 Risks에 "음수 입력의 허용 여부 미확정"과 "동시성에서 0 아래로 내려갈 수 있다"를 올렸습니다. 전칭 명제를 시나리오 규칙의 후행절로 적으면 아무도 나머지 경로를 검사하지 않기 때문입니다.

이 발견이 개입 형식을 정했습니다. 부족한 것이 발화가 아니라 칸이므로 **인터뷰 단계의 질문(Constraint Clarity)은 건드리지 않았습니다.** 원래 계획에 있던 그 편집은 폐기했습니다 — 측정 없이 개입을 하나 더 얹을 이유가 없습니다.

### `paths:`가 실제로 일하는 필드

`check:`만 있으면 "0 미만 차단 단위테스트"라고 적고 수동조정 경로를 그대로 놓칩니다. 슬롯 도입 후 한 케이스는 self-review 단계에서 스스로 모순을 잡아 Risks를 이렇게 고쳐 썼습니다:

> 수동 조정의 허용 범위: … 0 미만 입력을 거부하는 지점이 앱 입력 검증인지 서버 검증인지 **(거부 자체는 위 Invariants가 요구한다)**

열린 질문이 "막느냐"에서 "어디서 막느냐"로 좁혀졌습니다.

### 알려진 잔여

슬롯 도입 후 5회 중 2회가 Risks에 "하한 미확정"을 남긴 채 자기 invariant 검사를 통과시켰습니다. 판정식 "no path listed there contradicted by a Risks entry"를 "Risks 항목은 *규칙* 얘기지 *경로* 얘기가 아니다"로 읽은 것입니다. 3회는 스스로 화해시켰습니다.

지금 고치지 않습니다. writing-skills가 "이긴 recipe에 nuance 절을 덧붙이면 consistent → noisy로 퇴화"를 실측으로 기록해뒀고, 이 잔여가 하류에 해를 끼친다는 측정이 없습니다. 고치려면 별도 실패 재현이 먼저입니다.

### 테스트

`SKILL.test.ts`가 `"5 checks: …"` 문자열을 리터럴로 핀하고 있어 3건이 깨졌습니다. 6-check 문안으로 갱신하고, 낡은 5-check가 되살아나는 걸 막는 가드를 기존 4-check 가드와 같은 형태로 추가했습니다. 새 섹션에도 Non-Goals decider와 동급 핀 5건을 신설했습니다 — 존재, Constraints·Non-Goals 사이 순서, 모든 불릿의 두 필드, Constraint·Acceptance Criterion과의 대비, Risks 강등 금지.

## 범위 밖

`prometheus` 쪽 두 편집(작업 목표 표에 불변식 행 추가, 인수 기준 자가검사에 불릿 추가)은 착수하지 않았습니다. deep-interview 산출물이 불변식을 싣기 시작해야 측정할 수 있어서 이번 범위에서 뺐고, 이제 그 조건은 충족됐습니다.

## 측정 한계

대조군과 처치군 모두 같은 인터뷰 기록 하나만 씁니다. 다른 도메인의 기록에서도 같은 효과가 나는지는 재지 않았습니다.

## 검증

- 영향 범위 테스트 241 pass / 0 fail (rebase 후 재확인)
- `make validate` EXIT=0
- `codex-skill-deny-efficacy.test.ts` 통과 (실제 `codex debug prompt-input` 프로브 포함)
- `diagnose` 엔드투엔드 1회: job 상태 `done`, 멤버 `gpt`, 워커가 `codex exec`로 `gpt-5.6-sol`에 디스패치됨을 출력으로 확인
