### PR TITLE
feat: mise 툴체인 해석 rule 추가

### DIFF
--- a/rules/toolchain-mise.md
+++ b/rules/toolchain-mise.md
@@ -1,0 +1,13 @@
+# Toolchain via mise
+
+`mise.toml` — in the repo or in a directory above it — is the toolchain source
+of truth for the tools it declares. Don't install around it or hardcode a
+runtime path; add the missing version there. `mise ls --current` prints what
+actually resolves in the current directory.
+
+A system stub answering instead of the pinned version (`/usr/bin/java` saying
+"Unable to locate a Java Runtime", a `node` that disagrees with the pin) is a
+resolution failure, not a missing install — `mise activate` hooks only fire in
+interactive shells. Run it through `mise exec -- <command>`, which also injects
+`JAVA_HOME`. If the pinned tool is still unreachable, the config is untrusted:
+mise hard-errors there and the command never runs, so `mise trust <path>`.

--- a/sync.yaml
+++ b/sync.yaml
@@ -160,3 +160,4 @@ rules:
     - verification-discipline
     - e2e-driver-usage
     - outbound-local-reference
+    - toolchain-mise


### PR DESCRIPTION
## 📌 Summary
mise가 고정한 런타임 대신 시스템 스텁이 응답하는 상황을 "설치 누락"으로 오진하지 않도록, 툴체인 해석 규칙을 전역 rule로 추가한다.

---

## 🔧 Changes

### rules/toolchain-mise.md (신규)

- `mise.toml`(레포 내부 또는 상위 디렉터리)이 선언한 도구의 SSOT임을 명시 — 우회 설치·런타임 경로 하드코딩 금지
- 시스템 스텁이 응답하는 건 "설치 누락"이 아니라 "해석 실패"라는 판정 규정
- 복구 2단계: `mise exec -- <command>`(JAVA_HOME 포함 주입) → 그래도 안 되면 미신뢰 config이므로 `mise trust`
- 실효 버전 확인 명령으로 `mise ls --current` 지정

배경: `mise activate` 훅은 대화형 셸에서만 걸린다. 비대화형 셸(에이전트 툴콜·스크립트)은 `mise.toml`이 있는 디렉터리에 서 있어도 훅이 안 걸려 시스템 바이너리가 응답한다. 실제로 Java가 mise에 설치돼 있는데 `/usr/bin/java` 스텁이 잡혀 "Java Runtime 없음"으로 오진한 사례에서 출발했다.

**영향 범위**: rule 파일 1개 추가. 기존 rule 문안·동작 변경 없음, 하위 호환 영향 없음.

### sync.yaml

- `rules.items`에 `toolchain-mise` 등재

**영향 범위**: 전역 rule 7종 → 8종. gemini 어댑터는 rules를 지원하지 않아 실제 도달 대상은 claude·codex 2종.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.

### 1. docs 분리 대신 13줄 단일 rule

**배경 및 문제 상황:** rules는 항상 로드되는 층이라 분량이 곧 상시 비용이다. 초안은 명령 카탈로그와 복구 단계 나열을 담아 26줄이었다.

**해결 방안:** 실패 신호 한 줄 + 복구 두 단계만 남겨 13줄로 축약했고, `docs/` 분리는 하지 않았다.

**구현 세부사항:** `mise where`·trust 개념 설명·번호 목록을 걷어내고, "무엇이 SSOT인가"와 "무엇이 실패 신호이고 어떻게 복구하는가"만 남겼다.

**선택과 트레이드오프:** docs로 빼면 rule은 더 얇아지지만 인덱스 한 줄 + 문서 한 개가 늘어 총 표면은 오히려 커진다. 13줄이면 근거 문서 없이 자족하므로 단일 파일을 유지했다. 분량이 다시 늘어나면 그때 분리하는 게 맞다고 본다.

### 2. 복구 경로를 `mise exec` 우선, `trust`를 2순위로

**배경 및 문제 상황:** 해석 실패의 원인은 두 가지다 — activate 미적용, config 미신뢰.

**해결 방안:** 조용한 실패를 먼저, 시끄러운 실패를 나중에 배치했다.

**구현 세부사항:** 미신뢰 config는 경고가 아니라 하드 에러라 명령 자체가 실행되지 않는다(에러 본문이 원인을 이미 말해준다). 반면 activate 미적용은 아무 말 없이 다른 바이너리가 응답하므로 독자가 스스로 의심하지 못한다. 그래서 후자를 1순위 복구로 뒀다.

**선택과 트레이드오프:** 순서를 뒤집으면 대부분의 경우 trust 확인이 헛걸음이 된다. 대신 하드 에러를 본 사람은 2순위까지 안 읽고 멈출 수 있는데, 그 경우 에러 메시지가 `mise trust`를 직접 안내하므로 손실이 없다고 판단했다.

---

## ✅ Checklist

### toolchain-mise rule
- [ ] `mise.toml`이 지배하는 디렉터리에서 시스템 스텁이 응답할 때, rule의 1순위 복구(`mise exec --`)로 핀 버전이 실행된다
  - `rules/toolchain-mise.md`
- [ ] rule 본문이 특정 머신·레포에 의존하지 않아 다른 프로젝트에 배포해도 유효하다
  - `rules/toolchain-mise.md`

### 배포 배관
- [ ] `make sync-dry`가 claude·codex 양쪽에 `rules/toolchain-mise` 배포를 계획한다
  - `sync.yaml`
- [ ] `make validate-schema`·`make validate-components`가 통과한다
  - `sync.yaml`