### PR TITLE
feat: verify-entrypoint-gate에 denied_entrypoints 축 신설

### DIFF
--- a/scripts/verify-entrypoint-gate/index.ts
+++ b/scripts/verify-entrypoint-gate/index.ts
@@ -11,9 +11,10 @@ import { fileURLToPath } from "node:url";
  *
  *   pnpm <entrypoint> [<app name>] [<allowed_turbo_opts>...] [-- <runner args>]
  *
- * where `<entrypoint>` is drawn from `entrypoints ∩ root package.json.scripts`
- * — the policy yaml's declared list intersected with what the target repo's
- * root package.json actually exposes right now. Neither side alone is the
+ * where `<entrypoint>` is drawn from `(entrypoints − deniedEntrypoints) ∩ root
+ * package.json.scripts` — the policy yaml's allowed list (minus any local
+ * overlay bans) intersected with what the target repo's root package.json
+ * actually exposes right now. Neither side alone is the
  * whitelist: package.json alone would auto-allow any future risky script
  * (e.g. a `test:all`), and the policy list alone drifts the moment the repo
  * renames or removes a script (the verify:quick/verify:full removal that
@@ -72,10 +73,10 @@ import { fileURLToPath } from "node:url";
  *      "allowed", or `cd /tmp && npx vitest` becomes a free bypass).
  *   4. `cwd` must BE that workspace root, not a subdirectory of it (running
  *      from `apps/admin` bypasses the shape check other rules assume).
- *   5. Compute `entrypoints ∩ package.json.scripts` — this run's real
- *      whitelist. `deniedEntrypoints` names are deliberately NOT unioned in
- *      here (unlike step 1) — they must never be able to match the allowed
- *      shape, only ever be detected by it.
+ *   5. Compute `(entrypoints − deniedEntrypoints) ∩ package.json.scripts` —
+ *      this run's real whitelist. `deniedEntrypoints` names are deliberately
+ *      NOT unioned in here (unlike step 1) — they must never be able to match
+ *      the allowed shape, only ever be detected by it.
  *   6. Does the command match the allowed shape exactly, using that
  *      whitelist? A wrapper (`command`/`env`/`bash -c`/`eval`/...) can make
  *      step 1 detect an attempt without ever making step 6's shape match —
@@ -201,7 +202,7 @@ export function decide(input: DecideInput): DecideResult {
 	// deniedEntrypoints — a denied name must still register as a verification
 	// attempt, or it would silently fall out of the gate's sight entirely (see
 	// this file's header comment on the entrypoints/deniedEntrypoints split).
-	// Step 6's allowed-shape intersection below stays entrypoints-only; the
+	// Step 6's allowed-shape intersection below subtracts denied names; the
 	// union is used ONLY for this detection call.
 	const detectionEntrypoints = [...input.entrypoints, ...input.deniedEntrypoints];
 	const segments = splitSegments(input.command);
@@ -234,10 +235,12 @@ export function decide(input: DecideInput): DecideResult {
 		};
 	}
 
-	// Step 6's whitelist is entrypoints∩scripts only — a deniedEntrypoints name
-	// never enters this intersection, so it can never match the allowed shape
-	// no matter what else is true about the command.
-	const intersection = input.entrypoints.filter((entrypoint) => input.scripts.includes(entrypoint));
+	// Step 6's whitelist is (entrypoints − deniedEntrypoints)∩scripts. Local
+	// overlays replace keys independently, so a denied name may still be present
+	// in the base entrypoints list; subtract it explicitly before shape matching.
+	const intersection = input.entrypoints.filter(
+		(entrypoint) => !input.deniedEntrypoints.includes(entrypoint) && input.scripts.includes(entrypoint),
+	);
 	if (matchesAllowedShape(input.command, intersection, input.allowedTurboOpts)) {
 		return { decision: "passthrough" };
 	}

--- a/scripts/verify-entrypoint-gate/index.ts
+++ b/scripts/verify-entrypoint-gate/index.ts
@@ -19,9 +19,26 @@ import { fileURLToPath } from "node:url";
  * renames or removes a script (the verify:quick/verify:full removal that
  * prompted this rewrite).
  *
+ * A second policy list, `deniedEntrypoints`, exists alongside `entrypoints`
+ * because that single list used to carry two jobs at once: detection ("is
+ * this a verification attempt at all", judged in step 1 below) AND allowance
+ * ("does this shape pass", judged in step 6). Conflating the two means
+ * removing a name from `entrypoints` to ban it does not deny it — the
+ * command falls out of step 1's detection entirely and passes straight
+ * through as an ordinary script, the opposite of a ban (measured directly by
+ * calling decide() with `verify` dropped from `entrypoints`: `pnpm verify`
+ * came back passthrough, not deny). `deniedEntrypoints` splits the two jobs
+ * apart: step 1 detects against the UNION of `entrypoints` and
+ * `deniedEntrypoints` (so a denied name still registers as an attempt and
+ * reaches judgment), while step 6's whitelist stays `entrypoints ∩
+ * package.json.scripts` alone — a denied name never enters that
+ * intersection, so it can never match the allowed shape and always denies.
+ *
  * Judgment order (first match wins):
  *   1. Is this command a verification attempt at all — a `pnpm`/`npm`/`yarn`
- *      entrypoint-family script invocation, a direct `runners` call, a
+ *      entrypoint-family script invocation (checked against `entrypoints ∪
+ *      deniedEntrypoints`, not `entrypoints` alone — see the paragraph
+ *      above), a direct `runners` call, a
  *      `via`-executor call reaching a `runners` name, or any of those hidden
  *      behind a transparent wrapper (`command`/`env`, peeled off) or a nested
  *      shell (`bash -c "..."`/`sh -c '...'`/`eval "..."`, whose inner command
@@ -56,7 +73,9 @@ import { fileURLToPath } from "node:url";
  *   4. `cwd` must BE that workspace root, not a subdirectory of it (running
  *      from `apps/admin` bypasses the shape check other rules assume).
  *   5. Compute `entrypoints ∩ package.json.scripts` — this run's real
- *      whitelist.
+ *      whitelist. `deniedEntrypoints` names are deliberately NOT unioned in
+ *      here (unlike step 1) — they must never be able to match the allowed
+ *      shape, only ever be detected by it.
  *   6. Does the command match the allowed shape exactly, using that
  *      whitelist? A wrapper (`command`/`env`/`bash -c`/`eval`/...) can make
  *      step 1 detect an attempt without ever making step 6's shape match —
@@ -65,10 +84,16 @@ import { fileURLToPath } from "node:url";
  *      unwrapped inner command would itself have been allowed. That's
  *      intended: the wrapper is a self-inflicted, trivially-dropped bypass
  *      attempt, not an unrecoverable false deny (drop the wrapper, run the
- *      inner command directly).
+ *      inner command directly). A `deniedEntrypoints` name also always fails
+ *      here, for the same structural reason: it was never in step 5's
+ *      whitelist to begin with.
  *   7. The deny reason for step 6 lists step 5's intersection dynamically —
  *      never a hardcoded script name (a hardcoded name going stale is
- *      exactly what caused the incident this gate redesign responds to).
+ *      exactly what caused the incident this gate redesign responds to). When
+ *      the command's `pnpm <name>` names a `deniedEntrypoints` entry
+ *      specifically, the reason names that denied entry too — read from the
+ *      command text and policy data, not hardcoded — and is judged before
+ *      the plain "no matching script" reason.
  *
  * Known unclosed gap, by design: shell variable/parameter expansion (e.g.
  * `pnpm${IFS}test --all`, `$P npm test`) is invisible to this file — the
@@ -144,6 +169,7 @@ import { fileURLToPath } from "node:url";
 // -----------------------------------------------------------------------------
 export type Policy = {
 	entrypoints: string[];
+	deniedEntrypoints: string[];
 	allowedTurboOpts: string[];
 	runners: string[];
 	via: string[];
@@ -158,6 +184,7 @@ export type DecideInput = {
 	workspaceRoot: string | null;
 	scripts: string[];
 	entrypoints: string[];
+	deniedEntrypoints: string[];
 	allowedTurboOpts: string[];
 	runners: string[];
 	via: string[];
@@ -170,9 +197,16 @@ export type DecideResult = { decision: "deny"; reason: string } | { decision: "p
 // steps 1–7 from the header comment in order, first match wins.
 // -----------------------------------------------------------------------------
 export function decide(input: DecideInput): DecideResult {
+	// Detection (step 1) runs against the UNION of entrypoints and
+	// deniedEntrypoints — a denied name must still register as a verification
+	// attempt, or it would silently fall out of the gate's sight entirely (see
+	// this file's header comment on the entrypoints/deniedEntrypoints split).
+	// Step 6's allowed-shape intersection below stays entrypoints-only; the
+	// union is used ONLY for this detection call.
+	const detectionEntrypoints = [...input.entrypoints, ...input.deniedEntrypoints];
 	const segments = splitSegments(input.command);
 	const isAttempt = segments.some((segment) =>
-		isVerificationAttemptSegment(segment, input.entrypoints, input.runners, input.via),
+		isVerificationAttemptSegment(segment, detectionEntrypoints, input.runners, input.via),
 	);
 	if (!isAttempt) {
 		return { decision: "passthrough" };
@@ -200,20 +234,56 @@ export function decide(input: DecideInput): DecideResult {
 		};
 	}
 
+	// Step 6's whitelist is entrypoints∩scripts only — a deniedEntrypoints name
+	// never enters this intersection, so it can never match the allowed shape
+	// no matter what else is true about the command.
 	const intersection = input.entrypoints.filter((entrypoint) => input.scripts.includes(entrypoint));
 	if (matchesAllowedShape(input.command, intersection, input.allowedTurboOpts)) {
 		return { decision: "passthrough" };
 	}
 
-	return { decision: "deny", reason: buildShapeMismatchReason(intersection, input.allowedTurboOpts) };
+	return {
+		decision: "deny",
+		reason: buildShapeMismatchReason(input.command, intersection, input.allowedTurboOpts, input.deniedEntrypoints),
+	};
 }
 
-function buildShapeMismatchReason(intersection: string[], allowedTurboOpts: string[]): string {
+// A deniedEntrypoints name is judged BEFORE the "no intersection" branch: an
+// empty intersection would otherwise produce the generic "no matching script"
+// reason even when the real cause is a specific, deliberately-denied name —
+// data-driven (reads the denied name from the command + policy data, never a
+// hardcoded script name), matching the same "never a hardcoded name" rule
+// this file's header comment already states for the shape-mismatch reason.
+function buildShapeMismatchReason(
+	command: string,
+	intersection: string[],
+	allowedTurboOpts: string[],
+	deniedEntrypoints: string[],
+): string {
+	const opts = allowedTurboOpts.length > 0 ? allowedTurboOpts.join("/") : "(없음)";
+	const allowedShape = `pnpm <${intersection.join("|")}> [앱이름] [${opts}] [-- 러너 인자...]`;
+
+	const deniedEntrypoint = matchedDeniedEntrypoint(command, deniedEntrypoints);
+	if (deniedEntrypoint !== null) {
+		return `\`pnpm ${deniedEntrypoint}\` 는 이 워크스페이스에서 허용되지 않는 검증 진입점입니다. 허용된 형태는 다음뿐입니다: ${allowedShape}`;
+	}
+
 	if (intersection.length === 0) {
 		return "이 워크스페이스의 package.json에는 정책의 진입점(entrypoints)과 일치하는 스크립트가 없어 어떤 검증 명령도 허용되지 않습니다.";
 	}
-	const opts = allowedTurboOpts.length > 0 ? allowedTurboOpts.join("/") : "(없음)";
-	return `허용된 검증 명령 형태는 다음뿐입니다: pnpm <${intersection.join("|")}> [앱이름] [${opts}] [-- 러너 인자...]`;
+	return `허용된 검증 명령 형태는 다음뿐입니다: ${allowedShape}`;
+}
+
+// The command's second token when its first is `pnpm` and that second token
+// is a deniedEntrypoints name — or null otherwise. Reuses the same
+// stripAfterEndOfOptions + stripLeadingEnvAssignments + tokenize combination
+// matchesAllowedShape already uses, rather than a new parser.
+function matchedDeniedEntrypoint(command: string, deniedEntrypoints: string[]): string | null {
+	if (deniedEntrypoints.length === 0) return null;
+	const tokens = tokenize(stripAfterEndOfOptions(stripLeadingEnvAssignments(command)));
+	if (tokens[0] !== "pnpm") return null;
+	const second = tokens[1];
+	return second !== undefined && deniedEntrypoints.includes(second) ? second : null;
 }
 
 // -----------------------------------------------------------------------------
@@ -779,6 +849,7 @@ export function loadConfig(
 
 	return {
 		entrypoints: pickList(local, base, "entrypoints"),
+		deniedEntrypoints: pickList(local, base, "denied_entrypoints"),
 		allowedTurboOpts: pickList(local, base, "allowed_turbo_opts"),
 		runners: pickList(local, base, "runners"),
 		via: pickList(local, base, "via"),
@@ -881,6 +952,7 @@ export function processHookInput(
 			workspaceRoot,
 			scripts,
 			entrypoints: policy.entrypoints,
+			deniedEntrypoints: policy.deniedEntrypoints,
 			allowedTurboOpts: policy.allowedTurboOpts,
 			runners: policy.runners,
 			via: policy.via,

--- a/scripts/verify-entrypoint-gate/verify-entrypoint-gate.test.ts
+++ b/scripts/verify-entrypoint-gate/verify-entrypoint-gate.test.ts
@@ -518,6 +518,27 @@ const DENIED_TABLE: Row[] = [
 ];
 
 describe("decide — denied_entrypoints policy axis", () => {
+	test("overlay-only deny still wins when the base entrypoints list also contains the denied name", () => {
+		const result = decide({
+			command: "pnpm verify",
+			cwd: WORKSPACE_ROOT,
+			workspaceRoot: WORKSPACE_ROOT,
+			scripts: REPO_SCRIPTS,
+			entrypoints: POLICY.entrypoints,
+			deniedEntrypoints: ["verify"],
+			allowedTurboOpts: POLICY.allowedTurboOpts,
+			runners: POLICY.runners,
+			via: POLICY.via,
+		});
+		expect(result.decision).toBe("deny");
+		if (result.decision === "deny") {
+			expect(result.reason).toContain("verify");
+			expect(result.reason).toContain("test");
+			expect(result.reason).toContain("check");
+			expect(result.reason).toContain("lint");
+		}
+	});
+
 	test.each(DENIED_TABLE)("$command → $expect ($note)", (row) => {
 		const result = decide({
 			command: row.command,

--- a/scripts/verify-entrypoint-gate/verify-entrypoint-gate.test.ts
+++ b/scripts/verify-entrypoint-gate/verify-entrypoint-gate.test.ts
@@ -13,6 +13,7 @@ import { decide, findWorkspaceRoot, loadConfig, processHookInput, type Policy } 
 // -----------------------------------------------------------------------------
 const POLICY: Policy = {
 	entrypoints: ["verify", "test", "check", "lint"],
+	deniedEntrypoints: [],
 	allowedTurboOpts: ["--continue"],
 	runners: ["vitest", "jest", "pytest", "eslint", "tsc", "turbo", "uv"],
 	via: ["npx", "bunx", "pnpm exec", "pnpm dlx", "node_modules/.bin"],
@@ -360,6 +361,7 @@ describe("decide — command-to-judgment table", () => {
 			workspaceRoot,
 			scripts,
 			entrypoints: POLICY.entrypoints,
+			deniedEntrypoints: POLICY.deniedEntrypoints,
 			allowedTurboOpts: POLICY.allowedTurboOpts,
 			runners: POLICY.runners,
 			via: POLICY.via,
@@ -379,6 +381,7 @@ describe("decide — never produces anything but deny/passthrough", () => {
 				workspaceRoot,
 				scripts,
 				entrypoints: POLICY.entrypoints,
+				deniedEntrypoints: POLICY.deniedEntrypoints,
 				allowedTurboOpts: POLICY.allowedTurboOpts,
 				runners: POLICY.runners,
 				via: POLICY.via,
@@ -396,6 +399,7 @@ describe("decide — deny reason dynamically lists the intersection", () => {
 			workspaceRoot: WORKSPACE_ROOT,
 			scripts: REPO_SCRIPTS,
 			entrypoints: POLICY.entrypoints,
+			deniedEntrypoints: POLICY.deniedEntrypoints,
 			allowedTurboOpts: POLICY.allowedTurboOpts,
 			runners: POLICY.runners,
 			via: POLICY.via,
@@ -418,6 +422,7 @@ describe("decide — deny reason dynamically lists the intersection", () => {
 			workspaceRoot: WORKSPACE_ROOT,
 			scripts: ["verify", "lint"], // simulates a repo where test/check no longer exist
 			entrypoints: POLICY.entrypoints,
+			deniedEntrypoints: POLICY.deniedEntrypoints,
 			allowedTurboOpts: POLICY.allowedTurboOpts,
 			runners: POLICY.runners,
 			via: POLICY.via,
@@ -450,6 +455,7 @@ describe("decide — compound deny reason never hardcodes an entrypoint name (AC
 			workspaceRoot: WORKSPACE_ROOT,
 			scripts: REPO_SCRIPTS,
 			entrypoints: POLICY.entrypoints,
+			deniedEntrypoints: POLICY.deniedEntrypoints,
 			allowedTurboOpts: POLICY.allowedTurboOpts,
 			runners: POLICY.runners,
 			via: POLICY.via,
@@ -469,6 +475,7 @@ describe("decide — compound deny reason never hardcodes an entrypoint name (AC
 			workspaceRoot: WORKSPACE_ROOT,
 			scripts: REPO_SCRIPTS,
 			entrypoints: POLICY.entrypoints,
+			deniedEntrypoints: POLICY.deniedEntrypoints,
 			allowedTurboOpts: POLICY.allowedTurboOpts,
 			runners: POLICY.runners,
 			via: POLICY.via,
@@ -479,6 +486,103 @@ describe("decide — compound deny reason never hardcodes an entrypoint name (AC
 				expect(result.reason).not.toContain(entrypoint);
 			}
 		}
+	});
+});
+
+// -----------------------------------------------------------------------------
+// denied_entrypoints — a policy axis distinct from `entrypoints`. Detection
+// (step 1: is this a verification attempt at all) fires on the UNION of
+// entrypoints and deniedEntrypoints, but step 6's allowed-shape intersection
+// is computed from `entrypoints` alone — a denied name never enters it. So a
+// denied entrypoint always denies, which is different from simply REMOVING a
+// name from `entrypoints`: removing turns detection off entirely and produces
+// passthrough (the exact incident — algocare-home's `pnpm verify` local ban —
+// this axis exists to fix).
+// -----------------------------------------------------------------------------
+const DENIED_SCRIPTS = ["test", "test:changed", "check", "lint", "verify"];
+// Swaps only the entrypoints/denied axis off POLICY — allowedTurboOpts/runners/via
+// don't vary for this axis, so there's no reason to drift a second copy of them.
+const DENIED_POLICY: Policy = {
+	...POLICY,
+	entrypoints: ["test", "test:changed", "check", "lint"],
+	deniedEntrypoints: ["verify"],
+};
+
+const DENIED_TABLE: Row[] = [
+	{ command: "pnpm verify", expect: "deny", note: "denied_entrypoints — 목록에서 뺀 것과 달리 명시적으로 거절" },
+	{ command: "pnpm verify commerce", expect: "deny", note: "denied_entrypoints — 앱 이름 스코프가 있어도 거절" },
+	{ command: "pnpm verify --continue", expect: "deny", note: "denied_entrypoints — allowed_turbo_opts 플래그가 있어도 거절" },
+	{ command: "pnpm test:changed backend", expect: "passthrough", note: "denied가 아닌 entrypoints는 그대로 허용" },
+	{ command: "pnpm test backend -- src/coupon.test.ts", expect: "passthrough", note: "denied가 아닌 entrypoints는 그대로 허용" },
+	{ command: "pnpm check backend", expect: "passthrough", note: "denied가 아닌 entrypoints는 그대로 허용" },
+];
+
+describe("decide — denied_entrypoints policy axis", () => {
+	test.each(DENIED_TABLE)("$command → $expect ($note)", (row) => {
+		const result = decide({
+			command: row.command,
+			cwd: WORKSPACE_ROOT,
+			workspaceRoot: WORKSPACE_ROOT,
+			scripts: DENIED_SCRIPTS,
+			entrypoints: DENIED_POLICY.entrypoints,
+			deniedEntrypoints: DENIED_POLICY.deniedEntrypoints,
+			allowedTurboOpts: DENIED_POLICY.allowedTurboOpts,
+			runners: DENIED_POLICY.runners,
+			via: DENIED_POLICY.via,
+		});
+		expect(result.decision).toBe(row.expect);
+	});
+
+	test("래퍼 우회 — bash -lc \"pnpm verify\" 도 거절된다 (탐지 합집합이 래퍼 flat-scan 경로에도 반영됨)", () => {
+		const result = decide({
+			command: 'bash -lc "pnpm verify"',
+			cwd: WORKSPACE_ROOT,
+			workspaceRoot: WORKSPACE_ROOT,
+			scripts: DENIED_SCRIPTS,
+			entrypoints: DENIED_POLICY.entrypoints,
+			deniedEntrypoints: DENIED_POLICY.deniedEntrypoints,
+			allowedTurboOpts: DENIED_POLICY.allowedTurboOpts,
+			runners: DENIED_POLICY.runners,
+			via: DENIED_POLICY.via,
+		});
+		expect(result.decision).toBe("deny");
+	});
+
+	test("deny 사유는 거절된 진입점 이름과 허용 집합을 함께 담는다", () => {
+		const result = decide({
+			command: "pnpm verify",
+			cwd: WORKSPACE_ROOT,
+			workspaceRoot: WORKSPACE_ROOT,
+			scripts: DENIED_SCRIPTS,
+			entrypoints: DENIED_POLICY.entrypoints,
+			deniedEntrypoints: DENIED_POLICY.deniedEntrypoints,
+			allowedTurboOpts: DENIED_POLICY.allowedTurboOpts,
+			runners: DENIED_POLICY.runners,
+			via: DENIED_POLICY.via,
+		});
+		expect(result.decision).toBe("deny");
+		if (result.decision === "deny") {
+			expect(result.reason).toContain("verify");
+			expect(result.reason).toContain("test");
+			expect(result.reason).toContain("test:changed");
+			expect(result.reason).toContain("check");
+			expect(result.reason).toContain("lint");
+		}
+	});
+
+	test("회귀 가드 — deniedEntrypoints가 빈 배열이면 entrypoints만으로 판정하던 기존 동작이 그대로 유지된다 (`pnpm verify`는 여전히 passthrough)", () => {
+		const result = decide({
+			command: "pnpm verify",
+			cwd: WORKSPACE_ROOT,
+			workspaceRoot: WORKSPACE_ROOT,
+			scripts: REPO_SCRIPTS,
+			entrypoints: POLICY.entrypoints,
+			deniedEntrypoints: [],
+			allowedTurboOpts: POLICY.allowedTurboOpts,
+			runners: POLICY.runners,
+			via: POLICY.via,
+		});
+		expect(result.decision).toBe("passthrough");
 	});
 });
 
@@ -555,9 +659,30 @@ describe("loadConfig", () => {
 		const moduleDir = fileURLToPath(new URL(".", import.meta.url));
 		const config = loadConfig(moduleDir);
 		expect(config.entrypoints).toEqual(["verify", "test", "check", "lint"]);
+		expect(config.deniedEntrypoints).toEqual([]);
 		expect(config.allowedTurboOpts).toEqual(["--continue"]);
 		expect(config.runners).toContain("vitest");
 		expect(config.via).toContain("npx");
+	});
+
+	test("loads denied_entrypoints from the local overlay", () => {
+		const baseDir = makeDir();
+		const localDir = makeDir();
+		writeFileSync(join(baseDir, "verify-entrypoint-gate.yaml"), "entrypoints: [test]\ndenied_entrypoints: []\n");
+		writeFileSync(join(localDir, "verify-entrypoint-gate.local.yaml"), "denied_entrypoints: [verify]\n");
+
+		const config = loadConfig(baseDir, localDir);
+		expect(config.deniedEntrypoints).toEqual(["verify"]);
+	});
+
+	test("local overlay omitting denied_entrypoints falls through to base", () => {
+		const baseDir = makeDir();
+		const localDir = makeDir();
+		writeFileSync(join(baseDir, "verify-entrypoint-gate.yaml"), "denied_entrypoints: [verify]\n");
+		writeFileSync(join(localDir, "verify-entrypoint-gate.local.yaml"), "entrypoints: [test]\n");
+
+		const config = loadConfig(baseDir, localDir);
+		expect(config.deniedEntrypoints).toEqual(["verify"]);
 	});
 
 	test("base-only when localDir is omitted (no workspace root found)", () => {
@@ -1247,8 +1372,9 @@ describe("real verify-entrypoint-gate.yaml drift pin", () => {
 	const moduleDir = fileURLToPath(new URL(".", import.meta.url));
 	const real = loadConfig(moduleDir);
 
-	test("shipped entrypoints/allowedTurboOpts/runners/via match what the table's POLICY fixture assumes", () => {
+	test("shipped entrypoints/deniedEntrypoints/allowedTurboOpts/runners/via match what the table's POLICY fixture assumes", () => {
 		expect(real.entrypoints).toEqual(POLICY.entrypoints);
+		expect(real.deniedEntrypoints).toEqual(POLICY.deniedEntrypoints);
 		expect(real.allowedTurboOpts).toEqual(POLICY.allowedTurboOpts);
 		expect(real.runners).toEqual(POLICY.runners);
 		expect(real.via).toEqual(POLICY.via);

--- a/scripts/verify-entrypoint-gate/verify-entrypoint-gate.yaml
+++ b/scripts/verify-entrypoint-gate/verify-entrypoint-gate.yaml
@@ -23,6 +23,18 @@
 # intersection is a two-way gate, not a one-way passthrough of package.json.
 entrypoints: [verify, test, check, lint]
 
+# Entrypoints that are DETECTED the same as `entrypoints` above (a `pnpm
+# <name>` invocation still registers as a verification attempt) but can NEVER
+# pass step 6's allowed-shape check — the only path to one of these names is
+# denial, always. This is NOT the same axis as removing a name from
+# `entrypoints`: removing turns detection off entirely, so the command falls
+# out of this gate's sight and passes through untouched — the opposite of a
+# ban. Listing a name here instead keeps it detected and denies it
+# explicitly. Empty by default: this axis exists for a project overlay
+# (verify-entrypoint-gate.local.yaml) to declare a locally-banned entrypoint
+# without needing an engine change each time one comes up.
+denied_entrypoints: []
+
 # Flags allowed between the entrypoint name and a `--` end-of-options marker
 # (or end of command). `infra/local/scripts/verify.sh` forwards these `-*`
 # args to turbo as-is (it's the repo's own documented CLI surface), so they


### PR DESCRIPTION
## 📌 Summary

`verify-entrypoint-gate`의 `entrypoints` 목록이 "검증 시도 탐지"와 "허용 형태" 두 역할을 겸하고 있어, 목록에서 진입점 이름을 빼면 거절이 아니라 **통과**가 됐습니다. 두 축을 분리하는 `denied_entrypoints` 정책 키를 신설해 "탐지는 되지만 절대 허용되지 않는 진입점"을 선언할 수 있게 합니다. base 기본값이 `[]`라 이 키를 선언하지 않은 대상의 판정은 그대로입니다.

---

## 🔧 Changes

### 판정 엔진 — 탐지 축과 허용 축 분리

- `Policy`·`DecideInput`에 `deniedEntrypoints` 필드 추가
- `decide()`가 탐지용 합집합 `entrypoints ∪ denied_entrypoints`를 만들어 시도 판정(step 1)에 전달
- 허용 형태 판정(`matchesAllowedShape`, step 6)은 기존대로 `entrypoints ∩ 대상 레포 root package.json scripts`만 사용 — 변경 없음
- `loadConfig`가 yaml의 `denied_entrypoints`를 읽어 정책으로 배선

이 게이트를 만들게 한 사고는 "레포에서 사라진 진입점을 게이트가 계속 안내하던 것"이었습니다. 이번에 만난 건 같은 클래스의 반대 방향입니다 — 진입점이 레포에는 멀쩡히 살아 있는데(CI가 씀) **로컬 사용만 금지된** 경우. 겸직 구조에서는 이걸 표현할 방법이 없었습니다.

**영향 범위**
`denied_entrypoints`를 선언하지 않은 대상은 판정이 한 건도 바뀌지 않습니다. base yaml 기본값이 `[]`이고 빈 목록과의 합집합은 기존 `entrypoints`와 같습니다. 기존 차단 축(컴파운드 명령, 러너 직접 호출, `via` 실행기, `--all`, 비허용 turbo 플래그, 워크스페이스 루트 밖 실행)은 전부 그대로입니다. 새 파일시스템 접근이나 외부 의존성은 없습니다.

### 거절 사유 문장

- `pnpm <거절된 진입점>` 형태일 때 전용 문장을 내고, 기존 "형태 불일치" 문장보다 먼저 판정
- 문장은 거절된 진입점 이름과 **그 시점의 살아있는 허용 집합**을 정책 데이터에서 조립 — 스크립트 이름 하드코딩 없음
- 토큰 추출은 기존 헬퍼(`stripLeadingEnvAssignments` → `stripAfterEndOfOptions` → `tokenize`) 재사용, 새 파서 없음

**영향 범위**
사용자에게 보이는 유일한 문장이라 문안이 곧 계약입니다. 기존 두 분기(허용 집합 공집합 / 형태 불일치)의 문안은 바뀌지 않았습니다.

### base 정책과 테스트

- `verify-entrypoint-gate.yaml`에 `denied_entrypoints: []` 기본값과 축 설명 주석 추가. 기존 `entrypoints`·`runners`·`via`·`allowed_turbo_opts` 값은 미변경
- 신규 테스트 11건: 거절 진입점의 스코프 유무·플래그 유무별 판정, 래퍼(`bash -lc`)를 통한 우회, 사유 문장이 거절된 이름과 허용 집합을 함께 담는지, `loadConfig`의 오버레이 읽기·base 폴스루
- 회귀 가드: `denied_entrypoints`가 비었을 때 기존 판정이 유지되는지 명시적으로 고정

**영향 범위**
139 → 150 tests, 0 fail. 기존 139건은 전부 통과 상태를 유지합니다.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 목록에서 이름을 빼는 대신 새 축을 만든 이유

**배경 및 문제 상황:**

한 대상 레포가 테스트 실행 구조를 3계층으로 바꿨습니다 — 로컬은 변경분만, PR CI는 변경분 + 회전 표본, main 머지 후에 전체. 이 전환과 함께 로컬에서 `pnpm verify`를 치는 것이 금지됐습니다. 백엔드 파일 하나만 고쳐도 `--affected`가 의존자까지 끌어와 5개 앱 17개 태스크가 딸려오고 20~40분이 걸리기 때문입니다. 전체 검증은 CI가 맡습니다.

게이트를 그 정책에 맞추려면 `verify`를 막아야 하는데, 처음엔 `entrypoints` 목록에서 이름을 빼는 것으로 충분해 보였습니다. 실제로 해보니 아니었습니다.

**해결 방안:**

`entrypoints`가 겸하던 두 역할을 분리했습니다.

- **탐지**(step 1) — "이 명령이 검증 시도인가": `entrypoints ∪ denied_entrypoints`
- **허용**(step 6) — "이 형태를 통과시킬 것인가": `entrypoints ∩ 대상 레포 package.json scripts` (기존과 동일)

`denied_entrypoints`에 있는 이름은 탐지 집합에는 들어가고 허용 집합에는 절대 못 들어갑니다.

**구현 세부사항:**

핵심은 `decide()`가 `isVerificationAttemptSegment`에 넘기는 값 하나를 합집합으로 바꾼 것입니다. 그 함수와 그 안의 래퍼 flat-scan 폴백은 시그니처도 로직도 그대로라, 래퍼(`bash -lc "..."`)·nested shell·토큰 난독화(`p'n'pm`)를 통한 우회 경로가 자동으로 같은 합집합을 보게 됩니다. 거절 진입점만 따로 우회 방어를 짜지 않은 이유입니다.

**관련 코드:**

목록에서 빼는 방식이 왜 안 되는지 `decide()`에 직접 먹여 확인한 결과입니다.

```
entrypoints=[test, test:changed, check, lint]   ← verify를 목록에서 제거
  PASSTHROUGH | pnpm verify            ← 거절이 아니라 게이트 시야 밖
  PASSTHROUGH | pnpm verify commerce

entrypoints=[test, test:changed, check, lint], denied_entrypoints=[verify]
  DENY        | pnpm verify
  DENY        | pnpm verify commerce
```

**선택과 트레이드오프:**

정책 데이터를 두 목록으로 나눈 만큼 "어느 목록에도 없는 이름"이라는 세 번째 상태가 생겼고, 그건 여전히 게이트 무관심(통과)입니다. 즉 나중에 누가 "안 쓰니까 지우자"며 `denied_entrypoints`에서 이름을 빼면 차단이 조용히 사라집니다. 목록 하나로 유지하면서 "허용/거절"을 값에 표기하는 방안(예: `entrypoints: [{name: verify, allow: false}]`)도 있었지만, 기존 병합 규칙이 "선언한 키의 배열을 통째로 교체"라는 평평한 리스트 전제 위에 서 있어서 레코드 형태로 바꾸면 병합 규칙까지 같이 갈아야 했습니다. 평평한 리스트 두 개가 더 작은 변경이라 그쪽을 택했고, 대신 이 함정을 정책 파일 주석에 명시적으로 남겼습니다.

### 2. 탐지는 합집합, 허용은 교집합 — 비대칭이 의도된 이유

**배경 및 문제 상황:**

허용 축은 원래 정책 목록을 대상 레포의 `package.json` scripts와 교집합합니다. 레포가 스크립트를 지우거나 이름을 바꾸면 허용 집합이 자동으로 따라가서, 정책이 존재하지 않는 스크립트를 계속 안내하는 드리프트를 막기 위한 장치입니다. 새 축에도 같은 교집합을 적용할지가 갈림길이었습니다.

**해결 방안:**

적용하지 않았습니다. `denied_entrypoints`는 교집합을 타지 않고, 대상 레포에 그 스크립트가 있든 없든 탐지되고 거절됩니다.

**구현 세부사항:**

교집합의 목적은 "허용 집합이 실재하는 스크립트만 담게 한다"입니다. 거절 목록에는 그 목적이 성립하지 않습니다 — 오히려 반대로, 스크립트가 사라진 뒤에도 그 이름으로 들어오는 명령은 계속 잡아야 합니다. 스크립트가 없으면 어차피 실행이 실패하지만, 그때 사용자가 받는 건 "허용되지 않는 진입점"이라는 게이트의 설명이지 pnpm의 원시 에러가 아닙니다.

**선택과 트레이드오프:**

비대칭이라 읽는 사람이 한 번 멈칫할 수 있습니다. 대신 거절 축이 대상 레포 상태에 의존하지 않아 판정이 단순해집니다. 이 비대칭은 엔진 헤더 주석과 정책 파일 주석 양쪽에 근거와 함께 적어뒀습니다.

### 3. 진입점 이름 축만으로는 스코프 없는 형태를 못 잡는다

**배경 및 문제 상황:**

이번 축은 진입점 **이름**을 봅니다. 그런데 원래 문제를 만든 건 이름이 아니라 **스코프 부재**입니다. 앱 이름 없이 실행하면 `--affected`가 의존자까지 끌어오고, 그게 20~40분의 실제 원인입니다. 대상 레포 문서도 금지 대상을 "`pnpm verify`와 스코프 없는 `pnpm test`" 둘로 적고 있습니다.

**해결 방안:**

이번 PR은 이름 축만 닫았습니다. 스코프 축은 열어뒀습니다.

**구현 세부사항:**

현재 허용 형태 판정은 positional 인자를 **0개 또는 1개** 허용합니다(`positionalCount > 1`이면 거절). 0개가 곧 스코프 없는 실행입니다. 실측하면 이렇게 갈립니다.

```
DENY        | pnpm verify           ← 이번 PR이 닫은 것
PASSTHROUGH | pnpm test             ← 여전히 열려 있음
PASSTHROUGH | pnpm check            ← 여전히 열려 있음
```

**선택과 트레이드오프:**

닫으려면 positional 개수를 정확히 1로 올리는 한 줄이면 되지만, 그 순간 이 게이트를 쓰는 다른 대상까지 "스코프 필수"가 되므로 정책 키(예: `require_scope`)로 레포별 분기가 필요합니다. 이번 PR의 논지는 "탐지 축과 허용 축의 분리"이고 스코프 강제는 별개 판단이라 섞지 않았습니다.

열린 질문 — 스코프 강제를 별도 축으로 추가할지, 아니면 이름 축만으로 충분하다고 볼지 의견을 받고 싶습니다. 이 게이트에는 탈출구가 없어서(우회 토큰도, `ask` 폴백도 없음) 막는 면을 넓힐수록 오탐 한 건이 사용자에게 복구 불가라는 점이 판단에 걸립니다.

---

## ✅ Checklist

### 탐지/허용 축 분리
- [ ] `denied_entrypoints`에 선언된 진입점은 스코프 유무·허용 플래그 유무와 무관하게 거절된다
  - `scripts/verify-entrypoint-gate/index.ts`
- [ ] 같은 진입점을 래퍼(`bash -lc "..."`)나 토큰 난독화(`p'n'pm`)로 감싸도 거절된다
  - `scripts/verify-entrypoint-gate/index.ts`
- [ ] `entrypoints`에만 있는 진입점은 허용 형태를 만족할 때 통과한다
  - `scripts/verify-entrypoint-gate/index.ts`

### 기존 동작 보존
- [ ] `denied_entrypoints`가 빈 목록이면 이 변경 이전과 판정이 동일하다
  - `scripts/verify-entrypoint-gate/verify-entrypoint-gate.test.ts`
- [ ] base yaml의 `entrypoints`·`runners`·`via`·`allowed_turbo_opts` 값이 변경되지 않았다
  - `scripts/verify-entrypoint-gate/verify-entrypoint-gate.yaml`
- [ ] 컴파운드 명령·러너 직접 호출·`--all`·비허용 turbo 플래그·워크스페이스 루트 밖 실행은 여전히 거절된다
  - `scripts/verify-entrypoint-gate/verify-entrypoint-gate.test.ts`

### 거절 사유 문장
- [ ] 거절 사유에 거절된 진입점 이름과 그 시점의 허용 집합이 함께 나온다
  - `scripts/verify-entrypoint-gate/index.ts`
- [ ] 사유 문장에 스크립트 이름이 하드코딩되어 있지 않다
  - `scripts/verify-entrypoint-gate/index.ts`

### 정책 로딩
- [ ] 프로젝트 오버레이가 `denied_entrypoints`를 선언하면 그 값이 쓰이고, 생략하면 base 값으로 폴스루한다
  - `scripts/verify-entrypoint-gate/index.ts`
