### PR TITLE
feat: craft-issue 이슈 본문 불변·comment append 전환

### DIFF
--- a/agents/issue-reviewer.md
+++ b/agents/issue-reviewer.md
@@ -17,9 +17,11 @@ You are given two absolute file paths at dispatch (the resolved `SKILL.md` and `
 
 ## Payload Contract (dispatch precondition)
 
-The dispatch payload contains exactly three kinds of labeled blocks: the original raw request (Stage 1, verbatim), the parent issue body (when a parent exists), and one child body per child issue in the set. One labeled block per child: repeat the child:<title-slug> label N times for N children.
+The dispatch payload contains exactly four kinds of labeled blocks: the original raw request (Stage 1, verbatim), the parent issue body (when a parent exists), one child body per child issue in the set, and one append comment per existing issue being appended to. One labeled block per child: repeat the child:<title-slug> label N times for N children. One labeled block per append comment: repeat the comment:<issue-key> label M times for M comments.
 
-An incomplete payload (any of the three blocks missing) is a payload contract violation and PASS is forbidden. When a required block is missing, report a single finding with `**Rule:** payload contract`, quote the missing block name in `**Offending:**`, and stop — do not attempt to review the partial payload as if it were complete.
+A payload may carry child blocks, comment blocks, or both. A run that only appends to an existing issue sends the request block plus comment blocks and no child block — that is complete, not defective. Judge a comment:<issue-key> block against the Append Comment Shape in `references/issue-craft.md`, not against the Standard Body Shape.
+
+An incomplete payload (the request block missing, or the set carrying neither a child block nor a comment block, or a block sent label-only with no text) is a payload contract violation and PASS is forbidden. When a required block is missing, report a single finding with `**Rule:** payload contract`, quote the missing block name in `**Offending:**`, and stop — do not attempt to review the partial payload as if it were complete.
 
 ## Corpus Scoping
 
@@ -44,7 +46,7 @@ Every finding cites the rule it enforces per these eight norms:
 
 ## Input
 
-You receive, inline (never as file paths to re-read): the original raw request, the parent body (if any), one child body per child (each under its own `child:<title-slug>` label), and the two absolute rule-file paths described in Rule Source above.
+You receive, inline (never as file paths to re-read): the original raw request, the parent body (if any), one child body per child (each under its own `child:<title-slug>` label), one append comment per appended issue (each under its own `comment:<issue-key>` label), and the two absolute rule-file paths described in Rule Source above.
 
 ## Output Contract
 
@@ -64,7 +66,7 @@ On PASS, emit the Status line and nothing else.
 **Status:** REQUEST_CHANGES
 
 **Rule:** <heading or label cited per the Citation Norms above>
-**Where:** <target — request / parent / child:<title-slug>>
+**Where:** <target — request / parent / child:<title-slug> / comment:<issue-key>>
 **Offending:** <target> | <locator> | <verbatim quote, or the word absent>
 **Why:** <one sentence naming the checklist requirement being violated>
 ```

--- a/skills/craft-issue/SKILL.md
+++ b/skills/craft-issue/SKILL.md
@@ -195,6 +195,7 @@ Refuse to file (or refuse to enrich an existing issue) if ANY of the following h
 - **No consistent reproduction**: a bug or behavior report with no reproducible scenario, no log evidence, and no witness account.
 - **Runtime-evidence-free root-cause claim**: a root cause assertion that cannot be grounded in code, logs, or a reproducible trace — pure speculation is not a root cause.
 - **Un-observable AC**: every acceptance criterion must be verifiable by a defined method (test, query, manual step). An AC that cannot be verified is not an AC.
+- **Unreadable target-issue history**: the intake is an existing issue and its comment thread cannot be retrieved in full. Under the Append-Only History Contract the thread carries that issue's current state, so an append written without it can re-assert body lines a comment already retired. This is the one gather failure that blocks — every other unreachable source stays fail-open (`references/gather-crosslink.md` §3).
 
 When refusing, state clearly which condition triggered and what evidence is needed to unblock.
 
@@ -245,7 +246,7 @@ Dispatch payload (inline text, not file paths):
 <one comment:<issue-key> block per append comment in the set, each carrying that comment's full text — omit when the set contains no append>
 ```
 
-On the existing-issue path the set is the append comments, not bodies: emit them as `comment:<issue-key>` blocks. A run that writes only an append sends the request block plus exactly one `comment:<issue-key>` block.
+Each issue in the set is emitted as the artifact this run actually writes to it: an issue being created contributes its body as a `child:<title-slug>` block, and an issue that already has a body contributes its append comment as a `comment:<issue-key>` block. The two kinds coexist — a Stage 5 slice of an **existing** parent emits one `comment:<issue-key>` block for that parent plus one `child:<title-slug>` block per newly created child, and every one of those child bodies stays in the same dispatch. A run that only appends sends the request block plus exactly one `comment:<issue-key>` block.
 
 Rule files are passed as the two absolute paths printed by the RULES_RESOLVED step.
 

--- a/skills/craft-issue/SKILL.md
+++ b/skills/craft-issue/SKILL.md
@@ -20,10 +20,37 @@ intake
                            cause is unknown, run the diagnosis sub-pipeline — READ references/diagnose-rootcause.md)
       → record            (best-practice body — READ references/issue-craft.md at this stage)
         → slice           (Model A INVEST — READ references/issue-craft.md at this stage)
-          → write tail    (checklist gate → autonomous write; human review post-hoc)
+          → write tail    (checklist gate → autonomous write — body when the issue is new,
+                           append comment when it already exists; human review post-hoc)
 ```
 
 Each stage is described below. Refuse-to-file conditions, duplicate policy, and the INVEST slice gate are inline gates within this spine — do not skip them.
+
+---
+
+## Append-Only History Contract
+
+**An issue body is written exactly once — when the issue is created. After that it is immutable.**
+Every later finding, correction, decision, and diagnosis lands as a **new comment appended to that
+issue**. Nothing already written is edited away; the record accumulates, so a reader can reconstruct
+how the issue reached its current state and why.
+
+| What you are writing | Where it goes |
+|---|---|
+| An issue that does not exist yet | The **body**, in full, per Stages 4-5 |
+| An issue that already has a body — enrichment, correction, new diagnosis, re-scoping | An **append comment**. The body is not rewritten. |
+| Structural relations — related, parent, blocked-by, label | Written **directly**, on either path. These are graph edges, not body text, and have no comment form. |
+
+**The body's immutability binds its bytes, not the comment's authority.** An append comment states
+the corrected content in final, decided form — "완료 조건 1번은 이제 이렇다" — and the reader treats it
+as current. It is not a set of remarks *about* the body that leaves the merge to the reader. A
+comment that names which body lines are now doubtful without stating what replaces them has not done
+its job. The required shape is the **Append Comment Shape** in `references/issue-craft.md`.
+
+**A superseded line stays visible.** Because nothing is deleted, a wrong premise or a stale AC keeps
+sitting in the body looking alive. The only thing that retires it is an explicit supersede
+declaration in the append comment. Retiring it inside a paragraph does not count — it is a named,
+required field of the append shape.
 
 ---
 
@@ -31,7 +58,7 @@ Each stage is described below. Refuse-to-file conditions, duplicate policy, and 
 
 Identify what was handed to you. Three input modes:
 
-- **Assigned PM issue**: an issue already exists; enrich and cross-link it in place.
+- **Assigned PM issue**: an issue already exists; enrich and cross-link it by **appending a comment** — its body is immutable per the Append-Only History Contract above.
 - **Abstract free-text requirement**: no issue yet; synthesize one from scratch.
 - **Symptom report (cause unknown)**: a bug, regression, incident, or support report describing wrong behavior whose root cause is not yet established. This mode routes Stage 3 to the diagnosis sub-pipeline (not the light investigation): the issue's Root Cause cannot be written until the cause is established by evidence or explicitly marked hypothesis-grade.
 
@@ -51,9 +78,12 @@ Read `references/gather-crosslink.md` now (using the Read tool with path `refere
 |---|---|
 | collaboration-docs | spec pages, PRD, design docs, meeting notes |
 | PM | linked issues, parent epics, related issues |
+| target-issue history | the target issue's own comment thread, read in full and in order — mandatory whenever the intake is an existing issue |
 | messenger | slack threads, comment trails |
 | code-VCS | recent commits, blame, open PRs touching the area |
 | logs | error logs, monitoring alerts, incident records |
+
+**Effective state of an existing issue** — because the body is immutable (see the Append-Only History Contract), the body alone is NOT the current state. The current state is the body **as amended by its comment thread, in order**: a body line that a later comment declares superseded is dead, and the comment's Effective State replaces it. Read the whole thread before judging what the issue currently says. Enriching or diagnosing against the body alone reasons from retired facts.
 
 **Runtime tool-mapping note** (stated once): at gather time, map each abstract source TYPE to whatever MCP/CLI is available in the current runtime (e.g., a docs MCP for collaboration-docs, a PM MCP for PM, a Slack MCP for messenger, git/GitHub MCP for code-VCS, a log tool for logs). An unwired source type is skipped gracefully — gather incompleteness does not trigger refuse-to-file.
 
@@ -117,7 +147,7 @@ Read `references/issue-craft.md` (already loaded in Stage 4 — re-read only if 
 **Slice gate decision:**
 
 - If the issue passes INVEST as a single unit: proceed to Stage 6 (write as-is).
-- If the issue is too large (fails Independent or Estimable or Small): slice into child issues, each passing the per-child stage-check ("requirement-understanding vs implementation-planning"). Then restructure the parent body per the **Parent-Issue Body Shape** in `references/issue-craft.md` — follow its required/conditional column in full (the parent keeps its own Pre-Context; shared context placement follows the **Tiered Shared-Context Placement** rule there — Tier A parent-inline for small/stable context regardless of reuse count, Tier C canonical-document link for substantial/evolving context, Tier B full duplication only for a cross-team/external handoff). Each child carries its own Problem, Pre-Context, AC, and Non-Goals and references the canonical location (parent or Tier-C document) for shared definitions rather than duplicating them (except a Tier-B handoff child, which restates them in full).
+- If the issue is too large (fails Independent or Estimable or Small): slice into child issues, each passing the per-child stage-check ("requirement-understanding vs implementation-planning"). Then apply the **Parent-Issue Body Shape** in `references/issue-craft.md` to the parent — as its body when this run is creating the parent, or as an **append comment** on it when the parent already exists (Append-Only History Contract; the restructure is written as Effective State over the sections it changes, never as a body rewrite) — follow its required/conditional column in full (the parent keeps its own Pre-Context; shared context placement follows the **Tiered Shared-Context Placement** rule there — Tier A parent-inline for small/stable context regardless of reuse count, Tier C canonical-document link for substantial/evolving context, Tier B full duplication only for a cross-team/external handoff). Each child carries its own Problem, Pre-Context, AC, and Non-Goals and references the canonical location (parent or Tier-C document) for shared definitions rather than duplicating them (except a Tier-B handoff child, which restates them in full).
 - Settled child issues hand off to `prometheus` (for planning) or `sisyphus` (for execution) as appropriate.
 
 INVEST is the slice gate. File-count or LOC atomicity is NOT the gate.
@@ -184,9 +214,9 @@ Write to the PM tool autonomously once all refuse-to-file conditions pass. No pr
 
 ### Plain-Language Gate (before any write)
 
-Before executing the write steps below, check the **body about to be emitted to the issue** — not gather-stage summaries or authoring notes — against these four checks. Failing any check blocks the write: fix the issue, then re-check.
+Before executing the write steps below, check the **text about to be emitted to the issue — a body on the create path, an append comment on the existing-issue path** — not gather-stage summaries or authoring notes, against these four checks. Failing any check blocks the write: fix the issue, then re-check.
 
-1. **Header contract**: every emitted section header/subheading is the localized Render-Label from `references/issue-craft.md`'s Render Contract — no authoring-instruction leakage (Required/Conditional markers, trigger conditions, hedge language, the `— expected` separator) survives into a header or bracketed subtitle.
+1. **Header contract**: every emitted section header/subheading is the localized Render-Label from `references/issue-craft.md`'s Render Contract — for an append comment this covers its four 변경 요약 / 근거 / 대체 대상 / 정정 후 상태 headers and every localized header restated under 정정 후 상태 — no authoring-instruction leakage (Required/Conditional markers, trigger conditions, hedge language, the `— expected` separator) survives into a header or bracketed subtitle.
 2. **Symbol gloss**: every code symbol (function, module, file, service, constant) named in the body carries a first-occurrence what/where/does gloss, per `references/issue-craft.md`'s symbol-gloss contract.
 3. **Shorthand/abbreviation**: no undefined engineer shorthand or internal abbreviation (domain-internal shorthand in the style of `known-moved`, `recon`, `tx-body`, `markFailed-first`, `pre-capture`) appears without being spelled out at first use. Found one? Expand it at first use.
 4. **Reader-facing humanizer pass**: when the body's language is Korean (the team's working language), invoke `Skill(humanizer)` on the reader-facing prose immediately before the write — this is the point where engineer-shorthand register becomes PM-reader register.
@@ -212,7 +242,10 @@ Dispatch payload (inline text, not file paths):
 <original raw request, verbatim>
 <parent body, if any — omit this block when there is no parent>
 <one child:<title-slug> block per issue body in the set — an unsliced single issue (Stage 5 "write as-is") is still emitted as exactly one child:<title-slug> block, never sent body-less>
+<one comment:<issue-key> block per append comment in the set, each carrying that comment's full text — omit when the set contains no append>
 ```
+
+On the existing-issue path the set is the append comments, not bodies: emit them as `comment:<issue-key>` blocks. A run that writes only an append sends the request block plus exactly one `comment:<issue-key>` block.
 
 Rule files are passed as the two absolute paths printed by the RULES_RESOLVED step.
 
@@ -220,17 +253,17 @@ Rule files are passed as the two absolute paths printed by the RULES_RESOLVED st
 
 **Loop contract:** cycle starts at 0 and increments at reviewer dispatch; max_cycles=5 permits exactly 5 dispatches. A REQUEST_CHANGES on the 5th dispatch is terminal — no further revision is produced. Dispatch a fresh agent instance each cycle. Do not pass the prior verdict or its findings into the new prompt. The writer's self-assessment cannot substitute for a reviewer verdict. Same-Rule key = target + the **Rule:** string verbatim. Pin each target identifier at cycle 1 and never recompute it. Two verdicts are "the same" iff the Same-Rule key matches; the count resets to 1 when a different key appears. Three consecutive same-key verdicts trigger `Same-Rule-3x` termination — the same early-exit as exhausting `max_cycles=5`.
 
-**On loop exhaustion:** Terminal exit (max_cycles=5 exhausted, or Same-Rule-3x): write the issue anyway, and append the unresolved findings verbatim under Notes. The terminal write must record every unresolved finding verbatim under Notes — no other section receives them. The bytes written are exactly the body as last dispatched to the reviewer. The findings from that final verdict are recorded, not acted on — no post-terminal revision is produced. This terminal Notes block is appended after the Plain-Language Gate and is exempt from it — it is a verbatim machine record of the final reviewer verdict, not reader-facing prose, and is the only exception to the reviewed-bytes-equal-written-bytes invariant that governs every other write in this pipeline. Report the terminal write to the caller: the issue was written with N unresolved findings on <rule>; see Notes.
+**On loop exhaustion:** Terminal exit (max_cycles=5 exhausted, or Same-Rule-3x): write the issue anyway — body on the create path, append comment on the existing-issue path — and append the unresolved findings verbatim under Notes (메모) at the end of whichever text is written. The terminal write must record every unresolved finding verbatim under Notes — no other section receives them. The bytes written are exactly the body as last dispatched to the reviewer. The findings from that final verdict are recorded, not acted on — no post-terminal revision is produced. This terminal Notes block is appended after the Plain-Language Gate and is exempt from it — it is a verbatim machine record of the final reviewer verdict, not reader-facing prose, and is the only exception to the reviewed-bytes-equal-written-bytes invariant that governs every other write in this pipeline. Report the terminal write to the caller: the issue was written with N unresolved findings on <rule>; see Notes.
 
 Abstract write steps (in order):
 
 1. **Link related items**: attach previously gathered related issues/issues as related items in the PM tool.
 2. **Set parent**: if this is a child issue from the slice stage, set the parent relationship to the parent issue.
 3. **Set dependency links**: for child issues that carry a blocked-by ordering from the slice stage, attach the blocked-by relation to the predecessor issue. Independent children carry no dependency link.
-4. **Write body**: write the full issue body following the body shape from `references/issue-craft.md`.
+4. **Write the issue text**: for an issue being created, write the full body following the body shape from `references/issue-craft.md`. For an issue that already has a body, **append a comment** following the **Append Comment Shape** in the same file — do not write the body. Steps 1, 2, 3, and 5 run identically on both paths: structural relations and labels are written directly (Append-Only History Contract).
 5. **Label**: apply any labels derived from the issue genre (bug, feature, improvement, etc.) and the source domain.
 
-**Runtime tool binding** (this is the only place concrete tool identifiers may appear): when the PM tool is Linear, the write steps map to the Linear MCP: `save_issue` to create or update, `relatedTo` for related links, `parentId` for parent assignment, `blockedBy` for dependency links. When the PM tool differs, substitute the equivalent fields. The binding is resolved at runtime based on what MCP is wired — this skill carries no hardcoded assumption beyond Linear as the documented example.
+**Runtime tool binding** (this is the only place concrete tool identifiers may appear): when the PM tool is Linear, the write steps map to the Linear MCP: `save_issue` to create an issue, `create_comment` to append to one that already exists, `relatedTo` for related links, `parentId` for parent assignment, `blockedBy` for dependency links. `save_issue` with a `description` on an issue that already has one is the write the Append-Only History Contract forbids. When the PM tool differs, substitute the equivalent fields. The binding is resolved at runtime based on what MCP is wired — this skill carries no hardcoded assumption beyond Linear as the documented example.
 
 **Linear auto-relation fact**: Linear auto-creates a native `relatedTo` relation from any unescaped issue reference placed in a description body, including a bare issue key (for example, `B2C-4992` as normal text), an issue markdown link, or an issue URL. Therefore, when the PM tool is Linear: `relatedTo` is written only for the curated related set (step 1 above), `parentId` only for parent assignment (step 2 above), and PM issues that must be referenced in the body without becoming related — parent epics, context-only mentions, or duplicate-policy distinct siblings — are rendered as inline-code issue identifiers (for example, `` `B2C-4992` ``), which preserves literal text and does not create a Linear issue mention/relation. Do not render must-not-relate Linear issue references as bare keys, markdown issue links, or issue URLs in the body.
 
@@ -240,6 +273,6 @@ Human review is post-hoc: the issue is written first; the caller can review and 
 
 ## Reference Files
 
-- `references/gather-crosslink.md`: complete gather bound, curation rules, cross-link procedure, source-unreachable handling, impact & premises investigation delegation (§7), and cross-link annotation format. Read at Stage 2.
+- `references/gather-crosslink.md`: complete gather bound, curation rules, effective-state reconstruction from an existing issue's comment thread, cross-link procedure, source-unreachable handling, impact & premises investigation delegation (§7), and cross-link annotation format. Read at Stage 2.
 - `references/diagnose-rootcause.md`: the symptom-report diagnosis sub-pipeline — independent-diagnosis mandate (prior issues are hypotheses), delegation orchestration (explore/oracle/librarian + your own runtime-evidence track), competing-hypothesis disproof ledger, runtime-evidence gate, multi-path coverage, and the confidence gate. Read at Stage 3 when the cause is unknown.
-- `references/issue-craft.md`: best-practice body shape, observable-AC rubric (weasel-word prohibition, Action/Expected/Verification), RCA Bug-Report shape, anti-fluff rules, Model A INVEST slice rubric with per-child stage-check and settled-child handoff, Render Contract, and symbol-gloss contract. Read at Stages 4 and 5, and consulted again at Stage 6's Plain-Language Gate.
+- `references/issue-craft.md`: best-practice body shape, **Append Comment Shape** (변경 요약 / 근거 / 대체 대상 / 정정 후 상태), observable-AC rubric (weasel-word prohibition, Action/Expected/Verification), RCA Bug-Report shape, anti-fluff rules, Model A INVEST slice rubric with per-child stage-check and settled-child handoff, Render Contract, and symbol-gloss contract. Read at Stages 4 and 5, and consulted again at Stage 6's Plain-Language Gate.

--- a/skills/craft-issue/SKILL.test.ts
+++ b/skills/craft-issue/SKILL.test.ts
@@ -156,7 +156,7 @@ describe("A9: payload precondition", () => {
 
 	test("incomplete payload forbids PASS", () => {
 		expect(reviewerMd).toContain(
-			"An incomplete payload (any of the three blocks missing) is a payload contract violation and PASS is forbidden.",
+			"An incomplete payload (the request block missing, or the set carrying neither a child block nor a comment block, or a block sent label-only with no text) is a payload contract violation and PASS is forbidden.",
 		);
 	});
 });
@@ -356,7 +356,9 @@ describe("B4: post-hoc contract correction", () => {
 	});
 
 	test("pipeline diagram write-tail node names the gate", () => {
-		expect(skillMd).toContain("→ write tail    (checklist gate → autonomous write; human review post-hoc)");
+		expect(skillMd).toContain(
+			"→ write tail    (checklist gate → autonomous write — body when the issue is new,\n                           append comment when it already exists; human review post-hoc)",
+		);
 	});
 });
 
@@ -451,7 +453,7 @@ describe("D3: terminal findings recorded under Notes only (not Decisions Needed)
 describe("D4: terminal exit — write anyway, exact bytes, caller notification", () => {
 	test("terminal exit condition and write-anyway action", () => {
 		expect(skillMd).toContain(
-			"Terminal exit (max_cycles=5 exhausted, or Same-Rule-3x): write the issue anyway, and append the unresolved findings verbatim under Notes.",
+			"Terminal exit (max_cycles=5 exhausted, or Same-Rule-3x): write the issue anyway — body on the create path, append comment on the existing-issue path — and append the unresolved findings verbatim under Notes (메모) at the end of whichever text is written.",
 		);
 	});
 
@@ -527,5 +529,160 @@ describe("G4: no forced Decisions Needed section when the trigger fails", () => 
 describe("G5: dedup — one dispatch per open decision", () => {
 	test("one dispatch per decision", () => {
 		expect(skillMd).toContain("one dispatch per decision");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Append-Only History Contract — an existing issue's body is immutable; new
+// material lands as a comment shaped by the Append Comment Shape.
+// ---------------------------------------------------------------------------
+
+const gatherCrosslinkMd = readFileSync(join(import.meta.dir, "references/gather-crosslink.md"), "utf8");
+
+describe("H1: Append-Only History Contract in SKILL.md", () => {
+	test("body is written exactly once, at creation", () => {
+		expect(skillMd).toContain(
+			"**An issue body is written exactly once — when the issue is created. After that it is immutable.**",
+		);
+	});
+
+	test("structural relations are the named exception", () => {
+		expect(skillMd).toContain(
+			"| Structural relations — related, parent, blocked-by, label | Written **directly**, on either path. These are graph edges, not body text, and have no comment form. |",
+		);
+	});
+
+	test("immutability binds bytes, not the comment's authority", () => {
+		expect(skillMd).toContain("**The body's immutability binds its bytes, not the comment's authority.**");
+	});
+
+	test("a superseded line stays visible and needs an explicit declaration", () => {
+		expect(skillMd).toContain("**A superseded line stays visible.**");
+		expect(skillMd).toContain("it is a named,\nrequired field of the append shape.");
+	});
+
+	test("Stage 1 assigned-issue mode appends instead of enriching in place", () => {
+		expect(skillMd).toContain(
+			"enrich and cross-link it by **appending a comment** — its body is immutable per the Append-Only History Contract above.",
+		);
+	});
+});
+
+describe("H2: Append Comment Shape in issue-craft.md", () => {
+	test("section exists", () => {
+		expect(issueCraftMd).toContain("### Append Comment Shape");
+	});
+
+	for (const row of ["**Update Summary**", "**Basis**", "**Supersedes**", "**Effective State**"]) {
+		test("shape table carries the " + row + " row", () => {
+			expect(issueCraftMd).toContain("| " + row + " |");
+		});
+	}
+
+	test("Effective State is a rewrite, not a review", () => {
+		expect(issueCraftMd).toContain("**Effective State is a rewrite, not a review.**");
+	});
+
+	test("untouched sections are not restated", () => {
+		expect(issueCraftMd).toContain("**Untouched sections are not restated.**");
+	});
+
+	test("scope note forbids withholding the decision", () => {
+		expect(issueCraftMd).toContain("the comment IS where the decision is now recorded");
+	});
+
+	for (const [en, ko] of [
+		["Update Summary", "변경 요약"],
+		["Basis", "근거"],
+		["Supersedes", "대체 대상"],
+		["Effective State", "정정 후 상태"],
+	]) {
+		test("localization table maps " + en + " to " + ko, () => {
+			expect(issueCraftMd).toContain("| " + en + " | " + ko + " |");
+		});
+	}
+
+	test("Append Comment Shape is inside the every-emittable-header scope sentence", () => {
+		expect(issueCraftMd).toContain("Append Comment Shape, Parent-Issue Body Shape,");
+	});
+});
+
+describe("H3: gather reconstructs effective state from the comment thread", () => {
+	test("SKILL.md lists target-issue history as a source type", () => {
+		expect(skillMd).toContain(
+			"| target-issue history | the target issue's own comment thread, read in full and in order — mandatory whenever the intake is an existing issue |",
+		);
+	});
+
+	test("SKILL.md states the body alone is not the current state", () => {
+		expect(skillMd).toContain("**Effective state of an existing issue**");
+	});
+
+	test("gather reference exempts the thread from the recency window and per-source cap", () => {
+		expect(gatherCrosslinkMd).toContain(
+			"the per-source cap and recency window of Section 1 do NOT apply to it",
+		);
+	});
+
+	test("gather reference defines the replay procedure", () => {
+		expect(gatherCrosslinkMd).toContain("**Reconstructing an existing issue's effective state**");
+		expect(gatherCrosslinkMd).toContain(
+			"Judge duplicates, refuse-to-file conditions, and the INVEST gate against that reconstructed state, never against the raw body.",
+		);
+	});
+});
+
+describe("H4: Stage 5 and Stage 6 route by create-vs-exists", () => {
+	test("Stage 5 parent restructure branches on whether the parent already exists", () => {
+		expect(skillMd).toContain(
+			"as its body when this run is creating the parent, or as an **append comment** on it when the parent already exists",
+		);
+	});
+
+	test("write step 4 routes body vs append comment", () => {
+		expect(skillMd).toContain(
+			"For an issue that already has a body, **append a comment** following the **Append Comment Shape** in the same file — do not write the body.",
+		);
+	});
+
+	test("Linear binding names create_comment and forbids description-over-existing", () => {
+		expect(skillMd).toContain("`create_comment` to append to one that already exists");
+		expect(skillMd).toContain(
+			"`save_issue` with a `description` on an issue that already has one is the write the Append-Only History Contract forbids.",
+		);
+	});
+
+	test("Plain-Language Gate covers the append comment's own headers", () => {
+		expect(skillMd).toContain(
+			"for an append comment this covers its four 변경 요약 / 근거 / 대체 대상 / 정정 후 상태 headers",
+		);
+	});
+});
+
+describe("H5: reviewer payload accepts comment blocks", () => {
+	test("payload contract names four block kinds", () => {
+		expect(reviewerMd).toContain("The dispatch payload contains exactly four kinds of labeled blocks");
+	});
+
+	test("one comment:<issue-key> block per append comment", () => {
+		expect(reviewerMd).toContain(
+			"One labeled block per append comment: repeat the comment:<issue-key> label M times for M comments.",
+		);
+	});
+
+	test("an append-only run is complete without a child block", () => {
+		expect(reviewerMd).toContain(
+			"A run that only appends to an existing issue sends the request block plus comment blocks and no child block — that is complete, not defective.",
+		);
+	});
+
+	test("a comment block is judged against the Append Comment Shape", () => {
+		expect(reviewerMd).toContain(
+			"Judge a comment:<issue-key> block against the Append Comment Shape in `references/issue-craft.md`, not against the Standard Body Shape.",
+		);
+	});
+
+	test("Where field accepts a comment target", () => {
+		expect(reviewerMd).toContain("**Where:** <target — request / parent / child:<title-slug> / comment:<issue-key>>");
 	});
 });

--- a/skills/craft-issue/SKILL.test.ts
+++ b/skills/craft-issue/SKILL.test.ts
@@ -686,3 +686,69 @@ describe("H5: reviewer payload accepts comment blocks", () => {
 		expect(reviewerMd).toContain("**Where:** <target — request / parent / child:<title-slug> / comment:<issue-key>>");
 	});
 });
+
+// ---------------------------------------------------------------------------
+// H6: code-review fixes — target-issue history is the sole fail-open carve-out,
+// mixed child+comment payloads survive review, pre-contract issues baseline on
+// their current body.
+// ---------------------------------------------------------------------------
+
+describe("H6: unreadable target-issue history blocks the append", () => {
+	test("gather §3 carves target-issue history out of fail-open", () => {
+		expect(gatherCrosslinkMd).toContain("**Exception — `target-issue history`**: this one source type is NOT fail-open.");
+		expect(gatherCrosslinkMd).toContain("This is the sole carve-out from the three rules above.");
+	});
+
+	test("the carve-out sits after the Do-not-block rule it excepts", () => {
+		const doNotBlock = gatherCrosslinkMd.indexOf("- **Do not block**:");
+		const carveOut = gatherCrosslinkMd.indexOf("**Exception — `target-issue history`**");
+		expect(doNotBlock).toBeGreaterThan(-1);
+		expect(carveOut).toBeGreaterThan(doNotBlock);
+	});
+
+	test("SKILL.md refuse-to-file list carries the condition", () => {
+		expect(skillMd).toContain("- **Unreadable target-issue history**:");
+		expect(skillMd).toContain(
+			"This is the one gather failure that blocks — every other unreachable source stays fail-open",
+		);
+	});
+});
+
+describe("H6: mixed child + comment dispatch payload", () => {
+	test("each issue contributes the artifact this run writes to it", () => {
+		expect(skillMd).toContain(
+			"an issue being created contributes its body as a `child:<title-slug>` block, and an issue that already has a body contributes its append comment as a `comment:<issue-key>` block",
+		);
+	});
+
+	test("a sliced existing parent emits both kinds and keeps every child body", () => {
+		expect(skillMd).toContain(
+			"a Stage 5 slice of an **existing** parent emits one `comment:<issue-key>` block for that parent plus one `child:<title-slug>` block per newly created child, and every one of those child bodies stays in the same dispatch",
+		);
+	});
+});
+
+describe("H6: issues that predate the contract", () => {
+	test("filing-time framing is scoped to contract-era issues", () => {
+		expect(gatherCrosslinkMd).toContain(
+			"for an issue filed under the Append-Only History Contract (see `SKILL.md`) the body is immutable",
+		);
+	});
+
+	test("a pre-contract issue baselines on its current body", () => {
+		expect(gatherCrosslinkMd).toContain("**Issues that predate the contract**");
+		expect(gatherCrosslinkMd).toContain("**current body is the baseline**");
+	});
+
+	test("only append-shaped comments replay as state transitions", () => {
+		expect(gatherCrosslinkMd).toContain(
+			"Only comments carrying the append shape (a **대체 대상** or **정정 후 상태** section) are replayed as state transitions",
+		);
+	});
+
+	test("an unfulfilled pre-contract request is an open question, not a supersede", () => {
+		expect(gatherCrosslinkMd).toContain(
+			"is an open question to carry forward, not a superseding declaration to apply",
+		);
+	});
+});

--- a/skills/craft-issue/references/gather-crosslink.md
+++ b/skills/craft-issue/references/gather-crosslink.md
@@ -37,6 +37,7 @@ When a source type is not wired in the current runtime, or when a retrieval call
 - **Skip gracefully**: proceed without that source type.
 - **Annotate the gap**: add a one-line note in the References section (or inline if the section is empty) stating which source type was unreachable and why (e.g., "messenger: Slack MCP not connected in this session").
 - **Do not block**: gather incompleteness does NOT trigger the refuse-to-file gate. An issue may proceed to record with only a partial reference set.
+- **Exception — `target-issue history`**: this one source type is NOT fail-open. When the intake is an existing issue and its comment thread cannot be retrieved in full (the listing errors, is truncated, or the tool is unavailable), stop: do not append. The thread is not supporting context, it is where that issue's current state lives — appending without it means writing an Effective State derived from body lines a comment may already have retired. Report to the caller which retrieval failed and what is needed to unblock. This is the sole carve-out from the three rules above.
 - **Zero artifacts found**: if all source types are searched and no related artifacts are discovered, the References section may be omitted entirely or left empty. An empty References section is a valid outcome — it means the issue stands on its own with no prior context discovered.
 
 ---
@@ -56,7 +57,9 @@ Retrieve from each source type that is wired in the current runtime. Map each ab
 
 Apply the gather bound from Section 1 to every source type independently.
 
-**Reconstructing an existing issue's effective state**: the body is immutable (see the Append-Only History Contract in `SKILL.md`), so it records what was true at filing, not what is true now. Replay the comment thread over it in order — each comment's **대체 대상 (Supersedes)** retires the body or comment lines it names, and its **정정 후 상태 (Effective State)** is what now stands in their place. Everything neither superseded nor restated still holds. Judge duplicates, refuse-to-file conditions, and the INVEST gate against that reconstructed state, never against the raw body.
+**Reconstructing an existing issue's effective state**: for an issue filed under the Append-Only History Contract (see `SKILL.md`) the body is immutable, so it records what was true at filing, not what is true now. Replay the comment thread over it in order — each comment's **대체 대상 (Supersedes)** retires the body or comment lines it names, and its **정정 후 상태 (Effective State)** is what now stands in their place. Everything neither superseded nor restated still holds. Judge duplicates, refuse-to-file conditions, and the INVEST gate against that reconstructed state, never against the raw body.
+
+**Issues that predate the contract**: an issue filed under the earlier in-place-enrichment workflow has a body that was already edited after filing, so its **current body is the baseline** — read it as current, not as a filing-time snapshot. Only comments carrying the append shape (a **대체 대상** or **정정 후 상태** section) are replayed as state transitions; earlier comments are discussion context and retire nothing, however emphatically they argue for a change. A pre-contract comment asking for a change you cannot find in the body is an open question to carry forward, not a superseding declaration to apply.
 
 ---
 

--- a/skills/craft-issue/references/gather-crosslink.md
+++ b/skills/craft-issue/references/gather-crosslink.md
@@ -49,11 +49,14 @@ Retrieve from each source type that is wired in the current runtime. Map each ab
 |---|---|
 | collaboration-docs | spec pages, PRDs, design docs, meeting notes related to the issue's domain |
 | PM | linked issues, parent epics, related issues, sibling items in the same epic |
+| target-issue history | the target issue's own comment thread — every comment, in order. Mandatory whenever the intake is an existing issue; the per-source cap and recency window of Section 1 do NOT apply to it (a superseding comment may be older than 90 days and still be the live one). |
 | messenger | Slack threads, comment trails that discuss the requirement or the affected area |
 | code-VCS | recent commits, open PRs touching the affected area, blame for the relevant code path |
 | logs | error log entries, monitoring alerts, incident records for the affected component (strict bound applies — see Section 1) |
 
 Apply the gather bound from Section 1 to every source type independently.
+
+**Reconstructing an existing issue's effective state**: the body is immutable (see the Append-Only History Contract in `SKILL.md`), so it records what was true at filing, not what is true now. Replay the comment thread over it in order — each comment's **대체 대상 (Supersedes)** retires the body or comment lines it names, and its **정정 후 상태 (Effective State)** is what now stands in their place. Everything neither superseded nor restated still holds. Judge duplicates, refuse-to-file conditions, and the INVEST gate against that reconstructed state, never against the raw body.
 
 ---
 

--- a/skills/craft-issue/references/issue-craft.md
+++ b/skills/craft-issue/references/issue-craft.md
@@ -45,6 +45,10 @@ Korean-working teams, use this canonical mapping:
 | Core Concept | 핵심 개념 |
 | User Value | 사용자 가치 |
 | Scope of Application | 적용 범위 |
+| Update Summary | 변경 요약 |
+| Basis | 근거 |
+| Supersedes | 대체 대상 |
+| Effective State | 정정 후 상태 |
 | Notes | 메모 |
 | per-path status | 경로별 상태 |
 | References | References (그대로 둔다) |
@@ -52,7 +56,7 @@ Korean-working teams, use this canonical mapping:
 The observable-AC two-line shape (§2) is unchanged — only its labels localize: `**[결과]**` + `**검증**`.
 
 Every emittable header across this rubric's tables — Standard Body Shape, Bug-Genre Additions,
-Parent-Issue Body Shape, Transition-Genre Additions, the Two-Bucket bucket labels, and the RCA
+Append Comment Shape, Parent-Issue Body Shape, Transition-Genre Additions, the Two-Bucket bucket labels, and the RCA
 Bug-Report shape (§3 below; wired from `references/diagnose-rootcause.md`) — must have an entry in
 the mapping table above. A header with no entry above is a rubric bug, not a license to emit its raw
 canonical English name.
@@ -167,6 +171,37 @@ The three sub-items are:
 - **Blockers & Risks** — upstream dependencies, potential blocking points, and open questions; observations only, never solution proposals.
 
 Every sub-item must carry either an evidence citation (investigation result, document, code location, commit) or the marker `TBD — needs validation via {method}`. An unbacked assertion is a rule violation.
+
+### Append Comment Shape
+
+Per the **Append-Only History Contract** in `SKILL.md`, an issue that already carries a body is never
+rewritten — the new material is appended as a comment. That comment is a body-grade document, not a
+changelog line: same register, same localized headers, same observable-AC rubric (§2), same
+symbol-gloss contract, same anti-fluff rules as a body.
+
+| Section | Required / Conditional | Content |
+|---|---|---|
+| **Update Summary** | Required | What is being corrected or added, and why — the context that produced the change, as prose a PM reader can follow. Name what triggered it: who established what, when. One to three paragraphs. |
+| **Basis** | Required | The evidence this append rests on — the confirmation, log line, commit, code location, or measurement. Direct quote or paste, not paraphrase. When it rests on a single unreplicated report, say so; that judgment decides whether the restated content below lands as established or carries `TBD — needs validation via {method}`. |
+| **Supersedes** | Required when this append retires anything | One bullet per retired item, each naming its exact location in the existing record and what is now wrong with it — e.g. `본문 §전제 조건 2번 "펌웨어가 ack를 200으로 돌려준다" — 반증됨`. Retiring an item only inside an Update Summary paragraph does not count as declared. Omit the section only when the append retires nothing at all. |
+| **Effective State** | Required | Every section this append touches, restated in final decided form. Emit **only** the touched sections, each under its own localized header from the Working-Language Localization table. |
+
+**Effective State is a rewrite, not a review.** Write each touched section as it now stands, in the
+form a body would carry it — an AC keeps its two-line `**[결과]**` + `**검증**` shape (§2). Do not
+write *about* whether the old text still holds ("1번은 결과가 그대로 유효하고 근거만 바뀝니다",
+"2번은 다시 봐야 합니다"): commentary of that kind leaves the reader to merge body and comment in
+their head, which is the exact cost the append model exists to remove. When a touched item genuinely
+has no decided form yet, its restated form is that item carrying `TBD — needs validation via
+{method}` — written out, not deferred to a later comment.
+
+**Untouched sections are not restated.** A section this append does not change stays where it is.
+Re-rendering the whole body into every comment duplicates the record, buries what actually changed,
+and lets unchanged wording drift each time it is re-authored — which smuggles back in the body edit
+the contract forbids.
+
+**Scope note.** Immutability governs the issue body. It does not license withholding a decision: if
+this append settles what an AC or a premise should now say, Effective State says it. "본문을 고칠 수
+없으니 판단만 남긴다" is a misreading — the comment IS where the decision is now recorded.
 
 ### Parent-Issue Body Shape
 


### PR DESCRIPTION
## 📌 Summary

craft-issue 파이프라인의 전제를 바꿉니다. 이슈 본문은 생성 시 1회만 쓰고 그 뒤로는 불변이며, 이후의 모든 정정·진단·결정은 comment로 append됩니다. 본문을 덮어쓰면 폐기된 전제와 잘못된 수치가 흔적 없이 사라져, 이슈가 지금 상태에 이른 경위를 아무도 재구성할 수 없기 때문입니다.

---

## 🔧 Changes

### craft-issue 스킬 본체 (`SKILL.md`)

- `Append-Only History Contract` 섹션 신설. 생성 / 기존 이슈 / 구조적 관계 3분기를 표로 고정
- Stage 1 intake의 "enrich in place"를 comment append로 교체
- Stage 2에 `target-issue history` 소스 타입과 유효 상태 재구성 규칙 추가
- Stage 5 부모 재구성을 생성/기존에 따라 body write 또는 append comment로 분기
- Stage 6 write step 4를 두 경로로 분기, Linear 바인딩에 `create_comment` 추가, terminal write와 Plain-Language Gate 범위를 comment까지 확장

**영향 범위**
파이프라인의 write tail 전체와 intake·gather 판정. 기존에 이 스킬이 만든 이슈에는 소급 영향이 없고, 앞으로 기존 이슈를 다룰 때의 write 대상만 바뀝니다. 스킬 파일 변경이라 런타임 코드 의존성은 없습니다.

### 이슈 작성 규범 (`references/issue-craft.md`)

- `Append Comment Shape` 신설 — `변경 요약` / `근거` / `대체 대상` / `정정 후 상태` 4슬롯
- Working-Language Localization 표에 4개 라벨 매핑 추가

**영향 범위**
"모든 emittable 헤더는 이 표에 항목이 있어야 하며 없으면 rubric 버그"라는 기존 불변식을 유지하기 위해 localization 표를 함께 갱신했습니다. 표만 갱신하고 shape를 안 넣었거나 그 반대였다면 기존 규칙이 자기모순에 빠집니다.

### gather 절차 (`references/gather-crosslink.md`)

- 대상 이슈의 comment 스레드를 필수 소스로 추가하고, recency window(90일)와 per-source cap(10건)을 면제
- 중복 판정·refuse-to-file·INVEST 게이트를 raw body가 아니라 스레드를 재생한 유효 상태에 대해 수행하도록 명시

**영향 범위**
gather 비용이 이슈당 스레드 길이만큼 늘어납니다. cap을 면제한 이유는 30일 지난 comment가 여전히 유효한 supersede 선언일 수 있어서, 최신 N건만 읽으면 죽은 본문 줄을 살아있는 것으로 오독하기 때문입니다.

### 리뷰어 계약 (`agents/issue-reviewer.md`)

- 페이로드 블록에 `comment:<issue-key>` 추가, `**Where:**` 타겟에 comment 허용
- "3종 블록 중 하나라도 없으면 위반" 규칙을 "request 블록 부재 또는 child·comment 둘 다 없음"으로 교체

**영향 범위**
이 수정이 없으면 append 전용 실행(child 블록이 존재하지 않음)이 매번 페이로드 위반으로 반려되어 write에 도달하지 못합니다. 스킬 변경과 분리 불가능한 한 덩어리입니다.

### 회귀 테스트 (`SKILL.test.ts`)

- H1~H5 그룹 추가(계약·shape·gather·분기·리뷰어 페이로드), 기존 3개 테스트의 핀 문자열 갱신

**영향 범위**
`skills/craft-issue/SKILL.test.ts` 123 pass. 레포 전체 `make test` 5248 pass / 0 fail, `make validate` 통과.

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. comment를 델타 정정으로 둘 것인가, 매번 본문 전문 스냅샷으로 둘 것인가

**배경 및 문제 상황:**
"본문 불변, 나머지는 comment"만 정하면 comment의 형태가 미정으로 남습니다. 두 가지가 가능했습니다 — 매 comment가 그 시점의 본문 전문을 담는 스냅샷이거나, 이번에 바뀐 것만 담는 델타이거나.

**해결 방안:**
델타를 택하되, "건드린 섹션만 최종형으로 재기술"을 붙였습니다.

**구현 세부사항:**
`정정 후 상태` 슬롯은 이번 append가 건드린 섹션만 담습니다. 안 건드린 섹션은 쓰지 않습니다.

**선택과 트레이드오프:**
전문 스냅샷을 기각한 결정적 이유는 중복이 아니라 **드리프트**입니다. 매번 전문을 다시 쓴다는 건 아무도 건드리라고 하지 않은 `범위 제외` 문구를 세 번째 comment에서 LLM이 다시 작성한다는 뜻이고, 그러면 본문을 불변으로 만든 이유(원문이 변형되지 않는다)가 뒷문으로 무너집니다. 대신 델타는 고전적 비용을 남깁니다 — 같은 항목을 여러 comment가 연속 정정하면 "지금 유효한 완료 조건 1번"을 찾으러 스레드를 뒤로 훑어야 합니다. `대체 대상` 선언 덕에 훑기가 결정적(그 항목을 마지막으로 supersede한 comment 하나만 찾으면 됨)이라 감수 가능하다고 봤습니다. 스레드가 길어졌을 때 통합 스냅샷을 1회 쌓는 규칙은 **의도적으로 넣지 않았습니다** — 아직 겪지 않은 문제고, 겪으면 그때 트리거가 분명해집니다.

### 2. supersede를 산문에 맡기지 않고 필수 필드로 올린 것

**배경 및 문제 상황:**
append-only의 진짜 위험은 "죽은 내용이 살아있는 것처럼 보인다"는 겁니다. 틀린 전제가 본문에 영원히 남는데, 그걸 무효화할 장치가 없으면 이 전환은 오정보 보존 장치가 됩니다.

**해결 방안:**
`대체 대상`을 shape의 명명된 필수 슬롯으로 두고, 문단 안에서 언급하는 것은 선언으로 치지 않는다고 못 박았습니다.

**구현 세부사항:**
"본문 §전제 조건 2번 — 반증됨" 형태로 항목마다 정확한 위치와 무엇이 틀렸는지를 한 불릿으로 요구합니다.

**선택과 트레이드오프:**
형태 선택의 근거가 실측입니다. "본문 대신 comment에 append하라"만 준 대조군 2/2는 comment 경로는 지켰지만, supersede를 "이 전제는 성립하지 않습니다" 식으로 산문에 녹였고, 정정된 완료 조건을 최종형으로 다시 쓰는 대신 "1번은 결과가 그대로 유효하고 근거만 바뀝니다"라는 **논평**만 남겼습니다. 즉 실패의 정체가 "규칙을 알면서 어김"이 아니라 **"놓을 칸이 없어서 산문에 녹임"**이었습니다. 그래서 금지문("~하지 말라")이 아니라 슬롯을 줬습니다. 금지문은 경쟁하는 유인 앞에서 협상 대상이 되지만, 채워야 할 칸은 채워졌거나 안 채워졌거나 둘 중 하나입니다.

두 번째 실패("판단을 유보함")에 대해서는 `**Scope note.**` 한 문단을 별도로 붙였습니다. 대조군이 본문 불변을 "정정된 내용을 확정형으로 쓰는 것도 금지"로 오독했기 때문에, "immutability는 본문의 바이트를 묶을 뿐 comment의 판단 권위를 묶지 않는다"를 명시적으로 반박해야 했습니다.

### 3. 본문 불변의 경계를 어디에 그을 것인가

**배경 및 문제 상황:**
`relatedTo` / `parentId` / `blockedBy` / label은 comment로 표현할 방법이 없습니다. 이걸 불변 규칙에 넣으면 파이프라인의 관계 배선이 통째로 죽습니다.

**해결 방안:**
불변성을 **본문 텍스트에만** 적용하고, 구조적 관계는 두 경로 모두에서 직접 write로 남겼습니다.

**선택과 트레이드오프:**
근거는 "그래프 간선은 본문 텍스트가 아니고 comment 형태가 없다"입니다. 다만 이게 완전히 깨끗한 선은 아닙니다 — 기존 parent를 재지정하는 건 실제로 히스토리를 지우는 행위이고, 이 규칙은 그걸 막지 않습니다. 관계 변경도 추가만 허용하는(재지정 금지) 안을 검토했으나, 실제로 겪은 문제가 아니어서 넣지 않았습니다.

**남은 범위 밖 항목 하나**: 변경 전 baseline 관측에서 에이전트가 본문뿐 아니라 **제목까지** 바꿨습니다. 제목 변경도 히스토리 손실이지만, 이번에 정한 불변 단위가 "본문"이라 제목에 대한 규칙은 만들지 않았습니다. 필요하다고 보시면 별도로 다뤄야 합니다.

### 4. 리뷰어 게이트 — 페이로드는 열었으나 수렴은 미검증

**배경 및 문제 상황:**
Stage 6의 Checklist Review Gate는 `issue-reviewer`가 `**Status:** PASS`를 낼 때까지 write를 막습니다. 기존 페이로드 계약은 "request + parent + child 3종 중 하나라도 없으면 위반"이었는데, append 전용 실행은 child 블록이 아예 없습니다.

**해결 방안:**
`comment:<issue-key>` 블록을 추가하고, 완전성 조건을 "request 부재 또는 child·comment 둘 다 없음"으로 바꿨습니다. 리뷰어에게 comment 블록은 Standard Body Shape이 아니라 Append Comment Shape으로 심사하라고 지시합니다.

**구현 세부사항:**
리뷰어는 규칙 텍스트를 자기 안에 복사하지 않고 dispatch 시점에 규칙 파일을 읽는 SSOT 구조라, `Append Comment Shape`을 `issue-craft.md`에 넣은 것만으로 리뷰어가 새 규칙을 심사에 씁니다. 리뷰어 파일에는 페이로드 형태만 추가했습니다.

**선택과 트레이드오프:**
이 부분은 실제 디스패치로 검증됐습니다. 한 실행이 `issue-reviewer`를 5회 실제로 띄웠고, 4·5번째 사이클은 comment 블록 단일로 보냈는데 리뷰어가 페이로드 위반으로 반려하지 않고 `Append Comment Shape › Supersedes`를 인용해 정상 심사했습니다. 지적 내용도 정확했습니다(영향 범위에서 펌웨어 경로를 뺐는데 `대체 대상`에 선언하지 않음).

**다만 열어두고 싶은 질문이 있습니다.** 실제로 리뷰어를 띄운 두 실행 모두 `max_cycles=5`를 소진하고 terminal write로 떨어졌고, **`**Status:** PASS`는 한 번도 관측하지 못했습니다.** 이걸 이번 변경 탓으로 돌릴 근거는 없습니다 — 두 실행 다 앞쪽 사이클이 제가 파일을 편집하는 중이라 리뷰어와 작성자가 서로 다른 규칙 파일을 보고 있었고, 더 중요하게는 **변경 전 이 게이트가 원래 PASS에 도달했는지에 대한 대조군이 없습니다.** 새로 추가한 `Supersedes` 필수 규칙이 반복 반려를 유발해 append 경로가 매번 terminal write로 떨어진다면 게이트가 사실상 무력화되는데, 이건 정적 테스트로 잡히지 않습니다. 확인하려면 변경 전/후 각 1회씩 리뷰어 디스패치를 허용한 실행이 필요합니다.

---

## ✅ Checklist

### Append-Only 계약
- [ ] 본문이 있는 이슈에 대해 `save_issue(description=...)`이 발생하지 않고 `create_comment`만 발생한다
  - `skills/craft-issue/SKILL.md`
- [ ] 신규 이슈 생성 시에는 본문이 정상 작성된다(append 경로가 생성 경로를 삼키지 않는다)
  - `skills/craft-issue/SKILL.md`
- [ ] 구조적 관계(`relatedTo`/`parentId`/`blockedBy`/label)는 두 경로 모두에서 직접 write된다
  - `skills/craft-issue/SKILL.md`

### Append Comment Shape
- [ ] append comment가 `변경 요약`/`근거`/`대체 대상`/`정정 후 상태` 4슬롯을 모두 갖는다
  - `skills/craft-issue/references/issue-craft.md`
- [ ] 본문에서 폐기되는 항목마다 `대체 대상`에 위치를 지목한 불릿이 하나씩 존재한다
  - `skills/craft-issue/references/issue-craft.md`
- [ ] `정정 후 상태`가 논평이 아니라 최종형 재기술이다(완료 조건은 `**[결과]**`+`**검증**` 두 줄 형태 유지)
  - `skills/craft-issue/references/issue-craft.md`
- [ ] emittable 헤더 4종이 Working-Language Localization 표에 모두 존재한다
  - `skills/craft-issue/references/issue-craft.md`

### gather 유효 상태
- [ ] 기존 이슈 처리 시 comment 스레드 전체를 읽고, 유효 상태를 body+스레드 재생으로 판정한다
  - `skills/craft-issue/references/gather-crosslink.md`

### 리뷰어 페이로드
- [ ] child 블록 없이 comment 블록만 있는 페이로드가 완전한 것으로 통과한다
  - `agents/issue-reviewer.md`
- [ ] comment 블록이 Standard Body Shape이 아닌 Append Comment Shape으로 심사된다
  - `agents/issue-reviewer.md`

### 회귀
- [ ] `bun test skills/craft-issue/SKILL.test.ts` 123 pass / 0 fail
  - `skills/craft-issue/SKILL.test.ts`
- [ ] `make validate` 및 `make test` 통과
  - 레포 전체

---

https://claude.ai/code/session_01Q3FJ7CDj2Ca9A3B3RX5gqi
