### PR TITLE
chore: 리뷰 앵글 codex 커맨드에 service_tier=fast 적용

### DIFF
--- a/skills/orchestrate-review/orchestrate-review.config.yaml
+++ b/skills/orchestrate-review/orchestrate-review.config.yaml
@@ -47,28 +47,28 @@ chunk-review:
     # `cleanup` (is this more than necessary), `requirement` (was what was
     # asked for actually done, and is it actually verified).
     - name: correctness
-      command: codex exec
+      command: codex exec -c service_tier=fast
       model: gpt-5.6-luna
       emoji: "\U0001F517"
       color: "CYAN"
       effort_level: xhigh
       output_format: json
     - name: regression
-      command: codex exec
+      command: codex exec -c service_tier=fast
       model: gpt-5.6-luna
       emoji: "\U0001F5D1"
       color: "MAGENTA"
       effort_level: xhigh
       output_format: json
     - name: cleanup
-      command: codex exec
+      command: codex exec -c service_tier=fast
       model: gpt-5.6-luna
       emoji: "\U0001F9F9"
       color: "YELLOW"
       effort_level: xhigh
       output_format: json
     - name: requirement
-      command: codex exec
+      command: codex exec -c service_tier=fast
       model: gpt-5.6-luna
       emoji: "\U0001F4CB"
       color: "GREEN"


### PR DESCRIPTION
## 변경

orchestrate-review chunk-review job의 4개 검토 앵글(correctness, regression, cleanup, requirement) codex 커맨드에 `-c service_tier=fast`를 붙여, 각 앵글이 codex의 "fast" 요청 티어로 실행되게 한다.

과거 `32f656d9`에서 luna 앵글에 적용했다가 `75c691f5`에서 제거한 설정을 요청에 따라 재적용한 것이다.

## 검증

- `orchestrate-review.config.yaml`의 members `command:` 4줄 전부 `codex exec -c service_tier=fast`.
- `buildAugmentedCommand`가 이 앞부분에 `-m <model> -c model_reasoning_effort=<effort> --json` 등을 이어붙이는 구조라 기존 조립과 충돌 없음.
- 영향 테스트 그린: `bun test skills/orchestrate-review/scripts/job.test.ts skills/orchestrate-review/scripts/template-consistency.test.ts` → 209 pass, 0 fail. (테스트는 config의 실제 command 값을 핀하지 않음.)

## 참고

- 라이브 codex 스모크는 돌리지 않았다. 과거 적용 이력(약 11시간 정상 가동)으로 티어 수용은 확인된 상태.
- 이번 조사에서 나온 별도 후속 건(앵글별 모델 fallback 부재)은 이 PR과 무관하게 issue #265로 등록했다.

https://claude.ai/code/session_01RCcrp6nsYZpn8tgLsaDAw7
