### PR TITLE
chore: codex 0.149.0/0.149.1 버전 허용목록 추가

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,4 +19,4 @@ backup_retention_days: 3
 # Validated Codex CLI version allowlist. Codex auto-upgrades unpredictably, so
 # sync hard-fails against any version outside this probe-verified set instead
 # of pinning a single version (which would break every `make sync` on upgrade).
-codex-versions: ["0.144.1", "0.144.5", "0.145.0", "0.146.0", "0.146.1", "0.148.0"]
+codex-versions: ["0.144.1", "0.144.5", "0.145.0", "0.146.0", "0.146.1", "0.148.0", "0.149.0"]

--- a/config.yaml
+++ b/config.yaml
@@ -19,4 +19,4 @@ backup_retention_days: 3
 # Validated Codex CLI version allowlist. Codex auto-upgrades unpredictably, so
 # sync hard-fails against any version outside this probe-verified set instead
 # of pinning a single version (which would break every `make sync` on upgrade).
-codex-versions: ["0.144.1", "0.144.5", "0.145.0", "0.146.0", "0.146.1", "0.148.0", "0.149.0"]
+codex-versions: ["0.144.1", "0.144.5", "0.145.0", "0.146.0", "0.146.1", "0.148.0", "0.149.0", "0.149.1"]

--- a/tools/lib/codex-version.test.ts
+++ b/tools/lib/codex-version.test.ts
@@ -60,7 +60,7 @@ describe("assertCodexVersionIfTargeted (sync.ts entry-point wiring)", () => {
 		expect(fetchCalled).toBe(false);
 	});
 
-	it("positive control: real installed codex (probe-verified 0.149.0) is in the real allowlist -> resolves", async () => {
+	it("positive control: real installed codex (probe-verified 0.149.1) is in the real allowlist -> resolves", async () => {
 		// No fetchVersion override: exercises the real installed `codex` binary on
 		// PATH and the real config.yaml codex-versions allowlist.
 		await expect(

--- a/tools/lib/codex-version.test.ts
+++ b/tools/lib/codex-version.test.ts
@@ -60,7 +60,7 @@ describe("assertCodexVersionIfTargeted (sync.ts entry-point wiring)", () => {
 		expect(fetchCalled).toBe(false);
 	});
 
-	it("positive control: real installed codex (probe-verified 0.148.0) is in the real allowlist -> resolves", async () => {
+	it("positive control: real installed codex (probe-verified 0.149.0) is in the real allowlist -> resolves", async () => {
 		// No fetchVersion override: exercises the real installed `codex` binary on
 		// PATH and the real config.yaml codex-versions allowlist.
 		await expect(


### PR DESCRIPTION
## 개요

codex CLI가 `0.149.0` → `0.149.1`로 자동 업그레이드되며 `config.yaml`의
`codex-versions` allowlist를 벗어나 `make sync` 테스트 게이트가 하드 실패.
두 버전 모두 green arm probe로 실측 검증 후 허용.

## 검증

각 버전마다 green arm probe(`rules-runtime-leak-absence --arm=rewritten`)를
실제 codex 세션으로 실행 → `exit 0, verdict:"pass", leaked:[]`,
injectedContext 12177자(positive control 충족). rules 주입 파이프라인
정상 동작·금지 리터럴 무누출 확인.

## 변경

- `config.yaml`: `codex-versions`에 `0.149.0`, `0.149.1` 추가
- `tools/lib/codex-version.test.ts`: positive-control 테스트 라벨을 설치 버전에 맞춰 갱신

https://claude.ai/code/session_017vTKj31qgwbgq9bTv6iw7S