### PR TITLE
fix: ultragoal 상태 조기 GC 방지 — 타임스탬프 오프셋 오독 수정·reap breadcrumb

### DIFF
--- a/hooks/lib/state-liveness.sh
+++ b/hooks/lib/state-liveness.sh
@@ -478,13 +478,30 @@ is_state_live() {
   fi
 
   if [ -n "$ts" ]; then
-    # Parse ISO 8601 (strip timezone). BSD date (macOS) is the deploy target;
-    # GNU date -d is the Linux/CI fallback. Mirrors session-start.sh:84-85.
-    local time_part
+    # Parse ISO 8601. An explicit Z/offset suffix, when present, must be
+    # honored — not stripped and reparsed as local wall-clock, which would
+    # misread a genuinely UTC-stamped timestamp by this host's own UTC
+    # offset. BSD date (macOS) is the deploy target; GNU date -d is the
+    # Linux/CI fallback. No-suffix case mirrors session-start.sh:84-85
+    # unchanged.
+    local time_part suffix offset_hhmm
+    suffix=$(printf '%s' "$ts" | sed -nE 's/.*(Z|[+-][0-9]{2}:[0-9]{2})$/\1/p')
     time_part=$(printf '%s' "$ts" | sed -E 's/(Z|[+-][0-9]{2}:[0-9]{2})$//')
-    touched_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S" "$time_part" "+%s" 2>/dev/null \
-      || date -d "$time_part" "+%s" 2>/dev/null \
-      || true)
+    if [ -n "$suffix" ]; then
+      if [ "$suffix" = "Z" ]; then
+        offset_hhmm="+0000"
+      else
+        offset_hhmm=$(printf '%s' "$suffix" | tr -d ':')
+      fi
+      touched_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S%z" "${time_part}${offset_hhmm}" "+%s" 2>/dev/null \
+        || date -d "$ts" "+%s" 2>/dev/null \
+        || date -d "$time_part" "+%s" 2>/dev/null \
+        || true)
+    else
+      touched_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S" "$time_part" "+%s" 2>/dev/null \
+        || date -d "$time_part" "+%s" 2>/dev/null \
+        || true)
+    fi
   fi
 
   if [ -z "$touched_epoch" ]; then

--- a/hooks/lib/state-liveness.sh
+++ b/hooks/lib/state-liveness.sh
@@ -965,6 +965,26 @@ reap_dead_state_files() {
         continue
       fi
       if ! is_state_live "$f" "$now_epoch"; then
+        # reap-diag breadcrumb: raw inputs behind this reap decision, for
+        # debugging the intermittent ultragoal-state wipe. Reads the SAME
+        # raw fields is_state_live itself parses (one jq call, no re-parse
+        # of timestamps/age/TTL — that would risk drifting from
+        # is_state_live's own logic). STDERR only, both dry_run modes (this
+        # sits before the dry_run branch below), and must never itself fail
+        # the reap or alter control flow — jq absence or an unreadable file
+        # still emits the line with "absent" for the unresolved fields.
+        local _diag_fields _diag_active _diag_phase _diag_last_touched _diag_started _diag_mtime
+        _diag_fields=$(jq -r '[(.active // "absent"), (.phase // "absent"), (.last_touched_at // "absent"), (.started_at // "absent")] | @tsv' "$f" 2>/dev/null) || _diag_fields=""
+        if [ -n "$_diag_fields" ]; then
+          IFS=$'\t' read -r _diag_active _diag_phase _diag_last_touched _diag_started <<EOF
+$_diag_fields
+EOF
+        else
+          _diag_active="absent"; _diag_phase="absent"; _diag_last_touched="absent"; _diag_started="absent"
+        fi
+        _diag_mtime=$(_state_liveness_stat_mtime "$f" 2>/dev/null) || _diag_mtime=""
+        [ -n "$_diag_mtime" ] || _diag_mtime="absent"
+        echo "reap-diag: sid=$current_sid file=$f now=$now_epoch active=$_diag_active phase=$_diag_phase last_touched_at=$_diag_last_touched started_at=$_diag_started mtime=$_diag_mtime" >&2
         if [ "$dry_run" = "1" ]; then
           echo "$f"
         elif rm -f "$f" 2>/dev/null; then

--- a/hooks/lib/state-liveness_test.sh
+++ b/hooks/lib/state-liveness_test.sh
@@ -1253,6 +1253,61 @@ test_reap_dead_state_files_old_closed_bak_survives_json_anchor() {
   return 0
 }
 
+# Debugging aid for the intermittent ultragoal-state wipe: at the exact
+# moment a reap decision is made against a foreign (different sid) dead
+# state file, reap_dead_state_files must emit a `reap-diag:` breadcrumb line
+# to STDERR carrying the raw inputs (file, now_epoch, active, ...) that
+# produced the decision — WITHOUT recomputing/duplicating is_state_live's own
+# parse. This must hold in BOTH dry_run modes (breadcrumb sits before the
+# dry_run branch), and must never leak onto STDOUT — session-start.sh depends
+# on reap_dead_state_files's stdout staying byte-static (one reaped path per
+# line, nothing else).
+test_reap_dead_state_files_emits_diag_breadcrumb_to_stderr() {
+  local sid="diag-sid-42"
+  local d="$TEST_TMP_DIR"
+  local f="$d/ultragoal-state-other-$sid.json"
+  local touched_ago
+  touched_ago=$(iso_ago 25200)   # 7 hours — past ACTIVE_IDLE_TTL, a genuine dead candidate
+  write_state "$f" "{\"active\":true,\"last_touched_at\":\"$touched_ago\"}"
+
+  local err_file="$TEST_TMP_DIR/stderr.out"
+  local out
+  out=$(reap_dead_state_files "$d" "current-$sid" "$NOW" 0 2>"$err_file")
+
+  local err
+  err=$(cat "$err_file")
+
+  if ! printf '%s\n' "$err" | grep -q "reap-diag:"; then
+    echo "  ASSERTION FAILED: stderr must contain a reap-diag: breadcrumb line"
+    echo "  stderr: $err"
+    return 1
+  fi
+  if ! printf '%s\n' "$err" | grep -q "file=$f"; then
+    echo "  ASSERTION FAILED: breadcrumb must carry file=$f"
+    echo "  stderr: $err"
+    return 1
+  fi
+  if ! printf '%s\n' "$err" | grep -q "active=true"; then
+    echo "  ASSERTION FAILED: breadcrumb must carry active=true (raw .active value)"
+    echo "  stderr: $err"
+    return 1
+  fi
+  if ! printf '%s\n' "$err" | grep -q "now=$NOW"; then
+    echo "  ASSERTION FAILED: breadcrumb must carry now=$NOW"
+    echo "  stderr: $err"
+    return 1
+  fi
+
+  # Regression guard: the breadcrumb must not leak onto stdout — stdout stays
+  # exactly the reaped path, nothing else.
+  if [ "$out" != "$f" ]; then
+    echo "  ASSERTION FAILED: stdout must remain exactly the reaped path (breadcrumb must not leak to stdout)"
+    echo "  stdout: $out"
+    return 1
+  fi
+  return 0
+}
+
 # =============================================================================
 # reap_session_artifacts
 # =============================================================================
@@ -2167,6 +2222,7 @@ run_test test_reap_dead_state_files_execute_mode_echoes_real_path_not_constant
 run_test test_reap_dead_state_files_dry_run_emits_candidate_but_does_not_delete
 run_test test_reap_dead_state_files_dry_run_preserves_candidate_bytes
 run_test test_reap_dead_state_files_old_closed_bak_survives_json_anchor
+run_test test_reap_dead_state_files_emits_diag_breadcrumb_to_stderr
 run_test test_is_current_session_suffix_match_diverges_from_base_exact_match_over_preserves
 run_test test_reap_session_artifacts_current_session_self_artifact_survives
 run_test test_reap_session_artifacts_other_live_session_survives_without_sid

--- a/hooks/lib/state-liveness_test.sh
+++ b/hooks/lib/state-liveness_test.sh
@@ -346,7 +346,7 @@ iso_ago_utc_offset00() {
 iso_ago_local_offset09() {
   local secs="$1"
   local t=$((NOW - secs))
-  date -r "$t" "+%Y-%m-%dT%H:%M:%S+09:00" 2>/dev/null || date -d "@$t" "+%Y-%m-%dT%H:%M:%S+09:00" 2>/dev/null
+  TZ=Asia/Seoul date -r "$t" "+%Y-%m-%dT%H:%M:%S+09:00" 2>/dev/null || TZ=Asia/Seoul date -d "@$t" "+%Y-%m-%dT%H:%M:%S+09:00" 2>/dev/null
 }
 
 test_is_state_live_honors_utc_z_suffix_not_local_wall_clock() {

--- a/hooks/lib/state-liveness_test.sh
+++ b/hooks/lib/state-liveness_test.sh
@@ -316,6 +316,82 @@ test_is_state_live_active_ttl_boundary_is_dead() {
 }
 
 # =============================================================================
+# Defect coverage: an explicit Z/offset suffix must be honored, not stripped
+# and reparsed as local wall-clock. On this KST(+09:00) host, a timestamp
+# genuinely stamped in UTC-Z form 60s ago is misread by the stripped-local
+# parse as ~9h old — enough to blow past ACTIVE_IDLE_TTL and be judged dead.
+# =============================================================================
+
+# iso_ago_z <seconds> — UTC-Z ISO 8601 timestamp N seconds before NOW
+iso_ago_z() {
+  local secs="$1"
+  local t=$((NOW - secs))
+  date -u -r "$t" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "@$t" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null
+}
+
+# iso_ago_offset <seconds> <offset> — ISO 8601 timestamp N seconds before NOW,
+# rendered in UTC clock terms but suffixed with the given explicit offset.
+# Only used with offset="+00:00" (UTC) — the UTC clock rendering is correct
+# for that offset specifically.
+iso_ago_utc_offset00() {
+  local secs="$1"
+  local t=$((NOW - secs))
+  date -u -r "$t" "+%Y-%m-%dT%H:%M:%S+00:00" 2>/dev/null || date -u -d "@$t" "+%Y-%m-%dT%H:%M:%S+00:00" 2>/dev/null
+}
+
+# iso_ago_local_offset09 <seconds> — ISO 8601 timestamp N seconds before NOW,
+# rendered in this host's own local (KST, +09:00) clock terms and suffixed
+# with +09:00 — a regression guard that explicit-offset handling doesn't
+# break the common local-offset case.
+iso_ago_local_offset09() {
+  local secs="$1"
+  local t=$((NOW - secs))
+  date -r "$t" "+%Y-%m-%dT%H:%M:%S+09:00" 2>/dev/null || date -d "@$t" "+%Y-%m-%dT%H:%M:%S+09:00" 2>/dev/null
+}
+
+test_is_state_live_honors_utc_z_suffix_not_local_wall_clock() {
+  local file="$TEST_TMP_DIR/state.json"
+  local touched_ts
+  touched_ts=$(iso_ago_z 60)   # 60s ago, stamped in UTC-Z form
+  write_state "$file" "{\"active\":true,\"last_touched_at\":\"$touched_ts\"}"
+
+  if is_state_live "$file" "$NOW"; then
+    return 0
+  else
+    echo "  ASSERTION FAILED: a Z-suffixed timestamp 60s ago must be parsed as UTC, not local wall-clock — true age is 60s (live), stripping Z and reparsing as KST local misreads it as ~9h old (dead)"
+    return 1
+  fi
+}
+
+test_is_state_live_honors_explicit_utc_offset_suffix() {
+  local file="$TEST_TMP_DIR/state.json"
+  local touched_ts
+  touched_ts=$(iso_ago_utc_offset00 60)   # 60s ago, stamped +00:00
+  write_state "$file" "{\"active\":true,\"last_touched_at\":\"$touched_ts\"}"
+
+  if is_state_live "$file" "$NOW"; then
+    return 0
+  else
+    echo "  ASSERTION FAILED: a +00:00-suffixed timestamp 60s ago must be parsed against its explicit offset, not local wall-clock — true age is 60s (live)"
+    return 1
+  fi
+}
+
+test_is_state_live_honors_local_kst_offset_suffix_regression_guard() {
+  local file="$TEST_TMP_DIR/state.json"
+  local touched_ts
+  touched_ts=$(iso_ago_local_offset09 60)   # 60s ago, stamped +09:00 (this host's own offset)
+  write_state "$file" "{\"active\":true,\"last_touched_at\":\"$touched_ts\"}"
+
+  if is_state_live "$file" "$NOW"; then
+    return 0
+  else
+    echo "  ASSERTION FAILED: a +09:00-suffixed timestamp 60s ago (this host's own local offset) must still be live — offset handling must not break the common case"
+    return 1
+  fi
+}
+
+# =============================================================================
 # is_current_session — generalized sid-suffix matching
 # =============================================================================
 
@@ -2060,6 +2136,9 @@ run_test test_fallback_to_started_at_when_no_heartbeat_stale
 run_test test_fallback_to_mtime_when_no_timestamps_fresh
 run_test test_fallback_to_mtime_when_no_timestamps_stale
 run_test test_is_state_live_active_ttl_boundary_is_dead
+run_test test_is_state_live_honors_utc_z_suffix_not_local_wall_clock
+run_test test_is_state_live_honors_explicit_utc_offset_suffix
+run_test test_is_state_live_honors_local_kst_offset_suffix_regression_guard
 run_test test_is_current_session_matches_filename_sid
 run_test test_is_current_session_no_match_different_sid
 run_test test_is_current_session_matches_ultragoal_filename_sid


### PR DESCRIPTION
## 배경

ultragoal의 최종 독립 리뷰가 한 번에 1시간 이상 걸릴 때, 간헐적으로 `ultragoal-state-<sid>.json` 상태 파일이 삭제되는 문제를 진단했다.

핵심 메커니즘:
- 상태 삭제(`reap_dead_state_files`, `hooks/lib/state-liveness.sh`)는 자기 세션 파일은 항상 skip하고 **다른 세션 id의 dead 파일만** `rm`한다. GC는 SessionStart에서만 돈다. 즉 단일 세션은 자기 상태를 못 지우고, **다른 SID의 SessionStart가 한 번 더 떠야만** 삭제가 발화한다.
- liveness TTL은 `active:true → 6시간`, `active:false → 30분`으로 갈린다. 1시간+ 리뷰가 30분 창에 걸리려면 그 구간에 상태가 `active:false`로 강등돼야 한다.
- **가장 유력한 원인(미확정)**: 최종 리뷰가 harness가 추적하지 못하는 detached job으로 돌아 no-progress 카운터가 대기 중 계속 올라가고, cap을 넘기면 `budget_limited/active:false`로 강등 → TTL이 6시간에서 30분으로 전환된다. 리뷰가 길수록 그 구간에 걸리는 Stop이 많아져 발화 확률이 오르므로 "긴 리뷰일수록 간헐적으로 터진다"와 맞는다.

이 PR은 위 진단에서 **독립적으로 안전하고 고확신인 두 수**를 담는다. 실제 발화 원인(위 마지막 항목)의 수정은 breadcrumb가 실사건을 포착해 확증한 뒤 별도로 진행한다.

## 변경 사항

### 1. `is_state_live` 타임스탬프 UTC 오프셋 오독 수정
`is_state_live`의 파서가 ISO8601의 `Z`/오프셋 접미사를 떼어내고 로컬 시각으로 재파싱하던 버그를 고쳤다. 이제 접미사를 존중한다(`Z`→`+0000`, `±HH:MM`→`±HHMM`, BSD `%z` / GNU 네이티브 오프셋). 이 때문에 UTC(`Z`)로 찍힌 타임스탬프가 호스트 오프셋만큼(KST 기준 9시간) 과거로 오독돼 상태가 조기 GC되던 잠복 결함을 원천 차단한다. TS 패리티 사이트(`Date.parse`)는 이미 정상이라 bash만 정렬했다.

### 2. reap 판정 직전 원시 입력 breadcrumb
`reap_dead_state_files`가 dead 판정을 내린 직후 `rm` 이전에, 판정 근거가 된 원시 입력(`active`·`phase`·`last_touched_at`·`started_at`·`mtime`)을 `reap-diag:` 접두 breadcrumb로 STDERR에 남긴다. 다음 실제 삭제 사건을 하드 증거로 포착해 원인을 확정하기 위함이다. 타임스탬프/age/TTL을 재계산하지 않고 `is_state_live`와 동일한 jq/stat primitive로 원시값만 덤프해 로직 드리프트 위험이 없다. STDOUT의 byte-static 계약과 reap 판정 로직은 불변이다.

## 검증

- `bash hooks/lib/state-liveness_test.sh` → **91 passed, 0 failed**
- 파서 수정: RED(Z/오프셋 2건 실패, 예측된 이유) → GREEN, 무접미사 경로 byte-identical 회귀 없음
- breadcrumb: 신규 테스트로 STDERR 필드 존재 + STDOUT 순수성(누출 없음) 단언, jq 부재/unreadable 시 `absent` 폴백을 `set -euo pipefail`로 실측

## 유보 (의도적)

가설의 실제 원인 수정 — 리뷰 job을 추적 가능한 background task로 등록하거나 no-progress 카운터 가드가 살아있는 리뷰 job을 background 등가로 인식하게 하는 것 — 은 breadcrumb가 실사건을 잡아 확증한 뒤 별도 PR로 진행한다. TTL을 단순히 늘리는 것은 서로 다른 두 결함을 가리므로 하지 않는다.

https://claude.ai/code/session_01NXK5TQv8D172RJy9NgTJWj
