### PR TITLE
feat: explain-diff 변경·책임 축 재설계와 도메인·품질 강화

### DIFF
--- a/lib/explain-diff-structure.test.ts
+++ b/lib/explain-diff-structure.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { checkStructure, type DiffHunk } from "./explain-diff-structure";
 
-// v4 계약: 코드 섹션의 뼈대는 커밋이다. Change Group(관심사) 안에서 커밋 단위로
-// 내려가고(### `hash` — 제목), 커밋 아래 파일 블록(#### `file`)이 cf 컴포넌트로
-// 필드를 분리하며, 파일마다 핵심 로직 코드 펜스를 하나 둔다. 독립 Commit Journey는
-// 커밋을 그룹에 매핑하는 한 줄짜리 오버뷰로만 남는다.
+// v5 계약: 코드 섹션의 뼈대는 커밋이고, 단위는 파일이 아니라 변경(change)이다.
+// Change Group(관심사) 안에서 커밋 단위로 내려가고(### `hash` — 제목), 커밋 아래
+// 변경 블록(#### 변경 N: <한 일>)이 cf 컴포넌트로 필드를 분리한다. 한 변경은 여러
+// 책임(함께 바뀐 class·function) 항목으로 이뤄지고, 파일은 heading이 아니라 `바뀐 위치`
+// (cf-loc)의 위치 인용으로만 등장한다. R1 커버리지는 모든 signal 파일이 어느 변경 블록에든
+// 인용되는지를, R5는 그 인용이 실제 hunk에 드는지를, R13은 커밋 뼈대 + 변경당 코드 하나를 본다.
 const GOOD_GROUP = `## Change Group 1: 락을 공용 모듈로 뽑아낸다
 > 예고: 먼저 락 자체를 옮겨 놓아야 호출부 정리가 의미를 갖는다.
 > 순서: 추출이 먼저다 — 호출부를 먼저 고치면 가리킬 대상이 없다.
@@ -12,13 +14,13 @@ const GOOD_GROUP = `## Change Group 1: 락을 공용 모듈로 뽑아낸다
 ### \`ab12cd3\` — feat: 락을 공용 모듈로 추출
 이 커밋이 락 획득/해제를 한 파일로 모은다.
 
-#### \`lib/state-lock.ts\`
-<div class="cf">
-<p><strong>역할/변경 전</strong> — 이 파일은 새로 생겼다</p>
-<p><strong>바뀐 것</strong> — 락 획득/해제가 여기로 모였다</p>
-<p><strong>왜</strong> — 커밋 메시지가 통합이라고 적는다 <span class="cf-src">근거</span> "fix: 상태 갱신 락 통합"</p>
-<p><strong>효과</strong> — 두 CLI가 같은 락을 쓴다</p>
-<p class="cf-loc"><code>base:lib/state-lock.ts:0</code> → <code>head:lib/state-lock.ts:14</code></p>
+#### 변경 1: 락 획득·해제를 공용 모듈로 추출
+<div class="cf" data-change="new">
+<p><strong>책임 1 — 공용 락 유틸</strong> — <code>withLock()</code> (state 도메인의 락 유틸). 획득→실행→해제를 한 함수로 모은다.</p>
+<p><strong>왜</strong> — 두 CLI가 같은 락을 공유해야 하기 때문 <span class="cf-src">근거</span> "fix: 상태 갱신 락 통합"</p>
+<p><strong>효과·사이드이펙트</strong> — 두 CLI가 같은 락을 쓰므로 상태 파일 경쟁이 직렬화된다.</p>
+<p><strong>검증</strong> — state-lock.test.ts 가 동시 획득 직렬화를 고정한다.</p>
+<p class="cf-loc"><strong>바뀐 위치</strong> — <code>base:lib/state-lock.ts:0</code> → <code>head:lib/state-lock.ts:14</code></p>
 </div>
 
 \`\`\`ts
@@ -118,6 +120,9 @@ const GOAL = `## 목표
 
 ### 핵심
 코드를 보기 전에: 이 변경은 "도구 실행 준비"를 한 함수로 모은 작은 어댑터다.
+
+### 출처
+커밋 본문 "helper 복원"과 코드 추론.
 `;
 
 describe("goal 스텝 — R16만 평가", () => {
@@ -152,6 +157,14 @@ describe("goal 스텝 — R16만 평가", () => {
 		const doc = `# 설명\n\n${GOAL.replace(/### 무엇을·왜[\s\S]*?(?=### 핵심)/, "")}`;
 		const r = checkStructure(doc, { signalFiles: ["lib/state-lock.ts"], step: "goal" });
 		expect(r.items.find((i) => i.id === "R16")?.pass).toBe(false);
+	});
+
+	test("출처 슬롯이 빠지면 R16이 실패하고 그 슬롯을 사유에 담는다", () => {
+		const doc = `# 설명\n\n${GOAL.replace(/### 출처[\s\S]*$/, "")}`;
+		const r = checkStructure(doc, { signalFiles: ["lib/state-lock.ts"], step: "goal" });
+		const item = r.items.find((i) => i.id === "R16");
+		expect(item?.pass).toBe(false);
+		expect(item?.detail).toContain("출처");
 	});
 });
 
@@ -239,7 +252,7 @@ describe("code 스텝 — R2·R3·R5·R1(커버리지형)·R13", () => {
 		});
 		const item = r.items.find((i) => i.id === "R3");
 		expect(item?.pass).toBe(false);
-		expect(item?.detail).toContain("lib/state-lock.ts");
+		expect(item?.detail).toContain("변경 1");
 	});
 
 	test("추론 출처 태그도 R3를 통과시킨다", () => {
@@ -574,7 +587,7 @@ export function withLock() {}
 			expect(item?.detail).toContain("deadbee");
 		});
 
-		test("파일 블록에 핵심 로직 코드 펜스가 없으면 실패하고 그 파일을 담는다", () => {
+		test("변경 블록에 핵심 로직 코드 펜스가 없으면 실패하고 그 변경을 담는다", () => {
 			const body = GOOD_GROUP.replace(/```ts[\s\S]*?```/, "");
 			const r = checkStructure(withBackground(body), {
 				signalFiles: ["lib/state-lock.ts"],
@@ -583,11 +596,11 @@ export function withLock() {}
 			});
 			const item = r.items.find((i) => i.id === "R13");
 			expect(item?.pass).toBe(false);
-			expect(item?.detail).toContain("lib/state-lock.ts");
+			expect(item?.detail).toContain("변경 1");
 		});
 	});
 
-	describe("R1 커버리지형 — signal 파일이 파일 블록으로 정확히 한 번", () => {
+	describe("R1 커버리지형 — signal 파일이 어느 변경 블록엔가 인용된다", () => {
 		test("signal 파일이 Evidence 표에만 있고 파일 블록이 없으면 실패하고 경로를 담는다", () => {
 			const body = `## Evidence
 
@@ -622,19 +635,22 @@ const x = 1;
 			expect(item?.detail).toContain("lib/state-lock.ts");
 		});
 
-		test("같은 signal 파일 블록이 두 그룹에 각각 있으면 실패하고 중복임을 밝힌다", () => {
+		test("같은 signal 파일이 두 변경 블록에 인용돼도 통과한다 — 한 파일은 여러 변경에 참여할 수 있다", () => {
 			const duplicated = `${GOOD_GROUP}
 ## Change Group 2: 같은 파일을 또 다룬다
-> 예고: 같은 파일이 다시 등장한다.
+> 예고: 같은 파일이 다른 변경에서 다시 등장한다.
 > 순서: 두 번째 손질이 필요하다.
 
 ### \`ef45ab6\` — fix: 두 번째 손질
-같은 파일을 다시 만진다.
+같은 파일을 다른 이유로 다시 만진다.
 
-#### \`lib/state-lock.ts\`
-<div class="cf">
-<p><strong>왜</strong> — <span class="cf-src">근거</span> "두 번째 이유"</p>
-<p class="cf-loc"><code>base:lib/state-lock.ts:14</code> → <code>head:lib/state-lock.ts:20</code></p>
+#### 변경 2: 락 해제 타임아웃을 추가
+<div class="cf" data-change="mod">
+<p><strong>책임 1 — 락 해제</strong> — <code>withLock()</code> (state 도메인의 락 유틸). 해제에 타임아웃을 건다.</p>
+<p><strong>왜</strong> — 데드락 방지 <span class="cf-src">근거</span> "fix: 락 해제 타임아웃"</p>
+<p><strong>효과·사이드이펙트</strong> — 무한 대기 대신 타임아웃으로 실패한다.</p>
+<p><strong>검증</strong> — state-lock.test.ts 가 타임아웃 경로를 고정한다.</p>
+<p class="cf-loc"><strong>바뀐 위치</strong> — <code>base:lib/state-lock.ts:14</code> → <code>head:lib/state-lock.ts:20</code></p>
 </div>
 
 \`\`\`ts
@@ -646,10 +662,7 @@ const y = 2;
 				step: "code",
 				commitHashes: ["ab12cd3f00", "ef45ab6c11"],
 			});
-			const item = r.items.find((i) => i.id === "R1");
-			expect(item?.pass).toBe(false);
-			expect(item?.detail).toContain("lib/state-lock.ts");
-			expect(item?.detail).toContain("중복");
+			expect(r.items.find((i) => i.id === "R1")?.pass).toBe(true);
 		});
 
 		test("signal 파일이 하나도 없으면 통과가 아니다 — 빈 집합 공허참 차단", () => {
@@ -659,6 +672,52 @@ const y = 2;
 				commitHashes: ["ab12cd3f00"],
 			});
 			expect(r.items.find((i) => i.id === "R1")?.pass).toBe(false);
+		});
+
+		test("한 변경 블록이 여러 파일을 인용하면 그 파일들이 모두 커버된다 — 책임 묶음", () => {
+			// 하나의 변경이 함께 바뀐 두 책임(서로 다른 파일)으로 이뤄진다. 두 파일 모두
+			// 한 변경 블록의 cf-loc에 인용되므로 R1 커버리지를 통과해야 한다(파일당 1블록 강제 없음).
+			const grouped = `## Change Group 1: category 읽기로 전환
+> 예고: 읽기 경계를 category로 옮긴다.
+> 순서: 어댑터가 먼저다.
+
+### \`ab12cd3\` — refactor: category 읽기
+
+#### 변경 1: v2 제안 읽기를 category 정본으로만 조립
+<div class="cf" data-change="mod">
+<p><strong>책임 1 — 읽기 입구</strong> — <code>Adapter.read_v2()</code> (인프라 어댑터). product를 읽지 않는다.</p>
+<p><strong>책임 2 — 조립·실패</strong> — <code>compose()</code> (도메인 유틸). 없으면 NotFoundError.</p>
+<p><strong>왜</strong> — 정체성 기준을 category로 <span class="cf-src">근거</span> "refactor: category 읽기"</p>
+<p><strong>효과·사이드이펙트</strong> — 누락이 조용한 성공 대신 명시적 실패로 드러난다.</p>
+<p><strong>검증</strong> — read_v2.test 가 누락 시 실패를 고정한다.</p>
+<p class="cf-loc"><strong>바뀐 위치</strong> — <code>base:app/adapter.py:170</code> → <code>head:app/adapter.py:183</code>, <code>base:app/compose.py:40</code> → <code>head:app/compose.py:31</code></p>
+</div>
+
+\`\`\`py
+if not mirror:
+    raise NotFoundError()
+\`\`\`
+`;
+			const r = checkStructure(withBackground(grouped), {
+				signalFiles: ["app/adapter.py", "app/compose.py"],
+				step: "code",
+				commitHashes: ["ab12cd3f00"],
+			});
+			expect(r.items.find((i) => i.id === "R1")?.pass).toBe(true);
+			expect(r.items.find((i) => i.id === "R5")?.pass).toBe(true);
+			expect(r.items.find((i) => i.id === "R13")?.pass).toBe(true);
+		});
+
+		test("변경 블록이 인용하지 않은 signal 파일은 R1이 잡아낸다", () => {
+			// 두 파일이 signal인데 변경 블록이 한 파일만 인용하면, 빠진 파일을 사유에 담아 실패한다.
+			const r = checkStructure(withBackground(GOOD_GROUP), {
+				signalFiles: ["lib/state-lock.ts", "lib/forgotten.ts"],
+				step: "code",
+				commitHashes: ["ab12cd3f00"],
+			});
+			const item = r.items.find((i) => i.id === "R1");
+			expect(item?.pass).toBe(false);
+			expect(item?.detail).toContain("lib/forgotten.ts");
 		});
 
 		test("헤딩 백틱 뒤 괄호 주석(삭제·이동 표기)이 붙어도 파일 블록으로 센다", () => {
@@ -735,6 +794,18 @@ flowchart LR
 
 ### 경계·의존·유스케이스
 
+유스케이스: 표시 카탈로그 조회 흐름. 아래 시퀀스의 backend 조회 단계가 이 diff로 바뀐다.
+
+\`\`\`mermaid
+sequenceDiagram
+  participant Card as card
+  participant Resolver as resolver
+  participant Backend as Hono backend
+  Card->>Resolver: resolveDisplay(code)
+  Resolver->>Backend: GET /v1/supplement-catalog
+  Backend-->>Resolver: 표시 카탈로그
+\`\`\`
+
 <div class="arch-entity" data-change="new">
 <p><strong>이름</strong> display catalog 조회</p>
 <p><strong>한 일</strong> 삭제 포함 표시 카탈로그 경로 신설</p>
@@ -751,7 +822,7 @@ describe("architecture 스텝 — R9·R14·R15·R17·R18·R19", () => {
 			step: "architecture",
 		});
 		const ids = r.items.map((i) => i.id as string);
-		for (const id of ["R9", "R14", "R15", "R17", "R18", "R19"]) {
+		for (const id of ["R9", "R14", "R15", "R17", "R18", "R19", "R21"]) {
 			expect(ids).toContain(id);
 		}
 		expect(r.pass).toBe(true);
@@ -1040,6 +1111,120 @@ describe("architecture 스텝 — R9·R14·R15·R17·R18·R19", () => {
 		const item = r.items.find((i) => i.id === "R14");
 		expect(item?.pass).toBe(false);
 		expect(item?.detail).toContain("DB 스키마");
+	});
+
+	// R15 — 유스케이스 블록은 오케스트레이션을 다이어그램으로 보여야 한다(정적 카드가 아니라 흐름).
+	test("경계·유스케이스 블록에 오케스트레이션 다이어그램이 없으면 R15가 실패한다", () => {
+		const doc = withBackground(ARCH_OK.replace(/```mermaid\nsequenceDiagram[\s\S]*?```\n\n/, ""));
+		const item = checkStructure(doc, { signalFiles: ["a.ts"], step: "architecture" }).items.find(
+			(i) => i.id === "R15",
+		);
+		expect(item?.pass).toBe(false);
+		expect(item?.detail).toContain("오케스트레이션");
+	});
+
+	test("유스케이스 흐름이 정말 안 바뀌면 사유 있는 waiver로 R15 오케스트레이션을 대신할 수 있다", () => {
+		const doc = withBackground(
+			ARCH_OK.replace(
+				/유스케이스: 표시 카탈로그 조회 흐름[\s\S]*?```\n/,
+				"구조 변화 없음: 이 diff는 유스케이스 흐름을 바꾸지 않는다.\n",
+			),
+		);
+		const item = checkStructure(doc, { signalFiles: ["a.ts"], step: "architecture" }).items.find(
+			(i) => i.id === "R15",
+		);
+		expect(item?.pass).toBe(true);
+	});
+
+	// R21 — 도메인 레벨은 다이어그램만이 아니라 엔티티 카드(책임·변경종류)를 요구한다.
+	test("도메인 레벨이 waiver면 R21을 통과한다", () => {
+		const item = checkStructure(withBackground(ARCH_OK), {
+			signalFiles: ["a.ts"],
+			step: "architecture",
+		}).items.find((i) => i.id === "R21");
+		expect(item?.pass).toBe(true);
+	});
+
+	test("도메인 레벨에 다이어그램만 있고 엔티티 카드도 waiver도 없으면 R21이 실패한다", () => {
+		const doc = withBackground(
+			ARCH_OK.replace(
+				"### 도메인 레벨\n구조 변화 없음: 엔티티 관계는 이 diff에서 바뀌지 않는다.",
+				"### 도메인 레벨\n```mermaid\nclassDiagram\n  class SupplementCategory\n```",
+			),
+		);
+		const item = checkStructure(doc, { signalFiles: ["a.ts"], step: "architecture" }).items.find(
+			(i) => i.id === "R21",
+		);
+		expect(item?.pass).toBe(false);
+		expect(item?.detail).toContain("책임");
+	});
+
+	test("도메인 엔티티 카드가 책임·변경종류를 갖추면 R21을 통과한다", () => {
+		const doc = withBackground(
+			ARCH_OK.replace(
+				"### 도메인 레벨\n구조 변화 없음: 엔티티 관계는 이 diff에서 바뀌지 않는다.",
+				`### 도메인 레벨
+\`\`\`mermaid
+classDiagram
+  class SupplementCategory {
+    +code: string
+    +displayName: string
+    +isActive() bool
+  }
+\`\`\`
+
+<div class="arch-entity" data-change="new">
+<p><strong>이름</strong> <code>SupplementCategory</code></p>
+<p><strong>책임</strong> 영양제의 canonical 정체성을 보유하고, 상품 교체와 무관하게 유지된다</p>
+</div>`,
+			),
+		);
+		const item = checkStructure(doc, { signalFiles: ["a.ts"], step: "architecture" }).items.find(
+			(i) => i.id === "R21",
+		);
+		expect(item?.pass).toBe(true);
+	});
+
+	// R18/R21 — 다이어그램 노드는 컴포넌트/도메인 이름이지 파일 경로가 아니다.
+	// 실측(luna max): 컴포넌트 다이어그램 노드가 전체 파일 경로라 화면에서 중간이
+	// 잘렸다(`health-`, `proposal-`). 위치는 카드의 레이어 슬롯이 말한다.
+	test("컴포넌트 다이어그램 노드가 파일 경로면 R18이 실패한다", () => {
+		const doc = withBackground(
+			ARCH_OK.replace(
+				"flowchart LR\n  card --> resolver",
+				'flowchart LR\n  a["apps/backend/src/domains/health-profiles/routers/health-v2.router.ts"] --> b["packages/schemas/src/program/proposal-request-v2.ts"]',
+			),
+		);
+		const item = checkStructure(doc, { signalFiles: ["a.ts"], step: "architecture" }).items.find(
+			(i) => i.id === "R18",
+		);
+		expect(item?.pass).toBe(false);
+		expect(item?.detail).toContain("파일 경로");
+	});
+
+	test("도메인 객체 다이어그램의 클래스 박스가 비어 있으면 R21이 실패한다", () => {
+		const doc = withBackground(
+			ARCH_OK.replace(
+				"### 도메인 레벨\n구조 변화 없음: 엔티티 관계는 이 diff에서 바뀌지 않는다.",
+				`### 도메인 레벨
+\`\`\`mermaid
+classDiagram
+  class SupplementCategory
+  class Supplement
+  SupplementCategory --> Supplement
+\`\`\`
+
+<div class="arch-entity" data-change="new">
+<p><strong>이름</strong> <code>SupplementCategory</code></p>
+<p><strong>책임</strong> canonical 정체성 보유</p>
+</div>`,
+			),
+		);
+		const item = checkStructure(doc, { signalFiles: ["a.ts"], step: "architecture" }).items.find(
+			(i) => i.id === "R21",
+		);
+		expect(item?.pass).toBe(false);
+		expect(item?.detail).toContain("멤버");
 	});
 });
 

--- a/lib/explain-diff-structure.test.ts
+++ b/lib/explain-diff-structure.test.ts
@@ -269,7 +269,7 @@ describe("code 스텝 — R2·R3·R5·R1(커버리지형)·R13", () => {
 	});
 
 	test("코드 펜스 주석 안의 왜 단어는 R3의 출처 판정에 새지 않는다", () => {
-		// 핵심 로직 코드 펜스에 `// 왜냐하면` 같은 주석이 있어도, 파일 블록의 진짜
+		// 핵심 로직 코드 펜스에 `// 왜냐하면` 같은 주석이 있어도, 변경 블록의 진짜
 		// 왜 필드에 출처 태그가 없으면 실패해야 한다 — 펜스를 벗겨내고 판정한다.
 		const body = GOOD_GROUP.replace(
 			/<p><strong>왜<\/strong>.*<\/p>/,
@@ -301,7 +301,7 @@ describe("code 스텝 — R2·R3·R5·R1(커버리지형)·R13", () => {
 ### \`ab12cd3\` — feat: 락 도입
 동시 작성자 두 명을 막는 락을 새로 넣는다.
 
-#### \`lib/state-lock.ts\`
+#### 변경 1: 락을 도입한다
 <div class="cf">
 <p><strong>역할/변경 전</strong> — 이 파일은 새로 생겼다</p>
 <p><strong>바뀐 것</strong> — 락 획득/해제를 새로 넣었다</p>
@@ -336,7 +336,7 @@ export function withLock() {}
 ### \`ef45ab6\` — chore: 이미지 메타데이터 갱신
 비텍스트 파일은 텍스트 hunk가 없다.
 
-#### \`${fallbackPath}\`
+#### 변경 2: 비텍스트 파일 위치를 기록한다
 <div class="cf">
 <p class="cf-loc"><code>base:${fallbackPath}:12</code> → <code>head:${fallbackPath}:20</code></p>
 </div>
@@ -360,7 +360,7 @@ binary placeholder
 		expect(r.items.find((i) => i.id === "R5")?.pass).toBe(true);
 	});
 
-	test("공백이 있는 경로의 strict·fallback 앵커는 파일 블록 경로와 일치하면 통과한다", () => {
+	test("공백이 있는 경로의 strict·fallback 앵커는 변경 블록 위치와 일치하면 통과한다", () => {
 		const strictPath = "src/strict file.ts";
 		const fallbackPath = "assets/mode only file.bin";
 		const strict = GOOD_GROUP.replace(/lib\/state-lock\.ts/g, strictPath).replace(
@@ -374,7 +374,7 @@ binary placeholder
 ### \`ef45ab6\` — chore: 공백 경로 기록
 공백이 있는 비텍스트 경로다.
 
-#### \`${fallbackPath}\`
+#### 변경 2: 공백 경로의 위치를 기록한다
 <div class="cf">
 <p class="cf-loc"><code>base:${fallbackPath}:12</code> → <code>head:${fallbackPath}:20</code></p>
 </div>
@@ -486,7 +486,7 @@ binary placeholder
 ### \`ab12cd3\` — feat: 락 도입
 동시 작성자 두 명을 막는 락을 새로 넣는다.
 
-#### \`lib/state-lock.ts\`
+#### 변경 1: 락을 도입한다
 <div class="cf">
 <p><strong>역할/변경 전</strong> — 이 파일은 새로 생겼다</p>
 <p><strong>바뀐 것</strong> — 락 획득/해제를 새로 넣었다</p>
@@ -548,9 +548,9 @@ export function withLock() {}
 		expect(r.items.find((i) => i.id === "R5")?.pass).toBe(true);
 	});
 
-	describe("R13 — 커밋이 그룹의 뼈대이고 파일마다 핵심 로직 코드가 있다", () => {
+	describe("R13 — 커밋이 그룹의 뼈대이고 변경마다 핵심 로직 코드가 있다", () => {
 		test("그룹에 커밋 서브섹션이 하나도 없으면 실패한다", () => {
-			// 파일 블록을 그룹 바로 아래 두고 커밋 서브섹션을 생략한 옛 평면 구조.
+			// 변경 블록을 그룹 바로 아래 두고 커밋 서브섹션을 생략한 옛 평면 구조.
 			const flat = `## Change Group 1: 락 추출
 > 예고: 락을 옮긴다.
 > 순서: 추출이 먼저다.
@@ -720,7 +720,7 @@ if not mirror:
 			expect(item?.detail).toContain("lib/forgotten.ts");
 		});
 
-		test("헤딩 백틱 뒤 괄호 주석(삭제·이동 표기)이 붙어도 파일 블록으로 센다", () => {
+		test("v4 파일 블록은 변경 블록으로 인식하지 않아 code 스텝이 실패한다", () => {
 			const annotated = `## Change Group 1: 테스트 계약 교체
 > 예고: 옛 계약 테스트를 지운다.
 > 순서: 복원 코드가 먼저 있어야 한다.
@@ -743,7 +743,9 @@ v1 복원으로 사라진 404 계약 테스트를 지운다.
 				step: "code",
 				commitHashes: ["ab12cd3f00"],
 			});
-			expect(r.items.find((i) => i.id === "R1")?.pass).toBe(true);
+			expect(r.pass).toBe(false);
+			expect(r.items.find((i) => i.id === "R1")?.pass).toBe(false);
+			expect(r.items.find((i) => i.id === "R1")?.detail).toContain("tests/api/removed_routes.py");
 		});
 	});
 });
@@ -1226,6 +1228,33 @@ classDiagram
 		expect(item?.pass).toBe(false);
 		expect(item?.detail).toContain("멤버");
 	});
+
+	test("classDiagram의 한 클래스가 채워져도 다른 빈 클래스 박스를 가리지 못한다", () => {
+		const doc = withBackground(
+			ARCH_OK.replace(
+				"### 도메인 레벨\n구조 변화 없음: 엔티티 관계는 이 diff에서 바뀌지 않는다.",
+				`### 도메인 레벨
+\`\`\`mermaid
+classDiagram
+  class SupplementCategory {
+    +code: string
+  }
+  class Supplement
+  SupplementCategory --> Supplement
+\`\`\`
+
+<div class="arch-entity" data-change="new">
+<p><strong>이름</strong> <code>SupplementCategory</code></p>
+<p><strong>책임</strong> canonical 정체성 보유</p>
+</div>`,
+			),
+		);
+		const item = checkStructure(doc, { signalFiles: ["a.ts"], step: "architecture" }).items.find(
+			(i) => i.id === "R21",
+		);
+		expect(item?.pass).toBe(false);
+		expect(item?.detail).toContain("멤버");
+	});
 });
 
 const OVERVIEW = `## Commit Journey
@@ -1392,7 +1421,7 @@ describe("게이트 이완 보강 — R3 배지 형식·R13 코드 펜스", () =
 		expect(r.items.find((i) => i.id === "R3")?.pass).toBe(false);
 	});
 
-	test("R13 — 파일 블록의 유일한 펜스가 mermaid면 핵심 로직 코드로 인정되지 않는다", () => {
+	test("R13 — 변경 블록의 유일한 펜스가 mermaid면 핵심 로직 코드로 인정되지 않는다", () => {
 		const body = GOOD_GROUP.replace(
 			/```ts[\s\S]*?```/,
 			"```mermaid\nflowchart LR\n  A --> B\n```",

--- a/lib/explain-diff-structure.test.ts
+++ b/lib/explain-diff-structure.test.ts
@@ -166,6 +166,25 @@ describe("goal 스텝 — R16만 평가", () => {
 		expect(item?.pass).toBe(false);
 		expect(item?.detail).toContain("출처");
 	});
+
+	test("출처 헤딩만 있고 내용이 비어 있으면 R16이 실패한다", () => {
+		const doc = `# 설명
+
+## 목표
+
+### 무엇을·왜
+상태 갱신 경합을 없앤다.
+
+### 핵심
+락 획득과 해제를 공용 함수로 모은다.
+
+### 출처
+`;
+		const r = checkStructure(doc, { signalFiles: ["lib/state-lock.ts"], step: "goal" });
+		const item = r.items.find((i) => i.id === "R16");
+		expect(item?.pass).toBe(false);
+		expect(item?.detail).toContain("출처");
+	});
 });
 
 describe("intuition 스텝 — 고유 구조 항목 없음 (공통 R11만)", () => {
@@ -1125,6 +1144,20 @@ describe("architecture 스텝 — R9·R14·R15·R17·R18·R19", () => {
 		expect(item?.detail).toContain("오케스트레이션");
 	});
 
+	test("경계 블록의 비오케스트레이션 Mermaid는 R15를 통과시키지 않는다", () => {
+		const doc = withBackground(
+			ARCH_OK.replace(
+				/```mermaid\nsequenceDiagram[\s\S]*?```\n\n/,
+				"```mermaid\nclassDiagram\n  class Boundary\n```\n\n",
+			),
+		);
+		const item = checkStructure(doc, { signalFiles: ["a.ts"], step: "architecture" }).items.find(
+			(i) => i.id === "R15",
+		);
+		expect(item?.pass).toBe(false);
+		expect(item?.detail).toContain("오케스트레이션");
+	});
+
 	test("유스케이스 흐름이 정말 안 바뀌면 사유 있는 waiver로 R15 오케스트레이션을 대신할 수 있다", () => {
 		const doc = withBackground(
 			ARCH_OK.replace(
@@ -1240,6 +1273,30 @@ classDiagram
     +code: string
   }
   class Supplement
+  SupplementCategory --> Supplement
+\`\`\`
+
+<div class="arch-entity" data-change="new">
+<p><strong>이름</strong> <code>SupplementCategory</code></p>
+<p><strong>책임</strong> canonical 정체성 보유</p>
+</div>`,
+			),
+		);
+		const item = checkStructure(doc, { signalFiles: ["a.ts"], step: "architecture" }).items.find(
+			(i) => i.id === "R21",
+		);
+		expect(item?.pass).toBe(false);
+		expect(item?.detail).toContain("멤버");
+	});
+
+	test("관계로 암시된 빈 class도 R21에서 검사한다", () => {
+		const doc = withBackground(
+			ARCH_OK.replace(
+				"### 도메인 레벨\n구조 변화 없음: 엔티티 관계는 이 diff에서 바뀌지 않는다.",
+				`### 도메인 레벨
+\`\`\`mermaid
+classDiagram
+  SupplementCategory : +code: string
   SupplementCategory --> Supplement
 \`\`\`
 

--- a/lib/explain-diff-structure.test.ts
+++ b/lib/explain-diff-structure.test.ts
@@ -1237,6 +1237,33 @@ classDiagram
 		expect(item?.detail).toContain("파일 경로");
 	});
 
+	test("컴포넌트 다이어그램 edge label·note·comment의 파일 경로는 R18 노드 경로가 아니다", () => {
+		const doc = withBackground(
+			ARCH_OK.replace(
+				"flowchart LR\n  card --> resolver",
+				"flowchart LR\n%% reads src/comment.ts\n  card -->|reads src/config.ts| resolver\n  Note right of card: src/note.ts",
+			),
+		);
+		const item = checkStructure(doc, { signalFiles: ["a.ts"], step: "architecture" }).items.find(
+			(i) => i.id === "R18",
+		);
+		expect(item?.pass).toBe(true);
+	});
+
+	test("루트 파일명이 컴포넌트 다이어그램 노드면 R18이 실패한다", () => {
+		const doc = withBackground(
+			ARCH_OK.replace(
+				"flowchart LR\n  card --> resolver",
+				"flowchart LR\n  package.json --> resolver",
+			),
+		);
+		const item = checkStructure(doc, { signalFiles: ["a.ts"], step: "architecture" }).items.find(
+			(i) => i.id === "R18",
+		);
+		expect(item?.pass).toBe(false);
+		expect(item?.detail).toContain("파일 경로");
+	});
+
 	test("도메인 객체 다이어그램의 클래스 박스가 비어 있으면 R21이 실패한다", () => {
 		const doc = withBackground(
 			ARCH_OK.replace(
@@ -1304,6 +1331,22 @@ classDiagram
 <p><strong>이름</strong> <code>SupplementCategory</code></p>
 <p><strong>책임</strong> canonical 정체성 보유</p>
 </div>`,
+			),
+		);
+		const item = checkStructure(doc, { signalFiles: ["a.ts"], step: "architecture" }).items.find(
+			(i) => i.id === "R21",
+		);
+		expect(item?.pass).toBe(false);
+		expect(item?.detail).toContain("멤버");
+	});
+
+	test("공백 없는 class 관계의 암시된 빈 class도 R21에서 검사한다", () => {
+		const domainSection =
+			"### 도메인 레벨\n```mermaid\nclassDiagram\n  Populated : +id: string\n  Populated-->Empty\n```\n\n<div class=\"arch-entity\" data-change=\"new\">\n<p><strong>이름</strong> <code>Populated</code></p>\n<p><strong>책임</strong> canonical 정체성 보유</p>\n</div>";
+		const doc = withBackground(
+			ARCH_OK.replace(
+				"### 도메인 레벨\n구조 변화 없음: 엔티티 관계는 이 diff에서 바뀌지 않는다.",
+				domainSection,
 			),
 		);
 		const item = checkStructure(doc, { signalFiles: ["a.ts"], step: "architecture" }).items.find(

--- a/lib/explain-diff-structure.ts
+++ b/lib/explain-diff-structure.ts
@@ -346,6 +346,16 @@ const GOAL_SLOTS = [
 	{ label: "출처", re: /^###\s*출처/m },
 ] as const;
 
+function goalSlotHasContent(slice: string, slot: (typeof GOAL_SLOTS)[number]): boolean {
+	const heading = slot.re.exec(slice);
+	if (heading === null) return false;
+	const lineEnd = slice.indexOf("\n", heading.index);
+	const bodyStart = lineEnd >= 0 ? lineEnd + 1 : slice.length;
+	const nextHeading = slice.slice(bodyStart).search(/^#{1,3}\s/m);
+	const bodyEnd = nextHeading >= 0 ? bodyStart + nextHeading : slice.length;
+	return /\S/.test(slice.slice(bodyStart, bodyEnd));
+}
+
 // R16 — the goal / core-message beat, authored before any architecture or code.
 // Measured gap: the document jumped from Background straight to Architecture with
 // no statement of what the change is for or its one-line takeaway, so a reader met
@@ -363,7 +373,7 @@ function checkR16(text: string): CheckItem {
 			detail: "## 목표 섹션이 없습니다 — 코드 전에 이 변경의 목표와 핵심 한 줄을 먼저 전달하세요.",
 		};
 	}
-	const missing = GOAL_SLOTS.filter((s) => !s.re.test(slice)).map((s) => s.label);
+	const missing = GOAL_SLOTS.filter((s) => !goalSlotHasContent(slice, s)).map((s) => s.label);
 	return {
 		id: "R16",
 		title: "R16 목표·핵심 전달",
@@ -557,20 +567,32 @@ function diagramFilePathNodes(rawSlice: string): boolean {
 // A domain object diagram (`classDiagram`) drawn with empty class bodies is an
 // opaque box. Measured gap: the domain classDiagram showed only class names with
 // no members or methods, so a reader could not tell what each object holds or
-// does. Every declared class must carry at least one member/method — either in
-// its `{ ... }` body or in a `Class : +field` declaration.
+// does. Every rendered class must carry at least one member/method — explicit
+// declarations, relationship endpoints, and `Class : +field` declarations all
+// create class boxes in Mermaid.
 function classDiagramMissingMembers(rawSlice: string): boolean {
 	const fences = mermaidFences(rawSlice).filter((f) => /\bclassDiagram\b/.test(f));
 	if (fences.length === 0) return false;
 	return fences.some((fence) => {
 		const lines = fence.split(/\r?\n/);
-		const colonMembers = new Set<string>();
+		const classes = new Map<string, boolean>();
+		const declareClass = (name: string, hasMember = false): void => {
+			classes.set(name, (classes.get(name) ?? false) || hasMember);
+		};
+
 		for (const line of lines) {
 			const member = line.match(/^\s*([A-Za-z_][\w-]*)\s*:\s*[+\-#~]?\s*\S/);
-			if (member?.[1] !== undefined) colonMembers.add(member[1]);
+			if (member?.[1] !== undefined) declareClass(member[1], true);
+
+			const relationship = line.match(
+				/^\s*([A-Za-z_][\w-]*)\s+(?:["'][^"']*["']\s+)?[<|>*o.-]{2,}(?:\s+["'][^"']*["'])?\s+([A-Za-z_][\w-]*)\b/,
+			);
+			if (relationship?.[1] !== undefined && relationship[2] !== undefined) {
+				declareClass(relationship[1]);
+				declareClass(relationship[2]);
+			}
 		}
 
-		const classes: boolean[] = [];
 		for (let index = 0; index < lines.length; index += 1) {
 			const declaration = lines[index]?.match(/^\s*class\s+([A-Za-z_][\w-]*)\b(.*)$/);
 			if (declaration?.[1] === undefined) continue;
@@ -579,14 +601,14 @@ function classDiagramMissingMembers(rawSlice: string): boolean {
 			const tail = declaration[2] ?? "";
 			const openBrace = tail.indexOf("{");
 			if (openBrace < 0) {
-				classes.push(colonMembers.has(name));
+				declareClass(name);
 				continue;
 			}
 
 			const sameLineBody = tail.slice(openBrace + 1);
 			const closeBrace = sameLineBody.indexOf("}");
 			if (closeBrace >= 0) {
-				classes.push(sameLineBody.slice(0, closeBrace).trim().length > 0);
+				declareClass(name, sameLineBody.slice(0, closeBrace).trim().length > 0);
 				continue;
 			}
 
@@ -601,10 +623,10 @@ function classDiagramMissingMembers(rawSlice: string): boolean {
 					hasMember = true;
 				}
 			}
-			classes.push(hasMember);
+			declareClass(name, hasMember);
 		}
 
-		return classes.length > 0 && classes.some((hasMember) => !hasMember);
+		return classes.size > 0 && [...classes.values()].some((hasMember) => !hasMember);
 	});
 }
 
@@ -706,7 +728,9 @@ function checkR15(text: string): CheckItem {
 	// The orchestration must be a real diagram, not prose — the flow (call order,
 	// changed step) is shown, not narrated. A reasoned waiver stands in when the
 	// diff genuinely changes no use-case flow.
-	const hasOrchestration = /```mermaid/.test(rawSlice) || ARCH_WAIVER.test(rawSlice);
+	const hasOrchestration =
+		mermaidFences(rawSlice).some((fence) => /^\s*sequenceDiagram\b/m.test(fence)) ||
+		ARCH_WAIVER.test(rawSlice);
 	if (!hasOrchestration) missing.push("오케스트레이션 다이어그램(mermaid sequenceDiagram)");
 	return {
 		id: "R15",

--- a/lib/explain-diff-structure.ts
+++ b/lib/explain-diff-structure.ts
@@ -1,5 +1,5 @@
 /**
- * explain-diff structural checks — rubric items R1..R5, R9..R11, R13..R19.
+ * explain-diff structural checks — rubric items R1..R5, R9..R11, R13..R19, R21.
  *
  * These are the half of the rubric a script can decide, and the split is
  * deliberate (see skills/explain-diff/references/rubric.md): absence is
@@ -10,10 +10,16 @@
  * Each check looks for a named slot; a section that fills the slots passes, and
  * one that does not names the missing slot back to the author.
  *
- * v4 spine: the code section is organized by COMMIT. A Change Group (concern)
- * holds commit subsections (`### \`hash\` — title`), each commit holds file
- * blocks (`#### \`file\``), and each file block separates its fields with the
- * `cf` component and carries one core-logic code fence. R13 enforces that spine.
+ * v5 spine: the code section is organized by COMMIT, and its unit is the CHANGE,
+ * not the file. A Change Group (concern) holds commit subsections
+ * (`### \`hash\` — title`), each commit holds change blocks (`#### 변경 N: <한 일>`),
+ * and each change block separates its fields with the `cf` component — one or
+ * more `책임`(responsibility) entries naming the class/function touched, plus
+ * 왜/효과/검증 at the change level — and carries one core-logic code fence. The
+ * file appears only as a location citation inside the `cf-loc` slot, never as the
+ * block heading. R1 coverage therefore checks that every signal file is CITED by
+ * some change block's location anchors, R5 that those anchors land in real hunks,
+ * and R13 the commit spine + one code fence per change block.
  *
  * The document is written incrementally, one step at a time, so a rubric item
  * only ever has its slot filled once the step that owns it has been reached.
@@ -72,7 +78,8 @@ export interface CheckItem {
 		| "R16"
 		| "R17"
 		| "R18"
-		| "R19";
+		| "R19"
+		| "R21";
 	title: string;
 	pass: boolean;
 	detail: string;
@@ -86,9 +93,9 @@ export interface StructureResult {
 }
 
 const GROUP_HEADING = /^##\s+Change Group\s+\d+\s*:\s*\S.*$/gm;
-// 파일 블록은 h4다 — h3(### `hash` — 제목)은 커밋 서브섹션이라 파일이 아니다.
-// 백틱 뒤 괄호 주석(`(삭제)`, `(→ 새 경로)` 등)은 정당한 표기 — 경로 캡처에서 제외하고 허용.
-const FILE_BLOCK = /^####\s+`([^`]+)`(?:\s+\([^)]*\))?\s*$/gm;
+// 변경 블록은 h4 `#### 변경 N: <한 일>` — 파일이 아니라 변경이 단위다.
+// (h3 `### `hash` — 제목`은 커밋 서브섹션이라 변경 블록이 아니다.) 헤딩 텍스트를 캡처한다.
+const CHANGE_BLOCK = /^####\s+(\S.*?)\s*$/gm;
 // 커밋 서브섹션: h3 헤딩의 백틱 안 16진 해시.
 const COMMIT_SUBSECTION = /^###\s+`([0-9a-fA-F]{6,40})`/gm;
 
@@ -160,22 +167,46 @@ function withoutMarkdownCode(text: string): string {
 	return withoutFencedCode(text).replace(/`+[^`\n]*`+/g, "");
 }
 
-/** The slice of `text` belonging to one file block: from its heading to the next heading. */
-function fileBlocks(text: string): Array<{ path: string; body: string }> {
+/** The slice of `text` belonging to one change block: from its `#### ` heading to the next heading. */
+function changeBlocks(text: string): Array<{ heading: string; body: string }> {
 	const masked = maskFenced(text);
-	const out: Array<{ path: string; body: string }> = [];
-	const re = new RegExp(FILE_BLOCK.source, "gm");
-	const marks: Array<{ path: string; start: number }> = [];
+	const out: Array<{ heading: string; body: string }> = [];
+	const re = new RegExp(CHANGE_BLOCK.source, "gm");
+	const marks: Array<{ heading: string; start: number }> = [];
 	let m: RegExpExecArray | null = re.exec(masked);
 	while (m !== null) {
 		const captured = m[1];
-		if (captured !== undefined) marks.push({ path: captured, start: m.index + m[0].length });
+		if (captured !== undefined) marks.push({ heading: captured, start: m.index + m[0].length });
 		m = re.exec(masked);
 	}
 	for (const mark of marks) {
 		const next = masked.slice(mark.start).search(/^#{2,4}\s/m);
 		const end = next >= 0 ? mark.start + next : text.length;
-		out.push({ path: mark.path, body: text.slice(mark.start, end) });
+		out.push({ heading: mark.heading, body: text.slice(mark.start, end) });
+	}
+	return out;
+}
+
+/** One `cf-loc` location citation parsed from a change block's `base:`/`head:` anchors. */
+interface LocAnchor {
+	side: AnchorSide;
+	path: string;
+	/** The parsed `:<number>` line, or null when the anchor carries no numeric suffix. */
+	line: number | null;
+}
+
+/** Every `base:path:line` / `head:path:line` location anchor in one change block. */
+function blockAnchors(body: string): LocAnchor[] {
+	const clean = withoutFencedCode(body);
+	const out: LocAnchor[] = [];
+	for (const side of ["base", "head"] as AnchorSide[]) {
+		for (const value of anchorValues(clean, side)) {
+			if (value === "") continue;
+			const match = value.match(/^(.*):(\d+)$/);
+			if (match !== null && match[1] !== undefined)
+				out.push({ side, path: match[1], line: Number(match[2]) });
+			else out.push({ side, path: value, line: null });
+		}
 	}
 	return out;
 }
@@ -216,23 +247,28 @@ function checkR1Listing(text: string, signalFiles: string[]): CheckItem {
 	};
 }
 
-// R1, coverage form (code step) — every signal file has exactly one file block.
-function checkR1Coverage(blocks: Array<{ path: string }>, signalFiles: string[]): CheckItem {
-	const counts = new Map<string, number>();
-	for (const b of blocks) counts.set(b.path, (counts.get(b.path) ?? 0) + 1);
-	const zero = signalFiles.filter((p) => (counts.get(p) ?? 0) === 0);
-	const dup = signalFiles.filter((p) => (counts.get(p) ?? 0) >= 2);
-	const details: string[] = [];
-	if (zero.length > 0) details.push(`파일 블록에 등장하지 않는 파일: ${zero.join(", ")}`);
-	if (dup.length > 0) details.push(`여러 그룹에 중복 등장한 파일: ${dup.join(", ")}`);
+// R1, coverage form (code step) — every signal file is CITED by at least one
+// change block's location anchors. The unit is the change, not the file, so a
+// file may be cited by several changes (no exactly-once rule); what must not
+// happen is a signal file that never appears in any `바뀐 위치` slot — that is a
+// file the walkthrough silently dropped.
+function checkR1Coverage(
+	blocks: Array<{ heading: string; body: string }>,
+	signalFiles: string[],
+): CheckItem {
+	const cited = new Set<string>();
+	for (const b of blocks) for (const a of blockAnchors(b.body)) cited.add(a.path);
+	const missing = signalFiles.filter((p) => !cited.has(p));
 	return {
 		id: "R1",
-		title: "R1 signal 파일 파일 블록 커버리지 (커버리지형)",
-		pass: signalFiles.length > 0 && details.length === 0,
+		title: "R1 signal 파일 변경 블록 인용 커버리지 (커버리지형)",
+		pass: signalFiles.length > 0 && missing.length === 0,
 		detail:
 			signalFiles.length === 0
 				? "signal 파일이 하나도 분류되지 않았습니다 — evidence 스텝의 분류표를 확인하세요."
-				: details.join(" / "),
+				: missing.length > 0
+					? `어느 변경 블록의 '바뀐 위치'(cf-loc)에도 인용되지 않은 signal 파일: ${missing.join(", ")}`
+					: "",
 	};
 }
 
@@ -257,27 +293,27 @@ function checkR2(text: string): CheckItem {
 // R3 — provenance on every 왜. Not "don't explain why": say WHERE the why came
 // from. Read on the code-stripped body so a `[근거:]` inside a code comment can
 // not stand in for the file block's actual 왜 field.
-function checkR3(blocks: Array<{ path: string; body: string }>): CheckItem {
-	const bodies = blocks.map((b) => ({ path: b.path, body: withoutFencedCode(b.body) }));
+function checkR3(blocks: Array<{ heading: string; body: string }>): CheckItem {
+	const bodies = blocks.map((b) => ({ heading: b.heading, body: withoutFencedCode(b.body) }));
 	const unmarked = bodies
 		.filter((b) => WHY_PARAGRAPH.test(b.body))
 		.filter((b) => {
 			const m = b.body.match(WHY_PARAGRAPH);
 			return m === null || !PROVENANCE.test(m[0]);
 		})
-		.map((b) => b.path);
-	const noWhy = bodies.filter((b) => !WHY_PARAGRAPH.test(b.body)).map((b) => b.path);
+		.map((b) => b.heading);
+	const noWhy = bodies.filter((b) => !WHY_PARAGRAPH.test(b.body)).map((b) => b.heading);
 	return {
 		id: "R3",
 		title: "R3 왜의 출처 표시",
 		pass: blocks.length > 0 && unmarked.length === 0 && noWhy.length === 0,
 		detail:
 			blocks.length === 0
-				? "파일 블록이 하나도 없습니다."
+				? "변경 블록이 하나도 없습니다."
 				: noWhy.length > 0
-					? `"왜" 필드가 없는 파일: ${noWhy.join(", ")}`
+					? `"왜" 필드가 없는 변경: ${noWhy.join(", ")}`
 					: unmarked.length > 0
-						? `출처 태그(cf-src / [근거:] / [추론:] / Unknown) 없이 단정한 파일: ${unmarked.join(", ")}`
+						? `출처 태그(cf-src / [근거:] / [추론:] / Unknown) 없이 단정한 변경: ${unmarked.join(", ")}`
 						: "",
 	};
 }
@@ -300,10 +336,11 @@ function checkR4(text: string): CheckItem {
 	};
 }
 
-/** The two slots the 목표 section must fill (R16): goal+why, and a one-line core before code. */
+/** The slots the 목표 section must fill (R16): goal+why, a one-line core, and where the understanding came from. */
 const GOAL_SLOTS = [
 	{ label: "무엇을·왜", re: /^###\s*무엇을/m },
 	{ label: "핵심", re: /^###\s*핵심/m },
+	{ label: "출처", re: /^###\s*출처/m },
 ] as const;
 
 // R16 — the goal / core-message beat, authored before any architecture or code.
@@ -330,7 +367,7 @@ function checkR16(text: string): CheckItem {
 		pass: missing.length === 0,
 		detail:
 			missing.length > 0
-				? `목표 섹션에 없는 슬롯: ${missing.join(", ")} (### 무엇을·왜 / ### 핵심)`
+				? `목표 섹션에 없는 슬롯: ${missing.join(", ")} (### 무엇을·왜 / ### 핵심 / ### 출처 — 이 이해에 쓴 근거: Linear·Notion·Slack·커밋·PR·위키·코드 추론)`
 				: "",
 	};
 }
@@ -348,141 +385,126 @@ function anchorValues(body: string, side: AnchorSide): string[] {
 	return values;
 }
 
-/** Parse the final `:<number>` and accept it only for this file block's path. */
-function numericAnchor(body: string, side: AnchorSide, path: string): number | null {
-	for (const value of anchorValues(body, side)) {
-		const match = value.match(/^(.*):(\d+)$/);
-		if (match !== null && match[1] === path) return Number(match[2]);
+/** Location anchors collected per file path across all change blocks. */
+interface FileAnchors {
+	baseLines: number[];
+	headLines: number[];
+	baseNonNumeric: boolean;
+	headNonNumeric: boolean;
+}
+
+/** Gathers every change block's `base:`/`head:` anchors keyed by file path. */
+function collectFileAnchors(blocks: Array<{ body: string }>): Map<string, FileAnchors> {
+	const byPath = new Map<string, FileAnchors>();
+	for (const b of blocks) {
+		for (const a of blockAnchors(b.body)) {
+			const e = byPath.get(a.path) ?? {
+				baseLines: [],
+				headLines: [],
+				baseNonNumeric: false,
+				headNonNumeric: false,
+			};
+			if (a.line === null) {
+				if (a.side === "base") e.baseNonNumeric = true;
+				else e.headNonNumeric = true;
+			} else {
+				(a.side === "base" ? e.baseLines : e.headLines).push(a.line);
+			}
+			byPath.set(a.path, e);
+		}
 	}
-	return null;
+	return byPath;
 }
 
-/** The pre-hunk R5 contract: presence, with numeric anchors path-checked. */
-function hasLegacyAnchor(body: string, side: AnchorSide, path: string): boolean {
-	return anchorValues(body, side).some((value) => {
-		if (value === "") return false;
-		const match = value.match(/^(.*):(\d+)$/);
-		return match === null || match[1] === path;
-	});
-}
-
-function legacyR5Failures(
-	blocks: Array<{ path: string; body: string }>,
-	addedSet: Set<string>,
-): { noAnchor: string[]; placeholder: string[] } {
-	const noAnchor = blocks
-		.filter((block) => {
-			const body = withoutFencedCode(block.body);
-			const hasHead = hasLegacyAnchor(body, "head", block.path);
-			if (addedSet.has(block.path)) return !hasHead;
-			return !(hasHead && hasLegacyAnchor(body, "base", block.path));
-		})
-		.map((block) => block.path);
-	const placeholder = blocks
-		.filter((block) => {
-			if (addedSet.has(block.path)) return false;
-			const body = withoutFencedCode(block.body);
-			const base = numericAnchor(body, "base", block.path);
-			const head = numericAnchor(body, "head", block.path);
-			return base === 1 && head === 1;
-		})
-		.map((block) => block.path);
-	return { noAnchor, placeholder };
-}
-
-// R5 — both endpoints of the move (base:/head: anchors). An ADDED file is asked
-// for the head anchor alone. Read on the code-stripped body; the template places
-// these in the cf-loc slot. Without hunk metadata the check only asks that the
-// anchors be present; with metadata it also checks numeric anchors against ranges.
+// R5 — traceability, file-centric. Every signal file must have its before AND
+// after location cited somewhere in the change blocks' `바뀐 위치` (cf-loc)
+// slots — an ADDED file needs the head anchor alone, a DELETED file the base
+// alone — and every cited numeric anchor must land in a real diff hunk. Because
+// the unit is the change, one file's anchors may be spread across several change
+// blocks, so they are gathered per path first. New-ness comes from `A` in
+// `git diff --name-status`; deleted-ness (no head side) comes from the hunk
+// header. Without hunk metadata for a file, the check falls back to
+// presence-only and rejects the `:1 → :1` placeholder on a modified file.
 function checkR5(
-	blocks: Array<{ path: string; body: string }>,
+	blocks: Array<{ heading: string; body: string }>,
+	signalFiles: string[],
 	addedFiles: string[] | undefined,
 	diffHunks: DiffHunk[] | undefined,
 ): CheckItem {
 	const addedSet = new Set(addedFiles ?? []);
-	const hasDiffHunks = (diffHunks?.length ?? 0) > 0;
-	if (!hasDiffHunks) {
-		const { noAnchor, placeholder } = legacyR5Failures(blocks, addedSet);
-		return {
-			id: "R5",
-			title: "R5 추적성",
-			pass: blocks.length > 0 && noAnchor.length === 0 && placeholder.length === 0,
-			detail:
-				blocks.length === 0
-					? "파일 블록이 하나도 없습니다."
-					: noAnchor.length > 0
-						? `base/head 위치가 모두 있지 않은 파일: ${noAnchor.join(", ")}`
-						: placeholder.length > 0
-							? `cf-loc가 실제 변경 위치가 아니라 :1 → :1 플레이스홀더인 파일: ${placeholder.join(", ")} — git으로 변경 hunk의 base/head 라인을 확인해 적는다`
-							: "",
-		};
-	}
-
+	const byPath = collectFileAnchors(blocks);
 	const hunksByPath = new Map<string, DiffHunk[]>();
 	for (const hunk of diffHunks ?? []) {
 		const hunks = hunksByPath.get(hunk.path) ?? [];
 		hunks.push(hunk);
 		hunksByPath.set(hunk.path, hunks);
 	}
-	const fallbackBlocks = blocks.filter((block) => !hunksByPath.has(block.path));
-	const fallback = legacyR5Failures(fallbackBlocks, addedSet);
-	const missingAnchor: string[] = [];
-	const outsideHunk: string[] = [];
-	for (const block of blocks) {
-		const hunks = hunksByPath.get(block.path);
-		if (hunks === undefined) continue;
-		const body = withoutFencedCode(block.body);
-		const base = numericAnchor(body, "base", block.path);
-		const head = numericAnchor(body, "head", block.path);
-		const needsBase = !addedSet.has(block.path) && hunks.some((hunk) => hunk.base !== null);
-		const needsHead = hunks.some((hunk) => hunk.head !== null);
 
-		if (needsBase && base === null) missingAnchor.push(`${block.path} (base)`);
-		if (needsHead && head === null) missingAnchor.push(`${block.path} (head)`);
-		if (
-			needsBase &&
-			base !== null &&
-			!hunks.some(
-				(hunk) =>
-					hunk.base !== null &&
-					base >= hunk.base.start &&
-					base < hunk.base.start + hunk.base.count,
+	const missing: string[] = [];
+	const outside: string[] = [];
+	const placeholder: string[] = [];
+
+	for (const file of signalFiles) {
+		const e = byPath.get(file);
+		const hasBase = (e?.baseLines.length ?? 0) > 0 || (e?.baseNonNumeric ?? false);
+		const hasHead = (e?.headLines.length ?? 0) > 0 || (e?.headNonNumeric ?? false);
+		const hunks = hunksByPath.get(file);
+
+		if (hunks !== undefined && hunks.length > 0) {
+			const needsBase = !addedSet.has(file) && hunks.some((h) => h.base !== null);
+			const needsHead = hunks.some((h) => h.head !== null);
+			if (needsBase && (e?.baseLines.length ?? 0) === 0) missing.push(`${file} (base)`);
+			if (needsHead && (e?.headLines.length ?? 0) === 0) missing.push(`${file} (head)`);
+			for (const bl of e?.baseLines ?? [])
+				if (
+					!hunks.some(
+						(h) => h.base !== null && bl >= h.base.start && bl < h.base.start + h.base.count,
+					)
+				)
+					outside.push(`${file} (base:${bl})`);
+			for (const hl of e?.headLines ?? [])
+				if (
+					!hunks.some(
+						(h) => h.head !== null && hl >= h.head.start && hl < h.head.start + h.head.count,
+					)
+				)
+					outside.push(`${file} (head:${hl})`);
+		} else {
+			if (addedSet.has(file)) {
+				if (!hasHead) missing.push(`${file} (head)`);
+			} else if (!(hasBase && hasHead)) {
+				missing.push(`${file} (base/head)`);
+			}
+			if (
+				!addedSet.has(file) &&
+				e !== undefined &&
+				e.baseLines.length === 1 &&
+				e.baseLines[0] === 1 &&
+				e.headLines.length === 1 &&
+				e.headLines[0] === 1
 			)
-		)
-			outsideHunk.push(`${block.path} (base:${base})`);
-		if (
-			needsHead &&
-			head !== null &&
-			!hunks.some(
-				(hunk) =>
-					hunk.head !== null &&
-					head >= hunk.head.start &&
-					head < hunk.head.start + hunk.head.count,
-			)
-		)
-			outsideHunk.push(`${block.path} (head:${head})`);
+				placeholder.push(file);
+		}
 	}
+
 	return {
 		id: "R5",
 		title: "R5 추적성",
 		pass:
-			blocks.length > 0 &&
-			fallback.noAnchor.length === 0 &&
-			fallback.placeholder.length === 0 &&
-			missingAnchor.length === 0 &&
-			outsideHunk.length === 0,
+			signalFiles.length > 0 &&
+			missing.length === 0 &&
+			outside.length === 0 &&
+			placeholder.length === 0,
 		detail:
-			blocks.length === 0
-				? "파일 블록이 하나도 없습니다."
-				: fallback.noAnchor.length > 0
-					? `base/head 위치가 모두 있지 않은 파일(hunk 없는 파일은 legacy 규칙): ${fallback.noAnchor.join(", ")}`
-					: fallback.placeholder.length > 0
-						? `cf-loc가 실제 변경 위치가 아니라 :1 → :1 플레이스홀더인 파일: ${fallback.placeholder.join(", ")} — git으로 변경 hunk의 base/head 라인을 확인해 적는다`
-						: missingAnchor.length > 0
-							? `실제 diff hunk의 숫자 위치가 없는 파일: ${missingAnchor.join(", ")}`
-							: outsideHunk.length > 0
-								? `실제 diff hunk 범위 밖의 앵커: ${outsideHunk.join(", ")}`
-								: "",
+			signalFiles.length === 0
+				? "signal 파일이 하나도 없습니다."
+				: missing.length > 0
+					? `변경 블록의 '바뀐 위치'(cf-loc)에 base/head 위치가 인용되지 않은 signal 파일: ${missing.join(", ")}`
+					: outside.length > 0
+						? `실제 diff hunk 범위 밖의 위치 앵커: ${outside.join(", ")}`
+						: placeholder.length > 0
+							? `cf-loc가 실제 변경 위치가 아니라 :1 → :1 플레이스홀더인 파일: ${placeholder.join(", ")} — git으로 변경 hunk의 base/head 라인을 확인해 적는다`
+							: "",
 	};
 }
 
@@ -503,6 +525,45 @@ function levelSlice(text: string, level: string): string | null {
 	const start = m.index + m[0].length;
 	const next = text.slice(start).search(/^#{2,3}\s/m);
 	return next >= 0 ? text.slice(start, start + next) : text.slice(start);
+}
+
+/** The bodies of every ` ```mermaid ` fence in a raw (unmasked) slice. */
+function mermaidFences(rawSlice: string): string[] {
+	const out: string[] = [];
+	const re = /```mermaid\r?\n([\s\S]*?)```/g;
+	let m: RegExpExecArray | null = re.exec(rawSlice);
+	while (m !== null) {
+		if (m[1] !== undefined) out.push(m[1]);
+		m = re.exec(rawSlice);
+	}
+	return out;
+}
+
+/** A node/label token that is a source file path (a slashed path ending in a code extension). */
+const FILE_PATH_TOKEN = /[\w.@-]+\/[\w./@-]*\.(?:ts|tsx|js|jsx|mjs|cjs|py|md|json|sql|yaml|yml|css|scss)\b/i;
+
+// Component/domain diagram nodes must name a MODULE/concept (a feature, use case,
+// hook, service, entity), not a source file path — a file path is WHERE a symbol
+// lives (the card's `레이어` slot), not WHAT the component is. Measured gap: the
+// component diagram nodes were full file paths that truncated mid-path
+// (`health-`, `proposal-`) and told the reader a location, not a module.
+function diagramFilePathNodes(rawSlice: string): boolean {
+	return mermaidFences(rawSlice).some((fence) => FILE_PATH_TOKEN.test(fence));
+}
+
+// A domain object diagram (`classDiagram`) drawn with empty class bodies is an
+// opaque box. Measured gap: the domain classDiagram showed only class names with
+// no members or methods, so a reader could not tell what each object holds or
+// does. When a classDiagram is present, at least one member/method must appear —
+// either a `Class : +field` line or a non-empty `{ ... }` body.
+function classDiagramMissingMembers(rawSlice: string): boolean {
+	const fences = mermaidFences(rawSlice).filter((f) => /\bclassDiagram\b/.test(f));
+	if (fences.length === 0) return false;
+	return fences.some((fence) => {
+		const hasColonMember = /^\s*[A-Za-z_][\w]*\s*:\s*[+\-#~]?\S/m.test(fence);
+		const hasBracedMember = /\{[^}]*[+\-#~(][^}]*\}/.test(fence);
+		return !hasColonMember && !hasBracedMember;
+	});
 }
 
 // R9 — the three architecture levels, each with a mermaid diagram or a reasoned waiver.
@@ -575,11 +636,19 @@ function checkR14(text: string): CheckItem {
 const BOUNDARY_MARKERS = ["영향 인터페이스", "의존 방향"] as const;
 
 // R15 — the boundary / dependency / use-case change map, read on the
-// `### 경계·의존·유스케이스` sub-slice with fences masked (an example block inside a
-// fence must not satisfy the gate — same masking discipline as R14).
+// `### 경계·의존·유스케이스` sub-slice with fences masked for the slot check, but
+// the RAW slice for the orchestration-diagram check (a mermaid fence is masked
+// away, so it must be looked for before masking). Measured gap: the use-case
+// level was a list of static arch-entity cards with cryptic names
+// ("V2 proposal detail / active read") and no flow — a reader could not see the
+// call order or which step moved. The rewrite requires the block to SHOW the
+// orchestration as a mermaid diagram (a sequenceDiagram is the recommended type)
+// with the changed step marked (leveling/marker judged by R12), alongside the
+// existing behaviour-unit cards and the dependency-direction verdict.
 function checkR15(text: string): CheckItem {
+	const rawSlice = levelSlice(text, "경계·의존·유스케이스");
 	const slice = levelSlice(maskFenced(text), "경계·의존·유스케이스");
-	if (slice === null) {
+	if (slice === null || rawSlice === null) {
 		return {
 			id: "R15",
 			title: "R15 경계·의존·유스케이스 블록",
@@ -592,13 +661,18 @@ function checkR15(text: string): CheckItem {
 	// arch-entity opening tag — prose mentions or unsupported values are not a
 	// change map.
 	if (!hasValidArchEntity(slice)) missing.push("변경종류(data-change: new|mod|del)");
+	// The orchestration must be a real diagram, not prose — the flow (call order,
+	// changed step) is shown, not narrated. A reasoned waiver stands in when the
+	// diff genuinely changes no use-case flow.
+	const hasOrchestration = /```mermaid/.test(rawSlice) || ARCH_WAIVER.test(rawSlice);
+	if (!hasOrchestration) missing.push("오케스트레이션 다이어그램(mermaid sequenceDiagram)");
 	return {
 		id: "R15",
 		title: "R15 경계·의존·유스케이스 블록",
 		pass: missing.length === 0,
 		detail:
 			missing.length > 0
-				? `경계·의존·유스케이스 블록에 없는 슬롯: ${missing.join(", ")} — 동작 단위마다 변경종류(arch-entity data-change)와 영향 인터페이스를 적고, 의존 방향을 판정한다 (architecture-boundaries rule 참조)`
+				? `경계·의존·유스케이스 블록에 없는 슬롯: ${missing.join(", ")} — 유스케이스마다 오케스트레이션(mermaid sequenceDiagram)으로 흐름과 바뀐 단계를 보이고, 동작 단위마다 변경종류(arch-entity data-change)·영향 인터페이스를 적고, 의존 방향을 판정한다 (architecture-boundaries rule 참조)`
 				: "",
 	};
 }
@@ -680,8 +754,9 @@ function hasValidArchEntity(slice: string): boolean {
 // and interface (functions), plus a change kind. Measured gap: the component
 // diagram was bare class names — `CurrentBoostPackInfoCard` alone read as opaque.
 function checkR18(text: string): CheckItem {
+	const rawSlice = levelSlice(text, "컴포넌트 레벨");
 	const slice = levelSlice(maskFenced(text), "컴포넌트 레벨");
-	if (slice === null) {
+	if (slice === null || rawSlice === null) {
 		return {
 			id: "R18",
 			title: "R18 컴포넌트 레벨 노드 카드",
@@ -689,19 +764,28 @@ function checkR18(text: string): CheckItem {
 			detail: "컴포넌트 레벨 헤딩(### 컴포넌트 레벨)이 없습니다",
 		};
 	}
-	if (ARCH_WAIVER.test(slice)) {
+	// The diagram-node ban applies whether or not the level is waived — a waiver
+	// says "no structural change", not "file paths are fine as nodes".
+	const pathNode = diagramFilePathNodes(rawSlice);
+	if (ARCH_WAIVER.test(slice) && !pathNode) {
 		return { id: "R18", title: "R18 컴포넌트 레벨 노드 카드", pass: true, detail: "" };
 	}
-	const cards = archEntityCards(slice);
 	const missing: string[] = [];
-	if (cards.length === 0) {
-		missing.push("arch-entity 카드", "변경종류(data-change: new|mod|del)");
-	} else {
-		cards.forEach((card, index) => {
-			const cardMissing: string[] = COMPONENT_CARD_MARKERS.filter((label) => !card.body.includes(label));
-			if (!card.validDataChange) cardMissing.push("변경종류(data-change: new|mod|del)");
-			if (cardMissing.length > 0) missing.push(`카드 ${index + 1}: ${cardMissing.join(", ")}`);
-		});
+	if (pathNode)
+		missing.push(
+			"다이어그램 노드가 파일 경로 — 컴포넌트 노드는 모듈/개념 이름(피처·유스케이스·훅·서비스)으로 적고, 위치는 카드의 레이어 슬롯에 패키지/레이어 단위로 적는다",
+		);
+	if (!ARCH_WAIVER.test(slice)) {
+		const cards = archEntityCards(slice);
+		if (cards.length === 0) {
+			missing.push("arch-entity 카드", "변경종류(data-change: new|mod|del)");
+		} else {
+			cards.forEach((card, index) => {
+				const cardMissing: string[] = COMPONENT_CARD_MARKERS.filter((label) => !card.body.includes(label));
+				if (!card.validDataChange) cardMissing.push("변경종류(data-change: new|mod|del)");
+				if (cardMissing.length > 0) missing.push(`카드 ${index + 1}: ${cardMissing.join(", ")}`);
+			});
+		}
 	}
 	return {
 		id: "R18",
@@ -710,6 +794,62 @@ function checkR18(text: string): CheckItem {
 		detail:
 			missing.length > 0
 				? `컴포넌트 노드 카드에 없는 슬롯: ${missing.join(", ")} — 변경 노드마다 arch-entity로 레이어·책임·인터페이스·변경종류를 적는다`
+				: "",
+	};
+}
+
+/** The label each 도메인 레벨 arch-entity card must carry (R21). */
+const DOMAIN_CARD_MARKERS = ["책임"] as const;
+
+// R21 — the domain level, beyond the entity/relation diagram (R9/R12), decodes
+// each touched domain object with an arch-entity card: what it is responsible for
+// (its 책임 / invariant) and how it changed (data-change). Measured gap: the
+// domain level was the thinnest of the three — a bare diagram whose nodes were
+// sometimes narrative concepts (`ModelAlias`, `LegacyProductKey`) with no
+// responsibility or change kind, so a reader could not tell which domain object
+// this diff added or modified, or what it now guarantees. A reasoned
+// `구조 변화 없음: <사유>` waiver stands in when the diff changes no domain object.
+function checkR21(text: string): CheckItem {
+	const rawSlice = levelSlice(text, "도메인 레벨");
+	const slice = levelSlice(maskFenced(text), "도메인 레벨");
+	if (slice === null || rawSlice === null) {
+		return {
+			id: "R21",
+			title: "R21 도메인 레벨 엔티티 카드",
+			pass: false,
+			detail: "도메인 레벨 헤딩(### 도메인 레벨)이 없습니다",
+		};
+	}
+	const missing: string[] = [];
+	// The diagram bans hold even under a waiver: an object diagram, if drawn, must
+	// name domain concepts (not file paths) and must show each object's members.
+	if (diagramFilePathNodes(rawSlice))
+		missing.push(
+			"다이어그램 노드가 파일 경로 — 도메인 노드는 실재 비즈니스 개념/엔티티 이름으로 적는다",
+		);
+	if (classDiagramMissingMembers(rawSlice))
+		missing.push(
+			"객체 다이어그램의 클래스 박스가 비어 있음 — 각 객체의 멤버 변수와 메소드(메시지)를 채운다",
+		);
+	if (!ARCH_WAIVER.test(slice)) {
+		const cards = archEntityCards(slice);
+		if (cards.length === 0) {
+			missing.push("arch-entity 카드", "변경종류(data-change: new|mod|del)");
+		} else {
+			cards.forEach((card, index) => {
+				const cardMissing: string[] = DOMAIN_CARD_MARKERS.filter((label) => !card.body.includes(label));
+				if (!card.validDataChange) cardMissing.push("변경종류(data-change: new|mod|del)");
+				if (cardMissing.length > 0) missing.push(`카드 ${index + 1}: ${cardMissing.join(", ")}`);
+			});
+		}
+	}
+	return {
+		id: "R21",
+		title: "R21 도메인 레벨 엔티티 카드",
+		pass: missing.length === 0,
+		detail:
+			missing.length > 0
+				? `도메인 엔티티 카드에 없는 슬롯: ${missing.join(", ")} — 이 diff가 건드린 도메인 객체마다 arch-entity로 책임(불변식)·변경종류를 적는다(서사용 가짜 개념이 아니라 실재 도메인 객체)`
 				: "",
 	};
 }
@@ -826,7 +966,7 @@ function checkR10(text: string, commitHashes: string[] | undefined): CheckItem {
 // numbers without ever showing the logic.
 function checkR13(
 	text: string,
-	blocks: Array<{ path: string; body: string }>,
+	blocks: Array<{ heading: string; body: string }>,
 	commitHashes: string[] | undefined,
 ): CheckItem {
 	const groups = groupSlices(text);
@@ -849,8 +989,10 @@ function checkR13(
 			if (bogus.length > 0) problems.push(`${g.title}: 범위에 없는 커밋 해시 ${bogus.join(", ")}`);
 		}
 	}
-	const noCode = blocks.filter((b) => !hasCoreCodeFence(b.body)).map((b) => b.path);
-	if (noCode.length > 0) problems.push(`핵심 로직 코드 펜스(mermaid·빈 펜스 제외)가 없는 파일: ${noCode.join(", ")}`);
+	if (blocks.length === 0) problems.push("변경 블록(#### 변경 N: …)이 하나도 없습니다");
+	const noCode = blocks.filter((b) => !hasCoreCodeFence(b.body)).map((b) => b.heading);
+	if (noCode.length > 0)
+		problems.push(`핵심 로직 코드 펜스(mermaid·빈 펜스 제외)가 없는 변경: ${noCode.join(", ")}`);
 	return {
 		id: "R13",
 		title: "R13 커밋 뼈대 + 핵심 로직 코드",
@@ -905,7 +1047,7 @@ function checkR11(text: string): CheckItem {
 
 export function checkStructure(text: string, input: StructureInput): StructureResult {
 	const items: CheckItem[] = [];
-	const blocks = fileBlocks(text);
+	const blocks = changeBlocks(text);
 
 	switch (input.step) {
 		case "evidence":
@@ -924,6 +1066,7 @@ export function checkStructure(text: string, input: StructureInput): StructureRe
 			items.push(checkR17(text));
 			items.push(checkR18(text));
 			items.push(checkR19(text));
+			items.push(checkR21(text));
 			break;
 		case "intuition":
 			// No slot of its own — R6 (the judge) is its rubric coverage; the
@@ -935,7 +1078,7 @@ export function checkStructure(text: string, input: StructureInput): StructureRe
 		case "code":
 			items.push(checkR2(text));
 			items.push(checkR3(blocks));
-			items.push(checkR5(blocks, input.addedFiles, input.diffHunks));
+			items.push(checkR5(blocks, input.signalFiles, input.addedFiles, input.diffHunks));
 			items.push(checkR1Coverage(blocks, input.signalFiles));
 			items.push(checkR13(text, blocks, input.commitHashes));
 			break;

--- a/lib/explain-diff-structure.ts
+++ b/lib/explain-diff-structure.ts
@@ -42,7 +42,7 @@ export interface DiffHunk {
 }
 
 export interface StructureInput {
-	/** Changed files classified as signal — every one must appear exactly once. */
+	/** Changed files classified as signal — every one must be cited by a change block. */
 	signalFiles: string[];
 	/**
 	 * Signal files the diff ADDED. These have no base location to point at, so
@@ -94,8 +94,9 @@ export interface StructureResult {
 
 const GROUP_HEADING = /^##\s+Change Group\s+\d+\s*:\s*\S.*$/gm;
 // 변경 블록은 h4 `#### 변경 N: <한 일>` — 파일이 아니라 변경이 단위다.
-// (h3 `### `hash` — 제목`은 커밋 서브섹션이라 변경 블록이 아니다.) 헤딩 텍스트를 캡처한다.
-const CHANGE_BLOCK = /^####\s+(\S.*?)\s*$/gm;
+// (h3 `### `hash` — 제목`은 커밋 서브섹션이고, v4의 `#### `path``도 변경 블록이
+// 아니다.) 수평 공백만 소비해 빈 행을 행동 텍스트로 오인하지 않도록 한다.
+const CHANGE_BLOCK = /^####[ \t]+(변경[ \t]+\d+[ \t]*:[ \t]*\S[^\r\n]*?)[ \t]*\r?$/gm;
 // 커밋 서브섹션: h3 헤딩의 백틱 안 16진 해시.
 const COMMIT_SUBSECTION = /^###\s+`([0-9a-fA-F]{6,40})`/gm;
 
@@ -119,9 +120,9 @@ const FENCE_RE = /^(`{3,}|~{3,})[^\n]*\n[\s\S]*?^(?:`{3,}|~{3,})[^\n]*$/gm;
 const CODE_FENCE = /^(`{3,}|~{3,})([^\n]*)\n([\s\S]*?)^(?:`{3,}|~{3,})[^\n]*$/gm;
 
 /**
- * A file block satisfies R13's core-logic requirement only with a fence that is
+ * A change block satisfies R13's core-logic requirement only with a fence that is
  * NOT a mermaid diagram and is NOT empty. The template reserves mermaid for
- * diagrams and requires real code/pseudocode per file, so a mermaid-only or
+ * diagrams and requires real code/pseudocode per change, so a mermaid-only or
  * blank fence is not the logic R13 guarantees.
  */
 function hasCoreCodeFence(body: string): boolean {
@@ -155,7 +156,7 @@ function withoutFencedCode(text: string): string {
 /**
  * Blanks fenced code to same-length spaces (newlines kept), so heading and
  * boundary offsets computed on the masked copy still index the raw text. This
- * is what lets file blocks carry code fences without a `##` comment line inside
+ * is what lets change blocks carry code fences without a `##` comment line inside
  * the fence truncating the block early.
  */
 function maskFenced(text: string): string {
@@ -195,11 +196,13 @@ interface LocAnchor {
 	line: number | null;
 }
 
+const ANCHOR_SIDES: AnchorSide[] = ["base", "head"];
+
 /** Every `base:path:line` / `head:path:line` location anchor in one change block. */
 function blockAnchors(body: string): LocAnchor[] {
 	const clean = withoutFencedCode(body);
 	const out: LocAnchor[] = [];
-	for (const side of ["base", "head"] as AnchorSide[]) {
+	for (const side of ANCHOR_SIDES) {
 		for (const value of anchorValues(clean, side)) {
 			if (value === "") continue;
 			const match = value.match(/^(.*):(\d+)$/);
@@ -292,7 +295,7 @@ function checkR2(text: string): CheckItem {
 
 // R3 — provenance on every 왜. Not "don't explain why": say WHERE the why came
 // from. Read on the code-stripped body so a `[근거:]` inside a code comment can
-// not stand in for the file block's actual 왜 field.
+// not stand in for the change block's actual 왜 field.
 function checkR3(blocks: Array<{ heading: string; body: string }>): CheckItem {
 	const bodies = blocks.map((b) => ({ heading: b.heading, body: withoutFencedCode(b.body) }));
 	const unmarked = bodies
@@ -554,15 +557,54 @@ function diagramFilePathNodes(rawSlice: string): boolean {
 // A domain object diagram (`classDiagram`) drawn with empty class bodies is an
 // opaque box. Measured gap: the domain classDiagram showed only class names with
 // no members or methods, so a reader could not tell what each object holds or
-// does. When a classDiagram is present, at least one member/method must appear —
-// either a `Class : +field` line or a non-empty `{ ... }` body.
+// does. Every declared class must carry at least one member/method — either in
+// its `{ ... }` body or in a `Class : +field` declaration.
 function classDiagramMissingMembers(rawSlice: string): boolean {
 	const fences = mermaidFences(rawSlice).filter((f) => /\bclassDiagram\b/.test(f));
 	if (fences.length === 0) return false;
 	return fences.some((fence) => {
-		const hasColonMember = /^\s*[A-Za-z_][\w]*\s*:\s*[+\-#~]?\S/m.test(fence);
-		const hasBracedMember = /\{[^}]*[+\-#~(][^}]*\}/.test(fence);
-		return !hasColonMember && !hasBracedMember;
+		const lines = fence.split(/\r?\n/);
+		const colonMembers = new Set<string>();
+		for (const line of lines) {
+			const member = line.match(/^\s*([A-Za-z_][\w-]*)\s*:\s*[+\-#~]?\s*\S/);
+			if (member?.[1] !== undefined) colonMembers.add(member[1]);
+		}
+
+		const classes: boolean[] = [];
+		for (let index = 0; index < lines.length; index += 1) {
+			const declaration = lines[index]?.match(/^\s*class\s+([A-Za-z_][\w-]*)\b(.*)$/);
+			if (declaration?.[1] === undefined) continue;
+
+			const name = declaration[1];
+			const tail = declaration[2] ?? "";
+			const openBrace = tail.indexOf("{");
+			if (openBrace < 0) {
+				classes.push(colonMembers.has(name));
+				continue;
+			}
+
+			const sameLineBody = tail.slice(openBrace + 1);
+			const closeBrace = sameLineBody.indexOf("}");
+			if (closeBrace >= 0) {
+				classes.push(sameLineBody.slice(0, closeBrace).trim().length > 0);
+				continue;
+			}
+
+			let hasMember = false;
+			for (let bodyIndex = index + 1; bodyIndex < lines.length; bodyIndex += 1) {
+				const bodyLine = lines[bodyIndex]?.trim() ?? "";
+				if (bodyLine === "}") {
+					index = bodyIndex;
+					break;
+				}
+				if (bodyLine !== "" && !bodyLine.startsWith("%%") && !/^<<.*>>$/.test(bodyLine)) {
+					hasMember = true;
+				}
+			}
+			classes.push(hasMember);
+		}
+
+		return classes.length > 0 && classes.some((hasMember) => !hasMember);
 	});
 }
 
@@ -960,9 +1002,9 @@ function checkR10(text: string, commitHashes: string[] | undefined): CheckItem {
 }
 
 // R13 — the commit-spined walkthrough. Each Change Group holds at least one
-// commit subsection whose hash is a real range commit, and each file block
+// commit subsection whose hash is a real range commit, and each change block
 // carries one core-logic code fence. Measured baseline: the code section sat
-// disconnected from the commit history, and file blocks pointed at line
+// disconnected from the commit history, and change blocks pointed at line
 // numbers without ever showing the logic.
 function checkR13(
 	text: string,

--- a/lib/explain-diff-structure.ts
+++ b/lib/explain-diff-structure.ts
@@ -552,8 +552,58 @@ function mermaidFences(rawSlice: string): string[] {
 	return out;
 }
 
-/** A node/label token that is a source file path (a slashed path ending in a code extension). */
-const FILE_PATH_TOKEN = /[\w.@-]+\/[\w./@-]*\.(?:ts|tsx|js|jsx|mjs|cjs|py|md|json|sql|yaml|yml|css|scss)\b/i;
+/** A node/label token that is a source file path (including root-level files). */
+const FILE_PATH_TOKEN = /(?:^|[\s"'([{])(?:[\w.@-]+\/)*[\w.@-]+\.(?:ts|tsx|js|jsx|mjs|cjs|py|md|json|sql|yaml|yml|css|scss)\b/i;
+
+const DIAGRAM_TOKEN = "[A-Za-z0-9_./@-]+";
+const DIAGRAM_NON_NODE_LINE = /^(?:flowchart|graph|classDiagram|erDiagram|sequenceDiagram|stateDiagram(?:-v2)?|subgraph|end|direction|title|accTitle|accDescr|note|classDef|style|linkStyle|click)\b/i;
+const DIAGRAM_NODE_DECLARATION = new RegExp(
+	`(?:^|[\\s,])(${DIAGRAM_TOKEN})\\s*(?:\\[\\[([^\\]\\r\\n]*)\\]\\]|\\[([^\\]\\r\\n]*)\\]|\\(\\(([^)\\r\\n]*)\\)\\)|\\(([^)\\r\\n]*)\\)\\)|\\{\\{([^}\\r\\n]*)\\}\\}|\\{([^}\\r\\n]*)\\})`,
+	"g",
+);
+const DIAGRAM_RELATION = new RegExp(
+	`(?:^|[\\s,])(${DIAGRAM_TOKEN}?)\\s*(?:["'][^"\\r\\n]*["']\\s*)?[<|>*o.{}-]{2,}\\s*(?:["'][^"\\r\\n]*["']\\s*)?(${DIAGRAM_TOKEN})`,
+	"g",
+);
+
+function diagramNodeLabels(fence: string): string[] {
+	const labels: string[] = [];
+	for (const rawLine of fence.split(/\r?\n/)) {
+		const line = rawLine.replace(/%%.*$/, "").trim();
+		if (line === "" || DIAGRAM_NON_NODE_LINE.test(line)) continue;
+
+		const classDeclaration = new RegExp(`^class\\s+(${DIAGRAM_TOKEN})\\b`, "i").exec(line);
+		if (classDeclaration?.[1] !== undefined) {
+			labels.push(classDeclaration[1]);
+			continue;
+		}
+
+		const withoutEdgeLabels = line.replace(/\|[^|\r\n]*\|/g, "");
+		DIAGRAM_NODE_DECLARATION.lastIndex = 0;
+		let declaration: RegExpExecArray | null = DIAGRAM_NODE_DECLARATION.exec(withoutEdgeLabels);
+		while (declaration !== null) {
+			for (const value of declaration.slice(1)) {
+				if (value !== undefined) labels.push(value);
+			}
+			declaration = DIAGRAM_NODE_DECLARATION.exec(withoutEdgeLabels);
+		}
+
+		const block = new RegExp(`^(${DIAGRAM_TOKEN})\\s*\\{$`).exec(withoutEdgeLabels);
+		if (block?.[1] !== undefined) labels.push(block[1]);
+
+		DIAGRAM_RELATION.lastIndex = 0;
+		let relationship: RegExpExecArray | null = DIAGRAM_RELATION.exec(withoutEdgeLabels);
+		while (relationship !== null) {
+			if (relationship[1] !== undefined) labels.push(relationship[1]);
+			if (relationship[2] !== undefined) labels.push(relationship[2]);
+			relationship = DIAGRAM_RELATION.exec(withoutEdgeLabels);
+		}
+
+		const standalone = new RegExp(`^(${DIAGRAM_TOKEN})$`).exec(withoutEdgeLabels);
+		if (standalone?.[1] !== undefined) labels.push(standalone[1]);
+	}
+	return labels;
+}
 
 // Component/domain diagram nodes must name a MODULE/concept (a feature, use case,
 // hook, service, entity), not a source file path — a file path is WHERE a symbol
@@ -561,7 +611,9 @@ const FILE_PATH_TOKEN = /[\w.@-]+\/[\w./@-]*\.(?:ts|tsx|js|jsx|mjs|cjs|py|md|jso
 // component diagram nodes were full file paths that truncated mid-path
 // (`health-`, `proposal-`) and told the reader a location, not a module.
 function diagramFilePathNodes(rawSlice: string): boolean {
-	return mermaidFences(rawSlice).some((fence) => FILE_PATH_TOKEN.test(fence));
+	return mermaidFences(rawSlice).some((fence) =>
+		diagramNodeLabels(fence).some((label) => FILE_PATH_TOKEN.test(label)),
+	);
 }
 
 // A domain object diagram (`classDiagram`) drawn with empty class bodies is an
@@ -585,7 +637,7 @@ function classDiagramMissingMembers(rawSlice: string): boolean {
 			if (member?.[1] !== undefined) declareClass(member[1], true);
 
 			const relationship = line.match(
-				/^\s*([A-Za-z_][\w-]*)\s+(?:["'][^"']*["']\s+)?[<|>*o.-]{2,}(?:\s+["'][^"']*["'])?\s+([A-Za-z_][\w-]*)\b/,
+				/^\s*([A-Za-z_][\w-]*)\s*(?:["'][^"']*["']\s+)?[<|>*o.-]{2,}(?:\s+["'][^"']*["'])?\s*([A-Za-z_][\w-]*)\b/,
 			);
 			if (relationship?.[1] !== undefined && relationship[2] !== undefined) {
 				declareClass(relationship[1]);

--- a/skills/explain-diff/SKILL.md
+++ b/skills/explain-diff/SKILL.md
@@ -23,6 +23,8 @@ The document skeleton and the usable visual components are owned by `references/
 
 Each step must pass two gates — **structure check (script) → judgment (subagent, quote required)** — before it advances. The state CLI renders the pass verdict, and writes to the artifact path are permitted or rejected by a hook that reads that verdict. Steps cannot be skipped.
 
+**State purpose, not just mechanism — for the document and for each section.** The document opens (under the title, in the meta block from `markdown-template.md`) with **one line on what this document is for**: which change it teaches and why a reader should understand it. And each major section earns its place — begin Background, 목표, Architecture, Intuition, Code with a short framing of *why this section exists and what the reader takes from it*, not just its content. A reader who lands mid-document should always know why they are reading this part. The skill's own steps carry the how; the sections must also carry the why.
+
 </Role>
 
 ## State CLI
@@ -99,9 +101,12 @@ State the **goal and the one-line core before any structure or code** — the wa
 
 ### 핵심
 <코드를 보기 전에 독자가 먼저 쥐어야 할 핵심 한 줄>
+
+### 출처
+<이 목적·컨텍스트를 파악하는 데 실제로 쓴 근거 — Linear 이슈, Notion 문서, Slack 스레드, PR 설명, 커밋 본문, 위키 문서 경로, 또는 코드 추론. 접근할 수 있으면 식별자/경로를, 없으면 어디서 왔는지 한 줄>
 ```
 
-Both sub-headings are verified by the structure check (R16). What each says is yours to fill.
+All three sub-headings are verified by the structure check (R16). What each says is yours to fill. The `### 출처` names where the WHY came from so the reader can trace and trust it — the same provenance discipline R3 applies to each change's 왜, here applied to the whole document's purpose. In a sandbox with no external tools, cite the in-repo grounds (commit body, PR description, wiki) or say `코드 추론`; never leave it blank.
 
 ## Step 4 — architecture
 
@@ -121,11 +126,15 @@ Draw the structure needed to **understand this diff** at **three levels**. Each 
 |---|---|---|
 | <프로세스·서비스 경계> | <엔드포인트·쿼리·화면 URL> | <오가는 데이터> |
 
+**The `인터페이스` and `오가는 것` cells must show the actual message, not a naming-convention note.** A reader cannot tell what an interface does from "camelCase generationRequest" — write the signature and the request/response shape: the endpoint/procedure plus the fields it takes and returns, with types (`initiateGeneration(input: { generationRequest: { userRequest: string; intakeTimeCodes: string[] }, proposalType: enum }) → { asyncTaskId: string }`). Name the payload and response body concretely so the reader knows what value crosses the boundary; a bare field name or a convention label is not an interface.
+
 Then, a **change-contract table** (R14) across three axes — `서버 API` (endpoints, tRPC procedures, request/response schemas), `DB 스키마` (tables, columns, constraints), `클라이언트 의존` (contracts the client must change to match); each axis states the changing contract or `변경 없음: <사유>`. Order: diagram → standing-interface (context) → change-contract (delta). The three axis labels pass R14; the three rendered column labels (`경계`·`인터페이스`·`오가는 것`) pass R17. Format follows `markdown-template.md`.
 
-**The component level decodes each changed node (R18).** The mermaid graph shows how modules connect; bare class names do not say what a node *is*. A reasoned component-level `구조 변화 없음: <사유>` waiver is accepted. Otherwise, every authored `arch-entity` card is checked independently for `레이어` / `책임` / `인터페이스` (functions) and `data-change="new|mod|del"`; one complete card cannot mask an incomplete or invalid card. Prose-only card descriptions and unsupported `data-change` values do not count; a pure data/contract-only level must use the reasoned waiver instead of simply omitting cards. The labels and valid cards are what R18 checks.
+**The component level decodes each changed node (R18).** A component is a **module as a unit** — a feature, a use case, a hook, a service, a schema module — not a file. So the diagram's **nodes are module/concept names**, never source file paths: a file path as a node label tells the reader a location, not a component, and long paths truncate mid-word in the render (`health-`, `proposal-`). **Where** a component lives is said in the card's `레이어` slot at package/layer granularity (`packages/schemas/src/program`, `entities/supplement/api`) — the diagram names the component, the card says where it sits. R18 rejects a component diagram whose nodes are file paths. A reasoned component-level `구조 변화 없음: <사유>` waiver is accepted (but a file-path node fails even under the waiver). Otherwise, every authored `arch-entity` card is checked independently for `레이어` / `책임` / `인터페이스` (functions) and `data-change="new|mod|del"`; one complete card cannot mask an incomplete or invalid card. Prose-only card descriptions and unsupported `data-change` values do not count; a pure data/contract-only level must use the reasoned waiver instead of simply omitting cards. The labels and valid cards are what R18 checks.
 
-**The Architecture section closes with a boundary/dependency/use-case change map (R15).** After the three levels, add a `### 경계·의존·유스케이스` block that is **not** a static layer-classification table but a map of what this diff did to the boundary. The rendered block must contain a real renderer-recognized `arch-entity` with an allowed `data-change="new|mod|del"`, plus the `영향 인터페이스` and `의존 방향` slots; prose-only mentions or unsupported change values do not count. Describe each behaviour unit's affected interface, the touched layers/domains as a one-line backdrop, and close with a dependency-direction verdict (keeps/violates/restores unidirectional dependency; flag any reach-in, back-reference, or cycle). **Do not write methodology names (FSD·Feature-Sliced·Clean Architecture·DDD·bounded context) OR bare axis labels (`수평`/`수직`) in the Architecture prose (R19)** — name the touched areas in the codebase's own domain terms, not by sorting parts into a horizontal/vertical grid. The vocabulary follows the `architecture-boundaries` rule but the output speaks the codebase's own domain terms. Format follows `markdown-template.md`.
+**The domain level decodes each touched domain object (R21).** The `### 도메인 레벨` is the thinnest level if left as a bare diagram — a reader cannot tell which domain object this diff added or changed, or what invariant it now guarantees. The nodes and cards must be **real business concepts** — the things the domain actually models (a Program, an intake-time slot, a request kind like 온보딩 vs 일반 생성) — decoded in the codebase's own domain terms. A schema class name is acceptable **only when you explain the business concept it encodes**; a bare encoding name (`GenerationIntakeTimeCodesSchema`) with no business meaning is not a domain object. Above the entity/relation diagram (`erDiagram`/`classDiagram`), every touched domain object gets an `arch-entity` card carrying its `책임` (the duty/invariant it holds) and a `data-change` change kind. **If you draw an object/class diagram, fill each class box** — its member variables (what it holds) and its methods/messages (what it does); an empty box with only a class name teaches nothing, and R21 rejects a `classDiagram` whose boxes have no members. Diagram nodes are domain-concept names, never file paths. A reasoned `구조 변화 없음: <사유>` waiver stands in when the diff changes no domain object; otherwise every card is checked for `책임` + a valid `data-change`, the same way R18 checks component cards.
+
+**The Architecture section closes with a boundary/dependency/use-case change map (R15).** After the three levels, add a `### 경계·의존·유스케이스` block. A feature/use case mostly carries an **orchestration** responsibility, so this block's centre of gravity is the **flow**: show it as a mermaid `sequenceDiagram` — who calls whom in what order — and mark the step this diff changed (a `Note` or `:::changed`). A reasoned `구조 변화 없음: <사유>` waiver stands in when the diff changes no use-case flow (R15 checks the block for a mermaid diagram or that waiver). Above/around the diagram, add a renderer-recognized `arch-entity` per behaviour unit with an allowed `data-change="new|mod|del"`, plus the `영향 인터페이스` and `의존 방향` slots; prose-only mentions or unsupported change values do not count. The `영향 인터페이스` slot names the actual signature/payload the use case exposes or calls — endpoint/procedure plus the request and response shape — not a bare name. Close with a dependency-direction verdict (keeps/violates/restores unidirectional dependency; flag any reach-in, back-reference, or cycle). **Do not write methodology names (FSD·Feature-Sliced·Clean Architecture·DDD·bounded context) OR bare axis labels (`수평`/`수직`) in the Architecture prose (R19)** — name the touched areas in the codebase's own domain terms, not by sorting parts into a horizontal/vertical grid. The vocabulary follows the `architecture-boundaries` rule but the output speaks the codebase's own domain terms. Format follows `markdown-template.md`.
 
 R19 scans the rendered `## Architecture` prose after ignoring fenced blocks and inline-code examples, and rejects only standalone methodology or axis tokens (methodology matching is case-insensitive). A token embedded in a code identifier or example is not prose.
 
@@ -165,46 +174,47 @@ Commit hashes are compared against the list that `start` pinned into the state �
 
 ## Step 7 — code
 
-The first-class unit is the **Change Group** (a concern), but **the spine is the commit.** Inside a group you descend commit by commit, and under a commit come the file blocks that commit touched. A signal file enters exactly once, as exactly one file block.
+The unit is the **change (변경)**, not the file, and **the spine is the commit.** A Change Group (a concern) descends commit by commit; under a commit come **change blocks** (`#### 변경 N: <한 일>`). **A change is not a file** — one change is realized by several **책임(responsibilities)**, the class/function duties that were edited together for one reason. So a change block lists those responsibilities, each naming the class/function it touched and **where that symbol lives** (which layer/domain — pointing back to the architecture cards). The file appears only as a location citation in the `cf-loc` slot, never as the heading. A signal file may be cited by more than one change; what must not happen is a signal file no change cites (R1).
 
 ```markdown
-## Change Group 1: <제목>
+## Change Group 1: <관심사>
 > 예고: <what this group will do — 그룹 N presupposes 그룹 N-1>
 > 순서: <one line on why this order>
 
 ### `<short-hash>` — <커밋 제목>
 <one or two sentences on what this commit did in this group. If it spans multiple groups, one spillover line.>
 
-#### `path/to/file.ts`
-<div class="cf">
-<p><strong>역할/변경 전</strong> — <설명></p>
-<p><strong>바뀐 것</strong> — <설명></p>
-<p><strong>왜</strong> — <설명> <span class="cf-src">근거</span> "<원문 인용>"</p>
-<p><strong>효과</strong> — <설명></p>
-<p class="cf-loc"><code>base:path/to/file.ts:12</code> → <code>head:path/to/file.ts:15</code></p>
+#### 변경 1: <이 변경이 이룬 것 — 파일명이 아니라 한 일로>
+<div class="cf" data-change="mod">
+<p><strong>책임 1 — <역할></strong> — <code>Class.method()</code> (<어느 레이어·도메인의 무엇인지 배치>). <이 책임이 이제 하는 일 — 완결 문장>.</p>
+<p><strong>책임 2 — <역할></strong> — <code>otherFn()</code> (<배치>). <한 일>.</p>
+<p><strong>왜</strong> — <이 변경이 필요한 이유> <span class="cf-src">근거</span> "<원문 인용>"</p>
+<p><strong>효과·사이드이펙트</strong> — <이 변경이 부른 결과·부작용 — 완결 문장></p>
+<p><strong>검증</strong> — <이 변경을 고정하는 테스트와 무엇을 잠그는지></p>
+<p class="cf-loc"><strong>바뀐 위치</strong> — <code>base:path/a.ts:12</code>→<code>head:path/a.ts:15</code>, <code>base:path/b.ts:40</code>→<code>head:path/b.ts:31</code></p>
 </div>
 
 ​```ts
-// 핵심 로직 — real code or pseudocode (one required per file)
+// 핵심 로직 — real code or pseudocode (one required per change block)
 ​```
 ```
 
-The three slots fill R13, R3, and R5. The component, field labels, and code-fence rules follow `markdown-template.md`.
+The slots fill R13, R3, and R5. The `왜`·`효과·사이드이펙트`·`검증`·code are at the change level; the `책임` entries and `바뀐 위치` carry the symbols and their files. The component, field labels, and code-fence rules follow `markdown-template.md`.
 
 - **Commit subsection** (`### \`hash\``): at least one per group. The hash must be a range commit that `start` pinned (R13).
-- **Core-logic code**: one code fence per file block. Location anchors alone do not read as "what was done" (R13).
-- **`cf-loc` location anchors**: put `base:` (before) and `head:` (after) in a slot outside the prose (R5).
+- **Core-logic code**: one code fence per change block — the few lines that reveal the change's core (the central responsibility). Location anchors alone do not read as "what was done" (R13).
+- **`cf-loc` location anchors**: put `base:` (before) and `head:` (after) for **every file this change touched** in the `바뀐 위치` slot outside the prose (R5). This is a location citation, not a flow — flow is the use-case sequence diagram's job.
   `start` passes the original range unchanged to `git diff` for textual hunk capture, preserving
   `A...B` merge-base semantics; only `git rev-list` commit enumeration changes it to `A..B`. At the
-  `code` submission, hunk ranges are checked per file. If a changed file has no textual hunk while
-  another file does, that file uses the legacy per-file anchor-presence/placeholder fallback instead
-  of being rejected as globally missing. Numeric anchors parse the final `:<number>` suffix and are
-  accepted only when the path before it matches the enclosing file-block path, including paths with
-  spaces. A legitimate first-line hunk may therefore use `base:…:1 → head:…:1`; without hunk metadata
-  (or for a file with no textual hunk), the legacy fallback still rejects a modified file whose
-  numeric anchors are the `:1 → :1` placeholder. With metadata, added files need only a `head:` anchor,
-  deleted files only a `base:` anchor, and a zero-count side has no file lines and needs no anchor.
-  Read the real ranges from the captured hunk headers rather than inventing positions.
+  `code` submission, R5 gathers every `base:path:line` / `head:path:line` anchor across all change
+  blocks, keys them by their own cited path, and checks **per signal file** that its before and after
+  are cited and land in real hunks. If a signal file has no textual hunk while others do, it uses the
+  legacy presence/placeholder fallback instead of being rejected. A legitimate first-line hunk may use
+  `base:…:1 → head:…:1`; without hunk metadata for that file, the fallback still rejects a modified
+  file whose only anchors are the `:1 → :1` placeholder. With metadata, an added file needs only a
+  `head:` anchor, a deleted file only a `base:`, and a zero-count side needs none. New-ness comes from
+  `A` in `git diff --name-status`; deleted-ness (no head side) from the hunk header. Read the real
+  ranges from the captured hunk headers rather than inventing positions.
 - **`cf-src` provenance tag**: one of three on every 왜 field (R3).
 
 | Situation | Tag |
@@ -231,11 +241,11 @@ What this gate actually looks at differs per step — it inspects only the slots
 |---|---|
 | evidence | Does every signal file appear somewhere in the document |
 | background | Deep/narrow two-tier background + skip marker |
-| goal | Does the `## 목표` section carry both sub-slots — `### 무엇을·왜` and `### 핵심` (R16) |
-| architecture | Three level headings, each with a mermaid diagram or a reasoned waiver (R9); system level has the three change-contract axes (R14) and a real rendered three-column standing-interface table `경계`/`인터페이스`/`오가는 것` (R17); component level accepts a reasoned structure-no-change waiver or requires renderer-recognized `arch-entity` cards with `레이어`/`책임`/`인터페이스` and `data-change="new|mod|del"` (R18); boundary block requires a real `arch-entity` with allowed `data-change` plus `영향 인터페이스`/`의존 방향` slots (R15); rendered Architecture prose uses standalone-token filtering (R19) |
+| goal | Does the `## 목표` section carry all three sub-slots — `### 무엇을·왜`, `### 핵심`, and `### 출처` (R16) |
+| architecture | Three level headings, each with a mermaid diagram or a reasoned waiver (R9); system level has the three change-contract axes (R14) and a real rendered three-column standing-interface table `경계`/`인터페이스`/`오가는 것` (R17); component level accepts a reasoned waiver or requires `arch-entity` cards with `레이어`/`책임`/`인터페이스` and `data-change`, and rejects a diagram whose nodes are file paths (R18); domain level accepts a reasoned waiver or requires `arch-entity` cards with `책임` and `data-change`, rejects file-path nodes, and requires a `classDiagram`'s boxes to carry members/methods (R21); boundary/use-case block requires an orchestration mermaid diagram (or waiver) plus a real `arch-entity` with allowed `data-change` and `영향 인터페이스`/`의존 방향` slots (R15); rendered Architecture prose uses standalone-token filtering (R19) |
 | intuition | No item of its own — the substantive verdict is the judgment's (R6) |
 | commits | With two or more commits, does every hash appear in the Commit Journey overview (R10); a single commit may use the waiver marker |
-| code | Change Group title/herald/order-rationale three slots (R2), a provenance tag on every 왜 (R3), cf-loc traceability (R5), each signal file in exactly one file block (R1), a commit subsection with a valid hash per group + core-logic code per file (R13). `start` passes the original range unchanged to `git diff` (preserving `A...B` merge-base semantics); only `git rev-list` enumeration normalizes it to `A..B`. At `code` submission, textual hunk ranges are checked per file, and a file with no textual hunk uses the legacy per-file presence/placeholder fallback even when other files have hunks. The final `:<number>` suffix is matched against the enclosing file-block path, including paths with spaces. A legitimate first-line hunk may use `base:…:1 → head:…:1`; added files need `head:` only, deleted files `base:` only, and a zero-count side has no file lines. |
+| code | Change Group title/herald/order-rationale three slots (R2), a provenance tag on every 왜 (R3), cf-loc traceability (R5), every signal file cited by at least one change block's `바뀐 위치` anchors (R1 — a file may be cited by several changes), a commit subsection with a valid hash per group + core-logic code per change block (R13). `start` passes the original range unchanged to `git diff` (preserving `A...B` merge-base semantics); only `git rev-list` enumeration normalizes it to `A..B`. At `code` submission, R5 keys every `base:`/`head:` anchor by its own cited path and checks per signal file that its before/after are cited and land in real hunks; a file with no textual hunk uses the legacy presence/placeholder fallback. A legitimate first-line hunk may use `base:…:1 → head:…:1`; added files need `head:` only, deleted files `base:` only, and a zero-count side has no file lines. |
 | render | See Step 8 — it inspects the artifact HTML, mermaid render parity, and the technical-writing report |
 
 **Common to all authoring steps**: the whole accumulated document is checked for `<style>`, inline `style=`, and unsanctioned classes (R11).
@@ -296,6 +306,8 @@ The quiz is **a conversational stage, not a document section.** Do not write a `
 ### Question bank
 
 Fix at least one **required concept** per section, and one per subsystem the diff touched for the Code section. If the total exceeds 20, cut by importance and **note in the document that you cut.**
+
+**Test understanding, not metadata.** The quiz measures whether the reader grasped **what this change is for and why it was needed** — its purpose, the problem it solves, the tradeoff it makes, the reason one path was chosen over another. Do **not** ask about document metadata or bookkeeping — the git range, the signal/noise file counts, the number of commits — none of that proves comprehension of the change. Every question ties to the substance: the purpose (why this change exists), the mechanism (how it works), or the consequence (what it enables or prevents). If a question could be answered by skimming the header without understanding the change, cut it. At least one required concept must be a **why/purpose** question, phrased so the answer must state the reason, not just the mechanic.
 
 ```bash
 $CLI add-concept --id <concept> --required

--- a/skills/explain-diff/references/judge-prompt.md
+++ b/skills/explain-diff/references/judge-prompt.md
@@ -31,8 +31,14 @@ R12 — the architecture diagram's correspondence to the diff (only when the ste
   diagram must also be COMPLETE: every distinct process, service, or store the Evidence or
   Background prose names as involved in this change must appear as a node. If the prose names a
   process the diagram omits (e.g. a separate Python API or a CLI the prose references but the
-  diagram leaves out), that is a fail — quote the prose sentence naming the omitted process. In
-  the pass case put into quote the diagram's label string, the body sentence where the same
+  diagram leaves out), that is a fail — quote the prose sentence naming the omitted process.
+  For the 컴포넌트 레벨 and 도메인 레벨 specifically: nodes name a MODULE/component or a
+  business CONCEPT, never a source file path (a path is a location, told in the card's 레이어
+  slot — a file-path node fails). A 도메인 레벨 node must be a real business concept in the
+  codebase's own terms; a bare schema-encoding name with no business meaning attached
+  (`GenerationIntakeTimeCodesSchema` standing alone) is not a domain object and fails. If a
+  domain classDiagram is drawn, its class boxes must carry members/methods — empty boxes fail.
+  In the pass case put into quote the diagram's label string, the body sentence where the same
   identifier appears, and the phrase that evidences the change marker, together.
   If there is no diagram at all and all three levels have a reasoned
   `구조 변화 없음: <사유 한 문장>` waiver, R12 is a pass. In this all-waiver branch, quote must

--- a/skills/explain-diff/references/markdown-template.md
+++ b/skills/explain-diff/references/markdown-template.md
@@ -13,6 +13,7 @@
 # <제목> — 변경 설명
 
 <ul class="doc-meta">
+  <li><strong>목적</strong> <이 문서가 무엇을 가르치고 왜 이해해야 하는지 한 줄></li>
   <li><strong>범위</strong> <code><git range></code></li>
   <li><strong>커밋</strong> N개</li>
   <li><strong>파일</strong> signal N / noise N</li>
@@ -34,19 +35,23 @@
 <이 변경이 이루려는 것 + 왜 필요했는가(해결하는 문제) — 스텝 3>
 ### 핵심
 <코드를 보기 전에 독자가 먼저 쥐어야 할 핵심 한 줄>
+### 출처
+<이 목적·컨텍스트를 파악하는 데 쓴 근거 — Linear/Notion/Slack/PR/커밋/위키 식별자·경로 또는 "코드 추론" (R16)>
 
 ## Architecture
 ### 시스템 레벨
 <mermaid(간선=짧은 프로토콜: HTTP/SQL/REST) 또는 "구조 변화 없음: <사유>">
-<상시 인터페이스 표 — 정확한 3열 헤더·구분선과 최소 1개 데이터 행, 아래 참조 (R17)>
+<상시 인터페이스 표 — 정확한 3열 헤더·구분선과 최소 1개 데이터 행, `인터페이스`·`오가는 것`은 시그니처/페이로드/응답 바디를 실제로 적는다, 아래 참조 (R17)>
 <변경 계약 표 — 서버 API / DB 스키마 / 클라이언트 의존 3축, 아래 참조 (R14)>
 ### 컴포넌트 레벨
-<mermaid 의존 그래프 또는 "구조 변화 없음: <사유>">
-<변경 행위 노드마다 arch-entity 카드 — 레이어 / 책임 / 인터페이스 + 변경종류, 아래 참조 (R18)>
+<mermaid 의존 그래프 — 노드는 모듈/개념 이름(피처·유스케이스·훅·서비스), 파일 경로 금지 — 또는 "구조 변화 없음: <사유>">
+<변경 행위 노드마다 arch-entity 카드 — 레이어(어디에 있는지 패키지/레이어 단위) / 책임 / 인터페이스 + 변경종류, 아래 참조 (R18)>
 ### 도메인 레벨
-<mermaid 또는 "구조 변화 없음: <사유>">
+<mermaid(erDiagram/classDiagram) — 노드는 실재 비즈니스 개념 이름(파일 경로 금지), classDiagram이면 각 박스에 멤버 변수·메소드를 채운다 — 또는 "구조 변화 없음: <사유>">
+<도메인 객체마다 arch-entity — 책임(불변식) + 변경종류, 아래 참조 (R21)>
 
 ### 경계·의존·유스케이스
+<유스케이스 오케스트레이션 mermaid sequenceDiagram(흐름 + 바뀐 단계) 또는 waiver>
 <동작 단위마다 arch-entity — 변경종류 + 한 일 + 영향 인터페이스, + 의존 방향 판정 한 줄 — 아래 참조 (R15)>
 
 ## Intuition
@@ -59,30 +64,39 @@
 (`git rev-list --no-merges <base>..<head>`가 정확히 한 줄일 때만 섹션 대신:
 "단일 커밋 범위 — Commit Journey 생략.")
 
-## Change Group 1: <제목>
+## Change Group 1: <관심사>
 > 예고: <이 그룹이 무엇을 할지 — 그룹 N은 그룹 N-1을 전제>
 > 순서: <왜 이 순서인지>
 
 ### `<short-hash>` — <커밋 제목>
 <이 커밋이 이 그룹에서 한 일 한두 문장. 여러 그룹을 가로지르면 spillover 한 줄.>
 
-#### `path/to/file.ts`
-<div class="cf">
-<p><strong>역할/변경 전</strong> — <설명></p>
-<p><strong>바뀐 것</strong> — <설명></p>
-<p><strong>왜</strong> — <설명> <span class="cf-src">근거</span> "<원문 인용>"</p>
-<p><strong>효과</strong> — <설명></p>
-<p class="cf-loc"><code>base:path/to/file.ts:12</code> → <code>head:path/to/file.ts:15</code></p>
+#### 변경 1: <이 변경이 이룬 것 — 파일명이 아니라 "한 일"로 짓는다>
+<div class="cf" data-change="mod">
+<p><strong>책임 1 — <이 책임의 역할></strong> — <code>Class.method()</code>
+   (<어느 레이어·도메인의 무엇인지 한 줄 배치 — 아키텍처 섹션 카드를 가리킨다>).
+   <이 책임이 이제 하는 일 — 완결 문장>.</p>
+<p><strong>책임 2 — <역할></strong> — <code>otherFn()</code> (<배치>). <한 일>.</p>
+<p><strong>왜</strong> — <이 변경이 필요한 이유> <span class="cf-src">근거</span> "<원문 인용>"</p>
+<p><strong>효과·사이드이펙트</strong> — <이 변경이 부른 결과·부작용 — 완결 문장으로></p>
+<p><strong>검증</strong> — <이 변경을 고정하는 테스트와, 그 테스트가 무엇을 잠그는지></p>
+<p class="cf-loc"><strong>바뀐 위치</strong> — <code>base:path/a.ts:12</code>→<code>head:path/a.ts:15</code>,
+   <code>base:path/b.ts:40</code>→<code>head:path/b.ts:31</code></p>
 </div>
 
 ​```ts
-// 핵심 로직 — 실제 코드 또는 수도코드 (파일마다 하나 필수)
+// 핵심 로직 — 이 변경의 핵심 몇 줄 (변경 블록마다 하나 필수)
 ​```
 ```
 
-**뼈대는 커밋이다.** Change Group(관심사)이 1급 단위이지만, 그 안에서는 커밋 단위로
-내려가고(`### \`hash\` — 제목`), 커밋 아래 그 커밋이 건드린 파일 블록(`#### \`file\``)이
-온다. docs·noise 커밋은 별도 나열하지 않고 계약을 설명하는 그룹 안에서 한 줄로 흡수한다.
+**단위는 변경(change)이고, 뼈대는 커밋이다.** Change Group(관심사)이 1급 묶음이고, 그 안에서
+커밋 단위로 내려간다(`### \`hash\` — 제목`). 커밋 아래에는 그 커밋이 이룬 **변경 블록**
+(`#### 변경 N: <한 일>`)이 오며, **파일이 아니라 변경이 블록의 단위다.** 하나의 변경은 여러
+**책임**(함께 바뀌는 class·function의 duty)으로 이뤄지므로, 한 변경 블록은 그 책임들을
+`책임 N — <역할>` 항목으로 나열한다. 각 책임은 어떤 클래스의 어떤 함수인지 + 그것이 어느
+레이어·도메인에 사는지(배치)를 밝히고, 파일은 heading이 아니라 `바뀐 위치` 슬롯의 위치 인용으로만
+등장한다. `왜`·`효과·사이드이펙트`·`검증`·핵심 코드는 변경 레벨에 하나씩 붙는다. docs·noise
+커밋은 별도 나열하지 않고 계약을 설명하는 그룹 안에서 한 줄로 흡수한다.
 
 ## Architecture 세 레벨이 각각 답하는 질문
 
@@ -141,10 +155,17 @@ R17 = 지금 소통하는 상시 인터페이스**. 순서는 다이어그램 �
 이 표는 **실제로 렌더되는 Markdown 표**여야 한다. 헤더와 separator row는 정확히 세 열
 `경계`·`인터페이스`·`오가는 것`이어야 하고, separator 아래에 최소 한 개의 데이터 행이
 있어야 한다. 산문으로 열 이름만 쓰거나 펜스 안 예시, 헤더·separator만 있는 표로
-대체하면 R17을 통과하지 못한다. 무엇을 적는지는 저자의 몫이다.
+대체하면 R17을 통과하지 못한다. **`인터페이스`와 `오가는 것` 칸은 실제 메시지를 적는다** —
+"camelCase generationRequest" 같은 명명 규칙 메모가 아니라, 시그니처와 요청/응답 바디를 필드·타입으로
+쓴다(예: `오가는 것` = `{ generationRequest: { userRequest: string, intakeTimeCodes: string[] }, proposalType: enum } → { asyncTaskId: string }`). 무엇이 경계를 넘는 값인지 구체적으로 읽혀야 한다.
 
 ### 컴포넌트 레벨 — 노드 카드 (R18 필수)
 
+컴포넌트는 **하나의 모듈**이다 — 피처·유스케이스·훅·서비스·스키마 모듈 — 파일이 아니다.
+그래서 다이어그램 **노드는 모듈/개념 이름**이지 소스 파일 경로가 아니다(경로를 노드로 쓰면 독자에게
+위치만 알려주고 무엇인지는 못 알려주며, 긴 경로는 렌더에서 중간이 잘린다 — `health-`, `proposal-`).
+컴포넌트가 **어디에 있는지**는 카드의 `레이어` 슬롯이 패키지/레이어 단위로 말한다
+(`packages/schemas/src/program`, `entities/supplement/api`). 노드가 파일 경로면 R18이 거부한다.
 의존 그래프(mermaid)는 "무엇이 무엇에 연결되나"를 그리지만, 노드 이름만으로는
 `CurrentBoostPackInfoCard` 가 무엇을 하는지 읽히지 않는다. 컴포넌트 구조가 정말 바뀌지
 않는다면 그 이유를 담은 `구조 변화 없음: <사유>` waiver로 R18을 충족할 수 있다. 그 외에는
@@ -167,14 +188,66 @@ R17 = 지금 소통하는 상시 인터페이스**. 순서는 다이어그램 �
 컴포넌트 레벨 안에 있어야 R18을 통과한다(단, reasoned waiver는 카드 대신 허용된다).
 변경종류는 `data-change="new|mod|del"` 로 나르고 배지 색은 render.ts가 붙인다.
 
+### 도메인 레벨 — 엔티티 카드 (R21 필수)
+
+도메인 레벨은 세 레벨 중 가장 얇게 방치되기 쉽다 — 다이어그램 하나로 끝내면 독자는 어떤 도메인
+객체가 이 diff로 추가·변경됐고 그것이 무엇을 보장하는지 읽지 못한다. 노드와 카드는 **실재
+비즈니스 개념**이어야 한다 — 도메인이 실제로 모델링하는 것(Program, 섭취 시간대 슬롯, 온보딩 vs
+일반 생성 같은 요청 종류)을, 코드베이스 자신의 도메인 용어로 푼다. 스키마 클래스 이름은 **그것이
+인코딩하는 비즈니스 개념을 설명할 때에만** 도메인 객체로 쓸 수 있다 — 비즈니스 의미 없이 인코딩
+이름만 있는 노드(`GenerationIntakeTimeCodesSchema`)는 도메인 객체가 아니다. 엔티티/관계
+다이어그램(`erDiagram`/`classDiagram`) **위에**, 이 diff가 건드린 **도메인 객체마다 `arch-entity`
+카드**를 둔다 — 각 카드는 **책임(그 객체가 지는 duty·불변식)** 과 **변경종류(`data-change`)** 를
+적는다. **객체/클래스 다이어그램을 그리면 각 박스를 채운다** — 멤버 변수(무엇을 들고 있는지)와
+메소드/메시지(무엇을 하는지). 이름만 있는 빈 박스는 아무것도 가르치지 못하고, 멤버 없는
+`classDiagram`은 R21이 거부한다. 노드는 도메인 개념 이름이지 파일 경로가 아니다. 도메인 객체가
+정말 안 바뀌면 `구조 변화 없음: <사유>` waiver로 대신한다.
+
+```markdown
+### 도메인 레벨
+​```mermaid
+classDiagram
+  class SupplementCategory {
+    +code: string
+    +displayName: string
+    +isActive() bool
+  }
+  class ProposalCategoryMirror {
+    +categoryCode: string
+    +proposalId: string
+    +reflects() SupplementCategory
+  }
+  SupplementCategory "1" <-- "*" ProposalCategoryMirror : identifies
+​```
+
+<div class="arch-entity" data-change="mod">
+<p><strong>이름</strong> <code>SupplementCategory</code></p>
+<p><strong>책임</strong> 영양제의 canonical 정체성을 보유한다 — 판매 상품이 교체돼도 같은 카테고리로 유지되는 불변식.</p>
+</div>
+
+<div class="arch-entity" data-change="new">
+<p><strong>이름</strong> <code>ProposalCategoryMirror</code></p>
+<p><strong>책임</strong> 제안이 어떤 카테고리를 바꾸는지 canonical mirror 행으로 표현한다.</p>
+</div>
+```
+
+`책임` 라벨과 허용된 `data-change` 를 가진 `arch-entity` 카드가 도메인 레벨 안에 있어야 R21을
+통과한다(reasoned waiver는 카드 대신 허용된다). `classDiagram`을 그렸다면 각 박스의 멤버·메소드도
+채워야 한다.
+
 ## 경계·의존·유스케이스 블록 (R15 필수)
 
-이 블록은 각 파트를 어느 레이어에 분류하는 **정적 표**가 아니라, **이 diff가 닿은 경계의 변경
-지도**다. "누가 어느 레이어냐"가 아니라, 이번 변경에서 **동작을 끝까지 나르는 단위**가 무엇이
-추가/삭제/변경됐고, 그로 인해 **어떤 인터페이스에 영향**이 갔으며, **의존 방향**이 유지됐나
-뒤집혔나를 적는다. 무게중심은 동작 단위와 영향 인터페이스이고, 닿은 레이어·도메인은 그 위 한 줄
-배경으로만 훑는다.
+이 블록은 각 파트를 어느 레이어에 분류하는 **정적 표**가 아니라, **이 diff가 닿은 유스케이스의
+변경 지도**다. 피처·유스케이스는 대개 **오케스트레이션의 책임**을 지므로, 이 블록의 무게중심은
+**흐름**이다 — "누가 누구를 어떤 순서로 부르고, 그중 어느 단계가 이 diff로 바뀌었나". 그 흐름을
+**mermaid `sequenceDiagram`으로 그리고**(정적 카드로 말로 때우지 않는다), 바뀐 단계를 `Note`나
+`:::changed`로 지목한다. 그 위에 동작 단위마다 `arch-entity`로 한 일·영향 인터페이스를 얹고,
+의존 방향을 한 줄로 판정한다.
 
+- **오케스트레이션 다이어그램** — 유스케이스의 호출 흐름을 `sequenceDiagram`(권장)으로 그린다.
+  참가자는 실재 모듈·서비스·함수 이름이어야 하고(R12), 이 diff가 바꾼 단계를 표시한다. 흐름이
+  정말 안 바뀌면 `구조 변화 없음: <사유>` waiver로 대신한다. (R15가 이 블록에 mermaid 또는
+  waiver가 있는지 검사한다.)
 - **동작 단위** — 이 변경이 추가/삭제/변경한 행위 단위마다 `arch-entity` 하나. 변경종류는
   `data-change`, 각 단위는 **한 일 + 영향 인터페이스**를 적는다. 어휘·원리는
   `architecture-boundaries` rule의 2축을 따르되 **방법론 이름(DDD·FSD·Clean-arch·bounded context)도,
@@ -190,18 +263,24 @@ R19는 렌더되는 `## Architecture` 산문만 검사한다. fenced block과 in
 ```markdown
 ### 경계·의존·유스케이스
 
-> 닿은 곳 — 부스트팩 상담챗의 카드·도구(commerce `entities`·`features/ui`), 표시 카탈로그(backend `catalog`).
+> 유스케이스 — 부스트팩 상담챗이 표시 카탈로그를 읽어 카드를 그리는 흐름. 아래 시퀀스의
+> backend 조회 단계가 이 diff로 바뀐다.
+
+​```mermaid
+sequenceDiagram
+  participant Chat as 상담챗 feature
+  participant Resolver as entities resolver
+  participant Backend as backend catalog
+  Chat->>Resolver: resolveDisplay(code)
+  Resolver->>Backend: GET /v1/supplement-catalog?includeDeletedCategories=true
+  Note over Resolver,Backend: 이 diff — 삭제 카테고리까지 포함해 조회
+  Backend-->>Resolver: 표시 카탈로그(삭제 포함)
+​```
 
 <div class="arch-entity" data-change="new">
 <p><strong>이름</strong> display catalog 조회</p>
 <p><strong>한 일</strong> 삭제 카테고리까지 포함한 표시용 카탈로그 경로 신설</p>
 <p><strong>영향 인터페이스</strong> <code>GET /v1/supplement-catalog?includeDeletedCategories=true</code></p>
-</div>
-
-<div class="arch-entity" data-change="mod">
-<p><strong>이름</strong> 카드 category 축 전환</p>
-<p><strong>한 일</strong> row key·표시·편집 대상을 product에서 category로</p>
-<p><strong>영향 인터페이스</strong> 카드 snapshot 계약, pill override 키</p>
 </div>
 
 **의존 방향** — commerce feature → entities resolver → shared schema → backend REST 단방향 유지.
@@ -245,9 +324,10 @@ R15는 펜스를 마스킹한 실제 블록에서 `영향 인터페이스`·`의
 
 ## 핵심 로직 코드 (R13 필수)
 
-파일 블록마다 그 파일의 **핵심 로직**을 코드 펜스 하나로 보여준다 — 실제 diff 코드의
+변경 블록마다 그 변경의 **핵심 로직**을 코드 펜스 하나로 보여준다 — 실제 diff 코드의
 핵심 몇 줄이거나, 그것이 길면 수도코드로 요약한다. 위치 앵커만으로는 "무엇을 했나"가
-읽히지 않는다.
+읽히지 않는다. 한 변경이 여러 파일을 건드려도 코드 펜스는 그 변경의 핵심을 드러내는 하나면
+된다(가장 중심이 되는 책임의 코드).
 
 ```markdown
 ​```ts
@@ -275,12 +355,17 @@ export const SupplementCostItem = z.strictObject({
 </ul>
 ```
 
-### `cf` / `cf-src` / `cf-loc` — 바뀐 파일 하나의 필드 블록
+### `cf` / `cf-src` / `cf-loc` — 변경 하나의 필드 블록
 
-코드 섹션의 파일 블록(`#### \`file\``) 바로 아래에 온다. 필드마다 `<p>` 하나로 세워
-한 문단으로 뭉치지 않게 한다. 출처는 `cf-src` 배지로, 위치 앵커는 `cf-loc` 슬롯으로
-산문 밖에 둔다. 필드 라벨은 `<strong>` 으로 쓴다 — 마크다운 `**…**` 는 div 안에서
-살지 않는다.
+코드 섹션의 변경 블록(`#### 변경 N: <한 일>`) 바로 아래에 온다. **파일이 아니라 변경 하나**를
+설명하는 블록이다. 한 변경은 여러 **책임**(함께 바뀐 class·function의 duty)으로 이뤄지므로
+`책임 N — <역할>` 항목을 각각 `<p>` 하나로 세운다 — 각 항목은 어떤 클래스의 어떤 함수인지와
+그 함수가 어느 레이어·도메인에 사는지(배치)를 밝힌다. 그 아래 `왜`·`효과·사이드이펙트`·`검증`은
+변경 레벨에 하나씩, 완결 문장으로 쓴다. 출처는 `cf-src` 배지로, 위치는 `cf-loc` 슬롯으로
+산문 밖에 둔다. 변경종류(신설·변경·삭제) 배지는 `data-change` 로 싣고 색·라벨은 render.ts가
+붙인다 — 저자는 `new`·`mod`·`del` 종류만 준다. 필드 라벨은 `<strong>` 으로 쓴다 — 마크다운
+`**…**` 는 div 안에서 살지 않는다. `cf-loc` 슬롯은 흐름이 아니라 **위치 인용**이다 — 흐름은
+유스케이스 레벨의 시퀀스 다이어그램이 보여준다.
 
 `start`는 전달받은 range 문자열을 그대로 `git diff`에 넘겨 unified diff hunk 메타데이터를
 저장한다. 따라서 `A...B`의 merge-base diff 의미가 보존된다. `git rev-list` 커밋 열거만
@@ -295,12 +380,19 @@ suffix를 파싱하고, 그 앞의 경로가 감싸는 파일 블록의 경로�
 헤더에서 확인한다.
 
 ```html
-<div class="cf">
-<p><strong>역할/변경 전</strong> — 비용 입력·출력 item 스키마.</p>
-<p><strong>바뀐 것</strong> — <code>supplementCategoryId</code> 단독 strict 로 축소.</p>
-<p><strong>왜</strong> — 두 축 공존을 끝낸다 <span class="cf-src">근거</span> "feat!: 카테고리 축으로 고정"</p>
-<p><strong>효과</strong> — 구 클라이언트 요청이 검증 단계에서 거부된다.</p>
-<p class="cf-loc"><code>base:packages/schemas/src/commerce/supplement-cost.ts:8</code> → <code>head:…:6</code></p>
+<div class="cf" data-change="mod">
+<p><strong>책임 1 — 비용 item 계약</strong> — <code>SupplementCostItem</code> 스키마
+   (packages/schemas의 commerce 비용 계약, 서버·클라이언트가 공유). 두 식별자 축을
+   <code>supplementCategoryId</code> 단독 strict 로 축소한다.</p>
+<p><strong>책임 2 — 요청 검증</strong> — 이 스키마를 쓰는 비용 요청 파서. category 축만
+   받으므로 product 축이 섞인 구 요청을 파싱 단계에서 걸러낸다.</p>
+<p><strong>왜</strong> — 비용 계약의 두 축 공존을 끝내고 category 하나로 고정하기 위해
+   <span class="cf-src">근거</span> "feat!: 카테고리 축으로 고정"</p>
+<p><strong>효과·사이드이펙트</strong> — 이미 배포된 구 클라이언트가 product 축으로 보내는
+   비용 요청은 검증 단계에서 거부되므로, 클라이언트도 category 축으로 함께 올려야 한다.</p>
+<p><strong>검증</strong> — <code>supplement-cost.test.ts</code> 가 category 단독 통과와
+   product 축 혼입 거부를 함께 고정한다.</p>
+<p class="cf-loc"><strong>바뀐 위치</strong> — <code>base:packages/schemas/src/commerce/supplement-cost.ts:8</code>→<code>head:packages/schemas/src/commerce/supplement-cost.ts:6</code></p>
 </div>
 ```
 

--- a/skills/explain-diff/references/rubric.md
+++ b/skills/explain-diff/references/rubric.md
@@ -36,6 +36,7 @@ The document is written one step at a time, accumulating. So an item is evaluate
 | R17 | script | architecture |
 | R18 | script | architecture |
 | R19 | script | architecture |
+| R21 | script | architecture |
 
 The `intuition` step has no slot of its own — only R6 (judge) and the common R11 decide it. `render` and `quiz` score none of this table's items: `render` looks at the artifact check (HTML present and non-empty, mermaid→SVG parity, technical-writing `REVIEW: APPLIED`), and `quiz` runs a separate grading path (`grade`). Visual layout is not scored per document — it is a deterministic property render.ts owns (wide-diagram legibility is sealed by `normalizeSvgWidth` + the figure scroll container, regression-guarded by `render.test.ts`), so there is no visual-qa gate.
 
@@ -51,11 +52,12 @@ Not one file classified as signal is dropped. The required form differs at the t
 
 - **Listing form (evidence step)** — Change Groups are not written yet, so the file path merely needs to
   appear somewhere in the document.
-- **Coverage form (code step)** — each signal file must have **exactly one** file block (`#### \`path\``).
-  Zero means it never entered a group; two or more means the same file appears in multiple groups —
-  both fail. (A file block is h4 — an h3 `### \`hash\`` is a commit subsection.)
+- **Coverage form (code step)** — the unit is the change, not the file, so each signal file must be
+  **cited by at least one change block's `바뀐 위치` (cf-loc) anchors**. Zero citations means the
+  walkthrough silently dropped that file — fail. A file cited by several changes is fine (one file
+  often participates in several responsibilities), so there is no exactly-once rule.
 
-Decided by comparing the `git diff --name-only` list against the document.
+Decided by comparing the `git diff --name-only` list against the anchor paths cited in the document.
 
 > **RED 10/16.** Mostly upheld in small fixtures, but **all 4 runs failed** on a giant PR
 > (18 / 19 / 11 / 7 of 29). This is exactly where files silently vanish.
@@ -93,12 +95,13 @@ Both a deep background and a narrow background are present, and the deep backgro
 
 At `start`, the CLI passes the original range unchanged to `git diff` when it captures unified-diff
 hunk metadata, preserving `A...B` merge-base semantics. Only `git rev-list` commit enumeration
-normalizes `A...B` to `A..B`. At the `code` submission, textual hunk ranges and numeric
-`base:`/`head:` anchors are checked per file. If a changed file has no textual hunk while another
-file does, that file uses the legacy per-file anchor-presence/placeholder fallback rather than being
-rejected as globally missing. Numeric anchors parse the final `:<number>` suffix and are accepted
-only when the preceding path matches the enclosing file-block path, including paths with spaces. A
-legitimate first-line hunk may therefore use `base:…:1 → head:…:1`. If hunk metadata is unavailable,
+normalizes `A...B` to `A..B`. At the `code` submission, R5 gathers every `base:path:line` /
+`head:path:line` anchor across all change blocks, keys them by their own cited path, and checks **per
+signal file** that its before and after are cited and land in real hunks. If a signal file has no
+textual hunk while another does, it uses the legacy presence/placeholder fallback rather than being
+rejected as globally missing. Numeric anchors parse the final `:<number>` suffix against their own
+cited path, including paths with spaces. A legitimate first-line hunk may therefore use
+`base:…:1 → head:…:1`. If hunk metadata is unavailable,
 or unavailable for that file, the legacy fallback still rejects a modified file whose numeric anchors
 are the `:1 → :1` placeholder. With metadata, an added file needs only `head:`, a deleted file only
 `base:`, and a zero-count side has no file lines and needs no anchor. New-ness comes from `A` in
@@ -140,7 +143,7 @@ Nowhere in the document is there a `<style>` block or an inline `style=` attribu
 
 ### R13. Commit spine + core-logic code
 
-The code section is organized with the commit as its spine. Each Change Group has at least one commit subsection (`### \`hash\``) carrying a valid range hash, and each file block has one core-logic code fence — a mermaid-only or empty fence does not count (the template reserves mermaid for diagrams and requires real code/pseudocode per file). The gate forces this coarse spine — a commit subsection per group and a code fence per file; how the file blocks nest under commits and which cf fields each carries is the author's to fill from the template, not machine-forced. Hash validity is compared against the list `start` pinned — if enumeration failed and the list is empty, the validity check is skipped ("git failed" is not "every hash is fake").
+The code section is organized with the commit as its spine, and its unit is the change (`#### 변경 N: <한 일>`), not the file. Each Change Group has at least one commit subsection (`### \`hash\``) carrying a valid range hash, and each change block has one core-logic code fence — a mermaid-only or empty fence does not count (the template reserves mermaid for diagrams and requires real code/pseudocode per change). The gate forces this coarse spine — a commit subsection per group and a code fence per change block; how the responsibilities nest inside a change and which cf fields each carries is the author's to fill from the template, not machine-forced. Hash validity is compared against the list `start` pinned — if enumeration failed and the list is empty, the validity check is skipped ("git failed" is not "every hash is fake").
 
 > **RED — v3 artifact.** In the `b2c-6106` document, `## Commit Journey` (21 commits) and `## Change Group`
 > (per file) were fully separated, so commits were listed unrelated to the code explanation. File blocks
@@ -158,7 +161,7 @@ The code section is organized with the commit as its spine. Each Change Group ha
 
 ### R15. Boundary / dependency / use-case change map
 
-The Architecture section closes with a `### 경계·의존·유스케이스` block that is a **change map**, not a static layer-classification table. Read on the `### 경계·의존·유스케이스` sub-slice with fences masked. The rendered block must contain a renderer-recognized `arch-entity` opening tag whose `data-change` is one of `new`, `mod`, or `del`, plus the `영향 인터페이스` and `의존 방향` slots. Prose-only mentions of `data-change`, or unsupported values, do not count. What each slot says is the author's to fill. The vocabulary follows the `architecture-boundaries` rule but the output speaks the codebase's own terms (enforced by R19).
+The Architecture section closes with a `### 경계·의존·유스케이스` block that is a **use-case change map**, not a static layer-classification table. Because a feature/use case mostly carries an orchestration responsibility, the block must **show the flow as a mermaid diagram** (a `sequenceDiagram` is the recommended type) — who calls whom in what order, with the changed step marked — or a reasoned `구조 변화 없음: <사유>` waiver when the diff changes no use-case flow. Beyond the diagram, the block must contain a renderer-recognized `arch-entity` opening tag whose `data-change` is one of `new`, `mod`, or `del`, plus the `영향 인터페이스` and `의존 방향` slots. Prose-only mentions of `data-change`, or unsupported values, do not count. The orchestration-diagram check reads the raw sub-slice (a mermaid fence is masked away, so it is looked for before masking); the slot checks read the fence-masked sub-slice. What each slot says is the author's to fill. The vocabulary follows the `architecture-boundaries` rule but the output speaks the codebase's own terms (enforced by R19).
 
 > **RED — the v4 static table.** The earlier R15 forced a `파트/레이어/협력자/영향·수정` classification table
 > with a binary `수직 도메인 / 수평 유스케이스` layer choice. On an FSD codebase this miscategorised parts that
@@ -181,7 +184,15 @@ Prose-only labels, a fenced example, and a header/separator-only table are not t
 requires. Read on the 시스템 레벨 slice with fences masked; the executable checker requires this
 exact three-column header/separator shape plus a non-separator data row. This is distinct from R14 in
 layer — R14 enumerates what this diff *changes*, R17 the *standing* interface the diagram's
-short-protocol edges leave implicit. What each row says is the author's to fill.
+short-protocol edges leave implicit. What each row says is the author's to fill — but the
+`인터페이스`/`오가는 것` cells must carry the actual signature and request/response payload (fields
+with types), not a naming-convention note; the checker enforces the table shape, and the signature
+content is a documented authoring requirement the judge and RED/GREEN comparison hold to.
+
+> **RED — real artifact (`pr-3412`, luna max).** The standing-interface `오가는 것` cell said
+> "camelCase `generationRequest`, `proposalType`" — a naming convention, not a message. A reader could
+> not tell what value crossed the boundary. The requirement is the signature and payload shape
+> (`{ generationRequest: { userRequest: string, intakeTimeCodes: string[] }, proposalType: enum } → { asyncTaskId }`).
 
 > **RED — real artifact (`b2c-6105`).** The system diagram was `browser --> backend --> db` with every edge
 > unlabelled, and it *omitted* the Python health-profile API and the census→DB boundary that the prose itself
@@ -192,16 +203,51 @@ short-protocol edges leave implicit. What each row says is the author's to fill.
 ### R18. Component-level node cards
 
 The 컴포넌트 레벨 may use a reasoned `구조 변화 없음: <사유>` waiver when there is no component
-structure change. Otherwise, every authored `arch-entity` card in the slice is checked independently
-for the `레이어`, `책임`, and `인터페이스` fields and an allowed `data-change` value: `new`, `mod`, or
-`del`. One complete card cannot mask an incomplete or invalid card. Prose-only card descriptions and
-invalid `data-change` values do not count. Pure data/contract-only content cannot simply omit cards;
-it needs the reasoned waiver if no valid card is present.
+structure change. The diagram's **nodes must be module/concept names** (a feature, use case, hook,
+service, schema module), **never source file paths** — the checker rejects a component diagram whose
+nodes are file paths (a path with a code extension), and this ban holds even under the waiver. Where a
+component lives is stated in the card's `레이어` slot at package/layer granularity, not as a node
+label. Otherwise, every authored `arch-entity` card in the slice is checked independently for the
+`레이어`, `책임`, and `인터페이스` fields and an allowed `data-change` value: `new`, `mod`, or `del`.
+One complete card cannot mask an incomplete or invalid card. Prose-only card descriptions and invalid
+`data-change` values do not count. Pure data/contract-only content cannot simply omit cards; it needs
+the reasoned waiver if no valid card is present.
 
 > **RED — real artifact (`b2c-6105`).** The component level was a bare chain of class/function names —
 > `CurrentBoostPackInfoCard`, `useBoostPackSupplementCatalogResolvers` — with no responsibility, interface, or
 > layer anywhere, so a reader could not tell what any node *does*. The system level had gained a companion
 > table (R14); the component level had no counterpart, an asymmetry R18 closes.
+>
+> **RED — real artifact (`pr-3412`, luna max).** The component diagram's nodes were full source file paths
+> (`apps/backend/src/domains/health-profiles/routers/health-v2.router.ts`) that truncated mid-path in the
+> render (`health-`, `proposal-`), telling the reader a location instead of a module. A component is a module
+> unit; its location belongs in the card's `레이어`, not in the node label.
+
+### R21. Domain-level entity cards
+
+The `### 도메인 레벨` may use a reasoned `구조 변화 없음: <사유>` waiver when the diff changes no
+domain object. Otherwise, above the entity/relation diagram, every touched domain object gets an
+`arch-entity` card checked independently for the `책임` field (the duty/invariant it holds) and an
+allowed `data-change` value (`new`, `mod`, `del`). One complete card cannot mask an incomplete or
+invalid card. Nodes and cards must name **real business concepts** — the things the domain models
+(a Program, an intake-time slot, an onboarding vs regular request kind) — in the codebase's own terms;
+a bare schema-encoding name with no business meaning is not a domain object (reality judged by R12).
+Two structural bans hold even under the waiver: diagram nodes must not be file paths, and a
+`classDiagram`, if drawn, must fill each box with **members and methods** — an empty class box (name
+only) fails. This is the domain-level counterpart to R18.
+
+> **RED — real artifact (`pr-3412`, luna max).** The domain `classDiagram` drew boxes with class names
+> only and no members — `GenerationIntakeTimeCodesSchema`, `ProgramGenerationRequestV2Schema` — so a
+> reader could not tell what each object holds or does, nor whether these encoding names were real
+> business concepts. An object diagram must show member variables and methods; the domain level names
+> business concepts, not schema encodings without their meaning.
+
+> **RED — real artifacts (`pr-3557`, `pr-3556`).** The domain level was the thinnest of the three:
+> `pr-3557` drew a `classDiagram` whose nodes included narrative concepts (`ModelAlias`,
+> `LegacyProductKey`) with no responsibility or change kind, and `pr-3556` closed the level with a bare
+> `erDiagram` and one prose paragraph. A reader could not tell which domain object this diff added or
+> modified, or what invariant it now holds — the component level had cards (R18) but the domain level
+> had no counterpart, the same asymmetry R21 closes.
 
 ### R19. No methodology name or axis label in Architecture prose
 
@@ -222,7 +268,9 @@ internally, but the *output* forbids naming the methodology or its axes.
 
 ### R16. Goal / core-message beat
 
-Between Background and Architecture the document carries a `## 목표` section with both sub-slots — `### 무엇을·왜` (what the change achieves + why it was needed) and `### 핵심` (the one-line core the reader should hold before any code). Read on the fence-masked text so a `###` inside a code example does not stand in for the real slot. What each slot says is the author's to fill; the gate forces the two slots present.
+Between Background and Architecture the document carries a `## 목표` section with three sub-slots — `### 무엇을·왜` (what the change achieves + why it was needed), `### 핵심` (the one-line core the reader should hold before any code), and `### 출처` (where the purpose/context understanding came from — a Linear issue, Notion doc, Slack thread, PR description, commit body, wiki path, or `코드 추론`). Read on the fence-masked text so a `###` inside a code example does not stand in for the real slot. What each slot says is the author's to fill; the gate forces the three slots present. The `출처` slot applies R3's provenance discipline to the document's whole purpose — the reader can trace and trust the WHY.
+
+> **RED — real artifact (`pr-3412`, luna max).** The 목표 section was rated clear and understandable, but nothing said where the understanding came from — a reader could not tell whether the stated purpose was grounded in a Linear/Notion/PR source or invented. The `출처` slot closes that: name the source, or say `코드 추론`, never blank.
 
 > **RED — real artifact (`boostpack-tool-helper-restore`).** The document ran Evidence → Background →
 > Architecture with no statement anywhere of what the change was for or its one-line takeaway. The "왜"
@@ -265,9 +313,11 @@ Only what cannot be narrowed by machine or by quote is left. When the items grow
 
 ### R8. Quiz question discrimination
 
-Each question requires two or more rubric items, at least one of which is a concrete value unknowable without reading the document (identifier, coordinate, condition, order). Within the same concept, questions do not overlap in required rubric.
+Each question requires two or more rubric items, at least one of which is a concrete value unknowable without reading the document (identifier, coordinate, condition, order). Within the same concept, questions do not overlap in required rubric. **Questions test comprehension of the change — its purpose, mechanism, or consequence — not document metadata.** The git range, the signal/noise file counts, the commit count, and other bookkeeping prove nothing about whether the reader understood the change; such questions are banned. At least one required concept must be a why/purpose question whose answer must state the reason, not just the mechanic.
 
 > **Note — the controls' quiz form.** The gist control makes multiple-choice questions that show the options
 > (`<div class="q" data-answer="1">` form). The moment options are visible, what is measured drops from recall
 > to recognition. That is why this skill uses open-ended answers, and R8 looks at whether that open-ended form
 > actually discriminates.
+
+> **RED — real artifact (`pr-3412`, luna max).** The quiz led with "이 문서가 설명하는 git range와 signal 파일 수·noise 파일 수는 무엇인가?" — pure metadata a reader could answer by skimming the header, testing bookkeeping instead of whether they grasped the change's purpose and why it was needed.

--- a/skills/explain-diff/scripts/explain-diff-state.test.ts
+++ b/skills/explain-diff/scripts/explain-diff-state.test.ts
@@ -105,6 +105,15 @@ flowchart LR
 
 ### 경계·의존·유스케이스
 
+\`\`\`mermaid
+sequenceDiagram
+  participant CLI_A as ultragoal CLI
+  participant Lock as withLock (신설)
+  participant State as state file
+  CLI_A->>Lock: 상태 쓰기 요청
+  Lock->>State: 락 획득 → 쓰기 → 해제
+\`\`\`
+
 <div class="arch-entity" data-change="new">
 <p><strong>이름</strong> 상태 갱신 락 통합</p>
 <p><strong>한 일</strong> 두 CLI의 상태 쓰기를 공용 락으로 직렬화</p>
@@ -127,6 +136,9 @@ const GOAL_SECTION = `## 목표
 
 ### 핵심
 코드를 보기 전에: 락 획득/해제를 한 곳으로 모으는 작은 추출이다.
+
+### 출처
+커밋 본문 "상태 갱신 락 통합"과 코드 추론.
 `;
 
 /** 9스텝 전부의 구조 슬롯을 갖춘 문서. */
@@ -533,7 +545,7 @@ const x = 1;
 		expect(state().last_failure.items.join(" ")).toContain("lib/state-lock.ts");
 	});
 
-	test("같은 signal 파일의 파일 블록이 두 Change Group에 각각 있으면 code 스텝이 실패하고 사유가 중복임을 밝힌다", async () => {
+	test("같은 signal 파일을 두 변경 블록이 각각 인용해도 code 스텝은 통과한다 — 단위는 파일이 아니라 변경이다", async () => {
 		const { submitStep } = await advanceTo("code", WITH_ARCH_DOC);
 		const duplicatedDoc = `${WITH_BACKGROUND_DOC}
 ## Change Group 1: 락을 공용 모듈로 뽑아낸다
@@ -543,7 +555,7 @@ const x = 1;
 ### \`ab12cd3\` — fix: 첫 손질
 락을 옮긴다.
 
-#### \`lib/state-lock.ts\`
+#### 변경 1: 락 획득/해제를 공용 함수로 추출
 <div class="cf">
 <p><strong>왜</strong> — <span class="cf-src">근거</span> "첫 번째 이유"</p>
 <p class="cf-loc"><code>base:lib/state-lock.ts:1</code> → <code>head:lib/state-lock.ts:14</code></p>
@@ -560,7 +572,7 @@ const a = 1;
 ### \`ef45ab6\` — fix: 둘째 손질
 같은 파일을 다시 만진다.
 
-#### \`lib/state-lock.ts\`
+#### 변경 2: 같은 파일에 타임아웃 가드를 덧댄다
 <div class="cf">
 <p><strong>왜</strong> — <span class="cf-src">근거</span> "두 번째 이유"</p>
 <p class="cf-loc"><code>base:lib/state-lock.ts:14</code> → <code>head:lib/state-lock.ts:20</code></p>
@@ -571,10 +583,7 @@ const b = 2;
 \`\`\`
 `;
 		const rc = submitStep(SID, "code", docFile(duplicatedDoc), ["lib/state-lock.ts"], []);
-		expect(rc).toBe(1);
-		const items = state().last_failure.items.join(" ");
-		expect(items).toContain("lib/state-lock.ts");
-		expect(items).toContain("중복");
+		expect(rc).toBe(0);
 	});
 
 	test("intuition 스텝은 최소 문서로도 구조 검사를 통과한다", async () => {

--- a/skills/explain-diff/scripts/explain-diff-state.test.ts
+++ b/skills/explain-diff/scripts/explain-diff-state.test.ts
@@ -52,7 +52,7 @@ const GOOD_DOC = `# 설명
 ### \`ab12cd3\` — fix: 상태 갱신 락 통합
 락 획득/해제를 한 파일로 모은다.
 
-#### \`lib/state-lock.ts\`
+#### 변경 1: 락 획득·해제를 공용 모듈로 추출
 <div class="cf">
 <p><strong>역할/변경 전</strong> — 없던 파일</p>
 <p><strong>바뀐 것</strong> — 락이 여기로 모였다</p>
@@ -520,7 +520,7 @@ describe("스텝 스코핑 — 스텝마다 다른 슬롯만 본다", () => {
 		expect(items).toContain("lib/state-lock.ts");
 	});
 
-	test("signal 파일이 Evidence 표에만 있고 Change Group 파일 블록이 없으면 code 스텝이 실패하고 사유에 경로가 나온다", async () => {
+	test("signal 파일이 Evidence 표에만 있고 Change Group 변경 블록이 없으면 code 스텝이 실패하고 사유에 경로가 나온다", async () => {
 		const { submitStep } = await advanceTo("code", WITH_ARCH_DOC);
 		const noGroupDoc = `${WITH_BACKGROUND_DOC}
 ## Change Group 1: 관련 없는 변경

--- a/skills/explain-diff/scripts/render.ts
+++ b/skills/explain-diff/scripts/render.ts
@@ -287,14 +287,25 @@ h1, h2, h3, h4, p, li, blockquote, th, td { word-break: keep-all; }
   background: var(--code-bg); font-size: 0.95rem;
 }
 
-/* cf — 바뀐 파일 하나의 필드 블록. 필드가 각자 한 줄로 서고(붕괴 방지),
-   출처는 배지로, 위치 앵커는 산문 밖 회색 슬롯으로 뺀다. */
+/* cf — 변경 하나의 필드 블록. 책임 항목이 각자 한 줄로 서고(붕괴 방지),
+   출처는 배지로, 위치 앵커는 산문 밖 회색 슬롯으로 뺀다. 변경종류(data-change)
+   배지는 arch-entity 와 같은 색·라벨을 render.ts 가 붙인다 — 저자는 종류만 준다. */
 .cf {
   margin: 0.6rem 0 1rem; padding: 0.1rem 0 0.1rem 0.9rem;
   border-left: 2px solid var(--rule);
 }
 .cf p { margin: 0.3rem 0; font-size: 0.95rem; }
 .cf strong { color: var(--fg); font-weight: 650; }
+.cf[data-change]::before {
+  display: inline-block; font-size: 0.7rem; font-weight: 700; letter-spacing: 0.02em;
+  border-radius: 999px; padding: 0 0.5rem; margin: 0 0 0.35rem; color: #fff;
+}
+.cf[data-change="new"] { border-left-color: var(--ae-new); }
+.cf[data-change="new"]::before { content: "신설"; background: var(--ae-new); }
+.cf[data-change="mod"] { border-left-color: var(--ae-mod); }
+.cf[data-change="mod"]::before { content: "변경"; background: var(--ae-mod); }
+.cf[data-change="del"] { border-left-color: var(--ae-del); }
+.cf[data-change="del"]::before { content: "삭제"; background: var(--ae-del); }
 .cf-src {
   display: inline-block; font-size: 0.72rem; font-weight: 700;
   letter-spacing: 0.02em; color: var(--muted); background: var(--code-bg);


### PR DESCRIPTION
## 📌 Summary

explain-diff 문서의 설명 단위를 **파일에서 변경(변경 블록)·책임으로 뒤집고**, 실 PR 5건(gpt-5.6-luna max)으로 검증하며 드러난 품질 결함(도메인 빈약·유스케이스 난해·인터페이스 모호·출처 부재·퀴즈 트리비아)을 구조 검사와 가이던스로 봉인한다.

---

## 🔧 Changes

### 구조 검사기 (`lib/explain-diff-structure.ts`)

- 코드 섹션 파싱 축을 파일 블록에서 **변경 블록**(`#### 변경 N`)으로 전환 — 변경마다 책임(class/function) 엔트리, 파일은 `cf-loc` 위치 인용으로만 등장. `R1` 커버리지(모든 signal 파일이 어느 변경엔가 인용)·`R5` hunk 매칭·`R13` 커밋 뼈대 재키잉
- `R15` 재작성 — 경계·의존·유스케이스 블록에 오케스트레이션 mermaid `sequenceDiagram` 필수
- `R21` 신설 — 도메인 레벨 엔티티 카드(실재 도메인 객체·책임·변경종류). 다이어그램 노드 파일경로 금지, `classDiagram` 빈 박스 거부(멤버/메소드 필수)
- `R18` 강화 — 컴포넌트 다이어그램 노드는 모듈/개념 이름, 파일경로 금지(위치는 카드 레이어 슬롯)
- `R16` 슬롯 추가 — 목표 섹션에 `### 출처`(WHY의 근거)

**영향 범위**
explain-diff 스킬 전용. 검사기는 이 스킬의 상태 CLI만 호출한다. 문서 계약(변경 블록·출처 슬롯·다이어그램 규칙)이 바뀌므로 옛 포맷 문서는 재작성해야 통과한다. 외부 소비자 없음.

### 스킬 가이던스 (`SKILL.md`, `references/{rubric,markdown-template,judge-prompt}.md`)

- 표준 인터페이스 표·영향 인터페이스에 시그니처·페이로드·응답 바디 요구(명명 규칙 메모 금지)
- 도메인 레벨은 실재 비즈니스 개념(스키마 인코딩 이름은 의미를 설명할 때만)
- doc-meta `목적` 한 줄·섹션별 목적 프레이밍
- 퀴즈 `R8` — 메타데이터 트리비아(git range·파일 수) 금지, 목적/왜 문항 필수
- judge `R12` — 컴포넌트/도메인 노드 파일경로·비-비즈니스 개념·빈 박스를 심사가 함께 포착

**영향 범위**
문서 저작 지침. 구조 검사가 잡지 못하는 판단(인터페이스 시그니처 구체성·비즈니스 개념성)을 가이던스로 보완. 옛 지침과 하위 호환 불필요(스킬 내부 계약).

### 렌더러 (`skills/explain-diff/scripts/render.ts`)

- `cf[data-change]` 배지 CSS 추가(신설/변경/삭제) — 변경 블록의 변경종류를 한글 배지로 렌더

**영향 범위**
render.ts CSS만. `arch-entity` 배지와 동일 팔레트. 결정적 렌더(회귀는 `render.test.ts`가 가드).

---

## 💬 Review Points

> 각 포인트는 저자의 기술적 선택과 트레이드오프를 담고 있습니다.
> diff를 보지 않아도 PR의 핵심 결정을 이해할 수 있도록 작성되었습니다.

### 1. 설명 축을 파일에서 변경·책임으로 뒤집음

**배경 및 문제 상황:**
기존 explain-diff는 코드 섹션을 **파일 단위**로 서술했다. 실사용 피드백은 "파일 단위 설명이 싫다 — 어떤 객체·함수·책임이 왜 바뀌었는지를 봐야 한다"였다. 파일은 물리적 위치일 뿐, 변경의 논리적 단위가 아니다.

**해결 방안:**
서술 단위를 **변경(변경 블록)**으로 삼고, 한 변경을 여러 **책임**(함께 바뀐 class/function의 duty)으로 분해한다. 파일은 `cf-loc` 위치 인용으로만 남긴다 — "어디에 있는가"는 말하되 축은 아니다.

**구현 세부사항:**
`FILE_BLOCK` 파서를 `CHANGE_BLOCK`(`#### 변경 N`)으로 교체하고, `R1` 커버리지를 "파일당 정확히 한 블록"에서 "모든 signal 파일이 어느 변경엔가 인용(중복 허용)"으로 바꿨다. `R5` hunk 매칭은 파일 앵커를 각 변경 블록의 `cf-loc`에서 수집하도록 재키잉했으나 hunk 대조 로직 자체는 보존했다.

**선택과 트레이드오프:**
변경 축은 한 파일이 여러 변경에 등장하고 한 변경이 여러 파일을 건드리는 다대다를 허용한다. 파일당 유일성 규칙을 버린 대가로 커버리지 게이트가 느슨해 보이지만, 실제 위험(설명 없이 누락된 signal 파일)은 그대로 잡는다. 옛 포맷 문서는 전부 재작성 대상이 된다.

### 2. 어떤 피드백을 구조 게이트로, 어떤 것을 가이던스로

**배경 및 문제 상황:**
품질 결함 6종을 받았을 때, 전부를 기계 검사로 강제하면 브리틀해지고(특히 mermaid 내부 파싱), 전부를 가이던스로 두면 모델별로 일관되지 않는다.

**해결 방안:**
**부재가 셀 수 있는 것**은 구조 게이트로, **판단이 필요한 것**은 가이던스로 나눴다(writing-skills의 "match the form to the failure").

**구현 세부사항:**
- 구조 게이트: 출처 슬롯 부재(`R16`), 다이어그램 노드의 파일경로 존재(`R18`/`R21`), `classDiagram` 빈 박스(`R21`) — 정규식으로 명확히 판정
- 가이던스+judge: 인터페이스 시그니처의 구체성, 도메인 노드의 비즈니스 개념성, 퀴즈의 목적 지향 — 판단이 필요해 `R8`/`R12`와 문서 지침으로

**선택과 트레이드오프:**
`classDiagram` 멤버 검사는 mermaid 내부를 정규식으로 보는지라 취약할 수 있으나, "이름만 있는 빈 박스"라는 결함이 구체적이고 값어치가 커서 게이트로 넣었다. 인터페이스 시그니처는 "충분히 구체적인가"가 본질상 판단이라 게이트화하지 않았다.

### 3. 다이어그램 정직성 — 파일경로 노드·빈 박스 금지

**배경 및 문제 상황:**
검증 산출물에서 컴포넌트 다이어그램 노드가 전체 파일경로(`apps/backend/src/.../health-v2.router.ts`)라 렌더에서 중간이 잘렸고(`health-`, `proposal-`), 도메인 `classDiagram`은 클래스 이름만 있는 빈 박스였다. 둘 다 독자에게 위치·이름만 주고 실체를 주지 못한다.

**해결 방안:**
컴포넌트/도메인 다이어그램 노드는 모듈/개념 이름으로 제한하고(파일경로는 카드 레이어 슬롯이 말함), `classDiagram`은 멤버 변수·메소드를 채우도록 강제한다.

**선택과 트레이드오프:**
파일경로 감지는 "슬래시 경로 + 코드 확장자" 토큰으로 판정한다. Evidence 표와 `cf-loc`의 정당한 파일경로는 mermaid 펜스 밖이라 영향받지 않는다. 이 두 금지는 레벨 waiver 하에서도 유지된다 — "구조 변화 없음"이 "파일경로 노드 허용"을 뜻하지 않기 때문.

### 4. (열린 질문) 섹션별 목적 프레이밍의 일관성

**배경 및 문제 상황:**
"문서·섹션별 목적을 서술하라"는 가이던스로 넣었으나, 5개 검증 PR 중 2개(에셋 교체·REST 복원)는 최상위 섹션(Background/목표) 바로 아래 목적 한 줄을 생략했다(아키텍처 레벨 인트로는 충실).

**선택과 트레이드오프:**
현재는 가이던스로만 두었다. 매 `##` 섹션에 목적 줄을 구조 강제하면 무거운 검사가 필요하고 짧은 문서에서 형식적일 위험이 있다. 실질 목적 전달은 doc-meta 목적·목표 섹션·레벨 인트로로 이미 되므로 게이트화하지 않았으나, 최상위 프레이밍까지 강제할지는 리뷰 의견을 받고 싶다.

---

## ✅ Checklist

### 구조 검사기·테스트
- [ ] 신규/변경 rubric 항목의 통과·실패 경로가 테스트로 고정된다 (R16 출처 슬롯, R18/R21 파일경로 노드, R21 빈 박스)
  - `lib/explain-diff-structure.test.ts`
- [ ] 한 signal 파일을 두 변경 블록이 인용해도 code 스텝이 통과한다
  - `skills/explain-diff/scripts/explain-diff-state.test.ts`
- [ ] typecheck·전체 테스트가 통과한다 (구조+core 179, render 27)
  - `lib/explain-diff-structure.ts`

### 계약 정합성
- [ ] SKILL·rubric·template·judge의 rubric 설명이 검사기 동작과 일치한다
  - `skills/explain-diff/SKILL.md`
  - `skills/explain-diff/references/rubric.md`
- [ ] 렌더 시 cf 변경종류가 한글 배지(신설/변경/삭제)로 표시된다
  - `skills/explain-diff/scripts/render.ts`

---

## 📎 References
- [#274 explain-diff visual-qa 제거·mermaid 봉인](https://github.com/toongri/oh-my-toong-playground/pull/274)
- [#271 explain-diff Architecture v5 심화](https://github.com/toongri/oh-my-toong-playground/pull/271)
- [#264 explain-diff 커밋 뼈대 재편](https://github.com/toongri/oh-my-toong-playground/pull/264)
