### PR TITLE
fix: 관리 블록 마커 훼손 시 append 대신 에러 처리

### DIFF
--- a/tools/adapters/codex.test.ts
+++ b/tools/adapters/codex.test.ts
@@ -55,7 +55,7 @@ describe("insertManagedBlock", () => {
 		expect(result).toContain(`server = "test"`);
 	});
 
-	it("appends a fresh block when neither marker is present via `insertManagedBlock`", () => {
+	it("마커가 전혀 없으면 `insertManagedBlock`이 새 블록을 append한다", () => {
 		const existing = `# user config\nsome_setting = true\n`;
 		const result = insertManagedBlock(existing, "mcp", `server = "test"\n`);
 		expect(result).toContain("some_setting = true");
@@ -63,7 +63,7 @@ describe("insertManagedBlock", () => {
 		expect(result).toContain(`server = "test"`);
 	});
 
-	it("throws when the start marker survives but the end marker is orphaned away via `insertManagedBlock`", () => {
+	it("시작 마커는 남아 있고 끝 마커만 사라지면 `insertManagedBlock`이 예외를 던진다", () => {
 		// Reproduces the real incident: Codex CLI rewrote config.toml and left
 		// only the start marker behind, with the stale block body still in place.
 		const existing = `# --- omt:mcp ---\n[mcp_servers.figma]\ncommand = "npx"\nargs = ["-y", "figma-mcp"]\n`;
@@ -72,14 +72,14 @@ describe("insertManagedBlock", () => {
 		);
 	});
 
-	it("throws when the end marker survives but the start marker is orphaned away via `insertManagedBlock`", () => {
+	it("끝 마커는 남아 있고 시작 마커만 사라지면 `insertManagedBlock`이 예외를 던진다", () => {
 		const existing = `[mcp_servers.figma]\ncommand = "npx"\n# --- end omt:mcp ---\n`;
 		expect(() => insertManagedBlock(existing, "mcp", `server = "test"\n`)).toThrow(
 			/orphaned marker.*omt:mcp/,
 		);
 	});
 
-	it("throws (not replaces) when the start marker is duplicated via `insertManagedBlock`, preserving the user table sitting between the duplicates", () => {
+	it("시작 마커가 중복되면 `insertManagedBlock`이 교체 대신 예외를 던지고, 중복 마커 사이의 사용자 테이블을 보존한다", () => {
 		// Reproduces the real incident from PR #262: a stale sync re-appended a
 		// full block onto a file whose end marker had already been clobbered,
 		// leaving TWO start markers and only ONE end marker. A naive
@@ -110,7 +110,7 @@ describe("insertManagedBlock", () => {
 		);
 	});
 
-	it("throws when the end marker is duplicated via `insertManagedBlock`", () => {
+	it("끝 마커가 중복되면 `insertManagedBlock`이 예외를 던진다", () => {
 		const existing = [
 			`# --- omt:mcp ---`,
 			`[mcp_servers.figma]`,
@@ -126,7 +126,25 @@ describe("insertManagedBlock", () => {
 		);
 	});
 
-	it("throws when the resulting TOML would duplicate a key via `insertManagedBlock`", () => {
+	it("관리 블록 밖 TOML 문자열 값 안에 마커 리터럴이 들어 있어도 `insertManagedBlock`이 정상적으로 블록을 교체한다", () => {
+		// The start marker text appears mid-line inside a string value, not at
+		// the start of a line — a substring-based count (content.split(marker))
+		// would count this as a second start marker and misfire the "duplicate"
+		// throw path even though only one real structural marker pair exists.
+		const existing = [
+			`note = "see # --- omt:mcp --- for details"`,
+			`# --- omt:mcp ---`,
+			`old = "data"`,
+			`# --- end omt:mcp ---`,
+			``,
+		].join("\n");
+		const result = insertManagedBlock(existing, "mcp", `new = "data"\n`);
+		expect(result).toContain(`note = "see # --- omt:mcp --- for details"`);
+		expect(result).toContain(`new = "data"`);
+		expect(result).not.toContain(`old = "data"`);
+	});
+
+	it("결과 TOML에 키가 중복되면 `insertManagedBlock`이 예외를 던진다", () => {
 		// No markers present (append path), but the block being appended
 		// declares a table the surrounding content already declares — the
 		// exact duplicate-key shape that crashed Codex CLI on startup.

--- a/tools/adapters/codex.test.ts
+++ b/tools/adapters/codex.test.ts
@@ -158,19 +158,16 @@ describe("insertManagedBlock", () => {
 		// Reproduces the PR #262 P1 finding: the line-anchored marker regex
 		// only knows a marker sits at the start of its own line — it cannot
 		// tell that line is the BODY of a pre-existing `doc = """ ... """`
-		// multiline string rather than real structure. The replace still
-		// produces syntactically valid TOML (the existing `parse(result)`
-		// backstop alone would let this through), but the generated block
-		// ends up trapped inside the string instead of declared as real
-		// top-level structure — so the config it declares is never actually
-		// deployed even though sync reports success.
+		// multiline string rather than real structure. The replace would
+		// otherwise produce syntactically valid TOML (the existing
+		// `parse(result)` backstop alone would let this through), with the
+		// generated block trapped inside the string instead of declared as
+		// real top-level structure — so the config it declares would never
+		// actually be deployed even though sync reports success.
 		//
-		// The target file also carries a user-owned `[features]` table with
-		// an unrelated leaf key, to prove a shallow "does the top-level key
-		// exist" check is not enough: `parse(result).features` is truthy
-		// either way, so only descending to the actual leaf key/value
-		// (`features.multi_agent_v2.max_concurrent_threads_per_session`)
-		// can tell the declared config never landed.
+		// The pre-replace backstop now catches this first, on the EXISTING
+		// side: "사용자가 직접 쓴 설명 문단" is not valid TOML, so the matched
+		// markers cannot be wrapping a real managed block.
 		const existing = [
 			`[features]`,
 			`existing_flag = true`,
@@ -189,11 +186,52 @@ describe("insertManagedBlock", () => {
 				"mcp",
 				`[features.multi_agent_v2]\nmax_concurrent_threads_per_session = 4\n`,
 			),
-		).toThrow(/did not land at its intended location/);
+		).toThrow(/does not parse as TOML/);
 		// The throw IS the assertion that "사용자가 직접 쓴 설명 문단" was never
 		// spliced out: insertManagedBlock never produces a result for a
 		// caller to write to disk, so the original multiline string is left
 		// wherever the caller read `existing` from.
+	});
+
+	it("마커 리터럴이 멀티라인 TOML 문자열 안에 있고 새 본문이 주석뿐이어도 `insertManagedBlock`이 예외를 던진다 — 반환값이 없다는 사실 자체가 사용자 문단 보존의 증거다", () => {
+		// Reproduces the PR #262 P1 gap left by the previous fix: the new-body
+		// landing-site backstop (isDeepSubset(declaredStructure, parsedResult))
+		// only inspects what the NEW body declares. `flushMcpBlock` passes
+		// "# No MCP servers configured\n" when there are 0 MCP servers — that
+		// parses to `{}`, which is a subset of every object, so the backstop
+		// passes vacuously no matter where the block actually landed. This test
+		// validates the EXISTING side instead: the content trapped between the
+		// markers is not valid TOML (it's a plain user sentence), so replacing
+		// it must be refused before anything reaches disk.
+		const existing = [
+			`[features]`,
+			`existing_flag = true`,
+			``,
+			`[owner]`,
+			`doc = """`,
+			`# --- omt:mcp ---`,
+			`사용자가 직접 쓴 설명 문단`,
+			`# --- end omt:mcp ---`,
+			`"""`,
+			``,
+		].join("\n");
+		expect(() => insertManagedBlock(existing, "mcp", `# No MCP servers configured\n`)).toThrow(
+			/does not parse as TOML/,
+		);
+		// The throw IS the assertion that "사용자가 직접 쓴 설명 문단" was never
+		// spliced out: insertManagedBlock never produces a result for a caller
+		// to write to disk.
+	});
+
+	it("정상적인 기존 관리 블록을 주석뿐인 본문으로 교체하는 것은 여전히 성공한다 — 서버 0개 정리 경로의 회귀 방지", () => {
+		// Regression guard for the pre-replace backstop added above: a real
+		// managed block (valid TOML, reachable at the top level) must still be
+		// replaceable by the comment-only body `flushMcpBlock` writes when the
+		// MCP accumulator is empty.
+		const existing = `# --- omt:mcp ---\n[mcp_servers.figma]\ncommand = "npx"\n# --- end omt:mcp ---\n`;
+		const result = insertManagedBlock(existing, "mcp", `# No MCP servers configured\n`);
+		expect(result).toContain("# No MCP servers configured");
+		expect(result).not.toContain("mcp_servers.figma");
 	});
 });
 

--- a/tools/adapters/codex.test.ts
+++ b/tools/adapters/codex.test.ts
@@ -54,6 +54,40 @@ describe("insertManagedBlock", () => {
 		expect(result).toContain("# --- end omt:mcp ---");
 		expect(result).toContain(`server = "test"`);
 	});
+
+	it("appends a fresh block when neither marker is present via `insertManagedBlock`", () => {
+		const existing = `# user config\nsome_setting = true\n`;
+		const result = insertManagedBlock(existing, "mcp", `server = "test"\n`);
+		expect(result).toContain("some_setting = true");
+		expect(result).toContain("# --- omt:mcp ---");
+		expect(result).toContain(`server = "test"`);
+	});
+
+	it("throws when the start marker survives but the end marker is orphaned away via `insertManagedBlock`", () => {
+		// Reproduces the real incident: Codex CLI rewrote config.toml and left
+		// only the start marker behind, with the stale block body still in place.
+		const existing = `# --- omt:mcp ---\n[mcp_servers.figma]\ncommand = "npx"\nargs = ["-y", "figma-mcp"]\n`;
+		expect(() => insertManagedBlock(existing, "mcp", `server = "test"\n`)).toThrow(
+			/orphaned marker.*omt:mcp/,
+		);
+	});
+
+	it("throws when the end marker survives but the start marker is orphaned away via `insertManagedBlock`", () => {
+		const existing = `[mcp_servers.figma]\ncommand = "npx"\n# --- end omt:mcp ---\n`;
+		expect(() => insertManagedBlock(existing, "mcp", `server = "test"\n`)).toThrow(
+			/orphaned marker.*omt:mcp/,
+		);
+	});
+
+	it("throws when the resulting TOML would duplicate a key via `insertManagedBlock`", () => {
+		// No markers present (append path), but the block being appended
+		// declares a table the surrounding content already declares — the
+		// exact duplicate-key shape that crashed Codex CLI on startup.
+		const existing = `[features.multi_agent_v2]\nenabled = true\n`;
+		expect(() =>
+			insertManagedBlock(existing, "mcp", `[features.multi_agent_v2]\nenabled = false\n`),
+		).toThrow(/invalid TOML/);
+	});
 });
 
 // =============================================================================

--- a/tools/adapters/codex.test.ts
+++ b/tools/adapters/codex.test.ts
@@ -153,6 +153,48 @@ describe("insertManagedBlock", () => {
 			insertManagedBlock(existing, "mcp", `[features.multi_agent_v2]\nenabled = false\n`),
 		).toThrow(/invalid TOML/);
 	});
+
+	it("마커 리터럴이 대상 파일의 멀티라인 TOML 문자열 안에 단독 줄로 들어 있으면 `insertManagedBlock`이 예외를 던진다 — 반환값이 없다는 사실 자체가 사용자 문단이 훼손되지 않았다는 증거다", () => {
+		// Reproduces the PR #262 P1 finding: the line-anchored marker regex
+		// only knows a marker sits at the start of its own line — it cannot
+		// tell that line is the BODY of a pre-existing `doc = """ ... """`
+		// multiline string rather than real structure. The replace still
+		// produces syntactically valid TOML (the existing `parse(result)`
+		// backstop alone would let this through), but the generated block
+		// ends up trapped inside the string instead of declared as real
+		// top-level structure — so the config it declares is never actually
+		// deployed even though sync reports success.
+		//
+		// The target file also carries a user-owned `[features]` table with
+		// an unrelated leaf key, to prove a shallow "does the top-level key
+		// exist" check is not enough: `parse(result).features` is truthy
+		// either way, so only descending to the actual leaf key/value
+		// (`features.multi_agent_v2.max_concurrent_threads_per_session`)
+		// can tell the declared config never landed.
+		const existing = [
+			`[features]`,
+			`existing_flag = true`,
+			``,
+			`[owner]`,
+			`doc = """`,
+			`# --- omt:mcp ---`,
+			`사용자가 직접 쓴 설명 문단`,
+			`# --- end omt:mcp ---`,
+			`"""`,
+			``,
+		].join("\n");
+		expect(() =>
+			insertManagedBlock(
+				existing,
+				"mcp",
+				`[features.multi_agent_v2]\nmax_concurrent_threads_per_session = 4\n`,
+			),
+		).toThrow(/did not land at its intended location/);
+		// The throw IS the assertion that "사용자가 직접 쓴 설명 문단" was never
+		// spliced out: insertManagedBlock never produces a result for a
+		// caller to write to disk, so the original multiline string is left
+		// wherever the caller read `existing` from.
+	});
 });
 
 // =============================================================================

--- a/tools/adapters/codex.test.ts
+++ b/tools/adapters/codex.test.ts
@@ -79,6 +79,53 @@ describe("insertManagedBlock", () => {
 		);
 	});
 
+	it("throws (not replaces) when the start marker is duplicated via `insertManagedBlock`, preserving the user table sitting between the duplicates", () => {
+		// Reproduces the real incident from PR #262: a stale sync re-appended a
+		// full block onto a file whose end marker had already been clobbered,
+		// leaving TWO start markers and only ONE end marker. A naive
+		// existence-only check (`indexOf(...) !== -1`) treats the FIRST start
+		// marker and the ONLY end marker as a valid pair and replaces
+		// everything between them — silently deleting the Codex-runtime-owned
+		// `[hooks.state.*]` and `[tui.model_availability_nux]` tables that sit
+		// between the duplicate start markers. Asserting the throw (and thus
+		// the absence of any return value to write to disk) IS the assertion
+		// that those tables are never deleted — a thrown error means
+		// `insertManagedBlock` never produces a result for a caller to persist.
+		const existing = [
+			`# --- omt:mcp ---`,
+			`[mcp_servers.figma]`,
+			`command = "npx"`,
+			``,
+			`# --- omt:mcp ---`,
+			`[hooks.state.some_hook]`,
+			`enabled = true`,
+			``,
+			`[tui.model_availability_nux]`,
+			`seen = true`,
+			`# --- end omt:mcp ---`,
+			``,
+		].join("\n");
+		expect(() => insertManagedBlock(existing, "mcp", `server = "test"\n`)).toThrow(
+			/2 occurrence\(s\) of start marker.*1 occurrence\(s\) of end marker/,
+		);
+	});
+
+	it("throws when the end marker is duplicated via `insertManagedBlock`", () => {
+		const existing = [
+			`# --- omt:mcp ---`,
+			`[mcp_servers.figma]`,
+			`command = "npx"`,
+			`# --- end omt:mcp ---`,
+			``,
+			`some_other = true`,
+			`# --- end omt:mcp ---`,
+			``,
+		].join("\n");
+		expect(() => insertManagedBlock(existing, "mcp", `server = "test"\n`)).toThrow(
+			/1 occurrence\(s\) of start marker.*2 occurrence\(s\) of end marker/,
+		);
+	});
+
 	it("throws when the resulting TOML would duplicate a key via `insertManagedBlock`", () => {
 		// No markers present (append path), but the block being appended
 		// declares a table the surrounding content already declares — the

--- a/tools/adapters/codex.ts
+++ b/tools/adapters/codex.ts
@@ -67,6 +67,27 @@ function escapeRegExp(literal: string): string {
 }
 
 /**
+ * Returns true when every leaf key/value `expected` declares is reachable
+ * at the same path in `actual`. Plain objects recurse (actual may carry
+ * extra sibling keys — e.g. a user-owned `[features]` table alongside the
+ * managed one); everything else (string, number, boolean, array) is
+ * compared by value, with arrays requiring an exact match rather than a
+ * partial overlap.
+ */
+function isDeepSubset(expected: unknown, actual: unknown): boolean {
+	if (isPlainObject(expected)) {
+		return (
+			isPlainObject(actual) &&
+			Object.entries(expected).every(([key, val]) => isDeepSubset(val, actual[key]))
+		);
+	}
+	if (Array.isArray(expected)) {
+		return Array.isArray(actual) && JSON.stringify(expected) === JSON.stringify(actual);
+	}
+	return expected === actual;
+}
+
+/**
  * Finds every line-anchored occurrence of `marker`: the marker must start
  * the line and may be followed only by trailing horizontal whitespace
  * before the line ends. Anchoring to whole lines (rather than a raw
@@ -173,13 +194,35 @@ export function insertManagedBlock(
 	// return value straight to disk (syncConfig, flushMcpBlock) — a managed
 	// block that duplicates a key already in the surrounding content (e.g. a
 	// stale block appended alongside a fresh one) must never reach the file.
+	let parsedResult: Record<string, unknown>;
 	try {
-		parse(result);
+		parsedResult = parse(result);
 	} catch (err) {
 		const causeMessage = err instanceof Error ? err.message : String(err);
 		throw new Error(
 			`insertManagedBlock: writing managed block 'omt:${blockName}' would produce invalid TOML (not written) — ${causeMessage}`,
 			{ cause: err },
+		);
+	}
+
+	// Landing-site backstop: valid TOML syntax alone isn't enough — the
+	// line-anchored marker match above only knows a marker sits at the
+	// start of its own line, not whether that line is real structure or
+	// the body of a pre-existing multiline TOML string (e.g. a user-authored
+	// `doc = """ ... """` whose text happens to contain a line matching the
+	// marker literal). In that case the replace still produces syntactically
+	// valid TOML — the block just ends up trapped inside the string instead
+	// of declared at the top level. Confirm every leaf key/value
+	// `tomlContent` declares is actually readable back from the parsed
+	// result at its intended path before this is allowed to reach disk.
+	const declaredStructure: Record<string, unknown> = parse(tomlContent);
+	if (!isDeepSubset(declaredStructure, parsedResult)) {
+		throw new Error(
+			`insertManagedBlock: managed block 'omt:${blockName}' did not land at its intended location (not written) — ` +
+				`the configuration this block declares does not read back from the result at its intended path. ` +
+				`This happens when the target file has a structure such as a multiline TOML string whose body ` +
+				`contains a line matching the marker literal, trapping the managed block inside that string instead ` +
+				`of as real top-level structure. Nothing was written.`,
 		);
 	}
 

--- a/tools/adapters/codex.ts
+++ b/tools/adapters/codex.ts
@@ -61,6 +61,27 @@ export function resolveCodexAgentModel(
 // TOML Managed Block Helpers
 // =============================================================================
 
+/** Escapes a literal string for embedding in a RegExp source. */
+function escapeRegExp(literal: string): string {
+	return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Finds every line-anchored occurrence of `marker`: the marker must start
+ * the line and may be followed only by trailing horizontal whitespace
+ * before the line ends. Anchoring to whole lines (rather than a raw
+ * substring match) keeps a marker literal sitting inside a TOML string
+ * value or a plain comment from being mistaken for a structural marker.
+ * Trailing-whitespace tolerance exists because Codex re-serializing
+ * config.toml can append trailing spaces to the marker line — treating
+ * that as "marker absent" would fall through to append and duplicate the
+ * block.
+ */
+function matchMarkerLines(content: string, marker: string): RegExpMatchArray[] {
+	const pattern = new RegExp(`^${escapeRegExp(marker)}[ \t]*$`, "gm");
+	return [...content.matchAll(pattern)];
+}
+
 /**
  * Inserts or replaces a managed block in TOML content.
  *
@@ -87,20 +108,22 @@ export function insertManagedBlock(
 	// existence check, and the replace path below would then splice out
 	// everything between the FIRST start marker and the ONLY end marker —
 	// silently deleting any user-owned content sitting between the duplicates.
-	// Split-based counting is safe here because neither marker string is a
-	// substring of the other.
-	const startCount = content.split(startMarker).length - 1;
-	const endCount = content.split(endMarker).length - 1;
+	// Count and position come from the same line-anchored match (matchMarkerLines)
+	// so they can never disagree about which occurrence is "the" marker.
+	const startMatches = matchMarkerLines(content, startMarker);
+	const endMatches = matchMarkerLines(content, endMarker);
+	const startCount = startMatches.length;
+	const endCount = endMatches.length;
 
-	const startIdx = content.indexOf(startMarker);
-	const endIdx = content.indexOf(endMarker);
+	const startIdx = startMatches[0]?.index ?? -1;
+	const endIdx = endMatches[0]?.index ?? -1;
 
 	let result: string;
 
 	if (startCount === 1 && endCount === 1 && endIdx > startIdx) {
 		// Replace existing block (inclusive of markers)
 		const before = content.slice(0, startIdx);
-		const after = content.slice(endIdx + endMarker.length);
+		const after = content.slice(endIdx + endMatches[0][0].length);
 		// Trim trailing newlines from before, trim leading newlines from after
 		const beforeTrimmed = before.replace(/\n+$/, "");
 		const afterTrimmed = after.replace(/^\n+/, "");

--- a/tools/adapters/codex.ts
+++ b/tools/adapters/codex.ts
@@ -80,12 +80,24 @@ export function insertManagedBlock(
 
 	const block = `${startMarker}\n${tomlContent}${endMarker}`;
 
+	// Count, not just detect, each marker's occurrences: a corrupted pairing
+	// (e.g. two start markers and one end marker, observed after a stale sync
+	// appended a fresh block onto a file whose end marker had already been
+	// clobbered) still satisfies a naive "both present, end after start"
+	// existence check, and the replace path below would then splice out
+	// everything between the FIRST start marker and the ONLY end marker —
+	// silently deleting any user-owned content sitting between the duplicates.
+	// Split-based counting is safe here because neither marker string is a
+	// substring of the other.
+	const startCount = content.split(startMarker).length - 1;
+	const endCount = content.split(endMarker).length - 1;
+
 	const startIdx = content.indexOf(startMarker);
 	const endIdx = content.indexOf(endMarker);
 
 	let result: string;
 
-	if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+	if (startCount === 1 && endCount === 1 && endIdx > startIdx) {
 		// Replace existing block (inclusive of markers)
 		const before = content.slice(0, startIdx);
 		const after = content.slice(endIdx + endMarker.length);
@@ -101,30 +113,36 @@ export function insertManagedBlock(
 		} else {
 			result = `${block}\n`;
 		}
-	} else if (startIdx === -1 && endIdx === -1) {
+	} else if (startCount === 0 && endCount === 0) {
 		// Append at end
 		const trimmed = content.replace(/\n+$/, "");
 		result = trimmed ? `${trimmed}\n\n${block}\n` : `${block}\n`;
 	} else {
-		// Orphaned marker: exactly one of the pair is present, or the end marker
-		// precedes the start marker. This happens when something else rewrites
-		// the file and breaks the marker pairing (observed: Codex CLI rewriting
+		// Orphaned or duplicated marker: anything other than exactly one start +
+		// one end (in start-before-end order) leaves the stale block's true
+		// extent unknown — guessing where it ends risks deleting config the
+		// user owns. This happens when something else rewrites the file and
+		// breaks the marker pairing (observed: Codex CLI rewriting
 		// .codex/config.toml to persist its own runtime state clobbered one
-		// side of an `omt:mcp` marker pair). With only one marker left, the
-		// stale block's true extent is unknown — guessing where it ends risks
-		// deleting config the user owns. Silently falling through to append
-		// would leave the stale block's keys in place and duplicate-declare
-		// them alongside the freshly appended block, which crashes the Codex
-		// CLI on a `duplicate key` parse error. Fail loud instead.
-		const reason =
-			startIdx !== -1 && endIdx === -1
-				? `start marker '${startMarker}' is present but end marker '${endMarker}' is missing`
-				: startIdx === -1 && endIdx !== -1
-					? `end marker '${endMarker}' is present but start marker '${startMarker}' is missing`
-					: `end marker '${endMarker}' appears before start marker '${startMarker}'`;
+		// side of an `omt:mcp` marker pair — and, separately, a stale sync
+		// re-appending a full block onto that already-clobbered file produced a
+		// duplicated start marker). Silently falling through to append or
+		// replace would either duplicate-declare keys (crashing the Codex CLI on
+		// a `duplicate key` parse error) or delete content between duplicate
+		// markers. Fail loud instead.
+		let reason: string;
+		if (startCount >= 1 && endCount === 0) {
+			reason = `start marker '${startMarker}' is present but end marker '${endMarker}' is missing`;
+		} else if (startCount === 0 && endCount >= 1) {
+			reason = `end marker '${endMarker}' is present but start marker '${startMarker}' is missing`;
+		} else if (startCount === 1 && endCount === 1) {
+			reason = `end marker '${endMarker}' appears before start marker '${startMarker}'`;
+		} else {
+			reason = `found ${startCount} occurrence(s) of start marker '${startMarker}' and ${endCount} occurrence(s) of end marker '${endMarker}' — expected exactly one of each`;
+		}
 		throw new Error(
 			`insertManagedBlock: orphaned marker for managed block 'omt:${blockName}' — ${reason}. ` +
-				`Remove the orphaned marker and its stale block body by hand, then re-run sync.`,
+				`Remove the extra/orphaned marker(s) and any stale block body by hand, then re-run sync.`,
 		);
 	}
 

--- a/tools/adapters/codex.ts
+++ b/tools/adapters/codex.ts
@@ -14,7 +14,7 @@
 
 import fs from "fs/promises";
 import path from "path";
-import { stringify } from "smol-toml";
+import { stringify, parse } from "smol-toml";
 import { logInfo, logWarn, logDry } from "../lib/logger.ts";
 import { readTextFile, readJsonFile, writeJsonFile } from "../lib/json.ts";
 import { isPlainObject } from "../lib/deep-merge.ts";
@@ -83,6 +83,8 @@ export function insertManagedBlock(
 	const startIdx = content.indexOf(startMarker);
 	const endIdx = content.indexOf(endMarker);
 
+	let result: string;
+
 	if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
 		// Replace existing block (inclusive of markers)
 		const before = content.slice(0, startIdx);
@@ -91,22 +93,56 @@ export function insertManagedBlock(
 		const beforeTrimmed = before.replace(/\n+$/, "");
 		const afterTrimmed = after.replace(/^\n+/, "");
 		if (beforeTrimmed && afterTrimmed) {
-			return `${beforeTrimmed}\n\n${block}\n\n${afterTrimmed}`;
+			result = `${beforeTrimmed}\n\n${block}\n\n${afterTrimmed}`;
 		} else if (beforeTrimmed) {
-			return `${beforeTrimmed}\n\n${block}\n`;
+			result = `${beforeTrimmed}\n\n${block}\n`;
 		} else if (afterTrimmed) {
-			return `${block}\n\n${afterTrimmed}`;
+			result = `${block}\n\n${afterTrimmed}`;
 		} else {
-			return `${block}\n`;
+			result = `${block}\n`;
 		}
+	} else if (startIdx === -1 && endIdx === -1) {
+		// Append at end
+		const trimmed = content.replace(/\n+$/, "");
+		result = trimmed ? `${trimmed}\n\n${block}\n` : `${block}\n`;
+	} else {
+		// Orphaned marker: exactly one of the pair is present, or the end marker
+		// precedes the start marker. This happens when something else rewrites
+		// the file and breaks the marker pairing (observed: Codex CLI rewriting
+		// .codex/config.toml to persist its own runtime state clobbered one
+		// side of an `omt:mcp` marker pair). With only one marker left, the
+		// stale block's true extent is unknown — guessing where it ends risks
+		// deleting config the user owns. Silently falling through to append
+		// would leave the stale block's keys in place and duplicate-declare
+		// them alongside the freshly appended block, which crashes the Codex
+		// CLI on a `duplicate key` parse error. Fail loud instead.
+		const reason =
+			startIdx !== -1 && endIdx === -1
+				? `start marker '${startMarker}' is present but end marker '${endMarker}' is missing`
+				: startIdx === -1 && endIdx !== -1
+					? `end marker '${endMarker}' is present but start marker '${startMarker}' is missing`
+					: `end marker '${endMarker}' appears before start marker '${startMarker}'`;
+		throw new Error(
+			`insertManagedBlock: orphaned marker for managed block 'omt:${blockName}' — ${reason}. ` +
+				`Remove the orphaned marker and its stale block body by hand, then re-run sync.`,
+		);
 	}
 
-	// Append at end
-	const trimmed = content.replace(/\n+$/, "");
-	if (trimmed) {
-		return `${trimmed}\n\n${block}\n`;
+	// Backstop: parse the result before returning it. Callers write the
+	// return value straight to disk (syncConfig, flushMcpBlock) — a managed
+	// block that duplicates a key already in the surrounding content (e.g. a
+	// stale block appended alongside a fresh one) must never reach the file.
+	try {
+		parse(result);
+	} catch (err) {
+		const causeMessage = err instanceof Error ? err.message : String(err);
+		throw new Error(
+			`insertManagedBlock: writing managed block 'omt:${blockName}' would produce invalid TOML (not written) — ${causeMessage}`,
+			{ cause: err },
+		);
 	}
-	return `${block}\n`;
+
+	return result;
 }
 
 // =============================================================================

--- a/tools/adapters/codex.ts
+++ b/tools/adapters/codex.ts
@@ -142,6 +142,52 @@ export function insertManagedBlock(
 	let result: string;
 
 	if (startCount === 1 && endCount === 1 && endIdx > startIdx) {
+		// Pre-replace backstop: confirm the matched marker pair actually wraps a
+		// real managed block before splicing it out. The line-anchored marker
+		// match only knows a marker sits at the start of its own line — it
+		// cannot tell that line is real structure rather than the BODY of a
+		// pre-existing multiline TOML string (e.g. `doc = """ ... """`) whose
+		// text happens to contain lines matching both marker literals. Mirrors
+		// the new-body landing-site backstop below, but on the existing side.
+		const existingBody = content.slice(startIdx + startMatches[0][0].length, endIdx);
+		let existingDeclared: Record<string, unknown>;
+		try {
+			existingDeclared = parse(existingBody);
+		} catch (err) {
+			const causeMessage = err instanceof Error ? err.message : String(err);
+			throw new Error(
+				`insertManagedBlock: existing content between the 'omt:${blockName}' markers does not parse as TOML ` +
+					`(not written) — ${causeMessage}. This happens when the matched markers are not a real managed ` +
+					`block, such as a multiline TOML string in the target file whose body happens to contain lines ` +
+					`matching the marker literals. Nothing was written.`,
+				{ cause: err },
+			);
+		}
+		// The original content may be malformed for unrelated reasons; if so the
+		// existing parse(result) backstop further down already catches it, so this
+		// reachability check is skipped rather than raising a second, redundant error.
+		let parsedOriginalContent: Record<string, unknown> | undefined;
+		try {
+			parsedOriginalContent = parse(content);
+		} catch {
+			parsedOriginalContent = undefined;
+		}
+		if (parsedOriginalContent && !isDeepSubset(existingDeclared, parsedOriginalContent)) {
+			throw new Error(
+				`insertManagedBlock: existing content between the 'omt:${blockName}' markers does not read back ` +
+					`at the top level of the target file (not written) — the matched markers are not wrapping a ` +
+					`real managed block. This happens when the target file has a structure such as a multiline ` +
+					`TOML string whose body contains lines matching the marker literals, trapping what looks like ` +
+					`a block body inside that string instead of as real top-level structure. Nothing was written.`,
+			);
+		}
+		// lazy: when the trapped body AND the new tomlContent are both comment-only,
+		// both this check and the landing-site backstop below pass vacuously (an
+		// empty declared structure is a subset of anything) — loss is negligible
+		// since comment-only text replaces comment-only text either way. Upgrade
+		// path: a TOML string-boundary scanner that excludes marker lines living
+		// inside string literals.
+
 		// Replace existing block (inclusive of markers)
 		const before = content.slice(0, startIdx);
 		const after = content.slice(endIdx + endMatches[0][0].length);


### PR DESCRIPTION
## 📌 Summary

Codex 어댑터가 관리 블록 주석 마커의 짝이 깨진 `.codex/config.toml`에 새 블록을 덧붙여 중복 키를 만들고, Codex CLI를 `duplicate key` 파싱 에러로 기동 불가에 빠뜨리는 문제를 수정한다. 마커가 훼손된 상태를 조용히 append로 넘기지 않고 실패시키며, 결과 TOML을 파싱해 검증하는 backstop을 추가한다.

---

## 🔧 Changes

### tools/adapters/codex.ts — `insertManagedBlock`

- 마커의 **등장 횟수**로 판정: 시작 1개 + 끝 1개 + 정상 순서일 때만 교체, 둘 다 0개일 때만 append, 나머지 조합(한쪽만 존재 / 어느 쪽이든 중복 / 순서 역전)은 전부 `Error` throw
- 마커는 **줄 단위로 매칭**(`^<escaped-marker>[ \t]*$`, `gm`). 개수·위치·슬라이스 길이를 같은 매칭 결과에서 얻는다 — 문자열 값이나 주석 안의 마커 리터럴을 구조적 마커로 오인하지 않고, 진짜 마커 앞에 끼어든 리터럴이 replace 시작점을 어긋내지도 않는다. 후행 가로 공백은 허용한다(마커 줄에 공백이 붙었을 때 "없음"으로 오판하면 append로 흘러 블록이 중복되므로)
- 반환 직전 `smol-toml`의 `parse`로 결과 TOML을 검증하고, 실패 시 원본 파서 에러를 `cause`로 첨부해 재throw
- 파싱 성공 뒤 **안착 검증**(새 본문 쪽): 블록이 선언한 리프 키·값이 결과에서 의도한 경로로 읽히는지 확인하고, 아니면 쓰기 전에 throw
- 교체 직전 **기존 본문 검증**(원본 쪽): 마커 사이 기존 본문이 유효한 TOML로 파싱되고 그 선언 키가 원본의 최상위에서 읽힐 때만 교체 허용
- 기존 replace / append 경로의 동작은 그대로 유지

`.codex/config.toml`은 OMT sync와 Codex CLI가 **함께** 쓰는 파일이다. Codex가 자기 런타임 상태(`[hooks.state.*]`, `[projects.*].trust_level`, `[tui.model_availability_nux]`)를 기록하며 TOML을 재직렬화하는 과정에서 `omt:mcp` 관리 블록의 마커 짝이 깨진 사례가 실제로 관측됐다. 기존 구현은 마커 짝이 온전할 때만 블록을 교체하고 그 외에는 파일 끝에 append했기 때문에, stale 블록 본문이 그대로 남은 채 새 블록이 덧붙어 `[features.multi_agent_v2]`와 `[mcp_servers.*]` 9개가 중복 선언됐다.

**영향 범위**
호출자는 `syncConfig`와 `flushMcpBlock` 두 곳이며 시그니처 변경은 없다. 마커가 정상인 타겟에서는 동작이 달라지지 않는다. 마커가 깨진 타겟에서는 sync가 해당 블록 처리 지점에서 실패한다 — 기존에는 조용히 통과한 뒤 Codex CLI가 기동 불가가 됐다. 새 의존성은 없다(`smol-toml`은 이미 선언된 패키지이며 `parse`만 추가 import).

### tools/adapters/codex.test.ts

- 고아 마커 throw 2건(시작만 / 끝만), 마커 중복 throw 2건(시작 2개+끝 1개 / 시작 1개+끝 2개), 중복 키 throw 1건, 기존 append·replace 경로 회귀 방지 2건 추가

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 고아 마커를 자동 복구하지 않고 fail-loud로 처리한 선택

**배경 및 문제 상황:**

이 함수가 다루는 파일은 OMT가 단독 소유하지 않는다. Codex CLI가 같은 파일에 자기 상태를 쓰고 재직렬화하므로, 주석 마커는 언제든 한쪽만 남을 수 있다. 실제로 남았던 잔해는 `# --- omt:mcp ---`(시작만)와 `# --- end omt:config ---`(끝만) 두 개였고, 사라진 두 줄 자리에는 Codex가 새로 기록한 테이블들이 들어와 있었다.

문제는 이 상태가 **조용히** 실패한다는 점이다. 마커를 못 찾은 함수는 "관리 블록이 아직 없다"로 판단해 append하고, stale 블록의 키는 그대로 남아 중복 선언이 된다. sync는 성공했다고 보고하고, 사용자는 다음번 codex 실행에서야 기동 불가로 알게 된다.

**해결 방안:**

마커가 정확히 한쪽만 있거나 끝 마커가 시작 마커보다 앞서면 `Error`를 던진다. 어느 관리 블록인지, 어느 쪽 마커가 없는지, 그리고 "남은 고아 마커와 stale 본문을 손으로 제거한 뒤 sync를 다시 실행하라"는 복구 절차를 메시지에 담는다.

기각한 대안은 두 가지다.

- **고아 마커 라인만 제거하고 append**: 마커 줄은 사라지지만 stale 블록 *본문*이 남아 중복 키가 그대로 발생한다. 증상을 못 고친다.
- **고아 시작 마커부터 다음 마커 또는 EOF까지 삼켜서 제거**: 마커가 한쪽만 남은 시점에서 stale 블록의 진짜 끝은 알 수 없다. 이번 사례에서 그 구간에는 Codex가 쓴 `[hooks.state.*]`와 `[projects.*].trust_level`이 들어와 있었고, 삼켰다면 사용자의 신뢰 설정을 통째로 날렸을 것이다.

**구현 세부사항:**

분기를 replace / append / 손상 세 갈래로 나눴다. 기존 코드는 "짝이 온전한가"만 보고 아니면 전부 append로 흘려보내는 2갈래였는데, 그 fall-through가 정확히 이번 사고의 경로다.

판정 기준은 마커의 **존재 여부가 아니라 등장 횟수**다. 처음에는 존재 여부(`indexOf !== -1`)로 구현했는데, 리뷰에서 그 판정이 뚫리는 경로가 지적됐고 실제 데이터로 재현됐다. 구버전 sync가 훼손된 파일에 완전한 블록을 append하면 시작 마커 2개 + 끝 마커 1개인 파일이 만들어지는데, 이때 `indexOf`는 첫 시작 마커와 유일한 끝 마커를 찾아 `endIdx > startIdx`를 만족시킨다. 즉 **정상 짝으로 오인해 replace 경로를 타고**, 그 사이에 있던 Codex 런타임 소유 설정을 삭제한다. 실측으로 7881바이트가 762바이트가 됐고, 결과가 유효한 TOML이라 아래 2번의 파싱 backstop도 잡지 못했다.

그래서 시작 1개 + 끝 1개 + 정상 순서일 때만 교체하고, 둘 다 0개일 때만 append하며, 나머지는 전부 실패시킨다. 중복 케이스의 에러 메시지에는 실제로 몇 개씩 발견됐는지를 담아 사용자가 파일에서 무엇을 찾아야 할지 알 수 있게 했다.

**관련 코드:**

```ts
// Before: 짝이 안 맞으면 전부 append로 흘러감
if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
  // ... replace  (시작 2개 + 끝 1개도 여기로 들어옴 — 사고 경로)
}
// Append at end
const trimmed = content.replace(/\n+$/, "");
return trimmed ? `${trimmed}\n\n${block}\n` : `${block}\n`;

// After: 개수로 판정 — 1:1 정상 순서만 replace, 0:0만 append
} else if (startCount === 0 && endCount === 0) {
  const trimmed = content.replace(/\n+$/, "");
  result = trimmed ? `${trimmed}\n\n${block}\n` : `${block}\n`;
} else {
  // 한쪽만 존재 / 어느 쪽이든 중복 / 순서 역전 — 전부 실패
  throw new Error(
    `insertManagedBlock: orphaned marker for managed block 'omt:${blockName}' — ${reason}. ` +
      `Remove the extra/orphaned marker(s) and any stale block body by hand, then re-run sync.`,
  );
}
```

**선택과 트레이드오프:**

sync가 사람 손을 요구하며 멈춘다는 점에서 자동화 관점의 후퇴다. 다만 이 실패가 막는 대상이 "Codex CLI가 아예 뜨지 않는 상태"이므로, 사용자가 config를 손으로 한 번 정리하는 비용이 더 싸다고 판단했다. 손상 범위를 추정해 지우는 복구는 사용자 소유 설정을 잃을 수 있어 기본 동작으로 두기에 부적절하다고 봤다.

발생 빈도가 높아지면 `--repair` 같은 **명시적 옵트인** 복구 경로를 따로 두는 편이 낫다고 생각하는데, 지금 관측치는 1건이라 넣지 않았다. 이 판단에 이견이 있으면 듣고 싶다.

### 2. 반환 직전 TOML 파싱 backstop과 안착 검증

**배경 및 문제 상황:**

호출자 `syncConfig`와 `flushMcpBlock`은 이 함수의 반환값을 곧바로 `fs.writeFile`한다. 즉 이 함수가 깨진 문자열을 반환하는 순간 그대로 디스크에 쓰인다. 1번의 orphan 방어는 **관측된** 경로 하나를 막을 뿐이고, 중복 키를 만드는 다른 경로가 없다고 보장하지 못한다.

**해결 방안:**

분기와 무관하게 결과 문자열을 반환 직전에 `parse`로 파싱한다. 실패하면 어느 관리 블록을 쓰다 났는지와 "쓰지 않았다"는 사실을 메시지에 담아 재throw하고, 원본 파서 에러는 `cause`로 첨부한다.

**구현 세부사항:**

검증 위치가 호출자가 아니라 이 함수 안인 이유는, 깨진 문자열이 함수 밖으로 나가는 것 자체를 막기 위해서다. 호출자 쪽에 검증을 두면 호출자가 늘어날 때마다 같은 방어를 다시 짜야 한다.

구문 검증만으로는 부족한 경우가 리뷰에서 드러나 검증을 한 겹 더 뒀다. 줄 앵커 정규식은 TOML 멀티라인 문자열의 경계를 모른다. 사용자가 직접 쓴 `doc = """ ... """` 본문에 시작·끝 마커 리터럴이 각각 단독 줄로 들어 있으면 그 둘을 관리 쌍으로 인식해 사이를 교체하고, 사용자 문단을 지운 자리에 생성 블록을 문자열 **안에** 가둔다. 결과는 여전히 유효한 TOML이라 파싱 backstop이 통과하고, 설정은 최상위에 존재하지 않아 배포되지 않는데도 sync는 성공으로 보고한다.

그래서 파싱 성공 뒤에 **의미 불변식**을 확인한다. 블록 본문을 단독 파싱해 이 블록이 선언하는 구조를 얻고, 결과 파싱값이 그 구조를 리프 키·값 수준의 부분집합으로 포함하는지 본다. 얕은 최상위 키 확인으로는 잡히지 않는데, 대상 파일에 사용자 소유 `[features]`가 이미 있어 블록이 갇혀도 통과하기 때문이다.

**선택과 트레이드오프:**

sync마다 TOML 파싱 비용이 한 번씩 추가되지만 파일 크기를 감안하면 무시할 수준이다.

안착 검증에서 TOML 문자열 경계 스캐너를 만드는 길과 의미 검증 중 후자를 택했다. 정확한 스캐너는 `"""`/`'''`, 이스케이프, 줄끝 백슬래시 연속, 단일행 문자열, 문자열 안팎의 `#`을 모두 다뤄야 해서 그 자체가 새 결함원이 되고, 유발 조건(사람이 직접 쓴 멀티라인 문자열에 마커 리터럴이 순서대로 단독 줄로 들어 있는 경우)에 비해 비용이 과하다. `smol-toml`의 `stringify`는 개행을 이스케이프한 기본 문자열로 직렬화하고 `"""`를 쓰지 않으므로 OMT가 스스로 이 상태를 만들 수도 없다.

받아들인 대가가 있다. 스캐너 방식이었다면 이 입력에서도 sync가 성공했을 텐데(마커를 무시하고 최상위에 append), 의미 검증은 실패시켜 사용자가 config를 손보게 만든다. 결과 품질만 보면 스캐너 쪽이 낫다. 이 PR이 일관되게 택해온 "추정 복구 대신 시끄러운 실패" 기조에 맞춰 실패 쪽을 골랐다.

새 본문 쪽 검증만으로는 한쪽이 비었다. MCP 서버가 0개일 때 넘어오는 주석-only 본문은 파싱하면 빈 객체이고, 빈 객체는 모든 객체의 부분집합이라 검증이 항상 공허하게 통과한다. 그래서 대칭이 되는 원본 쪽 검증을 뒀다 — 교체 직전, 마커 사이 기존 본문이 유효한 TOML로 파싱되고 그 선언 키가 원본의 최상위에서 읽히는지 확인한다. 문자열에 갇힌 구간은 본문이 산문이라 파싱에서 걸리거나, 파싱되더라도 키가 최상위에 없어 걸린다.

남는 한계는 코드에 `lazy:` 주석으로 명시했다. 갇힌 기존 본문과 새 본문이 **둘 다** 주석-only이면 양쪽이 공허하게 통과하는데, 그때는 같은 성격의 텍스트가 같은 성격의 텍스트로 대체되므로 손실이 사실상 없다. 업그레이드 경로는 TOML 문자열 경계 스캐너다.

의도적으로 받아들인 부작용이 하나 있다. 마커 짝이 정상이더라도 사용자가 관리 블록 **밖**에 같은 테이블을 손으로 선언해 뒀다면, 이제 그 타겟의 sync는 실패한다. 기존에는 통과했지만 결과물은 Codex가 못 읽는 config였으므로, 조용히 깨진 파일을 쓰는 것보다 실패가 낫다고 봤다.

---

## ✅ Checklist

### insertManagedBlock 고아 마커 처리
- [ ] 시작 마커만 남은 content를 넘기면 append하지 않고 에러가 발생하며, 메시지가 블록 이름과 누락된 쪽 마커를 지목한다
  - `tools/adapters/codex.ts`
- [ ] 끝 마커만 남은 content에서도 동일하게 에러가 발생한다
  - `tools/adapters/codex.ts`
- [ ] 마커가 둘 다 없으면 기존과 동일하게 파일 끝에 append되고 주변 사용자 콘텐츠가 보존된다
  - `tools/adapters/codex.ts`
- [ ] 마커 짝이 온전하면 기존과 동일하게 블록이 교체된다
  - `tools/adapters/codex.ts`
- [ ] 시작 마커 2개 + 끝 마커 1개인 content에서 교체가 일어나지 않고 에러가 발생하며, 두 시작 마커 사이의 사용자 소유 테이블이 삭제되지 않는다
  - `tools/adapters/codex.ts`
- [ ] 시작 마커 1개 + 끝 마커 2개인 경우에도 에러가 발생하고, 메시지가 발견된 마커 개수를 담는다
  - `tools/adapters/codex.ts`
- [ ] 관리 블록 밖 TOML 문자열 값 안에 마커 리터럴이 들어 있어도 중복으로 판정하지 않고 교체가 수행되며, 그 문자열 값이 보존된다
  - `tools/adapters/codex.ts`
- [ ] 마커 줄에 후행 공백이 붙어 있어도 마커로 인식되어 교체되고, 블록이 중복 생성되지 않는다
  - `tools/adapters/codex.ts`

### TOML 파싱 backstop
- [ ] 결과 TOML에 중복 키가 생기는 입력에서, 파일에 쓰이기 전에 에러가 발생한다
  - `tools/adapters/codex.ts`
- [ ] 재throw된 에러에 원본 파서 에러가 `cause`로 첨부되어 있다
  - `tools/adapters/codex.ts`
- [ ] 멀티라인 TOML 문자열 본문에 마커 리터럴이 단독 줄로 들어 있는 대상 파일에서, 교체가 수행되지 않고 에러가 발생하며 그 문자열이 훼손되지 않는다
  - `tools/adapters/codex.ts`
- [ ] MCP 서버가 0개일 때의 빈 본문에서는 안착 검증이 실패하지 않는다
  - `tools/adapters/codex.ts`
- [ ] 멀티라인 문자열에 갇힌 마커 쌍에 주석-only 본문(MCP 서버 0개 정리)을 써도 교체가 일어나지 않고 에러가 발생한다
  - `tools/adapters/codex.ts`
- [ ] 최상위에 있는 정상 관리 블록은 주석-only 본문으로 교체되며 기존 서버가 제거된다
  - `tools/adapters/codex.ts`
