### PR TITLE
fix: Codex 훅 타임아웃·ultragoal 상태 삭제 근본 수정

### DIFF
--- a/hooks/lib/omt-dir.sh
+++ b/hooks/lib/omt-dir.sh
@@ -22,6 +22,22 @@ compute_omt_dir() {
     return 0
   fi
 
+  # cwd-independent file cache: keyed on the root path, keyed via pure bash
+  # parameter expansion only (no fork). Avoids re-forking `git` on every call
+  # (Codex has no env persistence across hook subprocesses).
+  local _omt_cache_dir _omt_cache_key _omt_cache_file
+  if [ -n "$1" ]; then
+    _omt_cache_dir="$HOME/.omt/.dir-cache"
+    _omt_cache_key="${1//\//_}"
+    _omt_cache_key="${_omt_cache_key// /-}"
+    _omt_cache_file="$_omt_cache_dir/$_omt_cache_key"
+    if [ -s "$_omt_cache_file" ]; then
+      IFS= read -r OMT_DIR < "$_omt_cache_file" || [ -n "${OMT_DIR:-}" ]
+      [ -d "$OMT_DIR" ] || mkdir -p "$OMT_DIR"
+      return 0
+    fi
+  fi
+
   local _omt_root="$1"
   local _omt_git_common
   _omt_git_common=$(git -C "$_omt_root" rev-parse --git-common-dir 2>/dev/null) || _omt_git_common=""
@@ -57,6 +73,12 @@ compute_omt_dir() {
   # Sanitize: replace spaces with hyphens
   OMT_DIR="$HOME/.omt/${_omt_name// /-}"
   mkdir -p "$OMT_DIR"
+
+  # Cache write: best-effort, atomic (tmp + mv). A write failure is not fatal
+  # — OMT_DIR is already valid, the cache is only a fork-avoidance optimization.
+  if [ -n "$1" ]; then
+    { mkdir -p "$_omt_cache_dir" && printf '%s\n' "$OMT_DIR" > "$_omt_cache_dir/.tmp.$$" && mv -f "$_omt_cache_dir/.tmp.$$" "$_omt_cache_file"; } || true
+  fi
 }
 
 # resolve_omt_dir <cwd>

--- a/hooks/lib/omt-dir.sh
+++ b/hooks/lib/omt-dir.sh
@@ -24,7 +24,11 @@ compute_omt_dir() {
 
   # cwd-independent file cache: keyed on the root path, keyed via pure bash
   # parameter expansion only (no fork). Avoids re-forking `git` on every call
-  # (Codex has no env persistence across hook subprocesses).
+  # (Codex has no env persistence across hook subprocesses). No invalidation:
+  # the root path is assumed to keep a stable git identity, since fingerprinting
+  # it would re-fork `git` and defeat the fork-avoidance this cache exists for. A
+  # root whose git identity later changes serves a stale OMT_DIR (and line 36
+  # re-mkdirs it) until the entry is removed by hand.
   local _omt_cache_dir _omt_cache_key _omt_cache_file
   if [ -n "$1" ]; then
     _omt_cache_dir="$HOME/.omt/.dir-cache"

--- a/hooks/lib/omt-dir_test.sh
+++ b/hooks/lib/omt-dir_test.sh
@@ -266,6 +266,191 @@ test_canonical_worktree_emits_no_warning() {
 }
 
 # =============================================================================
+# AC (f): cache hit avoids invoking git — behavioral core of the cwd-independent
+# file cache. Seeds the cache with a real git repo, then re-resolves the same
+# path with a decoy `git` on PATH that marks a file if invoked. No cache means
+# the second call hits the decoy and leaves a marker — that is the RED signal.
+# =============================================================================
+test_cache_hit_avoids_invoking_git() {
+  local repo
+  repo=$(mktemp -d)
+  (cd "$repo" && git init -q)
+
+  # Seed the cache with a real resolution (real git on PATH).
+  local first
+  first=$(call_resolve "$repo")
+
+  # Decoy `git`: if invoked, touches a marker and returns garbage.
+  local fakebin marker
+  fakebin=$(mktemp -d)
+  marker="$fakebin/marker-hit"
+  {
+    echo '#!/bin/bash'
+    echo "touch \"$marker\""
+    echo 'echo FAKE-GIT-OUTPUT'
+    echo 'exit 0'
+  } > "$fakebin/git"
+  chmod +x "$fakebin/git"
+
+  local second
+  second=$(
+    unset OMT_DIR || true
+    export PATH="$fakebin:$PATH"
+    source "$SCRIPT_DIR/omt-dir.sh"
+    resolve_omt_dir "$repo"
+  )
+
+  local marker_hit=0
+  [ -f "$marker" ] && marker_hit=1
+
+  rm -rf "$repo" "$fakebin"
+
+  if [ "$first" != "$second" ]; then
+    echo "  ASSERTION FAILED: cached value mismatch: seed='$first' second='$second'"
+    return 1
+  fi
+
+  if [ "$marker_hit" -eq 1 ]; then
+    echo "  ASSERTION FAILED: decoy git was invoked on the second call (cache miss)"
+    return 1
+  fi
+
+  return 0
+}
+
+# =============================================================================
+# AC (g): OMT_DIR env short-circuits before the cache is ever consulted or
+# written — preserves the existing Claude env-var fast path unchanged.
+# =============================================================================
+test_omt_dir_env_short_circuits_before_cache() {
+  local repo preset result
+  repo=$(mktemp -d)
+  preset="/some/preset/dir"
+
+  result=$(
+    export OMT_DIR="$preset"
+    source "$SCRIPT_DIR/omt-dir.sh"
+    compute_omt_dir "$repo"
+    printf '%s' "$OMT_DIR"
+  )
+
+  local key cache_file
+  key="${repo//\//_}"
+  key="${key// /-}"
+  cache_file="$HOME/.omt/.dir-cache/$key"
+
+  rm -rf "$repo"
+
+  if [ "$result" != "$preset" ]; then
+    echo "  ASSERTION FAILED: expected OMT_DIR '$preset' to survive, got '$result'"
+    return 1
+  fi
+
+  if [ -f "$cache_file" ]; then
+    echo "  ASSERTION FAILED: cache file created despite OMT_DIR env short-circuit: $cache_file"
+    return 1
+  fi
+
+  return 0
+}
+
+# =============================================================================
+# AC (h): cached value equals the freshly computed value (cache miss vs hit
+# return identical OMT_DIR for the same root path).
+# =============================================================================
+test_cached_value_equals_freshly_computed_value() {
+  local repo miss_result hit_result
+  repo=$(mktemp -d)
+  (cd "$repo" && git init -q)
+
+  miss_result=$(call_resolve "$repo")
+  hit_result=$(call_resolve "$repo")
+
+  rm -rf "$repo"
+
+  if [ "$miss_result" != "$hit_result" ]; then
+    echo "  ASSERTION FAILED: cache-miss result '$miss_result' != cache-hit result '$hit_result'"
+    return 1
+  fi
+
+  return 0
+}
+
+# =============================================================================
+# AC (i): empty argument skips cache logic entirely — no cache file is
+# created and existing fallback behavior for an empty root is untouched.
+# =============================================================================
+test_empty_argument_skips_cache_logic() {
+  local cache_dir="$HOME/.omt/.dir-cache"
+  local before_count after_count
+
+  before_count=0
+  if [ -d "$cache_dir" ]; then
+    before_count=$(find "$cache_dir" -type f 2>/dev/null | wc -l | tr -d ' ')
+  fi
+
+  (
+    unset OMT_DIR || true
+    source "$SCRIPT_DIR/omt-dir.sh"
+    compute_omt_dir ""
+  ) >/dev/null 2>&1 || true
+
+  after_count=0
+  if [ -d "$cache_dir" ]; then
+    after_count=$(find "$cache_dir" -type f 2>/dev/null | wc -l | tr -d ' ')
+  fi
+
+  if [ "$after_count" -ne "$before_count" ]; then
+    echo "  ASSERTION FAILED: cache file count changed from $before_count to $after_count on empty arg"
+    return 1
+  fi
+
+  return 0
+}
+
+# =============================================================================
+# AC (j): cache hit does not abort a `set -euo pipefail` consumer. Seeds the
+# cache with a first resolve, then re-resolves the same root in a genuinely
+# separate `bash -c 'set -euo pipefail; ...'` process — its own exit code must
+# be 0. Regression: the cache-read `read -r OMT_DIR < file` on a newline-less
+# cache file returns 1 at EOF even though OMT_DIR was assigned, which aborts
+# every `set -e` hook consumer (resume-forge-start.sh, session-start.sh,
+# codex-*.sh) at the moment of a cache hit.
+#
+# Must spawn a real subprocess rather than a nested subshell: bash ignores -e
+# for any compound command executing inside a context where -e is already
+# being ignored (here, this test function's own body, called via
+# `if "$test_name"` in run_test) — a `set -e` re-declared inside a nested
+# subshell in that context does not re-arm it, so the bug would go unnoticed.
+# Also unsets OMT_DIR inside the spawned process before `set -e`: OMT_DIR is
+# exported in the ambient dev/CI shell, and an inherited value would short-
+# circuit compute_omt_dir at its very first line, never reaching the cache
+# read this test targets.
+# =============================================================================
+test_cache_hit_does_not_abort_under_set_e() {
+  local repo
+  repo=$(mktemp -d)
+  (cd "$repo" && git init -q)
+
+  # Seed the cache with a first resolution.
+  call_resolve "$repo" >/dev/null
+
+  local rc=0
+  OMT_DIR_TEST_LIB="$SCRIPT_DIR/omt-dir.sh" OMT_DIR_TEST_REPO="$repo" \
+    bash -c 'unset OMT_DIR; set -euo pipefail; source "$OMT_DIR_TEST_LIB"; resolve_omt_dir "$OMT_DIR_TEST_REPO" >/dev/null' \
+    || rc=$?
+
+  rm -rf "$repo"
+
+  if [ "$rc" -ne 0 ]; then
+    echo "  ASSERTION FAILED: cache-hit resolve aborted under set -e (rc=$rc)"
+    return 1
+  fi
+
+  return 0
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 main() {
@@ -278,6 +463,11 @@ main() {
   run_test test_all_worktree_paths_resolve_to_canonical_name
   run_test test_nongit_path_emits_warning_and_resolves
   run_test test_canonical_worktree_emits_no_warning
+  run_test test_cache_hit_avoids_invoking_git
+  run_test test_omt_dir_env_short_circuits_before_cache
+  run_test test_cached_value_equals_freshly_computed_value
+  run_test test_empty_argument_skips_cache_logic
+  run_test test_cache_hit_does_not_abort_under_set_e
 
   echo "=========================================="
   echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/lib/persistent-mode-core/state.ts
+++ b/lib/persistent-mode-core/state.ts
@@ -143,10 +143,11 @@ export function updateGoalState(sessionId: string, partial: Partial<GoalState>):
 	// is backfilled once, it would never move again even while the loop keeps
 	// genuinely iterating, and an actively-pursued goal would eventually read as
 	// progress-dead to lib/state-core.ts's listOthers/adopt.
-	// writeFileNoCreate (single open-truncate-write syscall) throws ENOENT if the file
-	// was renamed away between our read and this write — i.e. the adopt TOCTOU window.
-	// Catching ENOENT preserves the existing "file absent → do nothing" semantics while
-	// closing the race: the write syscall itself refuses creation (ADR-7 / F10).
+	// writeFileNoCreate (temp-write + renameSync, crash-atomic) throws ENOENT if the
+	// file was renamed away before its existence gate — the adopt TOCTOU window.
+	// Catching ENOENT preserves the existing "file absent → do nothing" semantics; the
+	// gate refuses creation (ADR-7 / F10). See its doc comment for the residual
+	// gate→rename resurrection race that plain renameSync leaves open.
 	const ts = nowStamp();
 	const progressPatch =
 		Object.keys(partial).length === 0 ? backfillProgressTouchedAt(raw) : { progress_touched_at: ts };

--- a/lib/state-core.test.ts
+++ b/lib/state-core.test.ts
@@ -6,7 +6,8 @@
  * a mktemp fixture; real ~/.omt is never touched.
  */
 
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import * as fs from "fs";
 import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, readdirSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -430,7 +431,8 @@ describe("writeFileNoCreate", () => {
 		expect(readFileSync(p, "utf8")).toBe("short");
 	});
 
-	test("throws ENOENT when file does not exist", () => {
+	// no-create 계약 회귀 방지: 부재 파일 호출은 throw하고, 파일도 생성하지 않는다.
+	test("기존 파일에만 쓰고 부재 파일엔 ENOENT를 던진다", () => {
 		const p = join(omtDir, "nonexistent.json");
 		let code: string | undefined;
 		try {
@@ -439,6 +441,47 @@ describe("writeFileNoCreate", () => {
 			code = (e as NodeJS.ErrnoException).code;
 		}
 		expect(code).toBe("ENOENT");
+		expect(existsSync(p)).toBe(false);
+	});
+
+	test("빈 문자열도 원자적으로 쓴다", () => {
+		const p = join(omtDir, "empty.json");
+		writeFileSync(p, "old content");
+		writeFileNoCreate(p, "");
+		expect(readFileSync(p, "utf8")).toBe("");
+	});
+
+	// Crash-atomicity: rename 직전(또는 도중) 실패해도 원본이 옛 완전본으로 남아야 한다.
+	// 이 테스트는 temp+rename 구현을 전제로 renameSync를 실패점으로 모킹한다 — 이전 구현
+	// (open("r+") + ftruncateSync(0) + writeSync)은 renameSync를 아예 호출하지 않으므로
+	// 모킹이 걸리지 않고, throw 없이 path를 새 content로 완전히 덮어써 버린다(원본 보존
+	// 실패). 그래서 이 테스트는 이전 구현에서 RED(toThrow 불만족), temp+rename 구현에서
+	// GREEN이다 — RED의 근거는 "0바이트로 남는다"가 아니라 "커밋 지점이 없어 실패 주입
+	// 자체가 원본 보존을 강제하지 못한다"이다.
+	test("rename 직전 실패 시 원본이 옛 완전본으로 보존된다", () => {
+		const p = join(omtDir, "crash-atomic.json");
+		const originalContent = JSON.stringify({ active: true, outcome: "original-complete-state" });
+		writeFileSync(p, originalContent);
+
+		const renameSpy = spyOn(fs, "renameSync").mockImplementation(() => {
+			throw new Error("injected rename failure (simulated crash point)");
+		});
+		try {
+			expect(() => writeFileNoCreate(p, "new-content-that-must-not-land")).toThrow(
+				/injected rename failure/,
+			);
+		} finally {
+			renameSpy.mockRestore();
+		}
+
+		// path must still hold the OLD, COMPLETE content — never 0 bytes, never
+		// the new content, never truncated.
+		expect(readFileSync(p, "utf8")).toBe(originalContent);
+		expect(readFileSync(p, "utf8").length).toBeGreaterThan(0);
+
+		// the failed temp file must not be left behind.
+		const leftoverTmp = readdirSync(omtDir).filter((f) => f.startsWith("crash-atomic.json.tmp."));
+		expect(leftoverTmp).toEqual([]);
 	});
 });
 

--- a/lib/state-core.ts
+++ b/lib/state-core.ts
@@ -19,7 +19,8 @@
  *                                    progress_touched_at via writeFileNoCreate — adoption is a
  *                                    genuine progress event (explicit user resume), not a
  *                                    GC-only write
- *   writeFileNoCreate(path, s)    — single-syscall no-create write (ENOENT if absent)
+ *   writeFileNoCreate(path, s)    — crash-atomic no-create write (ENOENT if absent);
+ *                                    temp-write + renameSync, never truncate-in-place
  *   isPristine(type, parsed)      — true iff state is freshly seeded, safe for adoption overwrite
  *   touchSessionStates(sid)       — family-agnostic heartbeat: refreshes last_touched_at on
  *                                    every existing, non-pristine state file for sid
@@ -36,11 +37,12 @@
 import {
 	readdirSync,
 	readFileSync,
+	writeFileSync,
 	renameSync,
+	unlinkSync,
 	appendFileSync,
 	existsSync,
 	openSync,
-	ftruncateSync,
 	writeSync,
 	closeSync,
 } from "fs";
@@ -456,22 +458,46 @@ function purposeFor(type: StateType, parsed: Record<string, unknown>): string {
 // ---------------------------------------------------------------------------
 
 /**
- * Writes `content` to an existing file at `path` using a single open-truncate-write
- * sequence. Throws ENOENT if the file does not exist — callers decide whether to
- * create it. This eliminates the existsSync-then-writeFileSync TOCTOU window where
- * an adopt-rename between the two calls could resurrect an orphan file.
+ * Writes `content` to an existing file at `path`, crash-atomically. Throws ENOENT
+ * if the file does not exist — callers decide whether to create it; this function
+ * never creates `path` itself. This eliminates the existsSync-then-writeFileSync
+ * TOCTOU window where an adopt-rename between the two calls could resurrect an
+ * orphan file.
+ *
+ * Sequence:
+ *   1. Existence gate: openSync(path, "r+") proves `path` exists (ENOENT if not)
+ *      without writing through this fd — it is closed immediately.
+ *   2. Write `content` to a temp file in the SAME directory as `path`
+ *      (`path + ".tmp." + process.pid`), so it shares `path`'s filesystem —
+ *      required for renameSync to be atomic.
+ *   3. renameSync(tmp, path) — atomically replaces `path`'s content in one step.
+ *
+ * A prior version did open("r+") + ftruncateSync(0) + writeSync in place: a
+ * process kill between truncate and write left `path` at 0 bytes or a partial
+ * write, which a reader parses as invalid JSON — indistinguishable from the
+ * state having been deleted. The temp+rename sequence above never has that
+ * window: until step 3's rename completes, `path` still holds its old, complete
+ * content; after it completes, `path` holds the new, complete content. A crash
+ * at any point leaves `path` at one or the other, never in between.
+ *
+ * On failure in step 2 or 3, the temp file is best-effort unlinked and the
+ * original error is rethrown; `path` itself is untouched (step 3 either fully
+ * ran or didn't start), so it is never left in a partial state.
  */
 export function writeFileNoCreate(path: string, content: string): void {
-	const buf = Buffer.from(content, "utf8");
-	let fd: number | undefined;
+	closeSync(openSync(path, "r+"));
+
+	const tmp = `${path}.tmp.${process.pid}`;
 	try {
-		fd = openSync(path, "r+");
-		ftruncateSync(fd, 0);
-		if (buf.length > 0) {
-			writeSync(fd, buf, 0, buf.length, 0);
+		writeFileSync(tmp, content, "utf8");
+		renameSync(tmp, path);
+	} catch (err) {
+		try {
+			unlinkSync(tmp);
+		} catch {
+			// best-effort cleanup — the error rethrown below is what matters
 		}
-	} finally {
-		if (fd !== undefined) closeSync(fd);
+		throw err;
 	}
 }
 

--- a/lib/state-core.ts
+++ b/lib/state-core.ts
@@ -459,10 +459,15 @@ function purposeFor(type: StateType, parsed: Record<string, unknown>): string {
 
 /**
  * Writes `content` to an existing file at `path`, crash-atomically. Throws ENOENT
- * if the file does not exist — callers decide whether to create it; this function
- * never creates `path` itself. This eliminates the existsSync-then-writeFileSync
- * TOCTOU window where an adopt-rename between the two calls could resurrect an
- * orphan file.
+ * if the file does not exist at the existence gate (step 1) — callers decide
+ * whether to create it; this function never creates `path` on the absent-at-gate
+ * path. No-create is enforced at the gate, not at the commit: renameSync (step 3)
+ * creates its destination when absent, so an adopt-rename that removes `path` in
+ * the gate→rename window would let step 3 resurrect it. That window is narrow and
+ * requires a concurrent cross-process adopt; crash-atomicity (below) is the
+ * property this sequence guarantees, and that residual resurrection race is the
+ * accepted tradeoff for it — an in-place fd write would close the race but reopen
+ * the torn-write window this rewrite exists to remove.
  *
  * Sequence:
  *   1. Existence gate: openSync(path, "r+") proves `path` exists (ENOENT if not)
@@ -1008,7 +1013,8 @@ function typeFromStateFilename(filename: string): StateType | null {
  * that file's last genuine-activity timestamp.
  *
  * Read-modify-write, no lock: each iteration does read → parse → stamp →
- * writeFileNoCreate (truncate+write, no lock — see its own doc comment). This is
+ * writeFileNoCreate (temp-write + renameSync, crash-atomic, no lock — see its own
+ * doc comment). This is
  * only safe because the main thread is the sole writer of any given session state
  * file — the code review on PR #209 flagged this as a lost-update risk, and the
  * invariant that closes it is measured, not assumed: no agent definition under


### PR DESCRIPTION
## 배경

두 가지 간헐 장애의 근본을 수정한다.

1. **Codex `$explain-diff` PreToolUse 10s 타임아웃** — 서브에이전트 스폰 후 부모의 후속 Bash 툴콜마다 `hook timed out after 10s`가 반복됐다.
2. **ultragoal 상태 파일 간헐 삭제** — 최종 독립 리뷰가 1시간+ 걸릴 때 `ultragoal-state-<sid>.json`이 간헐적으로 사라졌다.

## 근본 원인 & 수정

### 1) OMT_DIR fork 경합 — cwd 캐시 (`8c01ef0b`)

Codex에는 `CLAUDE_ENV_FILE` 등가물이 없어 훅 서브프로세스 간 env가 영속되지 않는다. 그래서 매 Bash 툴콜마다 ~11개 훅이 각자 `git rev-parse`로 OMT_DIR을 재유도한다. 서브에이전트 동시 부하에서는 느림이 아니라 **process-creation starvation**으로 git fork가 10s 안에 끝나지 못해 균일하게 타임아웃(→ fail-open)된다.

`hooks/lib/omt-dir.sh`의 `compute_omt_dir`에 cwd-keyed 파일 캐시(`$HOME/.omt/.dir-cache`)를 도입해 히트 시 git fork를 제거한다. env early-return 뒤·git 유도 앞에 위치하며, 캐시 쓰기는 tmp+mv 원자적, 읽기는 `set -e` 소비자에서 EOF-무개행 abort를 막도록 가드했다.

### 2) 상태 쓰기 크래시-원자화 (`454cb939`)

`lib/state-core.ts`의 `writeFileNoCreate`가 open-r+ / ftruncate / write(truncate-in-place)라, 쓰기 도중 프로세스가 죽으면 0바이트·반쪽 파일이 남아 리더가 무효 JSON으로 읽는다. 이를 **temp-write + renameSync**로 재작성해 크래시 시 항상 옛 완전본 또는 새 완전본만 남게 했다. 특히 이 PR의 다른 절반이 유발하는 mid-write SIGKILL(타임아웃) 상황에서 torn-write를 차단한다. no-create 계약(부재 파일 ENOENT)은 존재 게이트에서 유지된다.

### 3) 리뷰 반영 — 계약·가정 주석 정정 (`f63905b1`)

독립 코드 검토 발견 3건을 반영한다(로직 무변·주석/docstring 한정):

- `writeFileNoCreate` docstring이 "existsSync-then-write TOCTOU를 제거한다"고 거짓 주장하던 것을 정정. temp+rename은 gate→rename 창에서 동시 cross-process adopt-rename이 `path`를 지우면 `renameSync`가 되살린다. no-create는 commit이 아니라 **gate에서만** 강제되며, 이 잔여 resurrection 경쟁은 crash-atomicity를 위한 용인된 트레이드오프임을 명시(흔한 mid-write kill을 막고 드문 동시 adopt만 노출).
- `state.ts`·`state-core.ts`의 stale 기술("single open-truncate-write"/"truncate+write")을 실제 구현으로 갱신.
- `omt-dir.sh` 캐시 블록에 무효화 부재 가정 명시 — git 지문 검증은 fork를 되살려 캐시 존재 이유를 무너뜨리므로 의도적 생략.

## 검증

- omt-dir: 10/10 + cache-safe-guard 3/3
- state-core: 120 pass + affected-scope 685 pass
- typecheck clean
- 독립 검토(code-reviewer): CONFIRMED·MEDIUM 1 + LOW 2 — 전부 위 3)에서 처리(MEDIUM은 트레이드오프 문서화로 proportionate 반영)

## 유보 (별건)

ultragoal 상태 삭제의 다른 축 — untracked 리뷰 job이 no-progress 카운터를 올려 `budget_limited`로 강등→30분 TTL→교차세션 reap을 부르는 가설 — 은 이 PR에 **포함하지 않는다**. 이미 main에 있는 breadcrumb 계측이 실사건을 포착해 `activeBackgroundTaskCount`=0을 확증한 뒤 착수한다. 추정만으로 TTL을 늘리면 두 결함을 가리므로 금지.

https://claude.ai/code/session_01KyeVkSc49FAPuzde4K2mfm
