### PR TITLE
fix: craft-tasks 티켓 제목·body·의존 표현 형태 교정

### DIFF
--- a/skills/craft-tasks/SKILL.md
+++ b/skills/craft-tasks/SKILL.md
@@ -109,7 +109,7 @@ Each task body carries exactly these three sections, in the team's working langu
 Everything else about a task is expressed through the PM tool's **native fields, not body prose**:
 
 - **Dependencies → native relation field, never body prose.** A sequenced task's predecessor is set through the PM tool's own relation (Linear `blockedBy` / `blocks`), which the team sees on the ticket and filters on. Never write a `## 의존` section or a "blocked by X" sentence in the body — a hard dependency described only in prose is invisible to the board. No hard dependency → no relation to set and nothing to write.
-- **Design anchor + parent link → structural metadata, never body prose.** The `designAnchor` (`design-anchor: deep-interview:<state.interview_id>`) is internal identity carried as a label/identity field (see the gates below), not a line of body text. A child reaches its shared invariants through the native **parent relation** (sub-issue → parent), which the reader clicks through — never through a prose sentence like "부모 X의 설계 확정 코멘트 참조". Both the raw anchor string and any "see the parent comment" boilerplate are leaks; keep them out of the body.
+- **Design anchor + parent link → structural metadata, never body prose.** The `designAnchor` (`design-anchor: deep-interview:<state.interview_id>`) lives once on the **parent** (in its settled-parent record; see the gates below) and reaches each child through the native **parent relation** (sub-issue → parent) — a child proves its anchor by belonging to the resolved anchor-bearing parent via `parentId`, so it needs no anchor string, comment, or per-child label of its own. The anchor is never a line of body text, and the child reaches its shared invariants through that same parent relation the reader clicks through — never through a prose sentence like "부모 X의 설계 확정 코멘트 참조". Both the raw anchor string and any "see the parent comment" boilerplate are leaks; keep them out of the body.
 
 **Shared design invariants are single-sourced on the parent.** Cross-cutting rules (the design's invariants, shared definitions) live once on the **parent** unit; each task inherits them through the native parent relation rather than re-declaring or prose-referencing them — the same Tier-A placement craft-issue uses. This keeps the invariant single-sourced so tasks cannot drift it.
 
@@ -121,7 +121,7 @@ Everything else about a task is expressed through the PM tool's **native fields,
   - **변경 대상** — `tools/sync.ts`의 `skills.items` 해석·배포 대상 수집 로직과 `tools/sync.test.ts`의 중복·누락·순환 참조 테스트.
   - **완료 조건 (DoD)** — `skills.items: [craft-tasks]`에서 시작해 참조된 스킬을 중복 없이 배포 대상에 포함하고 폐쇄 밖의 스킬은 포함하지 않는다(검증: `bun test tools/sync.test.ts`). 누락·순환 참조는 부분 배포 없이 명시적 오류로 실패한다(검증: `bun test tools/sync.test.ts`).
 
-(body는 위 세 섹션뿐이다. 의존·앵커·부모 링크는 body에 쓰지 않는다 — hard 의존 없음이면 관계 필드도 미설정, 앵커는 라벨/네이티브 부모 관계로만 존재.)
+(body는 위 세 섹션뿐이다. 의존·앵커·부모 링크는 body에 쓰지 않는다 — hard 의존 없음이면 관계 필드도 미설정, 앵커는 부모의 settled-parent record에만 있고 자식은 `parentId`로 상속한다.)
 
 ---
 
@@ -171,7 +171,7 @@ Any ambiguity, mismatch, append failure, re-read failure, or interruption stops 
 After the parent-resolution gate, and before any child create, read the verified parent's current child tree and use the organized-tree pattern: **validate → enrich → gap-fill**.
 
 - Match each intended task to an existing child by this rule: **identity is the exact tuple: anchor + purpose + changed target**; **title alone is insufficient**. A child that cannot prove the exact anchor is not a match; treat a possible legacy match as an ambiguity and stop rather than creating a replacement.
-- **Every child carries the same anchor and `parentId`** — as identity/relation metadata: the anchor as a label/identity field and the parent as the native parent relation, **never as body prose** (see Task Title & Body Shape). For matched children, preserve/enrich matched tickets append-only; never rewrite their bodies.
+- **Every child carries the same anchor and `parentId`** — the anchor is inherited through the native parent relation (the child belongs to the resolved anchor-bearing parent via `parentId`), not stamped on the child as its own label, comment, or **body prose** (see Task Title & Body Shape). For matched children, preserve/enrich matched tickets append-only; never rewrite their bodies.
 - For gaps, create only unmatched gaps that are genuine coverage gaps. If a match is ambiguous, stop and surface the ambiguity instead of creating.
 - After every append/create, **re-read and verify effective state after append/create** before continuing. After an interruption or create failure, re-read the current child tree, rematch, and create only the remaining gaps; any re-read failure or interruption stops before another child is created.
 
@@ -205,10 +205,10 @@ Only after this gate passes:
 ### STOP — your write leaked internal metadata or mis-shaped the ticket
 
 - The **title carries an ordinal** — `(item 3)`, `#2`, `task 3` — pulled from your internal task list; the board reader has no such list.
-- The **design anchor string** (`design-anchor: deep-interview:…`) or a **"부모 X 코멘트 참조"** sentence landed in a **child body** → that is internal identity/linkage metadata; it belongs on the anchor label and the native parent relation, not in reader-facing prose.
+- The **design anchor string** (`design-anchor: deep-interview:…`) or a **"부모 X 코멘트 참조"** sentence landed in a **child body** → that is internal identity/linkage metadata; the anchor stays on the parent and the child inherits it through the native parent relation, not in reader-facing prose.
 - A **`## 의존`** section (or a "blocked by X" sentence) sits in a **task body** → dependencies are the PM tool's native relation field (Linear `blockedBy` / `blocks`), never body prose.
 
-**All of these mean: the body is reader-facing prose only. Fix the title, move the anchor to its label, and set the dependency on the native relation field.**
+**All of these mean: the body is reader-facing prose only. Fix the title, keep the anchor on the parent (the child inherits it through the parent relation), and set the dependency on the native relation field.**
 
 ---
 

--- a/skills/craft-tasks/SKILL.md
+++ b/skills/craft-tasks/SKILL.md
@@ -89,25 +89,39 @@ This contract is what makes two runs land on the same grain instead of one cutti
 
 ---
 
-## Task Body Shape
+## Task Title & Body Shape
 
-Each task ticket carries, in the team's working language (Korean by default):
+### Title — name the change, not its position
+
+A task title names the **concrete change this task makes**, in the team's working language (Korean by default) — component/layer plus the action, specific enough to tell apart from its siblings without opening the body (e.g. `[모바일] 프로그램 상세: 미장착 슬롯 흐림 처리 복원`).
+
+- **No decomposition ordinals.** Never append `(item N)`, `(task 3)`, `#2`, or any index from your internal task list — that number is a scratchpad artifact, meaningless to whoever reads the board.
+- **Match sibling ticket titles** for any layer/platform prefix; do not invent a new prefix scheme on the spot.
+
+### Body — reader-facing prose only
+
+Each task body carries exactly these three sections, in the team's working language, and **nothing else**:
 
 - **목적** — what this task delivers toward the settled design (one or two sentences; cite the design decision it implements).
 - **변경 대상** — the component / layer / files this touches. Observational, evidence-backed (from the design's boundary map). This IS allowed here — unlike craft-issue, a task legitimately states HOW.
 - **완료 조건 (DoD)** — verifiable done-checks, each with a verification method (test / query / manual step). Same observable-AC bar as craft-issue's rubric (`../craft-issue/references/issue-craft.md` §2).
-- **의존** — `blocked-by` predecessor tasks, if any.
 
-**Shared design invariants are referenced, not restated.** Cross-cutting rules (the design's invariants, shared definitions) live once on the **parent** unit; each task references the parent rather than re-declaring them — the same Tier-A placement craft-issue uses. This keeps the invariant single-sourced so tasks cannot drift it.
+Everything else about a task is expressed through the PM tool's **native fields, not body prose**:
+
+- **Dependencies → native relation field, never body prose.** A sequenced task's predecessor is set through the PM tool's own relation (Linear `blockedBy` / `blocks`), which the team sees on the ticket and filters on. Never write a `## 의존` section or a "blocked by X" sentence in the body — a hard dependency described only in prose is invisible to the board. No hard dependency → no relation to set and nothing to write.
+- **Design anchor + parent link → structural metadata, never body prose.** The `designAnchor` (`design-anchor: deep-interview:<state.interview_id>`) is internal identity carried as a label/identity field (see the gates below), not a line of body text. A child reaches its shared invariants through the native **parent relation** (sub-issue → parent), which the reader clicks through — never through a prose sentence like "부모 X의 설계 확정 코멘트 참조". Both the raw anchor string and any "see the parent comment" boilerplate are leaks; keep them out of the body.
+
+**Shared design invariants are single-sourced on the parent.** Cross-cutting rules (the design's invariants, shared definitions) live once on the **parent** unit; each task inherits them through the native parent relation rather than re-declaring or prose-referencing them — the same Tier-A placement craft-issue uses. This keeps the invariant single-sourced so tasks cannot drift it.
 
 ### 예시 — 확정된 부모 설계와 자식 티켓 1개
 
 - **부모 설계(확정)** — `sync.yaml`의 `skills.items`를 시작점으로 삼아 각 `SKILL.md`의 `Skill(...)` 참조를 재귀적으로 해석하고, 중복을 제거한 스킬 의존성 폐쇄만 대상 플랫폼의 스킬 디렉터리에 배포한다. 누락·순환 참조는 동기화를 실패시키며 폐쇄 밖의 스킬은 건드리지 않는다. 경계는 `tools/sync.ts`, `tools/sync.test.ts`, 플랫폼별 스킬 배포 경로다.
-- **자식 티켓: 스킬 의존성 폐쇄 수집 단계 추가**
+- **자식 티켓 제목** — `sync: 스킬 의존성 폐쇄 수집 단계 추가` (순번·`(item N)` 없이 변경 내용만)
   - **목적** — 확정된 부모 설계에 따라 `skills.items`와 각 `SKILL.md`의 참조를 재귀 수집해 플랫폼별 배포 단계가 동일한 폐쇄 집합을 사용하게 한다.
   - **변경 대상** — `tools/sync.ts`의 `skills.items` 해석·배포 대상 수집 로직과 `tools/sync.test.ts`의 중복·누락·순환 참조 테스트.
   - **완료 조건 (DoD)** — `skills.items: [craft-tasks]`에서 시작해 참조된 스킬을 중복 없이 배포 대상에 포함하고 폐쇄 밖의 스킬은 포함하지 않는다(검증: `bun test tools/sync.test.ts`). 누락·순환 참조는 부분 배포 없이 명시적 오류로 실패한다(검증: `bun test tools/sync.test.ts`).
-  - **의존** — 없음(부모 설계 확정 후 착수).
+
+(body는 위 세 섹션뿐이다. 의존·앵커·부모 링크는 body에 쓰지 않는다 — hard 의존 없음이면 관계 필드도 미설정, 앵커는 라벨/네이티브 부모 관계로만 존재.)
 
 ---
 
@@ -157,7 +171,7 @@ Any ambiguity, mismatch, append failure, re-read failure, or interruption stops 
 After the parent-resolution gate, and before any child create, read the verified parent's current child tree and use the organized-tree pattern: **validate → enrich → gap-fill**.
 
 - Match each intended task to an existing child by this rule: **identity is the exact tuple: anchor + purpose + changed target**; **title alone is insufficient**. A child that cannot prove the exact anchor is not a match; treat a possible legacy match as an ambiguity and stop rather than creating a replacement.
-- **Every child carries the same anchor and `parentId`**. For matched children, preserve/enrich matched tickets append-only; never rewrite their bodies.
+- **Every child carries the same anchor and `parentId`** — as identity/relation metadata: the anchor as a label/identity field and the parent as the native parent relation, **never as body prose** (see Task Title & Body Shape). For matched children, preserve/enrich matched tickets append-only; never rewrite their bodies.
 - For gaps, create only unmatched gaps that are genuine coverage gaps. If a match is ambiguous, stop and surface the ambiguity instead of creating.
 - After every append/create, **re-read and verify effective state after append/create** before continuing. After an interruption or create failure, re-read the current child tree, rematch, and create only the remaining gaps; any re-read failure or interruption stops before another child is created.
 
@@ -176,7 +190,9 @@ Only after this gate passes:
 
 ---
 
-## Red Flags — STOP, you are doing craft-issue's job instead
+## Red Flags
+
+### STOP — you are doing craft-issue's job instead
 
 - You are **folding** an implementation step "because it has no stand-alone user value" → that is the craft-issue rule; on a settled design you **materialize** it.
 - You **refused a layer/platform split** as an anti-pattern → correct for requirement units, wrong for work items; the layer split is the point here.
@@ -185,6 +201,14 @@ Only after this gate passes:
 - You wrote a **"작업 분해 (제안)"** section in the parent body instead of creating the tickets.
 
 **All of these mean: you are applying WHAT-slicing to a HOW job. Re-read The Inversion and produce the settled unit's work-item tickets.**
+
+### STOP — your write leaked internal metadata or mis-shaped the ticket
+
+- The **title carries an ordinal** — `(item 3)`, `#2`, `task 3` — pulled from your internal task list; the board reader has no such list.
+- The **design anchor string** (`design-anchor: deep-interview:…`) or a **"부모 X 코멘트 참조"** sentence landed in a **child body** → that is internal identity/linkage metadata; it belongs on the anchor label and the native parent relation, not in reader-facing prose.
+- A **`## 의존`** section (or a "blocked by X" sentence) sits in a **task body** → dependencies are the PM tool's native relation field (Linear `blockedBy` / `blocks`), never body prose.
+
+**All of these mean: the body is reader-facing prose only. Fix the title, move the anchor to its label, and set the dependency on the native relation field.**
 
 ---
 


### PR DESCRIPTION
## 📌 Summary

craft-tasks가 실제로 생성한 Linear 티켓에서 드러난 세 가지 형태(shape) 결함 — 의존을 body 프로즈로 서술, 제목에 내부 순번 `(item N)`, body에 `designAnchor`·부모참조 메타데이터 누출 — 을 스킬의 제목/body 형태 계약을 보강해 교정.

---

## 🔧 Changes

### craft-tasks 스킬 (`skills/craft-tasks/SKILL.md`)

- **의존 → 네이티브 관계 전용**: Task Body Shape의 `**의존**` body 필드를 제거하고, 의존은 PM 툴의 네이티브 관계(Linear `blockedBy`/`blocks`)로만 표현하도록 명시. hard 의존이 없으면 관계도 미설정·body에 아무것도 쓰지 않음.
- **Title 계약 신설**: 제목은 변경 내용만 담고 `(item N)`·`#2` 등 내부 task 리스트 순번 금지, 형제 티켓 prefix 준수.
- **Body 형태 고정**: body는 reader-facing 프로즈(목적/변경대상/DoD) 전용. `designAnchor`와 부모 링크는 라벨·네이티브 부모 관계라는 구조 메타데이터로 규정 — 앵커 문자열·"부모 X 코멘트 참조" 보일러플레이트는 누출로 명시.
- 예시를 새 계약에 맞게 갱신하고, Red Flags에 write-shape 누수 자기점검 그룹 추가.

**영향 범위**
프롬프트 계약(문서)만 변경 — 코드 로직·컴포넌트 인벤토리 변화 없음. 기존 `SKILL.test.ts` 계약 테스트 22개 전부 통과(테스트가 보호하는 literal 유지). 하위 호환: 스킬 실행 시 산출되는 티켓의 형태만 달라짐.

---

## 💬 Review Points

### 1. 금지(prohibition)가 아니라 positive contract로 고친 이유

**배경 및 문제 상황:** 세 결함 모두 "규칙을 알면서 압박에 어긴" discipline 실패가 아니라, 순응했으나 **출력 형태가 틀린** wrong-shape 실패였다. 실제로 근본 원인은 SKILL.md가 body 필드로 `의존`을 직접 지시하고, 제목 계약이 아예 없던 것이다.

**해결 방안:** writing-skills의 "match the form to the failure"에 따라, wrong-shape에는 "무엇을 하지 마라"가 아니라 **출력이 무엇이어야 하는지(제목/body의 구성과 순서)를 규정하는 positive contract**를 넣었다. prohibition은 Red Flags 자기점검으로만 보조 배치.

**선택과 트레이드오프:** prohibition 위주로 고치면 경쟁 인센티브(티켓을 자족적으로 보이게) 아래서 재협상 여지가 남는다. 대신 형태를 못 박아 협상 여지를 없앴다. 트레이드오프로 body 섹션 서술이 다소 길어졌으나, 계약이 명시적이라 재발 위험이 낮다.

### 2. designAnchor를 body에서 분리하되 식별 계약은 유지

**배경 및 문제 상황:** `designAnchor`는 부모-해석·자식-식별용 내부 식별자이자 `SKILL.test.ts`가 보호하는 계약("Every child carries the same anchor and `parentId`")이다. 에이전트가 이 문구를 "앵커를 body에 써라"로 오독해 원문 문자열이 티켓 본문에 새어나왔다.

**해결 방안:** 앵커는 라벨/네이티브 부모 관계라는 **구조 메타데이터**로 존재하고 body 프로즈가 아니라는 점을 Body 계약과 식별 게이트 양쪽에 명시. 보호 literal은 그대로 두고 뒤에 "as body prose가 아님" 절만 덧붙여 테스트를 깨지 않으면서 오독을 차단.

**검증:** 수정된 스킬로 fresh 서브에이전트 3회 반복 실행(프로덕션 유사 설계·hard 의존 없음) → 3/3 전부 세 결함 재발 없이 동일 형태로 수렴, 앵커는 모두 body 밖 filing-metadata로 분리. 기존 계약 테스트 22개 통과.

**선택과 트레이드오프(open question):** 이미 생성된 티켓(B2C-6695~6699)은 여전히 옛 형태의 결함을 갖고 있다. 이 PR은 **스킬**만 고치며, 기존 티켓 정리(의존→관계 필드, body에서 앵커·부모참조 제거, 제목 순번 제거)는 별도 후속 작업으로 남긴다.

---

## ✅ Checklist

### craft-tasks 티켓 형태 계약
- [ ] 생성되는 태스크 제목에 `(item N)` 등 내부 순번이 포함되지 않는다
  - `skills/craft-tasks/SKILL.md`
- [ ] 태스크 body에 `## 의존` 섹션이 없고, 의존은 네이티브 관계 필드로만 표현된다
  - `skills/craft-tasks/SKILL.md`
- [ ] 태스크 body에 `designAnchor` 문자열·"부모 X 코멘트 참조" 보일러플레이트가 없다
  - `skills/craft-tasks/SKILL.md`
- [ ] 기존 계약 테스트가 전부 통과한다
  - `skills/craft-tasks/SKILL.test.ts`

---

## 📎 References
- [#284 craft-tasks 스킬 신설 PR](https://github.com/toongri/oh-my-toong-playground/pull/284) — 이번 수정의 대상 스킬
- [B2C-6697 결함이 관찰된 Linear 티켓](https://linear.app/algocare/issue/B2C-6697) — 세 형태 결함의 실제 산출물(algocare Linear 접근 필요)

https://claude.ai/code/session_01N34CUEMXbi8SarbyybAYsR